### PR TITLE
Add Suspicious Activity Monitor admin page

### DIFF
--- a/components/Nav.vue
+++ b/components/Nav.vue
@@ -341,6 +341,7 @@ const adminGroups = [
     key: 'logs',
     title: 'Admin — Logs',
     items: [
+      { label: 'Suspicious Activity', to: '/admin/suspicious-activity' },
       { label: 'Check Cheating', to: '/admin/check-cheating' },
       { label: 'Cheating Tool', to: '/admin/cheating-tool' },
       { label: 'Auction Logs', to: '/admin/auctions' },

--- a/pages/admin/suspicious-activity.vue
+++ b/pages/admin/suspicious-activity.vue
@@ -1,0 +1,791 @@
+<template>
+  <div class="p-6 space-y-6 mt-16 md:mt-20">
+    <Nav />
+
+    <div class="max-w-6xl mx-auto" style="margin-top: 50px;">
+      <div class="flex items-start justify-between mb-6">
+        <div>
+          <h1 class="text-2xl font-bold">Suspicious Activity Monitor</h1>
+          <p class="text-sm text-gray-500 mt-1">Define rules to flag users exhibiting suspicious patterns. Run analysis on demand to see current results.</p>
+        </div>
+      </div>
+
+      <!-- ── Rules section ────────────────────────────────────────────────── -->
+      <section class="bg-white border rounded p-4 mb-6">
+        <div class="flex items-center justify-between mb-3">
+          <h2 class="font-semibold text-lg">Rules</h2>
+          <button
+            class="bg-indigo-600 text-white text-sm px-3 py-1.5 rounded hover:bg-indigo-700"
+            @click="openCreateRuleModal"
+          >+ New Rule</button>
+        </div>
+
+        <div v-if="rulesLoading" class="text-sm text-gray-500 py-4 text-center">Loading rules…</div>
+
+        <div v-else-if="rules.length === 0" class="text-sm text-gray-400 py-4 text-center">
+          No rules yet. Create one to start monitoring.
+        </div>
+
+        <div v-else class="divide-y">
+          <div v-for="rule in rules" :key="rule.id" class="py-3 flex items-start gap-3">
+            <!-- Active indicator -->
+            <button
+              :title="rule.isActive ? 'Click to deactivate' : 'Click to activate'"
+              class="mt-0.5 flex-shrink-0"
+              @click="toggleRuleActive(rule)"
+            >
+              <span
+                class="inline-block w-3 h-3 rounded-full"
+                :class="rule.isActive ? 'bg-green-500' : 'bg-gray-300'"
+              ></span>
+            </button>
+
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="font-medium">{{ rule.name }}</span>
+                <span v-if="!rule.isActive" class="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">inactive</span>
+              </div>
+              <p v-if="rule.description" class="text-sm text-gray-500 mt-0.5">{{ rule.description }}</p>
+              <div class="text-xs text-gray-400 mt-1 space-x-2">
+                <span>{{ rule.timeWindowDays ? `Last ${rule.timeWindowDays} days` : 'All time' }}</span>
+                <span>·</span>
+                <span>{{ rule.conditionLogic }} logic</span>
+                <span>·</span>
+                <span>{{ rule.conditions.length }} condition{{ rule.conditions.length !== 1 ? 's' : '' }}</span>
+              </div>
+              <!-- Condition pills -->
+              <div class="flex flex-wrap gap-1 mt-1.5">
+                <span
+                  v-for="c in rule.conditions"
+                  :key="c.id"
+                  class="inline-block text-xs bg-indigo-50 text-indigo-700 border border-indigo-200 rounded px-1.5 py-0.5"
+                >
+                  {{ metricLabel(c.metric) }} {{ operatorLabel(c.operator) }} {{ c.threshold }}
+                </span>
+              </div>
+            </div>
+
+            <div class="flex gap-2 flex-shrink-0">
+              <button
+                class="text-sm text-blue-600 hover:underline"
+                @click="openEditRuleModal(rule)"
+              >Edit</button>
+              <button
+                class="text-sm text-red-600 hover:underline"
+                @click="deleteRule(rule)"
+              >Delete</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── Analysis section ─────────────────────────────────────────────── -->
+      <section class="bg-white border rounded p-4">
+        <div class="flex items-center gap-4 flex-wrap mb-4">
+          <button
+            class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50 font-medium"
+            :disabled="analyzing || rules.filter(r => r.isActive).length === 0"
+            @click="runAnalysis"
+          >
+            <span v-if="analyzing">Analyzing…</span>
+            <span v-else>▶ Run Analysis</span>
+          </button>
+
+          <label class="flex items-center gap-2 text-sm cursor-pointer select-none">
+            <input v-model="showMuted" type="checkbox" class="rounded" />
+            Show muted users
+          </label>
+
+          <span v-if="analysisResult" class="text-sm text-gray-400 ml-auto">
+            {{ rulesEvaluatedLabel }} · {{ analysisResult.flaggedUsers.length }} flagged ·
+            Last run {{ lastRunLabel }}
+          </span>
+        </div>
+
+        <div v-if="analyzeError" class="text-sm text-red-600 mb-3 bg-red-50 border border-red-200 rounded p-2">
+          {{ analyzeError }}
+        </div>
+
+        <div v-if="!analysisResult && !analyzing" class="text-sm text-gray-400 text-center py-8">
+          Click "Run Analysis" to evaluate all active rules against current user data.
+        </div>
+
+        <div v-else-if="displayedUsers.length === 0 && analysisResult" class="text-sm text-gray-400 text-center py-8">
+          <span v-if="analysisResult.flaggedUsers.length === 0">No users flagged by the current active rules.</span>
+          <span v-else>All flagged users are muted. Enable "Show muted users" to see them.</span>
+        </div>
+
+        <!-- Flagged user cards -->
+        <div v-else class="space-y-3">
+          <div
+            v-for="user in displayedUsers"
+            :key="user.userId"
+            class="border rounded"
+            :class="user.isMuted ? 'border-gray-200 opacity-60' : 'border-red-200'"
+          >
+            <!-- User header row -->
+            <div class="flex items-start gap-3 p-3">
+              <!-- Avatar -->
+              <img
+                v-if="user.avatar"
+                :src="user.avatar"
+                class="w-10 h-10 rounded-full flex-shrink-0 object-cover"
+                alt=""
+              />
+              <div v-else class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0 text-gray-500 text-sm font-bold">
+                {{ (user.username || '?')[0].toUpperCase() }}
+              </div>
+
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 flex-wrap">
+                  <a
+                    :href="`/admin/users?q=${user.username}`"
+                    target="_blank"
+                    class="font-semibold text-indigo-700 hover:underline"
+                  >{{ user.username || '(no username)' }}</a>
+                  <span v-if="user.discordTag" class="text-xs text-gray-400">{{ user.discordTag }}</span>
+                  <span
+                    v-if="user.isMuted"
+                    class="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded border"
+                    :title="user.muteInfo?.reason ? `Reason: ${user.muteInfo.reason}` : 'No reason given'"
+                  >muted{{ user.muteInfo?.mutedBy ? ` by ${user.muteInfo.mutedBy}` : '' }}</span>
+                </div>
+
+                <!-- Triggered rules -->
+                <div class="flex flex-wrap gap-1 mt-1">
+                  <span
+                    v-for="rule in user.triggeredRules"
+                    :key="rule.ruleId"
+                    class="inline-block text-xs bg-red-50 text-red-700 border border-red-200 rounded px-1.5 py-0.5"
+                  >{{ rule.ruleName }}</span>
+                </div>
+
+                <!-- Quick metric summary -->
+                <div class="text-xs text-gray-500 mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5">
+                  <span v-if="user.metrics.tradeOfferCount != null">
+                    {{ user.metrics.tradeOfferCount }} trade{{ user.metrics.tradeOfferCount !== 1 ? 's' : '' }}
+                  </span>
+                  <span v-if="user.metrics.tradeOfferPartnerCount != null">
+                    {{ user.metrics.tradeOfferPartnerCount }} unique partner{{ user.metrics.tradeOfferPartnerCount !== 1 ? 's' : '' }}
+                  </span>
+                  <span v-if="user.metrics.tradeOfferConcentrationPct != null">
+                    {{ user.metrics.tradeOfferConcentrationPct }}% trade concentration
+                  </span>
+                  <span v-if="user.metrics.auctionWinCount != null">
+                    {{ user.metrics.auctionWinCount }} auction win{{ user.metrics.auctionWinCount !== 1 ? 's' : '' }}
+                  </span>
+                  <span v-if="user.metrics.auctionWinSellerCount != null">
+                    from {{ user.metrics.auctionWinSellerCount }} seller{{ user.metrics.auctionWinSellerCount !== 1 ? 's' : '' }}
+                  </span>
+                  <span v-if="user.metrics.auctionWinConcentrationPct != null">
+                    {{ user.metrics.auctionWinConcentrationPct }}% win concentration
+                  </span>
+                  <span v-if="user.metrics.sharedIPUserCount != null">
+                    {{ user.metrics.sharedIPUserCount }} shared-IP account{{ user.metrics.sharedIPUserCount !== 1 ? 's' : '' }}
+                  </span>
+                </div>
+              </div>
+
+              <!-- Action buttons -->
+              <div class="flex gap-2 flex-shrink-0">
+                <button
+                  class="text-xs border rounded px-2 py-1 hover:bg-gray-50"
+                  @click="toggleExpand(user.userId)"
+                >{{ expandedUsers.has(user.userId) ? '▲ Hide' : '▼ Details' }}</button>
+                <button
+                  v-if="!user.isMuted"
+                  class="text-xs bg-orange-100 text-orange-700 border border-orange-200 rounded px-2 py-1 hover:bg-orange-200"
+                  @click="openMuteModal(user)"
+                >Mute</button>
+                <button
+                  v-else
+                  class="text-xs bg-blue-50 text-blue-700 border border-blue-200 rounded px-2 py-1 hover:bg-blue-100"
+                  @click="unmuteUser(user)"
+                >Unmute</button>
+              </div>
+            </div>
+
+            <!-- Expanded detail panel -->
+            <div v-if="expandedUsers.has(user.userId)" class="border-t bg-gray-50 p-3 space-y-4">
+
+              <!-- Matched conditions detail -->
+              <div>
+                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Why flagged</h4>
+                <div class="space-y-1">
+                  <div v-for="rule in user.triggeredRules" :key="rule.ruleId">
+                    <div class="text-xs font-medium text-gray-700">{{ rule.ruleName }}</div>
+                    <ul class="mt-0.5 space-y-0.5">
+                      <li
+                        v-for="(cond, i) in rule.matchedConditions"
+                        :key="i"
+                        class="text-xs text-gray-600 pl-3 before:content-['•'] before:mr-1"
+                      >{{ cond }}</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+
+              <!-- All computed metrics -->
+              <div>
+                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">All metrics computed</h4>
+                <div class="grid grid-cols-2 md:grid-cols-3 gap-1.5">
+                  <div
+                    v-for="[key, val] in Object.entries(user.metrics)"
+                    :key="key"
+                    class="bg-white border rounded px-2 py-1.5 text-xs"
+                  >
+                    <div class="text-gray-500">{{ metricLabel(key) }}</div>
+                    <div class="font-semibold text-gray-800">{{ val }}{{ metricUnit(key) }}</div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Trade partners -->
+              <div v-if="user.context.topTradePartners.length > 0">
+                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Top trade partners</h4>
+                <div class="flex flex-wrap gap-2">
+                  <a
+                    v-for="p in user.context.topTradePartners"
+                    :key="p.userId"
+                    :href="`/admin/users?q=${p.username}`"
+                    target="_blank"
+                    class="inline-flex items-center gap-1 text-xs bg-white border rounded px-2 py-1 hover:bg-indigo-50 text-indigo-700"
+                  >
+                    {{ p.username || '(unknown)' }}
+                    <span class="text-gray-400 font-normal">× {{ p.tradeCount }}</span>
+                  </a>
+                </div>
+              </div>
+
+              <!-- Auction sellers -->
+              <div v-if="user.context.topAuctionSellers.length > 0">
+                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Auction wins by seller</h4>
+                <div class="flex flex-wrap gap-2">
+                  <a
+                    v-for="s in user.context.topAuctionSellers"
+                    :key="s.userId"
+                    :href="`/admin/users?q=${s.username}`"
+                    target="_blank"
+                    class="inline-flex items-center gap-1 text-xs bg-white border rounded px-2 py-1 hover:bg-indigo-50 text-indigo-700"
+                  >
+                    {{ s.username || '(unknown)' }}
+                    <span class="text-gray-400 font-normal">{{ s.wins }} win{{ s.wins !== 1 ? 's' : '' }}</span>
+                  </a>
+                </div>
+              </div>
+
+              <!-- Shared IP users -->
+              <div v-if="user.context.sharedIPUsers.length > 0">
+                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Accounts sharing an IP</h4>
+                <div class="space-y-1">
+                  <div
+                    v-for="s in user.context.sharedIPUsers"
+                    :key="s.userId"
+                    class="flex items-center gap-2 text-xs"
+                  >
+                    <a
+                      :href="`/admin/users?q=${s.username}`"
+                      target="_blank"
+                      class="text-indigo-700 hover:underline font-medium"
+                    >{{ s.username || '(unknown)' }}</a>
+                    <span class="text-gray-400">via {{ s.sharedIPs.join(', ') }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div
+                v-if="user.context.topTradePartners.length === 0 && user.context.topAuctionSellers.length === 0 && user.context.sharedIPUsers.length === 0"
+                class="text-xs text-gray-400"
+              >No contextual data available for this user.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- ── Rule Create / Edit Modal ─────────────────────────────────────── -->
+    <div v-if="ruleModal.open" class="fixed inset-0 bg-black/40 z-50 flex items-start justify-center p-4 overflow-y-auto">
+      <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl my-8">
+        <div class="flex items-center justify-between p-4 border-b">
+          <h2 class="font-semibold text-lg">{{ ruleModal.mode === 'create' ? 'New Rule' : 'Edit Rule' }}</h2>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeRuleModal">×</button>
+        </div>
+
+        <div class="p-4 space-y-4">
+          <!-- Name -->
+          <div>
+            <label class="block text-sm font-medium mb-1">Rule name <span class="text-red-500">*</span></label>
+            <input v-model.trim="ruleForm.name" class="w-full border rounded px-3 py-2" placeholder="e.g. Alt Account Trade Funnel" />
+          </div>
+
+          <!-- Description -->
+          <div>
+            <label class="block text-sm font-medium mb-1">Description</label>
+            <textarea v-model.trim="ruleForm.description" class="w-full border rounded px-3 py-2 text-sm" rows="2" placeholder="Explain what this rule is looking for…"></textarea>
+          </div>
+
+          <!-- Row: time window + condition logic + active toggle -->
+          <div class="grid grid-cols-3 gap-3">
+            <div>
+              <label class="block text-sm font-medium mb-1">Time window</label>
+              <select v-model="ruleForm.timeWindowDays" class="w-full border rounded px-3 py-2 text-sm">
+                <option :value="null">All time</option>
+                <option :value="7">Last 7 days</option>
+                <option :value="14">Last 14 days</option>
+                <option :value="30">Last 30 days</option>
+                <option :value="60">Last 60 days</option>
+                <option :value="90">Last 90 days</option>
+                <option :value="180">Last 180 days</option>
+                <option :value="365">Last 365 days</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium mb-1">Condition logic</label>
+              <select v-model="ruleForm.conditionLogic" class="w-full border rounded px-3 py-2 text-sm">
+                <option value="AND">AND — all conditions must match</option>
+                <option value="OR">OR — any condition matches</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium mb-1">Active</label>
+              <label class="flex items-center gap-2 mt-2.5 cursor-pointer">
+                <input v-model="ruleForm.isActive" type="checkbox" class="rounded" />
+                <span class="text-sm">{{ ruleForm.isActive ? 'Yes — included in analysis' : 'No — skipped' }}</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Conditions -->
+          <div>
+            <div class="flex items-center justify-between mb-2">
+              <label class="block text-sm font-medium">Conditions <span class="text-red-500">*</span></label>
+              <button
+                type="button"
+                class="text-xs text-indigo-600 hover:underline"
+                @click="addCondition"
+              >+ Add condition</button>
+            </div>
+
+            <div v-if="ruleForm.conditions.length === 0" class="text-sm text-gray-400 border border-dashed rounded p-3 text-center">
+              No conditions yet. Add at least one.
+            </div>
+
+            <div class="space-y-2">
+              <div
+                v-for="(cond, i) in ruleForm.conditions"
+                :key="i"
+                class="flex items-center gap-2 flex-wrap bg-gray-50 border rounded p-2"
+              >
+                <!-- Metric selector -->
+                <div class="flex-1 min-w-[180px]">
+                  <select v-model="cond.metric" class="w-full border rounded px-2 py-1.5 text-sm">
+                    <option value="" disabled>Select metric…</option>
+                    <optgroup v-for="cat in metricCategories" :key="cat.name" :label="cat.name">
+                      <option v-for="m in cat.metrics" :key="m.key" :value="m.key">{{ m.label }}</option>
+                    </optgroup>
+                  </select>
+                </div>
+
+                <!-- Operator selector -->
+                <div>
+                  <select v-model="cond.operator" class="border rounded px-2 py-1.5 text-sm">
+                    <option value="gt">is greater than</option>
+                    <option value="gte">is ≥</option>
+                    <option value="lt">is less than</option>
+                    <option value="lte">is ≤</option>
+                    <option value="eq">equals</option>
+                  </select>
+                </div>
+
+                <!-- Threshold input -->
+                <div class="w-24">
+                  <input
+                    v-model.number="cond.threshold"
+                    type="number"
+                    min="0"
+                    step="any"
+                    class="w-full border rounded px-2 py-1.5 text-sm"
+                    placeholder="0"
+                  />
+                </div>
+
+                <!-- Unit hint -->
+                <span v-if="cond.metric" class="text-xs text-gray-400">{{ metricUnit(cond.metric) }}</span>
+
+                <button
+                  type="button"
+                  class="text-red-400 hover:text-red-600 text-lg leading-none ml-auto"
+                  @click="removeCondition(i)"
+                >×</button>
+              </div>
+            </div>
+
+            <!-- Human readable preview -->
+            <div v-if="ruleForm.conditions.filter(c => c.metric).length > 0" class="mt-2 text-xs text-gray-500 bg-indigo-50 border border-indigo-100 rounded p-2">
+              <span class="font-medium text-indigo-700">Preview: </span>
+              Flag user if
+              <span
+                v-for="(cond, i) in ruleForm.conditions.filter(c => c.metric)"
+                :key="i"
+              ><span v-if="i > 0"> <span class="font-semibold text-indigo-600">{{ ruleForm.conditionLogic }}</span> </span><em>{{ metricLabel(cond.metric) }}</em> {{ operatorSymbol(cond.operator) }} {{ cond.threshold }}{{ metricUnit(cond.metric) }}</span>
+            </div>
+          </div>
+
+          <!-- Metric reference -->
+          <details class="text-xs">
+            <summary class="cursor-pointer text-gray-500 hover:text-gray-700">Metric reference ▾</summary>
+            <div class="mt-2 space-y-1">
+              <div v-for="[key, def] in Object.entries(METRIC_DEFINITIONS)" :key="key" class="flex gap-2">
+                <span class="font-mono text-indigo-600 flex-shrink-0">{{ key }}</span>
+                <span class="text-gray-500">— {{ def.description }}</span>
+              </div>
+            </div>
+          </details>
+
+          <p v-if="ruleFormError" class="text-sm text-red-600">{{ ruleFormError }}</p>
+        </div>
+
+        <div class="flex justify-end gap-2 p-4 border-t">
+          <button class="border rounded px-4 py-2 text-sm hover:bg-gray-50" @click="closeRuleModal">Cancel</button>
+          <button
+            class="bg-indigo-600 text-white px-4 py-2 rounded text-sm hover:bg-indigo-700 disabled:opacity-50"
+            :disabled="ruleSaving"
+            @click="saveRule"
+          >{{ ruleSaving ? 'Saving…' : ruleModal.mode === 'create' ? 'Create Rule' : 'Save Changes' }}</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Mute Modal ──────────────────────────────────────────────────────── -->
+    <div v-if="muteModal.open" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-white rounded-lg shadow-xl w-full max-w-md">
+        <div class="p-4 border-b flex items-center justify-between">
+          <h2 class="font-semibold">Mute user from monitor</h2>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="muteModal.open = false">×</button>
+        </div>
+        <div class="p-4 space-y-3">
+          <p class="text-sm">
+            Muting <strong>{{ muteModal.user?.username }}</strong> will hide them from the suspicious activity list
+            (unless "Show muted users" is toggled on). They will still appear in all other admin tools.
+          </p>
+          <div>
+            <label class="block text-sm font-medium mb-1">Reason (optional)</label>
+            <textarea
+              v-model.trim="muteReason"
+              class="w-full border rounded px-3 py-2 text-sm"
+              rows="2"
+              placeholder="e.g. Investigated and confirmed legitimate activity"
+            ></textarea>
+          </div>
+          <p v-if="muteError" class="text-sm text-red-600">{{ muteError }}</p>
+        </div>
+        <div class="flex justify-end gap-2 p-4 border-t">
+          <button class="border rounded px-4 py-2 text-sm hover:bg-gray-50" @click="muteModal.open = false">Cancel</button>
+          <button
+            class="bg-orange-600 text-white px-4 py-2 rounded text-sm hover:bg-orange-700 disabled:opacity-50"
+            :disabled="muteSaving"
+            @click="confirmMute"
+          >{{ muteSaving ? 'Muting…' : 'Mute User' }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { METRIC_DEFINITIONS, OPERATOR_LABELS } from '~/server/utils/suspiciousActivityMetrics'
+
+definePageMeta({ middleware: ['auth', 'admin'], layout: 'default' })
+
+// ── Rules state ────────────────────────────────────────────────────────────
+const rules = ref([])
+const rulesLoading = ref(false)
+
+// ── Rule modal state ───────────────────────────────────────────────────────
+const ruleModal = ref({ open: false, mode: 'create', editId: null })
+const ruleForm = ref(emptyRuleForm())
+const ruleFormError = ref('')
+const ruleSaving = ref(false)
+
+// ── Analysis state ─────────────────────────────────────────────────────────
+const analysisResult = ref(null)
+const analyzing = ref(false)
+const analyzeError = ref('')
+const showMuted = ref(false)
+const expandedUsers = ref(new Set())
+
+// ── Mute modal state ───────────────────────────────────────────────────────
+const muteModal = ref({ open: false, user: null })
+const muteReason = ref('')
+const muteSaving = ref(false)
+const muteError = ref('')
+
+// ── Computed ───────────────────────────────────────────────────────────────
+const displayedUsers = computed(() => {
+  if (!analysisResult.value) return []
+  const users = analysisResult.value.flaggedUsers
+  return showMuted.value ? users : users.filter(u => !u.isMuted)
+})
+
+const rulesEvaluatedLabel = computed(() => {
+  if (!analysisResult.value) return ''
+  const n = analysisResult.value.rulesEvaluated
+  return `${n} rule${n !== 1 ? 's' : ''} evaluated`
+})
+
+const lastRunLabel = computed(() => {
+  if (!analysisResult.value) return ''
+  const d = new Date(analysisResult.value.evaluatedAt)
+  const diffMs = Date.now() - d.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  return d.toLocaleTimeString()
+})
+
+const metricCategories = computed(() => {
+  const cats = {}
+  for (const [key, def] of Object.entries(METRIC_DEFINITIONS)) {
+    if (!cats[def.category]) cats[def.category] = { name: def.category, metrics: [] }
+    cats[def.category].metrics.push({ key, label: def.label })
+  }
+  return Object.values(cats)
+})
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+function metricLabel(key) {
+  return METRIC_DEFINITIONS[key]?.label ?? key
+}
+
+function metricUnit(key) {
+  const u = METRIC_DEFINITIONS[key]?.unit
+  if (!u) return ''
+  return u === '%' ? '%' : ` ${u}`
+}
+
+function operatorLabel(op) {
+  return OPERATOR_LABELS[op] ?? op
+}
+
+function operatorSymbol(op) {
+  return { gt: '>', gte: '≥', lt: '<', lte: '≤', eq: '=' }[op] ?? op
+}
+
+function emptyRuleForm() {
+  return {
+    name: '',
+    description: '',
+    isActive: true,
+    timeWindowDays: 30,
+    conditionLogic: 'AND',
+    conditions: [],
+  }
+}
+
+function addCondition() {
+  ruleForm.value.conditions.push({ metric: '', operator: 'lte', threshold: 0 })
+}
+
+function removeCondition(i) {
+  ruleForm.value.conditions.splice(i, 1)
+}
+
+// ── Data loading ───────────────────────────────────────────────────────────
+async function loadRules() {
+  rulesLoading.value = true
+  try {
+    const data = await $fetch('/api/admin/suspicious-activity/rules', { credentials: 'include' })
+    rules.value = data
+  } catch (e) {
+    console.error('Failed to load rules', e)
+  } finally {
+    rulesLoading.value = false
+  }
+}
+
+// ── Rule modal actions ─────────────────────────────────────────────────────
+function openCreateRuleModal() {
+  ruleForm.value = emptyRuleForm()
+  ruleFormError.value = ''
+  ruleModal.value = { open: true, mode: 'create', editId: null }
+}
+
+function openEditRuleModal(rule) {
+  ruleForm.value = {
+    name: rule.name,
+    description: rule.description,
+    isActive: rule.isActive,
+    timeWindowDays: rule.timeWindowDays ?? null,
+    conditionLogic: rule.conditionLogic,
+    conditions: rule.conditions.map(c => ({ metric: c.metric, operator: c.operator, threshold: c.threshold })),
+  }
+  ruleFormError.value = ''
+  ruleModal.value = { open: true, mode: 'edit', editId: rule.id }
+}
+
+function closeRuleModal() {
+  ruleModal.value.open = false
+}
+
+async function saveRule() {
+  ruleFormError.value = ''
+  if (!ruleForm.value.name.trim()) {
+    ruleFormError.value = 'Rule name is required.'
+    return
+  }
+  const filledConditions = ruleForm.value.conditions.filter(c => c.metric)
+  if (filledConditions.length === 0) {
+    ruleFormError.value = 'At least one condition is required.'
+    return
+  }
+
+  ruleSaving.value = true
+  try {
+    const payload = {
+      name: ruleForm.value.name,
+      description: ruleForm.value.description,
+      isActive: ruleForm.value.isActive,
+      timeWindowDays: ruleForm.value.timeWindowDays,
+      conditionLogic: ruleForm.value.conditionLogic,
+      conditions: filledConditions,
+    }
+
+    if (ruleModal.value.mode === 'create') {
+      const newRule = await $fetch('/api/admin/suspicious-activity/rules', {
+        method: 'POST',
+        body: payload,
+        credentials: 'include',
+      })
+      rules.value.push(newRule)
+    } else {
+      const updated = await $fetch(`/api/admin/suspicious-activity/rules/${ruleModal.value.editId}`, {
+        method: 'PUT',
+        body: payload,
+        credentials: 'include',
+      })
+      const idx = rules.value.findIndex(r => r.id === ruleModal.value.editId)
+      if (idx !== -1) rules.value[idx] = updated
+    }
+    closeRuleModal()
+  } catch (e) {
+    ruleFormError.value = e?.data?.statusMessage ?? e?.message ?? 'Failed to save rule.'
+  } finally {
+    ruleSaving.value = false
+  }
+}
+
+async function deleteRule(rule) {
+  if (!confirm(`Delete rule "${rule.name}"? This cannot be undone.`)) return
+  try {
+    await $fetch(`/api/admin/suspicious-activity/rules/${rule.id}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+    rules.value = rules.value.filter(r => r.id !== rule.id)
+    // Clear analysis since rules changed
+    analysisResult.value = null
+  } catch (e) {
+    alert(e?.data?.statusMessage ?? 'Failed to delete rule.')
+  }
+}
+
+async function toggleRuleActive(rule) {
+  try {
+    const updated = await $fetch(`/api/admin/suspicious-activity/rules/${rule.id}`, {
+      method: 'PUT',
+      body: {
+        name: rule.name,
+        description: rule.description,
+        isActive: !rule.isActive,
+        timeWindowDays: rule.timeWindowDays,
+        conditionLogic: rule.conditionLogic,
+        conditions: rule.conditions.map(c => ({ metric: c.metric, operator: c.operator, threshold: c.threshold })),
+      },
+      credentials: 'include',
+    })
+    const idx = rules.value.findIndex(r => r.id === rule.id)
+    if (idx !== -1) rules.value[idx] = updated
+  } catch (e) {
+    alert(e?.data?.statusMessage ?? 'Failed to update rule.')
+  }
+}
+
+// ── Analysis ───────────────────────────────────────────────────────────────
+async function runAnalysis() {
+  analyzing.value = true
+  analyzeError.value = ''
+  expandedUsers.value = new Set()
+  try {
+    const data = await $fetch('/api/admin/suspicious-activity/analyze', {
+      method: 'POST',
+      credentials: 'include',
+    })
+    analysisResult.value = data
+  } catch (e) {
+    analyzeError.value = e?.data?.statusMessage ?? e?.message ?? 'Analysis failed.'
+  } finally {
+    analyzing.value = false
+  }
+}
+
+function toggleExpand(userId) {
+  const s = new Set(expandedUsers.value)
+  if (s.has(userId)) s.delete(userId)
+  else s.add(userId)
+  expandedUsers.value = s
+}
+
+// ── Mute actions ───────────────────────────────────────────────────────────
+function openMuteModal(user) {
+  muteModal.value = { open: true, user }
+  muteReason.value = ''
+  muteError.value = ''
+}
+
+async function confirmMute() {
+  muteError.value = ''
+  muteSaving.value = true
+  try {
+    await $fetch('/api/admin/suspicious-activity/mutes', {
+      method: 'POST',
+      body: { userId: muteModal.value.user.userId, reason: muteReason.value || null },
+      credentials: 'include',
+    })
+    // Update local state
+    if (analysisResult.value) {
+      const user = analysisResult.value.flaggedUsers.find(u => u.userId === muteModal.value.user.userId)
+      if (user) {
+        user.isMuted = true
+        user.muteInfo = { reason: muteReason.value || null, mutedBy: 'you', mutedAt: new Date().toISOString() }
+      }
+    }
+    muteModal.value.open = false
+  } catch (e) {
+    muteError.value = e?.data?.statusMessage ?? 'Failed to mute user.'
+  } finally {
+    muteSaving.value = false
+  }
+}
+
+async function unmuteUser(user) {
+  if (!confirm(`Unmute ${user.username}?`)) return
+  try {
+    await $fetch(`/api/admin/suspicious-activity/mutes/${user.userId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+    if (analysisResult.value) {
+      const u = analysisResult.value.flaggedUsers.find(u => u.userId === user.userId)
+      if (u) {
+        u.isMuted = false
+        u.muteInfo = null
+      }
+    }
+  } catch (e) {
+    alert(e?.data?.statusMessage ?? 'Failed to unmute user.')
+  }
+}
+
+// ── Init ───────────────────────────────────────────────────────────────────
+onMounted(loadRules)
+</script>

--- a/prisma/migrations/20260425120000_add_suspicious_activity/migration.sql
+++ b/prisma/migrations/20260425120000_add_suspicious_activity/migration.sql
@@ -1,0 +1,64 @@
+-- CreateTable
+CREATE TABLE "SuspiciousActivityRule" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "timeWindowDays" INTEGER,
+    "conditionLogic" TEXT NOT NULL DEFAULT 'AND',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdById" TEXT NOT NULL,
+
+    CONSTRAINT "SuspiciousActivityRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SuspiciousActivityCondition" (
+    "id" TEXT NOT NULL,
+    "ruleId" TEXT NOT NULL,
+    "metric" TEXT NOT NULL,
+    "operator" TEXT NOT NULL,
+    "threshold" DOUBLE PRECISION NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "SuspiciousActivityCondition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SuspiciousActivityMute" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "mutedById" TEXT NOT NULL,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SuspiciousActivityMute_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SuspiciousActivityRule_isActive_idx" ON "SuspiciousActivityRule"("isActive");
+
+-- CreateIndex
+CREATE INDEX "SuspiciousActivityRule_createdAt_idx" ON "SuspiciousActivityRule"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "SuspiciousActivityCondition_ruleId_idx" ON "SuspiciousActivityCondition"("ruleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SuspiciousActivityMute_userId_key" ON "SuspiciousActivityMute"("userId");
+
+-- CreateIndex
+CREATE INDEX "SuspiciousActivityMute_createdAt_idx" ON "SuspiciousActivityMute"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "SuspiciousActivityRule" ADD CONSTRAINT "SuspiciousActivityRule_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SuspiciousActivityCondition" ADD CONSTRAINT "SuspiciousActivityCondition_ruleId_fkey" FOREIGN KEY ("ruleId") REFERENCES "SuspiciousActivityRule"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SuspiciousActivityMute" ADD CONSTRAINT "SuspiciousActivityMute_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SuspiciousActivityMute" ADD CONSTRAINT "SuspiciousActivityMute_mutedById_fkey" FOREIGN KEY ("mutedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -451,6 +451,11 @@ model User {
   userMonsterItems UserMonsterItem[]
   scanEvents       UserScan[]
 
+  // Suspicious Activity Monitor relations
+  suspiciousActivityRules      SuspiciousActivityRule[] @relation("RuleCreatedBy")
+  suspiciousActivityMute       SuspiciousActivityMute?  @relation("SuspiciousMutedUser")
+  suspiciousActivityMutesGiven SuspiciousActivityMute[] @relation("SuspiciousMutedBy")
+
   @@unique([discordId, active]) // at most one active user per Discord ID
 }
 
@@ -2210,4 +2215,48 @@ model CZoneContestVote {
 model ServerHeartbeat {
   id       String   @id @default("singleton")
   lastBeat DateTime @updatedAt
+}
+
+// ── Suspicious Activity Monitor ───────────────────────────────────────────────
+
+model SuspiciousActivityRule {
+  id             String   @id @default(uuid())
+  name           String
+  description    String   @default("")
+  isActive       Boolean  @default(true)
+  timeWindowDays Int?     // null = all time
+  conditionLogic String   @default("AND") // "AND" or "OR"
+  conditions     SuspiciousActivityCondition[]
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  createdById    String
+  createdBy      User     @relation("RuleCreatedBy", fields: [createdById], references: [id])
+
+  @@index([isActive])
+  @@index([createdAt])
+}
+
+model SuspiciousActivityCondition {
+  id        String                 @id @default(uuid())
+  ruleId    String
+  rule      SuspiciousActivityRule @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+  metric    String
+  operator  String   // 'lt' | 'lte' | 'gt' | 'gte' | 'eq'
+  threshold Float
+  order     Int      @default(0)
+
+  @@index([ruleId])
+}
+
+model SuspiciousActivityMute {
+  id        String   @id @default(uuid())
+  userId    String   @unique
+  mutedById String
+  reason    String?
+  createdAt DateTime @default(now())
+
+  user    User @relation("SuspiciousMutedUser", fields: [userId], references: [id], onDelete: Cascade)
+  mutedBy User @relation("SuspiciousMutedBy", fields: [mutedById], references: [id])
+
+  @@index([createdAt])
 }

--- a/server/api/admin/suspicious-activity/analyze.post.js
+++ b/server/api/admin/suspicious-activity/analyze.post.js
@@ -1,0 +1,23 @@
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { runAllRules } from '@/server/utils/suspiciousActivityMetrics'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch {}
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const rules = await db.suspiciousActivityRule.findMany({
+    where: { isActive: true },
+    include: { conditions: { orderBy: { order: 'asc' } } },
+  })
+
+  const { flaggedUsers, rulesEvaluated } = await runAllRules(db, rules)
+
+  return {
+    flaggedUsers,
+    rulesEvaluated,
+    evaluatedAt: new Date().toISOString(),
+  }
+})

--- a/server/api/admin/suspicious-activity/mutes.get.js
+++ b/server/api/admin/suspicious-activity/mutes.get.js
@@ -1,0 +1,19 @@
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch {}
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const mutes = await db.suspiciousActivityMute.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      user: { select: { id: true, username: true, discordTag: true } },
+      mutedBy: { select: { id: true, username: true } },
+    },
+  })
+
+  return mutes
+})

--- a/server/api/admin/suspicious-activity/mutes.post.js
+++ b/server/api/admin/suspicious-activity/mutes.post.js
@@ -1,0 +1,23 @@
+import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch {}
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const { userId, reason } = await readBody(event)
+  if (!userId) throw createError({ statusCode: 400, statusMessage: 'userId is required' })
+
+  const user = await db.user.findUnique({ where: { id: userId }, select: { id: true } })
+  if (!user) throw createError({ statusCode: 404, statusMessage: 'User not found' })
+
+  const mute = await db.suspiciousActivityMute.upsert({
+    where: { userId },
+    create: { userId, mutedById: me.id, reason: reason?.trim() || null },
+    update: { mutedById: me.id, reason: reason?.trim() || null, createdAt: new Date() },
+  })
+
+  return mute
+})

--- a/server/api/admin/suspicious-activity/mutes/[userId].delete.js
+++ b/server/api/admin/suspicious-activity/mutes/[userId].delete.js
@@ -1,0 +1,18 @@
+import { defineEventHandler, getRequestHeader, getRouterParam, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch {}
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const userId = getRouterParam(event, 'userId')
+
+  const existing = await db.suspiciousActivityMute.findUnique({ where: { userId } })
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Mute not found' })
+
+  await db.suspiciousActivityMute.delete({ where: { userId } })
+
+  return { ok: true }
+})

--- a/server/api/admin/suspicious-activity/rules.get.js
+++ b/server/api/admin/suspicious-activity/rules.get.js
@@ -1,0 +1,19 @@
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch {}
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const rules = await db.suspiciousActivityRule.findMany({
+    orderBy: { createdAt: 'asc' },
+    include: {
+      conditions: { orderBy: { order: 'asc' } },
+      createdBy: { select: { id: true, username: true } },
+    },
+  })
+
+  return rules
+})

--- a/server/api/admin/suspicious-activity/rules.post.js
+++ b/server/api/admin/suspicious-activity/rules.post.js
@@ -1,0 +1,51 @@
+import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { METRIC_DEFINITIONS } from '@/server/utils/suspiciousActivityMetrics'
+
+const VALID_OPERATORS = ['gt', 'gte', 'lt', 'lte', 'eq']
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch {}
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const body = await readBody(event)
+  const { name, description, isActive, timeWindowDays, conditionLogic, conditions } = body
+
+  if (!name?.trim()) throw createError({ statusCode: 400, statusMessage: 'name is required' })
+  if (!Array.isArray(conditions) || conditions.length === 0)
+    throw createError({ statusCode: 400, statusMessage: 'At least one condition is required' })
+
+  const validMetrics = new Set(Object.keys(METRIC_DEFINITIONS))
+  for (const c of conditions) {
+    if (!validMetrics.has(c.metric))
+      throw createError({ statusCode: 400, statusMessage: `Unknown metric: ${c.metric}` })
+    if (!VALID_OPERATORS.includes(c.operator))
+      throw createError({ statusCode: 400, statusMessage: `Invalid operator: ${c.operator}` })
+    if (typeof c.threshold !== 'number' || isNaN(c.threshold))
+      throw createError({ statusCode: 400, statusMessage: 'threshold must be a number' })
+  }
+
+  const rule = await db.suspiciousActivityRule.create({
+    data: {
+      name: name.trim(),
+      description: description?.trim() ?? '',
+      isActive: isActive !== false,
+      timeWindowDays: timeWindowDays ? Number(timeWindowDays) : null,
+      conditionLogic: conditionLogic === 'OR' ? 'OR' : 'AND',
+      createdById: me.id,
+      conditions: {
+        create: conditions.map((c, i) => ({
+          metric: c.metric,
+          operator: c.operator,
+          threshold: Number(c.threshold),
+          order: i,
+        })),
+      },
+    },
+    include: { conditions: { orderBy: { order: 'asc' } } },
+  })
+
+  return rule
+})

--- a/server/api/admin/suspicious-activity/rules/[id].delete.js
+++ b/server/api/admin/suspicious-activity/rules/[id].delete.js
@@ -1,0 +1,19 @@
+import { defineEventHandler, getRequestHeader, getRouterParam, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch {}
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const id = getRouterParam(event, 'id')
+
+  const existing = await db.suspiciousActivityRule.findUnique({ where: { id } })
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Rule not found' })
+
+  // Conditions cascade-delete via schema
+  await db.suspiciousActivityRule.delete({ where: { id } })
+
+  return { ok: true }
+})

--- a/server/api/admin/suspicious-activity/rules/[id].put.js
+++ b/server/api/admin/suspicious-activity/rules/[id].put.js
@@ -1,0 +1,60 @@
+import { defineEventHandler, getRequestHeader, readBody, getRouterParam, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { METRIC_DEFINITIONS } from '@/server/utils/suspiciousActivityMetrics'
+
+const VALID_OPERATORS = ['gt', 'gte', 'lt', 'lte', 'eq']
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch {}
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const id = getRouterParam(event, 'id')
+  const body = await readBody(event)
+  const { name, description, isActive, timeWindowDays, conditionLogic, conditions } = body
+
+  if (!name?.trim()) throw createError({ statusCode: 400, statusMessage: 'name is required' })
+  if (!Array.isArray(conditions) || conditions.length === 0)
+    throw createError({ statusCode: 400, statusMessage: 'At least one condition is required' })
+
+  const validMetrics = new Set(Object.keys(METRIC_DEFINITIONS))
+  for (const c of conditions) {
+    if (!validMetrics.has(c.metric))
+      throw createError({ statusCode: 400, statusMessage: `Unknown metric: ${c.metric}` })
+    if (!VALID_OPERATORS.includes(c.operator))
+      throw createError({ statusCode: 400, statusMessage: `Invalid operator: ${c.operator}` })
+    if (typeof c.threshold !== 'number' || isNaN(c.threshold))
+      throw createError({ statusCode: 400, statusMessage: 'threshold must be a number' })
+  }
+
+  const existing = await db.suspiciousActivityRule.findUnique({ where: { id } })
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Rule not found' })
+
+  // Replace conditions: delete old, create new
+  const rule = await db.$transaction(async (tx) => {
+    await tx.suspiciousActivityCondition.deleteMany({ where: { ruleId: id } })
+
+    return tx.suspiciousActivityRule.update({
+      where: { id },
+      data: {
+        name: name.trim(),
+        description: description?.trim() ?? '',
+        isActive: isActive !== false,
+        timeWindowDays: timeWindowDays ? Number(timeWindowDays) : null,
+        conditionLogic: conditionLogic === 'OR' ? 'OR' : 'AND',
+        conditions: {
+          create: conditions.map((c, i) => ({
+            metric: c.metric,
+            operator: c.operator,
+            threshold: Number(c.threshold),
+            order: i,
+          })),
+        },
+      },
+      include: { conditions: { orderBy: { order: 'asc' } } },
+    })
+  })
+
+  return rule
+})

--- a/server/utils/suspiciousActivityMetrics.js
+++ b/server/utils/suspiciousActivityMetrics.js
@@ -1,0 +1,595 @@
+/**
+ * Suspicious Activity Metrics Utility
+ *
+ * Provides metric definitions and computation functions for the
+ * Suspicious Activity Monitor admin page.
+ *
+ * Adding a new metric:
+ *  1. Add an entry to METRIC_DEFINITIONS
+ *  2. Add a case in computeMetricForUsers()
+ */
+
+/** Human-readable metadata for every supported metric. */
+export const METRIC_DEFINITIONS = {
+  // ── Trading ────────────────────────────────────────────────────────────────
+  tradeOfferCount: {
+    label: 'Trade offers (accepted)',
+    description: 'Total number of accepted trade offers the user was involved in (as initiator or recipient)',
+    category: 'Trading',
+    unit: 'trades',
+  },
+  tradeOfferPartnerCount: {
+    label: 'Unique trade partners',
+    description: 'Number of distinct users this user has completed accepted trade offers with',
+    category: 'Trading',
+    unit: 'users',
+  },
+  tradeOfferConcentrationPct: {
+    label: 'Trade concentration % (top partner)',
+    description: 'Percentage of accepted trades conducted with their single most-frequent partner (0–100). High values mean almost all trades go to/from one person.',
+    category: 'Trading',
+    unit: '%',
+  },
+  pointsReceivedFromTrades: {
+    label: 'Points received via trades',
+    description: 'Total points the user received as the recipient in accepted trade offers',
+    category: 'Trading',
+    unit: 'points',
+  },
+
+  // ── Auctions ───────────────────────────────────────────────────────────────
+  auctionWinCount: {
+    label: 'Auctions won',
+    description: 'Number of auctions this user won (status = CLOSED, user is winnerId)',
+    category: 'Auctions',
+    unit: 'auctions',
+  },
+  auctionWinSellerCount: {
+    label: 'Unique sellers won from',
+    description: 'Number of distinct users whose auctions this user has won',
+    category: 'Auctions',
+    unit: 'users',
+  },
+  auctionWinConcentrationPct: {
+    label: 'Auction-win concentration % (top seller)',
+    description: 'Percentage of auction wins that came from a single seller. High values mean wins are concentrated on one seller.',
+    category: 'Auctions',
+    unit: '%',
+  },
+  auctionUniqueBiddersCount: {
+    label: 'Unique bidders on own auctions',
+    description: 'Number of distinct users who have bid on auctions this user created',
+    category: 'Auctions',
+    unit: 'users',
+  },
+  auctionBidOnSellerCount: {
+    label: 'Unique sellers bid on',
+    description: 'Number of distinct auction creators this user has placed bids on',
+    category: 'Auctions',
+    unit: 'users',
+  },
+
+  // ── IP / Account ───────────────────────────────────────────────────────────
+  sharedIPUserCount: {
+    label: 'Accounts sharing an IP',
+    description: 'Number of other user accounts that share at least one recorded IP address with this user',
+    category: 'IP / Account',
+    unit: 'users',
+  },
+}
+
+/** Operator evaluation helper */
+function evalOperator(value, operator, threshold) {
+  switch (operator) {
+    case 'gt':  return value >  threshold
+    case 'gte': return value >= threshold
+    case 'lt':  return value <  threshold
+    case 'lte': return value <= threshold
+    case 'eq':  return value === threshold
+    default:    return false
+  }
+}
+
+/** Human-readable operator labels for display. */
+export const OPERATOR_LABELS = {
+  gt:  'is greater than',
+  gte: 'is greater than or equal to',
+  lt:  'is less than',
+  lte: 'is less than or equal to',
+  eq:  'equals',
+}
+
+/**
+ * Compute every requested metric for every user who has any relevant activity
+ * within the optional time window.
+ *
+ * Returns a Map<userId, { [metricKey]: number }>
+ *
+ * @param {import('@prisma/client').PrismaClient} prisma
+ * @param {Set<string>} metricKeys   - which metrics to compute
+ * @param {Date|null}   sinceDate    - only consider activity on/after this date (null = all time)
+ */
+async function computeAllUserMetrics(prisma, metricKeys, sinceDate) {
+  /** @type {Map<string, Record<string, number>>} */
+  const results = new Map()
+
+  function ensure(userId) {
+    if (!results.has(userId)) results.set(userId, {})
+    return results.get(userId)
+  }
+
+  const dateFilter = sinceDate ? { gte: sinceDate } : undefined
+
+  // ── Trade metrics ──────────────────────────────────────────────────────────
+  const needsTrade = metricKeys.has('tradeOfferCount') ||
+                     metricKeys.has('tradeOfferPartnerCount') ||
+                     metricKeys.has('tradeOfferConcentrationPct') ||
+                     metricKeys.has('pointsReceivedFromTrades')
+
+  if (needsTrade) {
+    const offers = await prisma.tradeOffer.findMany({
+      where: {
+        status: 'ACCEPTED',
+        ...(dateFilter ? { updatedAt: dateFilter } : {}),
+      },
+      select: {
+        initiatorId: true,
+        recipientId: true,
+        pointsOffered: true,
+      },
+    })
+
+    // Build per-user partner maps: userId → Map<partnerId, count>
+    const partnerCounts = new Map() // userId → Map<partnerId, tradeCount>
+    const tradeTotal    = new Map() // userId → total trades
+    const pointsRx      = new Map() // userId → points received as recipient
+
+    for (const offer of offers) {
+      const { initiatorId, recipientId, pointsOffered } = offer
+
+      // initiator side
+      if (!partnerCounts.has(initiatorId)) partnerCounts.set(initiatorId, new Map())
+      const iMap = partnerCounts.get(initiatorId)
+      iMap.set(recipientId, (iMap.get(recipientId) ?? 0) + 1)
+      tradeTotal.set(initiatorId, (tradeTotal.get(initiatorId) ?? 0) + 1)
+
+      // recipient side
+      if (!partnerCounts.has(recipientId)) partnerCounts.set(recipientId, new Map())
+      const rMap = partnerCounts.get(recipientId)
+      rMap.set(initiatorId, (rMap.get(initiatorId) ?? 0) + 1)
+      tradeTotal.set(recipientId, (tradeTotal.get(recipientId) ?? 0) + 1)
+
+      // points received by recipient
+      if (pointsOffered > 0) {
+        pointsRx.set(recipientId, (pointsRx.get(recipientId) ?? 0) + pointsOffered)
+      }
+    }
+
+    for (const [userId, pMap] of partnerCounts) {
+      const rec = ensure(userId)
+      const total = tradeTotal.get(userId) ?? 0
+      const partnerCount = pMap.size
+      const maxWithOne = Math.max(...pMap.values(), 0)
+      const concentrationPct = total > 0 ? Math.round((maxWithOne / total) * 100 * 10) / 10 : 0
+
+      if (metricKeys.has('tradeOfferCount'))           rec.tradeOfferCount = total
+      if (metricKeys.has('tradeOfferPartnerCount'))    rec.tradeOfferPartnerCount = partnerCount
+      if (metricKeys.has('tradeOfferConcentrationPct')) rec.tradeOfferConcentrationPct = concentrationPct
+    }
+
+    if (metricKeys.has('pointsReceivedFromTrades')) {
+      for (const [userId, pts] of pointsRx) {
+        ensure(userId).pointsReceivedFromTrades = pts
+      }
+    }
+  }
+
+  // ── Auction win metrics ────────────────────────────────────────────────────
+  const needsWins = metricKeys.has('auctionWinCount') ||
+                    metricKeys.has('auctionWinSellerCount') ||
+                    metricKeys.has('auctionWinConcentrationPct')
+
+  if (needsWins) {
+    const wins = await prisma.auction.findMany({
+      where: {
+        status: 'CLOSED',
+        winnerId: { not: null },
+        ...(dateFilter ? { winnerAt: dateFilter } : {}),
+      },
+      select: {
+        winnerId: true,
+        creatorId: true,
+      },
+    })
+
+    // winnerId → Map<sellerId, winCount>
+    const winnerSellerMap = new Map()
+
+    for (const { winnerId, creatorId } of wins) {
+      if (!winnerId) continue
+      if (!winnerSellerMap.has(winnerId)) winnerSellerMap.set(winnerId, new Map())
+      const sMap = winnerSellerMap.get(winnerId)
+      const seller = creatorId ?? '__unknown__'
+      sMap.set(seller, (sMap.get(seller) ?? 0) + 1)
+    }
+
+    for (const [userId, sMap] of winnerSellerMap) {
+      const rec = ensure(userId)
+      const total = [...sMap.values()].reduce((a, b) => a + b, 0)
+      const sellerCount = sMap.size
+      const maxFromOne = Math.max(...sMap.values(), 0)
+      const concentrationPct = total > 0 ? Math.round((maxFromOne / total) * 100 * 10) / 10 : 0
+
+      if (metricKeys.has('auctionWinCount'))           rec.auctionWinCount = total
+      if (metricKeys.has('auctionWinSellerCount'))     rec.auctionWinSellerCount = sellerCount
+      if (metricKeys.has('auctionWinConcentrationPct')) rec.auctionWinConcentrationPct = concentrationPct
+    }
+  }
+
+  // ── Unique bidders on own auctions ─────────────────────────────────────────
+  if (metricKeys.has('auctionUniqueBiddersCount')) {
+    const myAuctions = await prisma.auction.findMany({
+      where: {
+        creatorId: { not: null },
+        ...(dateFilter ? { createdAt: dateFilter } : {}),
+      },
+      select: {
+        id: true,
+        creatorId: true,
+        bids: { select: { userId: true } },
+      },
+    })
+
+    // creatorId → Set<bidderId>
+    const creatorBidders = new Map()
+    for (const auction of myAuctions) {
+      if (!auction.creatorId) continue
+      if (!creatorBidders.has(auction.creatorId)) creatorBidders.set(auction.creatorId, new Set())
+      const bSet = creatorBidders.get(auction.creatorId)
+      for (const bid of auction.bids) bSet.add(bid.userId)
+    }
+
+    for (const [userId, bSet] of creatorBidders) {
+      ensure(userId).auctionUniqueBiddersCount = bSet.size
+    }
+  }
+
+  // ── Unique sellers bid on ──────────────────────────────────────────────────
+  if (metricKeys.has('auctionBidOnSellerCount')) {
+    const bids = await prisma.bid.findMany({
+      where: {
+        ...(dateFilter ? { createdAt: dateFilter } : {}),
+      },
+      select: {
+        userId: true,
+        auction: { select: { creatorId: true } },
+      },
+    })
+
+    // bidderId → Set<sellerId>
+    const bidderSellers = new Map()
+    for (const bid of bids) {
+      const sellerId = bid.auction?.creatorId
+      if (!sellerId || sellerId === bid.userId) continue // skip self
+      if (!bidderSellers.has(bid.userId)) bidderSellers.set(bid.userId, new Set())
+      bidderSellers.get(bid.userId).add(sellerId)
+    }
+
+    for (const [userId, sSet] of bidderSellers) {
+      ensure(userId).auctionBidOnSellerCount = sSet.size
+    }
+  }
+
+  // ── Shared IP user count ───────────────────────────────────────────────────
+  if (metricKeys.has('sharedIPUserCount')) {
+    // Get all userIP records
+    const allIPs = await prisma.userIP.findMany({
+      select: { userId: true, ip: true },
+    })
+
+    // ip → Set<userId>
+    const ipUsers = new Map()
+    for (const { userId, ip } of allIPs) {
+      if (!ipUsers.has(ip)) ipUsers.set(ip, new Set())
+      ipUsers.get(ip).add(userId)
+    }
+
+    // For each user, find all other users sharing any of their IPs
+    // userId → Set<userId>
+    const userSharedWith = new Map()
+
+    for (const { userId, ip } of allIPs) {
+      const others = ipUsers.get(ip)
+      if (!others || others.size <= 1) continue
+      if (!userSharedWith.has(userId)) userSharedWith.set(userId, new Set())
+      for (const otherId of others) {
+        if (otherId !== userId) userSharedWith.get(userId).add(otherId)
+      }
+    }
+
+    for (const [userId, otherSet] of userSharedWith) {
+      ensure(userId).sharedIPUserCount = otherSet.size
+    }
+  }
+
+  return results
+}
+
+/**
+ * Collect all context data needed to explain why a user was flagged.
+ * Returns top trade partners, top auction sellers, and shared IP accounts.
+ *
+ * @param {import('@prisma/client').PrismaClient} prisma
+ * @param {string[]} userIds
+ * @param {Date|null} sinceDate
+ */
+async function buildContextForUsers(prisma, userIds, sinceDate) {
+  if (userIds.length === 0) return {}
+
+  const dateFilter = sinceDate ? { gte: sinceDate } : undefined
+  const context = {}
+  for (const id of userIds) context[id] = { topTradePartners: [], topAuctionSellers: [], sharedIPUsers: [] }
+
+  // ── Trade partners ─────────────────────────────────────────────────────────
+  const offers = await prisma.tradeOffer.findMany({
+    where: {
+      status: 'ACCEPTED',
+      OR: [{ initiatorId: { in: userIds } }, { recipientId: { in: userIds } }],
+      ...(dateFilter ? { updatedAt: dateFilter } : {}),
+    },
+    select: {
+      initiatorId: true,
+      recipientId: true,
+      initiator: { select: { id: true, username: true } },
+      recipient: { select: { id: true, username: true } },
+    },
+  })
+
+  // userId → Map<partnerId, { user, count }>
+  const tradeMap = new Map()
+  for (const id of userIds) tradeMap.set(id, new Map())
+
+  for (const offer of offers) {
+    const { initiatorId, recipientId, initiator, recipient } = offer
+    if (tradeMap.has(initiatorId)) {
+      const m = tradeMap.get(initiatorId)
+      if (!m.has(recipientId)) m.set(recipientId, { user: recipient, count: 0 })
+      m.get(recipientId).count++
+    }
+    if (tradeMap.has(recipientId)) {
+      const m = tradeMap.get(recipientId)
+      if (!m.has(initiatorId)) m.set(initiatorId, { user: initiator, count: 0 })
+      m.get(initiatorId).count++
+    }
+  }
+
+  for (const [userId, partnerMap] of tradeMap) {
+    const sorted = [...partnerMap.values()]
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10)
+      .map(({ user, count }) => ({ userId: user.id, username: user.username, tradeCount: count }))
+    context[userId].topTradePartners = sorted
+  }
+
+  // ── Top auction sellers ────────────────────────────────────────────────────
+  const wins = await prisma.auction.findMany({
+    where: {
+      status: 'CLOSED',
+      winnerId: { in: userIds },
+      ...(dateFilter ? { winnerAt: dateFilter } : {}),
+    },
+    select: {
+      winnerId: true,
+      creatorId: true,
+      creator: { select: { id: true, username: true } },
+    },
+  })
+
+  // userId → Map<sellerId, { user, wins }>
+  const auctionMap = new Map()
+  for (const id of userIds) auctionMap.set(id, new Map())
+
+  for (const win of wins) {
+    if (!win.winnerId || !win.creatorId || !auctionMap.has(win.winnerId)) continue
+    const m = auctionMap.get(win.winnerId)
+    if (!m.has(win.creatorId)) m.set(win.creatorId, { user: win.creator, wins: 0 })
+    m.get(win.creatorId).wins++
+  }
+
+  for (const [userId, sellerMap] of auctionMap) {
+    const sorted = [...sellerMap.values()]
+      .sort((a, b) => b.wins - a.wins)
+      .slice(0, 10)
+      .map(({ user, wins }) => ({ userId: user?.id, username: user?.username, wins }))
+    context[userId].topAuctionSellers = sorted
+  }
+
+  // ── Shared IP users ────────────────────────────────────────────────────────
+  const myIPs = await prisma.userIP.findMany({
+    where: { userId: { in: userIds } },
+    select: { userId: true, ip: true },
+  })
+
+  // Build: ip → Set<userId> for all IPs relevant to flagged users
+  const relevantIPs = [...new Set(myIPs.map(r => r.ip))]
+
+  if (relevantIPs.length > 0) {
+    const sharedRows = await prisma.userIP.findMany({
+      where: { ip: { in: relevantIPs } },
+      select: {
+        userId: true,
+        ip: true,
+        user: { select: { id: true, username: true } },
+      },
+    })
+
+    // ip → [{ userId, username }]
+    const ipUserMap = new Map()
+    for (const row of sharedRows) {
+      if (!ipUserMap.has(row.ip)) ipUserMap.set(row.ip, [])
+      ipUserMap.get(row.ip).push({ userId: row.userId, username: row.user.username })
+    }
+
+    // For each flagged user, build list of other users per shared IP
+    for (const { userId, ip } of myIPs) {
+      if (!context[userId]) continue
+      const others = (ipUserMap.get(ip) ?? []).filter(u => u.userId !== userId)
+      if (others.length === 0) continue
+
+      // Aggregate: otherUserId → { user, ips[] }
+      const existing = context[userId].sharedIPUsers
+      for (const other of others) {
+        const found = existing.find(e => e.userId === other.userId)
+        if (found) {
+          if (!found.sharedIPs.includes(ip)) found.sharedIPs.push(ip)
+        } else {
+          existing.push({ userId: other.userId, username: other.username, sharedIPs: [ip] })
+        }
+      }
+    }
+  }
+
+  return context
+}
+
+/**
+ * Evaluate a single rule against all users.
+ * Returns array of matching userId strings.
+ *
+ * @param {Map<string, Record<string, number>>} allMetrics
+ * @param {{ conditionLogic: string, conditions: Array<{ metric, operator, threshold }> }} rule
+ */
+function evaluateRule(allMetrics, rule) {
+  const matched = []
+  const logic = rule.conditionLogic === 'OR' ? 'OR' : 'AND'
+
+  for (const [userId, metrics] of allMetrics) {
+    let passes
+    if (logic === 'AND') {
+      passes = rule.conditions.every(c => {
+        const val = metrics[c.metric] ?? 0
+        return evalOperator(val, c.operator, c.threshold)
+      })
+    } else {
+      passes = rule.conditions.some(c => {
+        const val = metrics[c.metric] ?? 0
+        return evalOperator(val, c.operator, c.threshold)
+      })
+    }
+    if (passes) matched.push(userId)
+  }
+
+  return matched
+}
+
+/**
+ * Run all active rules and return flagged users with metrics and context.
+ *
+ * @param {import('@prisma/client').PrismaClient} prisma
+ * @param {Array} rules - SuspiciousActivityRule rows with conditions[]
+ * @returns {Promise<{ flaggedUsers: Array, rulesEvaluated: number }>}
+ */
+export async function runAllRules(prisma, rules) {
+  const activeRules = rules.filter(r => r.isActive && r.conditions.length > 0)
+
+  if (activeRules.length === 0) return { flaggedUsers: [], rulesEvaluated: 0 }
+
+  // Collect all needed metric keys across all rules
+  const allMetricKeys = new Set()
+  for (const rule of activeRules) {
+    for (const cond of rule.conditions) allMetricKeys.add(cond.metric)
+  }
+
+  // Use smallest time window across all rules to avoid over-fetching
+  // (each rule applies its own sinceDate when filtering results)
+  // For context fetching we use null (all time) — rules do their own filtering
+  const globalMetrics = await computeAllUserMetrics(prisma, allMetricKeys, null)
+
+  // Evaluate each rule independently with its own time window
+  // For per-rule time filtering we re-compute only for that rule's metrics if it has a window
+  // For simplicity (and to avoid N DB round-trips), we compute a per-rule filtered metric set
+  // only when a rule has a timeWindowDays set.
+
+  // userId → { rules: [], metrics: {} }
+  const flagMap = new Map()
+
+  for (const rule of activeRules) {
+    const sinceDate = rule.timeWindowDays
+      ? new Date(Date.now() - rule.timeWindowDays * 24 * 60 * 60 * 1000)
+      : null
+
+    let metricsToUse = globalMetrics
+    if (sinceDate) {
+      const ruleMetricKeys = new Set(rule.conditions.map(c => c.metric))
+      metricsToUse = await computeAllUserMetrics(prisma, ruleMetricKeys, sinceDate)
+    }
+
+    const matchedUserIds = evaluateRule(metricsToUse, rule)
+
+    for (const userId of matchedUserIds) {
+      if (!flagMap.has(userId)) flagMap.set(userId, { rules: [], metrics: {} })
+      const entry = flagMap.get(userId)
+
+      entry.rules.push({
+        ruleId: rule.id,
+        ruleName: rule.name,
+        matchedConditions: rule.conditions.map(c => {
+          const val = (metricsToUse.get(userId) ?? {})[c.metric] ?? 0
+          const opLabel = OPERATOR_LABELS[c.operator] ?? c.operator
+          const metaLabel = METRIC_DEFINITIONS[c.metric]?.label ?? c.metric
+          return `${metaLabel} ${opLabel} ${c.threshold} (actual: ${val})`
+        }),
+      })
+
+      // Merge metrics
+      const userMetrics = metricsToUse.get(userId) ?? {}
+      Object.assign(entry.metrics, userMetrics)
+    }
+  }
+
+  if (flagMap.size === 0) return { flaggedUsers: [], rulesEvaluated: activeRules.length }
+
+  const flaggedUserIds = [...flagMap.keys()]
+
+  // Fetch user info + mute status
+  const users = await prisma.user.findMany({
+    where: { id: { in: flaggedUserIds } },
+    select: {
+      id: true,
+      username: true,
+      discordTag: true,
+      avatar: true,
+      discordAvatar: true,
+      suspiciousActivityMute: {
+        select: { id: true, reason: true, createdAt: true, mutedBy: { select: { username: true } } },
+      },
+    },
+  })
+
+  const userMap = new Map(users.map(u => [u.id, u]))
+
+  // Build context (top partners, sellers, shared IPs)
+  const contextMap = await buildContextForUsers(prisma, flaggedUserIds, null)
+
+  const flaggedUsers = flaggedUserIds.map(userId => {
+    const user = userMap.get(userId)
+    const entry = flagMap.get(userId)
+    const mute = user?.suspiciousActivityMute ?? null
+
+    return {
+      userId,
+      username: user?.username ?? null,
+      discordTag: user?.discordTag ?? null,
+      avatar: user?.avatar ?? user?.discordAvatar ?? null,
+      isMuted: !!mute,
+      muteInfo: mute
+        ? { reason: mute.reason, mutedBy: mute.mutedBy?.username, mutedAt: mute.createdAt }
+        : null,
+      triggeredRules: entry.rules,
+      metrics: entry.metrics,
+      context: contextMap[userId] ?? { topTradePartners: [], topAuctionSellers: [], sharedIPUsers: [] },
+    }
+  })
+
+  return { flaggedUsers, rulesEvaluated: activeRules.length }
+}


### PR DESCRIPTION
Introduces a flexible, admin-configurable monitoring system to flag
users exhibiting suspicious patterns such as alt-account trade/auction
collusion and shared IP addresses.

- Prisma: 3 new models (SuspiciousActivityRule, SuspiciousActivityCondition,
  SuspiciousActivityMute) with migration
- server/utils/suspiciousActivityMetrics.js: 10 computable metrics across
  Trading, Auctions, and IP/Account categories; rule evaluation engine
  with AND/OR logic and per-rule time windows
- 8 admin API endpoints: rules CRUD, analyze, mutes CRUD
- pages/admin/suspicious-activity.vue: full admin page with rule builder
  modal, on-demand analysis runner, expandable flagged user cards with
  trade partner / auction seller / shared-IP context, and mute system
- Nav.vue: added Suspicious Activity link in Admin — Logs section

https://claude.ai/code/session_01HNG3jiyLhvoRFym3RPG6XE