### PR TITLE
Implement admin-scheduled dissolve auction queue release

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -11,11 +11,12 @@
  *   nuxt-server       – Nuxt 3 HTTP server, cluster mode (2 instances, stateless JWT)
  *   socket-server     – Standalone Socket.io server, fork mode (single instance,
  *                       coordinates all real-time game state)
- *   worker-mint       – BullMQ worker: NFT minting
- *   worker-mint-end   – BullMQ worker: time-based mint window closure
- *   worker-dissolve   – BullMQ worker: account dissolution
- *   worker-achieve    – BullMQ worker: daily achievements
- *   guild-checker     – Cron: Discord guild member sync
+ *   worker-mint                   – BullMQ worker: NFT minting
+ *   worker-mint-end               – BullMQ worker: time-based mint window closure
+ *   worker-dissolve               – BullMQ worker: account dissolution
+ *   worker-dissolve-auction-launch – BullMQ worker: dissolve auction launch
+ *   worker-achieve                – BullMQ worker: daily achievements
+ *   guild-checker                 – Cron: Discord guild member sync
  *
  * Workers run as single fork-mode instances to prevent double-processing of jobs.
  */
@@ -117,6 +118,16 @@ module.exports = {
     {
       name:      'worker-dissolve',
       script:    'server/workers/dissolve.worker.js',
+      exec_mode: 'fork',
+      instances: 1,
+      env:             { NODE_ENV: 'production' },
+      env_development: { NODE_ENV: 'development' },
+    },
+
+    // ── BullMQ worker: dissolve auction launch ────────────────────────────
+    {
+      name:      'worker-dissolve-auction-launch',
+      script:    'server/workers/dissolve-auction-launch.worker.js',
       exec_mode: 'fork',
       instances: 1,
       env:             { NODE_ENV: 'production' },

--- a/ecosystem.dev.config.cjs
+++ b/ecosystem.dev.config.cjs
@@ -62,6 +62,15 @@ module.exports = {
       env: { NODE_ENV: 'development' },
     },
 
+    // ── BullMQ worker: dissolve auction launch ────────────────────────────
+    {
+      name:      'worker-dissolve-auction-launch',
+      script:    'server/workers/dissolve-auction-launch.worker.js',
+      exec_mode: 'fork',
+      instances: 1,
+      env: { NODE_ENV: 'development' },
+    },
+
     // ── BullMQ worker: daily achievements ─────────────────────────────────
     {
       name:      'worker-achieve',


### PR DESCRIPTION
Replaces the daily 50-per-day cron with a BullMQ-based system where admins
configure the release schedule (per-category counts + cadence) directly in
the dissolve modal. Pokémon and Crazy Rare toons are automatically marked as
featured auctions.

- Adds category, isFeatured, scheduledFor fields to DissolveAuctionQueue schema
- Dissolve worker now detects Pokemon/CR/Other category and sets isFeatured
- Schedule config (startAtUtc, cadenceDays, per-category counts) flows from
  the dissolve modal → API → worker → BullMQ delayed jobs per toon
- New dissolveAuctionLaunch worker creates the live Auction at scheduled time
- Removes the old processDissolveAuctionQueue daily cron entirely
- Admin dissolve modal now includes release schedule form with sensible defaults
- New /admin/dissolve-queue page for post-hoc management (view, reschedule, cancel)
- New admin API endpoints: GET /dissolve-queue, POST /dissolve-queue/schedule,
  DELETE /dissolve-queue/[id]

https://claude.ai/code/session_011UEs5eFQAH93mCmxe1Bg7V