### PR TITLE
Display auction seller information on auctions page

### DIFF
--- a/pages/auctions.vue
+++ b/pages/auctions.vue
@@ -722,6 +722,15 @@
                   <p class="text-sm text-gray-600 mb-1">
                     Bids: {{ auction.bidCount ?? 0 }}
                   </p>
+                  <p v-if="auction.seller" class="text-sm text-gray-600 mb-1">
+                    Seller:
+                    <NuxtLink
+                      :to="`/czone/${auction.seller}`"
+                      class="text-indigo-600 hover:text-indigo-800 hover:underline"
+                    >
+                      {{ auction.seller }}
+                    </NuxtLink>
+                  </p>
                   <p v-if="auction.winningBidder" class="text-sm text-gray-600 mb-3">
                     Winner:
                     <NuxtLink

--- a/server/api/auctions/all.get.js
+++ b/server/api/auctions/all.get.js
@@ -183,6 +183,7 @@ export default defineEventHandler(async (event) => {
             },
           },
         },
+        creator: { select: { username: true } },
         bids: {
           orderBy: { amount: 'desc' },
           take: 1,
@@ -235,6 +236,7 @@ export default defineEventHandler(async (event) => {
       createdAt: a.createdAt.toISOString(),
       endAt: a.endAt.toISOString(),
       initialBid: a.initialBet,
+      seller: a.creator?.username ?? null,
       winningBid: a.bids[0]?.amount ?? null,
       winningBidder: a.bids[0]?.user?.username ?? null,
       bidCount: a._count?.bids ?? 0,


### PR DESCRIPTION
## Summary
Added seller information display to the auctions listing page, allowing users to see who is selling each auction and navigate to their profile.

## Key Changes
- **Frontend (pages/auctions.vue)**: Added a new seller display section that shows the seller's username as a clickable link to their profile page (`/czone/{username}`)
- **Backend (server/api/auctions/all.get.js)**: 
  - Updated the Prisma query to include the `creator` relationship and select their `username`
  - Added `seller` field to the API response, mapping from `creator.username`

## Implementation Details
- The seller information is conditionally rendered only when `auction.seller` exists
- The seller username is displayed as a styled link (indigo text with hover effects) consistent with the existing winner link styling
- The seller field is positioned between the bid count and winning bidder information for logical flow

https://claude.ai/code/session_01T5maBQ75S4eNLT89MwLLUf