### PR TITLE
Implement scheduled dissolve auction releases with queue management

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test",
-    "dev": "concurrently \"nuxt dev\" \"npm:worker\" \"npm:mint-end\" \"npm:guildchecker\" \"npm:achievements\" \"npm:dissolve\"",
+    "dev": "concurrently \"nuxt dev\" \"npm:worker\" \"npm:mint-end\" \"npm:guildchecker\" \"npm:achievements\" \"npm:dissolve\" \"npm:dissolve-launch\"",
     "worker": "node server/workers/mint.worker.js",
     "mint-end": "node server/workers/mint-end.worker.js",
     "dissolve": "node server/workers/dissolve.worker.js",
+    "dissolve-launch": "node server/workers/dissolve-auction-launch.worker.js",
     "achievements": "node server/workers/achievements.worker.js",
     "guildchecker": "node ./server/cron/sync-guild-members.js",
     "build": "nuxt build",

--- a/pages/admin/dissolve-queue.vue
+++ b/pages/admin/dissolve-queue.vue
@@ -1,0 +1,221 @@
+<template>
+  <div class="min-h-screen bg-gray-50 p-6 mt-16 md:mt-20">
+    <Nav />
+
+    <div class="max-w-5xl mx-auto mt-6 space-y-6">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold">Dissolve Queue</h1>
+        <button @click="loadData" class="text-sm text-blue-600 underline">Refresh</button>
+      </div>
+
+      <!-- Summary cards -->
+      <div v-if="stats" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div v-for="cat in categories" :key="cat.key"
+             class="bg-white rounded-lg shadow p-4">
+          <div class="text-sm font-semibold text-gray-500 mb-1">{{ cat.label }}</div>
+          <div class="text-2xl font-bold">{{ stats.byCategory[cat.key]?.total ?? 0 }}</div>
+          <div class="text-xs text-gray-500 mt-1">
+            <span class="text-emerald-600">{{ stats.byCategory[cat.key]?.scheduled ?? 0 }} scheduled</span>
+            <span class="mx-1">·</span>
+            <span class="text-orange-500">{{ stats.byCategory[cat.key]?.unscheduled ?? 0 }} unscheduled</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Upcoming scheduled auctions -->
+      <div class="bg-white rounded-lg shadow">
+        <div class="p-4 border-b">
+          <h2 class="font-semibold">Upcoming Scheduled Auctions</h2>
+          <p class="text-xs text-gray-500 mt-0.5">Next 20 entries, times in CST</p>
+        </div>
+        <div v-if="upcoming.length" class="divide-y">
+          <div v-for="entry in upcoming" :key="entry.id"
+               class="flex items-center gap-3 px-4 py-3 text-sm">
+            <div class="flex-1 min-w-0">
+              <div class="font-medium truncate">{{ entry.ctoonName || '—' }}</div>
+              <div class="text-xs text-gray-500">
+                {{ entry.rarity }}
+                <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>
+                <span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium"
+                      :class="categoryChip(entry.category)">{{ entry.category }}</span>
+                <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
+              </div>
+            </div>
+            <div class="text-xs text-gray-600 shrink-0">{{ fmtCST(entry.scheduledFor) }}</div>
+            <button
+              @click="cancelEntry(entry.id)"
+              class="text-xs text-red-500 hover:text-red-700 shrink-0"
+              :disabled="cancellingId === entry.id"
+            >{{ cancellingId === entry.id ? '…' : 'Unschedule' }}</button>
+          </div>
+        </div>
+        <div v-else class="p-6 text-center text-sm text-gray-400">No upcoming scheduled auctions</div>
+      </div>
+
+      <!-- Reschedule All form -->
+      <div class="bg-white rounded-lg shadow p-5">
+        <h2 class="font-semibold mb-1">Reschedule All</h2>
+        <p class="text-xs text-gray-500 mb-4">
+          Set a new schedule for all unscheduled entries. Toggle "Reschedule all" to also reset existing scheduled entries.
+        </p>
+
+        <div class="space-y-3 max-w-sm">
+          <div class="flex items-center gap-2">
+            <label class="w-40 text-xs text-gray-600 shrink-0">Start date (local)</label>
+            <input v-model="form.startAtLocal" type="datetime-local"
+                   class="flex-1 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <label class="w-40 text-xs text-gray-600 shrink-0">Cadence (days)</label>
+            <input v-model.number="form.cadenceDays" type="number" min="1"
+                   class="w-24 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <label class="w-40 text-xs text-gray-600 shrink-0">Pokémon / cadence</label>
+            <input v-model.number="form.pokemonPerCadence" type="number" min="1"
+                   class="w-24 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <label class="w-40 text-xs text-gray-600 shrink-0">Crazy Rare / cadence</label>
+            <input v-model.number="form.crazyRarePerCadence" type="number" min="1"
+                   class="w-24 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <label class="w-40 text-xs text-gray-600 shrink-0">Other / cadence</label>
+            <input v-model.number="form.otherPerCadence" type="number" min="1"
+                   class="w-24 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <input v-model="form.reschedule" type="checkbox" id="reschedule-all"
+                   class="rounded border-gray-300" />
+            <label for="reschedule-all" class="text-xs text-gray-600">
+              Reschedule all (including already-scheduled entries)
+            </label>
+          </div>
+        </div>
+
+        <div v-if="scheduleError" class="mt-3 text-xs text-red-600">{{ scheduleError }}</div>
+        <div v-if="scheduleSuccess" class="mt-3 text-xs text-emerald-600">{{ scheduleSuccess }}</div>
+
+        <div class="mt-4">
+          <button
+            @click="applySchedule"
+            :disabled="scheduling"
+            class="px-4 py-2 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+          >{{ scheduling ? 'Scheduling…' : 'Apply Schedule' }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRequestHeaders } from '#app'
+import Nav from '~/components/Nav.vue'
+
+definePageMeta({ title: 'Admin - Dissolve Queue', middleware: ['auth', 'admin'], layout: 'default' })
+
+const headers = process.server ? useRequestHeaders(['cookie']) : undefined
+
+const stats    = ref(null)
+const upcoming = ref([])
+
+const categories = [
+  { key: 'POKEMON',    label: 'Pokémon' },
+  { key: 'CRAZY_RARE', label: 'Crazy Rare' },
+  { key: 'OTHER',      label: 'Other' },
+]
+
+function defaultStartLocal() {
+  const d = new Date()
+  d.setDate(d.getDate() + 1)
+  d.setHours(10, 0, 0, 0)
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+const form = ref({
+  startAtLocal:        defaultStartLocal(),
+  cadenceDays:         7,
+  pokemonPerCadence:   2,
+  crazyRarePerCadence: 1,
+  otherPerCadence:     10,
+  reschedule:          false,
+})
+
+const scheduling    = ref(false)
+const scheduleError = ref('')
+const scheduleSuccess = ref('')
+const cancellingId  = ref(null)
+
+async function loadData() {
+  try {
+    const data = await $fetch('/api/admin/dissolve-queue', { headers })
+    stats.value    = data
+    upcoming.value = data.upcoming || []
+  } catch (e) {
+    console.error('Failed to load dissolve queue', e)
+  }
+}
+
+onMounted(loadData)
+
+async function applySchedule() {
+  scheduling.value    = true
+  scheduleError.value = ''
+  scheduleSuccess.value = ''
+  try {
+    const f = form.value
+    const res = await $fetch('/api/admin/dissolve-queue/schedule', {
+      method: 'POST',
+      body: {
+        startAtUtc:          new Date(f.startAtLocal).toISOString(),
+        cadenceDays:         f.cadenceDays,
+        pokemonPerCadence:   f.pokemonPerCadence,
+        crazyRarePerCadence: f.crazyRarePerCadence,
+        otherPerCadence:     f.otherPerCadence,
+        reschedule:          f.reschedule,
+      }
+    })
+    scheduleSuccess.value = `Scheduled ${res.scheduled} entries.`
+    await loadData()
+  } catch (e) {
+    scheduleError.value = e?.data?.statusMessage || 'Failed to apply schedule.'
+  } finally {
+    scheduling.value = false
+  }
+}
+
+async function cancelEntry(id) {
+  cancellingId.value = id
+  try {
+    await $fetch(`/api/admin/dissolve-queue/${id}`, { method: 'DELETE' })
+    upcoming.value = upcoming.value.filter(e => e.id !== id)
+    await loadData()
+  } catch (e) {
+    console.error('Failed to unschedule entry', e)
+  } finally {
+    cancellingId.value = null
+  }
+}
+
+function fmtCST(iso) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString([], {
+    timeZone: 'America/Chicago',
+    hour12: true,
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }) + ' CST'
+}
+
+function categoryChip(cat) {
+  if (cat === 'POKEMON')    return 'bg-blue-100 text-blue-700'
+  if (cat === 'CRAZY_RARE') return 'bg-purple-100 text-purple-700'
+  return 'bg-gray-100 text-gray-600'
+}
+</script>

--- a/pages/admin/users.vue
+++ b/pages/admin/users.vue
@@ -406,10 +406,41 @@
       <div v-if="dissolvePhase === 'confirm'" class="mt-2 text-sm text-gray-700 space-y-2">
         <p>
           Confirming will make this user Inactive, transfer all of their points to
-          <strong>{{ official?.username || '—' }}</strong>, reassign their cToons to
-          <strong>{{ official?.username || '—' }}</strong>, and immediately start 24‑hour auctions for those items.
+          <strong>{{ official?.username || '—' }}</strong>, and reassign their cToons to
+          <strong>{{ official?.username || '—' }}</strong>.
+          Their cToons will be queued for scheduled auction release based on the settings below.
         </p>
-        <p class="text-xs text-gray-500">Large accounts with many cToons are processed in the background — you'll see progress here.</p>
+        <p class="text-xs text-gray-500">Large accounts are processed in the background — you'll see progress here.</p>
+
+        <div class="mt-3 border-t pt-3 space-y-2">
+          <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Release Schedule</p>
+
+          <div class="flex items-center gap-2">
+            <label class="w-36 text-xs text-gray-600 shrink-0">Start date (local)</label>
+            <input v-model="dissolveSchedule.startAtLocal" type="datetime-local"
+                   class="flex-1 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
+            <input v-model.number="dissolveSchedule.cadenceDays" type="number" min="1"
+                   class="w-24 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <label class="w-36 text-xs text-gray-600 shrink-0">Pokémon / cadence</label>
+            <input v-model.number="dissolveSchedule.pokemonPerCadence" type="number" min="1"
+                   class="w-24 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <label class="w-36 text-xs text-gray-600 shrink-0">Crazy Rare / cadence</label>
+            <input v-model.number="dissolveSchedule.crazyRarePerCadence" type="number" min="1"
+                   class="w-24 text-xs border rounded px-2 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <label class="w-36 text-xs text-gray-600 shrink-0">Other / cadence</label>
+            <input v-model.number="dissolveSchedule.otherPerCadence" type="number" min="1"
+                   class="w-24 text-xs border rounded px-2 py-1" />
+          </div>
+        </div>
       </div>
 
       <!-- Progress bar (queued / active) -->
@@ -430,9 +461,12 @@
         <ul v-if="dissolveSummary" class="text-xs space-y-0.5 mt-1">
           <li>Points transferred: {{ dissolveSummary.pointsTransferred }}</li>
           <li>cToons transferred: {{ dissolveSummary.ctoonsTransferred }}</li>
-          <li>Auctions created: {{ dissolveSummary.auctionsCreated }}</li>
+          <li>cToons queued for auction: {{ dissolveSummary.ctoonsQueued }}</li>
           <li>Bids removed: {{ dissolveSummary.bidsDeleted }}</li>
         </ul>
+        <p class="text-xs mt-2">
+          <a href="/admin/dissolve-queue" class="underline font-medium text-emerald-800">View Dissolve Queue →</a>
+        </p>
       </div>
 
       <!-- Error -->
@@ -931,6 +965,23 @@ const dissolveStep = ref('')
 const dissolveSummary = ref(null)
 let dissolvePoller = null
 
+function defaultStartLocal() {
+  const d = new Date()
+  d.setDate(d.getDate() + 1)
+  d.setHours(10, 0, 0, 0)
+  // datetime-local value format: YYYY-MM-DDTHH:mm
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+const dissolveSchedule = ref({
+  startAtLocal:        defaultStartLocal(),
+  cadenceDays:         7,
+  pokemonPerCadence:   2,
+  crazyRarePerCadence: 1,
+  otherPerCadence:     10,
+})
+
 function openDissolveModal(u) {
   dissolveTarget.value = u
   dissolveError.value = ''
@@ -939,6 +990,13 @@ function openDissolveModal(u) {
   dissolvePct.value = 0
   dissolveStep.value = ''
   dissolveSummary.value = null
+  dissolveSchedule.value = {
+    startAtLocal:        defaultStartLocal(),
+    cadenceDays:         7,
+    pokemonPerCadence:   2,
+    crazyRarePerCadence: 1,
+    otherPerCadence:     10,
+  }
   showDissolveModal.value = true
 }
 function closeDissolveModal() {
@@ -951,6 +1009,13 @@ function closeDissolveModal() {
   dissolvePct.value = 0
   dissolveStep.value = ''
   dissolveSummary.value = null
+  dissolveSchedule.value = {
+    startAtLocal:        defaultStartLocal(),
+    cadenceDays:         7,
+    pokemonPerCadence:   2,
+    crazyRarePerCadence: 1,
+    otherPerCadence:     10,
+  }
 }
 function parseDissolveError(e) {
   const statusMessage = e?.data?.statusMessage || ''
@@ -997,7 +1062,19 @@ async function confirmDissolve() {
   dissolveWorking.value = true
   dissolveError.value = ''
   try {
-    await $fetch(`/api/admin/users/${dissolveTarget.value.id}/dissolve`, { method: 'POST' })
+    const s = dissolveSchedule.value
+    await $fetch(`/api/admin/users/${dissolveTarget.value.id}/dissolve`, {
+      method: 'POST',
+      body: {
+        scheduleConfig: {
+          startAtUtc:          new Date(s.startAtLocal).toISOString(),
+          cadenceDays:         s.cadenceDays,
+          pokemonPerCadence:   s.pokemonPerCadence,
+          crazyRarePerCadence: s.crazyRarePerCadence,
+          otherPerCadence:     s.otherPerCadence,
+        }
+      }
+    })
     dissolvePhase.value = 'working'
     dissolvePct.value = 0
     dissolveStep.value = 'Queued…'

--- a/prisma/migrations/20260426120000_dissolve_queue_scheduling/migration.sql
+++ b/prisma/migrations/20260426120000_dissolve_queue_scheduling/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: add category, isFeatured, scheduledFor to DissolveAuctionQueue
+ALTER TABLE "DissolveAuctionQueue" ADD COLUMN "category" TEXT NOT NULL DEFAULT 'OTHER';
+ALTER TABLE "DissolveAuctionQueue" ADD COLUMN "isFeatured" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "DissolveAuctionQueue" ADD COLUMN "scheduledFor" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "DissolveAuctionQueue_category_idx" ON "DissolveAuctionQueue"("category");
+
+-- CreateIndex
+CREATE INDEX "DissolveAuctionQueue_scheduledFor_idx" ON "DissolveAuctionQueue"("scheduledFor");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1521,13 +1521,18 @@ model AuctionOnly {
 }
 
 model DissolveAuctionQueue {
-  id          String   @id @default(uuid())
-  userCtoonId String   @unique
-  createdAt   DateTime @default(now())
+  id           String    @id @default(uuid())
+  userCtoonId  String    @unique
+  category     String    @default("OTHER")  // "POKEMON" | "CRAZY_RARE" | "OTHER"
+  isFeatured   Boolean   @default(false)
+  scheduledFor DateTime?                     // UTC; null = not yet scheduled
+  createdAt    DateTime  @default(now())
 
   userCtoon UserCtoon @relation(fields: [userCtoonId], references: [id])
 
   @@index([createdAt])
+  @@index([category])
+  @@index([scheduledFor])
 }
 
 model HomepageConfig {

--- a/server/api/admin/dissolve-queue/[id].delete.js
+++ b/server/api/admin/dissolve-queue/[id].delete.js
@@ -1,0 +1,33 @@
+// server/api/admin/dissolve-queue/[id].delete.js
+// Cancel (and optionally delete) a single dissolve-queue entry.
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { cancelDissolveAuctionLaunch } from '@/server/utils/queues'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const { id } = event.context.params || {}
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing id' })
+
+  const entry = await prisma.dissolveAuctionQueue.findUnique({ where: { id } })
+  if (!entry) throw createError({ statusCode: 404, statusMessage: 'Queue entry not found' })
+
+  // Cancel the BullMQ delayed job if one exists
+  await cancelDissolveAuctionLaunch(id)
+
+  // Clear scheduledFor so the entry stays in the queue but is unscheduled
+  await prisma.dissolveAuctionQueue.update({
+    where: { id },
+    data:  { scheduledFor: null }
+  })
+
+  return { ok: true }
+})

--- a/server/api/admin/dissolve-queue/index.get.js
+++ b/server/api/admin/dissolve-queue/index.get.js
@@ -1,0 +1,62 @@
+// server/api/admin/dissolve-queue/index.get.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const allEntries = await prisma.dissolveAuctionQueue.findMany({
+    include: {
+      userCtoon: {
+        select: {
+          id: true,
+          mintNumber: true,
+          ctoon: { select: { name: true, rarity: true, series: true } }
+        }
+      }
+    },
+    orderBy: [{ scheduledFor: 'asc' }, { createdAt: 'asc' }]
+  })
+
+  const byCategory = {
+    POKEMON:    { total: 0, scheduled: 0, unscheduled: 0 },
+    CRAZY_RARE: { total: 0, scheduled: 0, unscheduled: 0 },
+    OTHER:      { total: 0, scheduled: 0, unscheduled: 0 },
+  }
+
+  for (const e of allEntries) {
+    const cat = byCategory[e.category] || byCategory.OTHER
+    cat.total++
+    if (e.scheduledFor) cat.scheduled++
+    else cat.unscheduled++
+  }
+
+  // Next 20 scheduled entries
+  const upcoming = allEntries
+    .filter(e => e.scheduledFor)
+    .slice(0, 20)
+    .map(e => ({
+      id:          e.id,
+      category:    e.category,
+      isFeatured:  e.isFeatured,
+      scheduledFor: e.scheduledFor,
+      createdAt:   e.createdAt,
+      ctoonName:   e.userCtoon?.ctoon?.name,
+      rarity:      e.userCtoon?.ctoon?.rarity,
+      series:      e.userCtoon?.ctoon?.series,
+      mintNumber:  e.userCtoon?.mintNumber,
+    }))
+
+  return {
+    total: allEntries.length,
+    byCategory,
+    upcoming,
+  }
+})

--- a/server/api/admin/dissolve-queue/schedule.post.js
+++ b/server/api/admin/dissolve-queue/schedule.post.js
@@ -1,0 +1,79 @@
+// server/api/admin/dissolve-queue/schedule.post.js
+// Reschedule all (or unscheduled) dissolve-queue entries from the management page.
+import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { scheduleDissolveAuctionLaunch, cancelDissolveAuctionLaunch } from '@/server/utils/queues'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const body = await readBody(event) || {}
+  const {
+    startAtUtc,
+    cadenceDays,
+    pokemonPerCadence,
+    crazyRarePerCadence,
+    otherPerCadence,
+    reschedule = false,
+  } = body
+
+  if (!startAtUtc) throw createError({ statusCode: 400, statusMessage: 'startAtUtc required' })
+  const startMs = new Date(startAtUtc).getTime()
+  if (isNaN(startMs)) throw createError({ statusCode: 400, statusMessage: 'Invalid startAtUtc' })
+  if (!cadenceDays || Number(cadenceDays) < 1) throw createError({ statusCode: 400, statusMessage: 'cadenceDays must be >= 1' })
+
+  const perCategory = {
+    POKEMON:    Number(pokemonPerCadence)   || 0,
+    CRAZY_RARE: Number(crazyRarePerCadence) || 0,
+    OTHER:      Number(otherPerCadence)     || 0,
+  }
+
+  // Fetch entries to schedule
+  const entries = await prisma.dissolveAuctionQueue.findMany({
+    where: reschedule ? {} : { scheduledFor: null },
+    orderBy: { createdAt: 'asc' },
+    select: { id: true, category: true, scheduledFor: true }
+  })
+
+  if (!entries.length) return { scheduled: 0 }
+
+  // If rescheduling, cancel existing BullMQ jobs first
+  if (reschedule) {
+    for (const e of entries) {
+      if (e.scheduledFor) {
+        await cancelDissolveAuctionLaunch(e.id)
+      }
+    }
+  }
+
+  // Group by category
+  const grouped = { POKEMON: [], CRAZY_RARE: [], OTHER: [] }
+  for (const e of entries) grouped[e.category]?.push(e.id)
+
+  let scheduled = 0
+
+  for (const [cat, ids] of Object.entries(grouped)) {
+    const countPerCadence = perCategory[cat]
+    if (!countPerCadence || !ids.length) continue
+    const intervalMs = (Number(cadenceDays) * 24 * 3600 * 1000) / countPerCadence
+
+    for (let i = 0; i < ids.length; i++) {
+      const scheduledFor = new Date(startMs + i * intervalMs)
+      await prisma.dissolveAuctionQueue.update({
+        where: { id: ids[i] },
+        data:  { scheduledFor }
+      })
+      await scheduleDissolveAuctionLaunch(ids[i], scheduledFor)
+      scheduled++
+    }
+  }
+
+  return { scheduled }
+})

--- a/server/api/admin/users/[id]/dissolve.post.js
+++ b/server/api/admin/users/[id]/dissolve.post.js
@@ -1,5 +1,5 @@
 // server/api/admin/users/[id]/dissolve.post.js
-import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { dissolveQueue } from '@/server/utils/queues'
 
@@ -18,6 +18,9 @@ export default defineEventHandler(async (event) => {
 
   const { id } = event.context.params || {}
   if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing user id' })
+
+  const body = await readBody(event).catch(() => ({})) || {}
+  const { scheduleConfig = null } = body
 
   // Resolve official account
   const officialUsername = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
@@ -58,6 +61,7 @@ export default defineEventHandler(async (event) => {
       officialUsername,
       adminId: me.id,
       adminUsername: me.username || me.id,
+      scheduleConfig,
     },
     { jobId: id }
   )

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -6,7 +6,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { prisma } from '../prisma.js'
 import cron from 'node-cron'
-import { achievementsQueue, scheduleAuctionClose } from '../../server/utils/queues.js'
+import { achievementsQueue } from '../../server/utils/queues.js'
 import { runTournamentScheduler } from '../../server/utils/gtoonTournament.js'
 
 const BOT_TOKEN   = process.env.BOT_TOKEN
@@ -1105,83 +1105,6 @@ async function createDailyFeaturedAuction() {
   }
 }
 
-async function processDissolveAuctionQueue() {
-  const username = process.env.OFFICIAL_USERNAME
-  if (!username) return
-
-  try {
-    const officialUser = await prisma.user.findUnique({
-      where: { username },
-      select: { id: true }
-    })
-    if (!officialUser) return
-
-    const rarityFloor = (r) => {
-      const s = (r || '').trim().toLowerCase()
-      if (s === 'common') return 25
-      if (s === 'uncommon') return 50
-      if (s === 'rare') return 100
-      if (s === 'very rare') return 187
-      if (s === 'crazy rare') return 312
-      return 50
-    }
-
-    const batch = await prisma.dissolveAuctionQueue.findMany({
-      orderBy: { createdAt: 'asc' },
-      take: 50,
-      include: {
-        userCtoon: { select: { id: true, ctoon: { select: { rarity: true } } } }
-      }
-    })
-
-    if (!batch.length) return
-
-    const now = new Date()
-    const endAt = new Date(now.getTime() + 24 * 60 * 60 * 1000)
-
-    for (const row of batch) {
-      try {
-        const result = await prisma.$transaction(async (tx) => {
-          const existing = await tx.auction.findFirst({
-            where: { userCtoonId: row.userCtoonId, status: 'ACTIVE' },
-            select: { id: true }
-          })
-
-          await tx.dissolveAuctionQueue.delete({ where: { id: row.id } })
-
-          if (existing) return null
-
-          const initialBet = rarityFloor(row.userCtoon?.ctoon?.rarity)
-          const created = await tx.auction.create({
-            data: {
-              userCtoonId: row.userCtoonId,
-              initialBet,
-              duration: 1,
-              endAt,
-              creatorId: officialUser.id,
-            },
-            select: { id: true }
-          })
-
-          await tx.userCtoon.update({
-            where: { id: row.userCtoonId },
-            data: { isTradeable: false }
-          })
-
-          return { auctionId: created.id, endAt }
-        })
-
-        if (result) {
-          await scheduleAuctionClose(result.auctionId, result.endAt)
-        }
-      } catch {
-        // swallow per-item errors; continue with rest of batch
-      }
-    }
-  } catch (e) {
-    // swallow in cron context
-  }
-}
 
 async function runTournamentCron() {
   try {
@@ -1241,8 +1164,6 @@ async function enqueueAchievementsDaily() {
 // await enqueueAchievementsDaily()
 cron.schedule('0 3 * * *', enqueueAchievementsDaily, { timezone: 'America/Chicago' })
 
-await processDissolveAuctionQueue()
-cron.schedule('0 10 * * *', processDissolveAuctionQueue, { timezone: 'America/Chicago' }) // 10:00 CST daily
 
 await runTournamentCron()
 cron.schedule('*/15 * * * *', runTournamentCron)

--- a/server/utils/queues.js
+++ b/server/utils/queues.js
@@ -106,3 +106,45 @@ export async function cancelMintEnd(ctoonId) {
   const existing = await mintEndQueue.getJob(String(ctoonId))
   if (existing) { try { await existing.remove() } catch {} }
 }
+
+// Queue for launching individual dissolve-queue auctions at their scheduled time
+export const dissolveAuctionLaunchQueue = new Queue(
+  process.env.DISSOLVE_AUCTION_LAUNCH_QUEUE_KEY || 'dissolveAuctionLaunch',
+  {
+    connection,
+    defaultJobOptions: {
+      removeOnComplete: { count: 500 },
+      removeOnFail:     { count: 500 },
+    },
+  }
+)
+
+/**
+ * Schedule (or reschedule) a delayed BullMQ job that creates one dissolve auction.
+ * Uses the DissolveAuctionQueue.id as the BullMQ job ID for easy lookup/cancellation.
+ * @param {string} queueEntryId
+ * @param {Date|string} scheduledFor
+ */
+export async function scheduleDissolveAuctionLaunch(queueEntryId, scheduledFor) {
+  const delay = Math.max(0, new Date(scheduledFor).getTime() - Date.now())
+  const existing = await dissolveAuctionLaunchQueue.getJob(queueEntryId)
+  if (existing) {
+    const state = await existing.getState()
+    if (state === 'active') return
+    try { await existing.remove() } catch {}
+  }
+  await dissolveAuctionLaunchQueue.add(
+    'launch',
+    { queueEntryId },
+    { jobId: queueEntryId, delay }
+  )
+}
+
+/**
+ * Cancel a pending dissolve auction launch job.
+ * @param {string} queueEntryId
+ */
+export async function cancelDissolveAuctionLaunch(queueEntryId) {
+  const existing = await dissolveAuctionLaunchQueue.getJob(queueEntryId)
+  if (existing) { try { await existing.remove() } catch {} }
+}

--- a/server/workers/dissolve-auction-launch.worker.js
+++ b/server/workers/dissolve-auction-launch.worker.js
@@ -1,0 +1,76 @@
+import { Worker } from 'bullmq'
+import { prisma } from '../prisma.js'
+import { scheduleAuctionClose } from '../utils/queues.js'
+
+const QUEUE_NAME = process.env.DISSOLVE_AUCTION_LAUNCH_QUEUE_KEY || 'dissolveAuctionLaunch'
+const OFFICIAL_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
+
+const connection = {
+  host: process.env.REDIS_HOST,
+  port: Number(process.env.REDIS_PORT),
+  password: process.env.REDIS_PASSWORD?.trim() || undefined,
+}
+
+function rarityFloor(r) {
+  const s = (r || '').trim().toLowerCase()
+  if (s === 'common')     return 25
+  if (s === 'uncommon')   return 50
+  if (s === 'rare')       return 100
+  if (s === 'very rare')  return 187
+  if (s === 'crazy rare') return 312
+  return 50
+}
+
+new Worker(QUEUE_NAME, async (job) => {
+  const { queueEntryId } = job.data
+
+  const officialUser = await prisma.user.findUnique({
+    where: { username: OFFICIAL_USERNAME },
+    select: { id: true }
+  })
+  if (!officialUser) throw new Error('Official account not found')
+
+  const entry = await prisma.dissolveAuctionQueue.findUnique({
+    where: { id: queueEntryId },
+    include: {
+      userCtoon: { select: { id: true, ctoon: { select: { rarity: true } } } }
+    }
+  })
+  if (!entry) return  // already processed or deleted
+
+  const endAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
+
+  const result = await prisma.$transaction(async (tx) => {
+    const existing = await tx.auction.findFirst({
+      where: { userCtoonId: entry.userCtoonId, status: 'ACTIVE' },
+      select: { id: true }
+    })
+
+    await tx.dissolveAuctionQueue.delete({ where: { id: entry.id } })
+
+    if (existing) return null
+
+    const created = await tx.auction.create({
+      data: {
+        userCtoonId: entry.userCtoonId,
+        initialBet:  rarityFloor(entry.userCtoon?.ctoon?.rarity),
+        duration:    1,
+        endAt,
+        creatorId:   officialUser.id,
+        isFeatured:  entry.isFeatured,
+      },
+      select: { id: true }
+    })
+
+    await tx.userCtoon.update({
+      where: { id: entry.userCtoonId },
+      data:  { isTradeable: false }
+    })
+
+    return { auctionId: created.id, endAt }
+  })
+
+  if (result) {
+    await scheduleAuctionClose(result.auctionId, result.endAt)
+  }
+}, { connection })

--- a/server/workers/dissolve.worker.js
+++ b/server/workers/dissolve.worker.js
@@ -1,6 +1,7 @@
 import { Worker } from 'bullmq'
 import { prisma } from '../prisma.js'
 import { logAdminChange } from '../utils/adminChangeLog.js'
+import { scheduleDissolveAuctionLaunch } from '../utils/queues.js'
 
 const QUEUE_NAME = process.env.DISSOLVE_QUEUE_KEY || 'dissolveQueue'
 
@@ -80,9 +81,11 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
   // ── Step 2: cToons ───────────────────────────────────────────────────────
   const userCtoons = await prisma.userCtoon.findMany({
     where: { userId, burnedAt: null },
-    select: { id: true, ctoon: { select: { id: true, rarity: true } }, mintNumber: true }
+    select: { id: true, ctoon: { select: { id: true, rarity: true, series: true } }, mintNumber: true }
   })
   const total = userCtoons.length
+
+  const queuedEntries = []  // { id, category } — tracked for Step 9 scheduling
 
   for (let i = 0; i < userCtoons.length; i++) {
     const uc = userCtoons[i]
@@ -112,11 +115,18 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
       })
       ctoonsTransferred++
 
-      await prisma.dissolveAuctionQueue.upsert({
-        where: { userCtoonId: uc.id },
+      const isPokemon   = (uc.ctoon?.series || '').toLowerCase() === 'pokemon'
+      const isCrazyRare = (uc.ctoon?.rarity || '').toLowerCase() === 'crazy rare'
+      const category    = isPokemon ? 'POKEMON' : (isCrazyRare ? 'CRAZY_RARE' : 'OTHER')
+      const isFeatured  = isPokemon || isCrazyRare
+
+      const queueEntry = await prisma.dissolveAuctionQueue.upsert({
+        where:  { userCtoonId: uc.id },
         update: {},
-        create: { userCtoonId: uc.id }
+        create: { userCtoonId: uc.id, category, isFeatured },
+        select: { id: true, category: true }
       })
+      queuedEntries.push({ id: queueEntry.id, category: queueEntry.category })
       ctoonsQueued++
     }
 
@@ -242,6 +252,37 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
       tradeOffersReassigned
     }
   })
+
+  // ── Step 9: Schedule dissolve auction launches ───────────────────────────
+  const { scheduleConfig } = job.data
+  if (scheduleConfig && queuedEntries.length) {
+    const { startAtUtc, cadenceDays, pokemonPerCadence, crazyRarePerCadence, otherPerCadence } = scheduleConfig
+    const startMs = new Date(startAtUtc).getTime()
+
+    const perCategory = {
+      POKEMON:    Number(pokemonPerCadence)    || 0,
+      CRAZY_RARE: Number(crazyRarePerCadence)  || 0,
+      OTHER:      Number(otherPerCadence)      || 0,
+    }
+
+    const grouped = { POKEMON: [], CRAZY_RARE: [], OTHER: [] }
+    for (const e of queuedEntries) grouped[e.category].push(e.id)
+
+    for (const [cat, ids] of Object.entries(grouped)) {
+      const countPerCadence = perCategory[cat]
+      if (!countPerCadence || !ids.length) continue
+      const intervalMs = (Number(cadenceDays) * 24 * 3600 * 1000) / countPerCadence
+
+      for (let i = 0; i < ids.length; i++) {
+        const scheduledFor = new Date(startMs + i * intervalMs)
+        await prisma.dissolveAuctionQueue.update({
+          where: { id: ids[i] },
+          data:  { scheduledFor }
+        })
+        await scheduleDissolveAuctionLaunch(ids[i], scheduledFor)
+      }
+    }
+  }
 
   await progress(job, 100, 'Done')
 


### PR DESCRIPTION
## Summary
Refactored the dissolve user workflow to queue cToons for scheduled auction release instead of creating auctions immediately. Admins can now configure release schedules per category (Pokémon, Crazy Rare, Other) and manage the queue through a new admin dashboard.

## Key Changes

- **New Dissolve Queue Management Page** (`pages/admin/dissolve-queue.vue`)
  - Dashboard showing queue statistics by category (scheduled vs. unscheduled)
  - List of upcoming scheduled auctions with ability to unschedule individual entries
  - Bulk reschedule form to apply release schedules across all or unscheduled entries
  - Displays times in CST for clarity

- **Updated User Dissolution Flow** (`pages/admin/users.vue`)
  - Modified confirmation dialog to include release schedule configuration
  - Removed immediate 24-hour auction creation; cToons now queued instead
  - Updated summary to show "cToons queued for auction" instead of "Auctions created"
  - Added link to Dissolve Queue management page

- **New BullMQ Worker** (`server/workers/dissolve-auction-launch.worker.js`)
  - Processes delayed jobs to create auctions at scheduled times
  - Handles rarity-based initial bid calculation and auction setup
  - Schedules auction close notifications via existing queue

- **New API Endpoints**
  - `GET /api/admin/dissolve-queue` — Fetch queue statistics and upcoming entries
  - `POST /api/admin/dissolve-queue/schedule` — Reschedule all or unscheduled entries
  - `DELETE /api/admin/dissolve-queue/[id]` — Unschedule a single entry

- **Queue Infrastructure** (`server/utils/queues.js`)
  - Added `dissolveAuctionLaunchQueue` for delayed auction creation jobs
  - New functions: `scheduleDissolveAuctionLaunch()` and `cancelDissolveAuctionLaunch()`
  - Jobs use queue entry ID as BullMQ job ID for easy lookup/cancellation

- **Dissolve Worker Updates** (`server/workers/dissolve.worker.js`)
  - Now categorizes cToons (POKEMON, CRAZY_RARE, OTHER) and marks featured items
  - Accepts `scheduleConfig` in job data to schedule launches during dissolution
  - Queues entries instead of creating auctions immediately

- **Database Schema** (`prisma/schema.prisma`)
  - Added `category`, `isFeatured`, and `scheduledFor` fields to `DissolveAuctionQueue`
  - Added indexes on `category` and `scheduledFor` for query performance

- **Removed Legacy Code** (`server/cron/sync-guild-members.js`)
  - Removed `processDissolveAuctionQueue()` cron job (replaced by BullMQ delayed jobs)
  - Removed `scheduleAuctionClose` import (no longer needed in cron context)

## Implementation Details

- Schedule configuration allows per-category cadence control (e.g., 2 Pokémon per 7 days, 1 Crazy Rare per 7 days)
- Entries are distributed evenly across the cadence period using calculated intervals
- Rescheduling cancels existing BullMQ jobs before creating new ones
- Auction creation preserves featured status from queue entry
- All times displayed to admins in CST; stored/processed in UTC

https://claude.ai/code/session_011UEs5eFQAH93mCmxe1Bg7V