### PR TITLE
Add seller and winner filters to auctions page

### DIFF
--- a/pages/auctions.vue
+++ b/pages/auctions.vue
@@ -662,6 +662,62 @@
 
         <!-- All Auctions -->
         <template v-else-if="activeTab === 'all'">
+          <!-- Seller / Winner username filters -->
+          <div class="flex flex-wrap gap-4 mb-4">
+            <!-- Filter by Seller -->
+            <div class="relative">
+              <label class="block text-sm font-medium text-gray-700 mb-1">Filter by Seller</label>
+              <input
+                type="text"
+                v-model="sellerFilter"
+                @input="onSellerInput"
+                @focus="showSellerSuggestions = true"
+                @blur="onSellerBlur"
+                placeholder="Seller username…"
+                class="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 w-52"
+              />
+              <div
+                v-if="showSellerSuggestions && sellerSuggestions.length"
+                class="absolute z-10 w-full bg-white border border-gray-200 rounded mt-1 shadow max-h-48 overflow-auto"
+              >
+                <button
+                  v-for="s in sellerSuggestions"
+                  :key="s"
+                  class="w-full text-left px-3 py-1.5 text-sm hover:bg-indigo-50"
+                  @mousedown.prevent="applySellerSuggestion(s)"
+                >
+                  {{ s }}
+                </button>
+              </div>
+            </div>
+            <!-- Filter by Winner -->
+            <div class="relative">
+              <label class="block text-sm font-medium text-gray-700 mb-1">Filter by Winner</label>
+              <input
+                type="text"
+                v-model="winnerFilter"
+                @input="onWinnerInput"
+                @focus="showWinnerSuggestions = true"
+                @blur="onWinnerBlur"
+                placeholder="Winner username…"
+                class="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 w-52"
+              />
+              <div
+                v-if="showWinnerSuggestions && winnerSuggestions.length"
+                class="absolute z-10 w-full bg-white border border-gray-200 rounded mt-1 shadow max-h-48 overflow-auto"
+              >
+                <button
+                  v-for="s in winnerSuggestions"
+                  :key="s"
+                  class="w-full text-left px-3 py-1.5 text-sm hover:bg-indigo-50"
+                  @mousedown.prevent="applyWinnerSuggestion(s)"
+                >
+                  {{ s }}
+                </button>
+              </div>
+            </div>
+          </div>
+
           <div v-if="isLoadingAll" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             <div v-for="n in 6" :key="n" class="bg-white rounded-lg shadow p-4 animate-pulse h-64"></div>
           </div>
@@ -834,6 +890,13 @@ const wishlistCtoonIds = ref([])
 const isLoadingWishlist = ref(false)
 const hasLoadedWishlist = ref(false)
 
+const sellerFilter = ref('')
+const winnerFilter = ref('')
+const sellerSuggestions = ref([])
+const winnerSuggestions = ref([])
+const showSellerSuggestions = ref(false)
+const showWinnerSuggestions = ref(false)
+
 // Route + URL query sync
 const route  = useRoute()
 const router = useRouter()
@@ -879,6 +942,12 @@ function updateUrlQueryFromFilters() {
 
   if (gtoonsOnly.value) newQuery.gtoon = '1'
   else delete newQuery.gtoon
+
+  if (sellerFilter.value.trim()) newQuery.seller = sellerFilter.value.trim()
+  else delete newQuery.seller
+
+  if (winnerFilter.value.trim()) newQuery.winner = winnerFilter.value.trim()
+  else delete newQuery.winner
 
   if (sortBy.value && sortBy.value !== 'endAsc') newQuery.sort = sortBy.value
   else delete newQuery.sort
@@ -933,6 +1002,11 @@ onMounted(() => {
   if (['1','true','yes'].includes(hasBidsParam.toLowerCase())) hasBidsOnly.value = true
   if (['1','true','yes'].includes(gtoonParam.toLowerCase())) gtoonsOnly.value = true
   if (pageParam > 1) currentPage.value = pageParam
+
+  const sellerParam = typeof route.query.seller === 'string' ? route.query.seller : ''
+  const winnerParam = typeof route.query.winner === 'string' ? route.query.winner : ''
+  if (sellerParam.trim()) sellerFilter.value = sellerParam.trim()
+  if (winnerParam.trim()) winnerFilter.value = winnerParam.trim()
 
   // Normalize URL based on initialized values
   updateUrlQueryFromFilters()
@@ -1011,6 +1085,8 @@ function buildFilterParams() {
   if (wishlistOnly.value) params.set('wishlist', '1')
   if (hasBidsOnly.value) params.set('hasBids', '1')
   if (gtoonsOnly.value) params.set('gtoon', '1')
+  if (sellerFilter.value.trim()) params.set('seller', sellerFilter.value.trim())
+  if (winnerFilter.value.trim()) params.set('winner', winnerFilter.value.trim())
   return params
 }
 
@@ -1135,6 +1211,17 @@ watch(wishlistOnly, value => {
   if (value) loadWishlist()
 })
 
+watch([sellerFilter, winnerFilter], () => {
+  const seller = sellerFilter.value.trim()
+  const winner = winnerFilter.value.trim()
+  // Skip reload while user is mid-type (1–2 chars); wait for 0 (cleared) or 3+
+  if ((seller.length > 0 && seller.length < 3) || (winner.length > 0 && winner.length < 3)) return
+  updateUrlQueryFromFilters()
+  if (activeTab.value !== 'all') return
+  if (allPage.value !== 1) allPage.value = 1
+  else loadAllAuctions()
+})
+
 watch(hasBidsOnly, () => {
   loadAuctions()
   loadTrendingAuctions({ force: true })
@@ -1150,6 +1237,49 @@ function resetFilters() {
   wishlistOnly.value = false
   hasBidsOnly.value = false
   gtoonsOnly.value = false
+  sellerFilter.value = ''
+  winnerFilter.value = ''
+}
+
+async function fetchUserSuggestions(q) {
+  try {
+    const data = await $fetch(`/api/users/search?q=${encodeURIComponent(q)}&limit=8`)
+    return (data?.items || []).map(u => u.username)
+  } catch {
+    return []
+  }
+}
+
+async function onSellerInput() {
+  showSellerSuggestions.value = true
+  const q = sellerFilter.value.trim()
+  sellerSuggestions.value = q.length >= 3 ? await fetchUserSuggestions(q) : []
+}
+
+function applySellerSuggestion(username) {
+  sellerFilter.value = username
+  sellerSuggestions.value = []
+  showSellerSuggestions.value = false
+}
+
+function onSellerBlur() {
+  setTimeout(() => { showSellerSuggestions.value = false }, 120)
+}
+
+async function onWinnerInput() {
+  showWinnerSuggestions.value = true
+  const q = winnerFilter.value.trim()
+  winnerSuggestions.value = q.length >= 3 ? await fetchUserSuggestions(q) : []
+}
+
+function applyWinnerSuggestion(username) {
+  winnerFilter.value = username
+  winnerSuggestions.value = []
+  showWinnerSuggestions.value = false
+}
+
+function onWinnerBlur() {
+  setTimeout(() => { showWinnerSuggestions.value = false }, 120)
 }
 
 function isEnded(endAt) {
@@ -1193,7 +1323,9 @@ const hasActiveFilters = computed(() => {
     featuredOnly.value ||
     wishlistOnly.value ||
     hasBidsOnly.value ||
-    gtoonsOnly.value
+    gtoonsOnly.value ||
+    sellerFilter.value.trim() ||
+    winnerFilter.value.trim()
   )
 })
 const filterSources = computed(() => [

--- a/server/api/auctions/all.get.js
+++ b/server/api/auctions/all.get.js
@@ -89,6 +89,8 @@ export default defineEventHandler(async (event) => {
   const hasBidsOnly = isTruthy(query.hasBids)
   const sort = typeof query.sort === 'string' ? query.sort : 'endAsc'
   const orderBy = buildSortOrder(sort)
+  const seller = typeof query.seller === 'string' ? query.seller.trim() : ''
+  const winner = typeof query.winner === 'string' ? query.winner.trim() : ''
 
   let ownedIds = null
   let ownedSet = null
@@ -153,6 +155,51 @@ export default defineEventHandler(async (event) => {
   if (featuredOnly) where.isFeatured = true
   if (hasBidsOnly) where.bids = { some: {} }
   if (Object.keys(ctoonWhere).length) where.userCtoon = { ctoon: ctoonWhere }
+  if (seller) where.creator = { username: { contains: seller, mode: 'insensitive' } }
+
+  if (winner) {
+    const matchingUsers = await prisma.user.findMany({
+      where: { username: { contains: winner, mode: 'insensitive' } },
+      select: { id: true }
+    })
+    if (!matchingUsers.length) {
+      return { page: pageNum, pageSize: take, total: 0, totalPages: 1, items: [] }
+    }
+    const matchingUserIds = matchingUsers.map(u => u.id)
+
+    // Find auctions where a matching user holds the highest bid
+    const userMaxBids = await prisma.bid.groupBy({
+      by: ['auctionId'],
+      where: { userId: { in: matchingUserIds }, auction: { status: 'CLOSED' } },
+      _max: { amount: true }
+    })
+    if (!userMaxBids.length) {
+      return { page: pageNum, pageSize: take, total: 0, totalPages: 1, items: [] }
+    }
+    const candidateAuctionIds = userMaxBids.map(b => b.auctionId)
+
+    // Get the true max bid per candidate auction
+    const auctionMaxBids = await prisma.bid.groupBy({
+      by: ['auctionId'],
+      where: { auctionId: { in: candidateAuctionIds } },
+      _max: { amount: true }
+    })
+    const maxBidMap = new Map(auctionMaxBids.map(b => [b.auctionId, b._max.amount]))
+
+    // Keep only auctions where the user's max bid equals the auction's max bid
+    const winningAuctionIds = userMaxBids
+      .filter(b => {
+        const userMax = Number(b._max.amount ?? 0)
+        const auctionMax = Number(maxBidMap.get(b.auctionId) ?? 0)
+        return auctionMax > 0 && userMax >= auctionMax
+      })
+      .map(b => b.auctionId)
+
+    if (!winningAuctionIds.length) {
+      return { page: pageNum, pageSize: take, total: 0, totalPages: 1, items: [] }
+    }
+    where.id = { in: winningAuctionIds }
+  }
 
   const [total, auctions] = await Promise.all([
     prisma.auction.count({ where }),


### PR DESCRIPTION
## Summary
Added filtering capabilities to the "All Auctions" tab, allowing users to filter auctions by seller username and by auction winner. Both filters include autocomplete suggestions fetched from the user search API.

## Key Changes

**Frontend (pages/auctions.vue):**
- Added two new filter input fields with autocomplete suggestions for "Filter by Seller" and "Filter by Winner"
- Implemented autocomplete logic that fetches user suggestions after 3+ characters are typed
- Added reactive state management for both filters with suggestion dropdowns
- Integrated filters into URL query parameters for bookmarkable/shareable filter states
- Added filter persistence on page load from URL query parameters
- Updated `resetFilters()` to clear both new filters
- Updated `hasActiveFilters` computed property to include the new filters
- Added watchers to trigger auction reloads when filters change (with debouncing for partial input)

**Backend (server/api/auctions/all.get.js):**
- Added `seller` query parameter handling with case-insensitive username matching
- Implemented `winner` filter logic that:
  - Finds users matching the winner filter
  - Identifies closed auctions where those users have the highest bid
  - Returns only auctions won by matching users
- Both filters are applied to the database query with proper WHERE clause construction

## Implementation Details

- Seller filter uses a simple case-insensitive `contains` query on the creator's username
- Winner filter performs a multi-step query: finds matching users → finds their max bids on closed auctions → verifies those bids are the auction's max bid
- Autocomplete suggestions only appear after 3+ characters to reduce unnecessary API calls
- Filters are debounced to avoid reloading while user is still typing (1-2 characters)
- Both filters integrate seamlessly with existing filter system and URL query synchronization

https://claude.ai/code/session_01LMLj4383jdjgSSBaA7T66o