### PR TITLE
Add winner username filter to admin auction logs

### DIFF
--- a/pages/admin/auctions.vue
+++ b/pages/admin/auctions.vue
@@ -37,15 +37,30 @@
         />
       </div>
 
-      <div>
+      <div class="relative">
         <label for="winnerSearch" class="block text-sm font-medium text-gray-700 mb-1">Winner</label>
         <input
           id="winnerSearch"
           v-model="winnerQuery"
           type="text"
           placeholder="Type a username…"
+          autocomplete="off"
           class="w-full border rounded px-3 py-2 text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          @blur="hideWinnerSuggestions"
         />
+        <ul
+          v-if="winnerSuggestions.length > 0"
+          class="absolute z-10 mt-1 w-full bg-white border rounded shadow-lg max-h-48 overflow-y-auto"
+        >
+          <li
+            v-for="user in winnerSuggestions"
+            :key="user.id"
+            class="px-3 py-2 text-sm cursor-pointer hover:bg-indigo-50"
+            @mousedown.prevent="selectWinner(user.username)"
+          >
+            {{ user.username }}
+          </li>
+        </ul>
       </div>
 
       <div>
@@ -180,6 +195,7 @@ const ctoonNameQuery = ref('')
 const characterQuery = ref('')
 const creatorQuery = ref('')
 const winnerQuery = ref('')
+const winnerSuggestions = ref([])
 const selectedRarity = ref('')
 const selectedStatus = ref('')
 const selectedHasBidder = ref('')
@@ -228,6 +244,30 @@ function scheduleFilterFetch() {
     await nextTick()
     scrollTop()
   }, 300)
+}
+
+// Winner autocomplete
+let winnerSuggestDebounceId = null
+watch(winnerQuery, (val) => {
+  if (winnerSuggestDebounceId) clearTimeout(winnerSuggestDebounceId)
+  const trimmed = val.trim()
+  if (trimmed.length < 3) {
+    winnerSuggestions.value = []
+    return
+  }
+  winnerSuggestDebounceId = setTimeout(async () => {
+    const results = await $fetch('/api/admin/auction-winners', { query: { q: trimmed } })
+    winnerSuggestions.value = results
+  }, 300)
+})
+
+function selectWinner(username) {
+  winnerQuery.value = username
+  winnerSuggestions.value = []
+}
+
+function hideWinnerSuggestions() {
+  setTimeout(() => { winnerSuggestions.value = [] }, 150)
 }
 
 // React to text filters with debounce

--- a/pages/admin/auctions.vue
+++ b/pages/admin/auctions.vue
@@ -38,6 +38,17 @@
       </div>
 
       <div>
+        <label for="winnerSearch" class="block text-sm font-medium text-gray-700 mb-1">Winner</label>
+        <input
+          id="winnerSearch"
+          v-model="winnerQuery"
+          type="text"
+          placeholder="Type a username…"
+          class="w-full border rounded px-3 py-2 text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+        />
+      </div>
+
+      <div>
         <label for="rarityFilter" class="block text-sm font-medium text-gray-700 mb-1">Rarity</label>
         <select
           id="rarityFilter"
@@ -91,6 +102,7 @@
             <th class="px-4 py-2">Duration</th>
             <th class="px-4 py-2">Hours Left</th>
             <th class="px-4 py-2">Highest Bidder</th>
+            <th class="px-4 py-2">Winner</th>
             <th class="px-4 py-2">Highest Bid</th>
             <th class="px-4 py-2"># of Bids</th>
           </tr>
@@ -106,6 +118,7 @@
             <td class="px-4 py-2">{{ auc.duration }} days</td>
             <td class="px-4 py-2">{{ hoursLeft(auc.endAt) }}</td>
             <td class="px-4 py-2">{{ auc.highestBidder?.username || '—' }}</td>
+            <td class="px-4 py-2">{{ auc.winner?.username || '—' }}</td>
             <td class="px-4 py-2">{{ auc.highestBid }}</td>
             <td class="px-4 py-2">{{ auc.bids.length }}</td>
           </tr>
@@ -129,6 +142,7 @@
           <div><span class="font-medium">Created:</span> {{ formatDate(auc.createdAt) }}</div>
           <div><span class="font-medium">Duration:</span> {{ auc.duration }} days</div>
           <div><span class="font-medium">Top Bidder:</span> {{ auc.highestBidder?.username || '—' }}</div>
+          <div><span class="font-medium">Winner:</span> {{ auc.winner?.username || '—' }}</div>
           <div><span class="font-medium">Highest Bid:</span> {{ auc.highestBid }}</div>
           <div><span class="font-medium"># of Bids:</span> {{ auc.bids.length }}</div>
         </div>
@@ -165,6 +179,7 @@ const auctions = ref([])
 const ctoonNameQuery = ref('')
 const characterQuery = ref('')
 const creatorQuery = ref('')
+const winnerQuery = ref('')
 const selectedRarity = ref('')
 const selectedStatus = ref('')
 const selectedHasBidder = ref('')
@@ -189,6 +204,7 @@ async function fetchAuctions() {
       page: page.value,
       limit: pageSize,
       creator: creatorQuery.value.trim() || undefined,
+      winner: winnerQuery.value.trim() || undefined,
       ctoonName: ctoonNameQuery.value.trim() || undefined,
       characters: characterQuery.value.trim() || undefined,
       rarity: selectedRarity.value || undefined,
@@ -215,7 +231,7 @@ function scheduleFilterFetch() {
 }
 
 // React to text filters with debounce
-watch([ctoonNameQuery, characterQuery, creatorQuery], () => {
+watch([ctoonNameQuery, characterQuery, creatorQuery, winnerQuery], () => {
   scheduleFilterFetch()
 })
 

--- a/server/api/admin/auction-winners.get.js
+++ b/server/api/admin/auction-winners.get.js
@@ -1,0 +1,35 @@
+import { defineEventHandler, getRequestHeader, getQuery, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  let me = event.context.user
+  if (!me) {
+    const cookie = getRequestHeader(event, 'cookie') || ''
+    try {
+      me = await $fetch('/api/auth/me', { headers: { cookie } })
+    } catch {
+      throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+    }
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const { q = '' } = getQuery(event)
+  const query = String(q).trim()
+
+  const rows = await prisma.auction.findMany({
+    distinct: ['winnerId'],
+    where: {
+      winnerId: { not: null },
+      winner: { username: { contains: query, mode: 'insensitive' } }
+    },
+    select: {
+      winner: { select: { id: true, username: true } }
+    },
+    take: 10
+  })
+
+  const winners = rows.map(r => r.winner).filter(Boolean)
+  winners.sort((a, b) => (a.username || '').localeCompare(b.username || ''))
+
+  return winners
+})

--- a/server/api/admin/auctions.get.js
+++ b/server/api/admin/auctions.get.js
@@ -16,6 +16,7 @@ export default defineEventHandler(async (event) => {
     page = '1',
     limit = '100',
     creator = '',
+    winner = '',
     status = '',
     hasBidder = '',
     ctoonName = '',
@@ -31,6 +32,9 @@ export default defineEventHandler(async (event) => {
   if (status) where.status = String(status)
   if (creator) {
     where.creator = { username: { contains: String(creator), mode: 'insensitive' } }
+  }
+  if (winner) {
+    where.winner = { username: { contains: String(winner), mode: 'insensitive' } }
   }
   if (hasBidder === 'has') where.highestBidderId = { not: null }
   if (hasBidder === 'none') where.highestBidderId = null
@@ -70,6 +74,7 @@ export default defineEventHandler(async (event) => {
         },
         creator: { select: { id: true, username: true } },
         highestBidder: { select: { id: true, username: true } },
+        winner: { select: { id: true, username: true } },
         bids: { select: { id: true } }
       }
     })
@@ -89,6 +94,7 @@ export default defineEventHandler(async (event) => {
       userCtoon: { ctoon: a.userCtoon?.ctoon ?? null },
       creator: a.creator ?? null,
       highestBidder: a.highestBidder ?? null,
+      winner: a.winner ?? null,
       bids: a.bids ?? []
     }))
   }


### PR DESCRIPTION
Adds a Winner filter to the admin auction logs page, mirroring the existing Creator filter. After typing 3+ characters, an autocomplete dropdown appears with matching winner usernames.

## Changes
- **New API endpoint** `/api/admin/auction-winners` — returns up to 10 winner usernames matching a query string (case-insensitive substring, debounced)
- **Updated API** `/api/admin/auctions` — accepts a `winner` query param and filters by `winner.username`; also includes `winner` in the select and response payload
- **Admin auction logs page** — adds a Winner filter input with autocomplete dropdown (triggers at 3+ chars), a Winner column to the desktop table, and a Winner field to mobile cards

https://claude.ai/code/session_01SMzmneLBoRsppNADrC4hxP