### PR TITLE
Skip achievement announcements for users not in the Discord guild

### DIFF
--- a/server/utils/discord.js
+++ b/server/utils/discord.js
@@ -326,8 +326,8 @@ function formatList(items) {
 
 export async function announceAchievement(prisma, userId, achievementTitle, rewardSummary = null, roleName = null) {
   try {
-    const user = await prisma.user.findUnique({ where: { id: userId }, select: { discordId: true, username: true } })
-    if (!user?.discordId) return
+    const user = await prisma.user.findUnique({ where: { id: userId }, select: { discordId: true, username: true, inGuild: true } })
+    if (!user?.discordId || user.inGuild === false) return
     const config = await prisma.globalGameConfig.findUnique({
       where: { id: 'singleton' },
       select: { achievementDiscordChannelId: true }


### PR DESCRIPTION
When a user's discordId exists but they're not in the server (inGuild === false),
mentioning them with <@userId> renders as "@unknown-user" in Discord. Adding the
same inGuild guard that assignDiscordRoleByName already uses prevents these messages.

https://claude.ai/code/session_01Chk25YkecXuneCLDPkAs6E