### PR TITLE
Implement admin-scheduled dissolve auction queue release

### DIFF
--- a/pages/admin/users.vue
+++ b/pages/admin/users.vue
@@ -412,7 +412,7 @@
         </p>
         <p class="text-xs text-gray-500">Large accounts are processed in the background — you'll see progress here.</p>
 
-        <div class="mt-3 border-t pt-3 space-y-2">
+        <div class="mt-3 border-t pt-3 space-y-3">
           <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Release Schedule</p>
 
           <div class="flex items-center gap-2">
@@ -420,25 +420,65 @@
             <input v-model="dissolveSchedule.startAtLocal" type="datetime-local"
                    class="flex-1 text-xs border rounded px-2 py-1" />
           </div>
-          <div class="flex items-center gap-2">
-            <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
-            <input v-model.number="dissolveSchedule.cadenceDays" type="number" min="1"
-                   class="w-24 text-xs border rounded px-2 py-1" />
+
+          <!-- Pokémon category -->
+          <div class="rounded border border-blue-100 bg-blue-50 p-2 space-y-1.5">
+            <p class="text-xs font-medium text-blue-700">
+              Pokémon
+              <span class="ml-1 font-normal text-blue-500">
+                ({{ dissolveCategoryCounts ? dissolveCategoryCounts.pokemon : '…' }} sea tunes)
+              </span>
+            </p>
+            <div class="flex items-center gap-2">
+              <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
+              <input v-model.number="dissolveSchedule.pokemonCadenceDays" type="number" min="1"
+                     class="w-24 text-xs border rounded px-2 py-1" />
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="w-36 text-xs text-gray-600 shrink-0">Per cadence</label>
+              <input v-model.number="dissolveSchedule.pokemonPerCadence" type="number" min="1"
+                     class="w-24 text-xs border rounded px-2 py-1" />
+            </div>
           </div>
-          <div class="flex items-center gap-2">
-            <label class="w-36 text-xs text-gray-600 shrink-0">Pokémon / cadence</label>
-            <input v-model.number="dissolveSchedule.pokemonPerCadence" type="number" min="1"
-                   class="w-24 text-xs border rounded px-2 py-1" />
+
+          <!-- Crazy Rare category -->
+          <div class="rounded border border-purple-100 bg-purple-50 p-2 space-y-1.5">
+            <p class="text-xs font-medium text-purple-700">
+              Crazy Rare
+              <span class="ml-1 font-normal text-purple-500">
+                ({{ dissolveCategoryCounts ? dissolveCategoryCounts.crazyRare : '…' }} sea tunes)
+              </span>
+            </p>
+            <div class="flex items-center gap-2">
+              <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
+              <input v-model.number="dissolveSchedule.crazyRareCadenceDays" type="number" min="1"
+                     class="w-24 text-xs border rounded px-2 py-1" />
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="w-36 text-xs text-gray-600 shrink-0">Per cadence</label>
+              <input v-model.number="dissolveSchedule.crazyRarePerCadence" type="number" min="1"
+                     class="w-24 text-xs border rounded px-2 py-1" />
+            </div>
           </div>
-          <div class="flex items-center gap-2">
-            <label class="w-36 text-xs text-gray-600 shrink-0">Crazy Rare / cadence</label>
-            <input v-model.number="dissolveSchedule.crazyRarePerCadence" type="number" min="1"
-                   class="w-24 text-xs border rounded px-2 py-1" />
-          </div>
-          <div class="flex items-center gap-2">
-            <label class="w-36 text-xs text-gray-600 shrink-0">Other / cadence</label>
-            <input v-model.number="dissolveSchedule.otherPerCadence" type="number" min="1"
-                   class="w-24 text-xs border rounded px-2 py-1" />
+
+          <!-- Other category -->
+          <div class="rounded border border-gray-200 bg-gray-50 p-2 space-y-1.5">
+            <p class="text-xs font-medium text-gray-700">
+              Other
+              <span class="ml-1 font-normal text-gray-500">
+                ({{ dissolveCategoryCounts ? dissolveCategoryCounts.other : '…' }} sea tunes)
+              </span>
+            </p>
+            <div class="flex items-center gap-2">
+              <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
+              <input v-model.number="dissolveSchedule.otherCadenceDays" type="number" min="1"
+                     class="w-24 text-xs border rounded px-2 py-1" />
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="w-36 text-xs text-gray-600 shrink-0">Per cadence</label>
+              <input v-model.number="dissolveSchedule.otherPerCadence" type="number" min="1"
+                     class="w-24 text-xs border rounded px-2 py-1" />
+            </div>
           </div>
         </div>
       </div>
@@ -963,6 +1003,7 @@ const dissolvePhase = ref('confirm') // 'confirm' | 'working' | 'done'
 const dissolvePct = ref(0)
 const dissolveStep = ref('')
 const dissolveSummary = ref(null)
+const dissolveCategoryCounts = ref(null)
 let dissolvePoller = null
 
 function defaultStartLocal() {
@@ -974,15 +1015,21 @@ function defaultStartLocal() {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
-const dissolveSchedule = ref({
-  startAtLocal:        defaultStartLocal(),
-  cadenceDays:         7,
-  pokemonPerCadence:   2,
-  crazyRarePerCadence: 1,
-  otherPerCadence:     10,
-})
+function defaultDissolveSchedule() {
+  return {
+    startAtLocal:          defaultStartLocal(),
+    pokemonCadenceDays:    7,
+    pokemonPerCadence:     2,
+    crazyRareCadenceDays:  7,
+    crazyRarePerCadence:   1,
+    otherCadenceDays:      7,
+    otherPerCadence:       10,
+  }
+}
 
-function openDissolveModal(u) {
+const dissolveSchedule = ref(defaultDissolveSchedule())
+
+async function openDissolveModal(u) {
   dissolveTarget.value = u
   dissolveError.value = ''
   dissolveWorking.value = false
@@ -990,14 +1037,14 @@ function openDissolveModal(u) {
   dissolvePct.value = 0
   dissolveStep.value = ''
   dissolveSummary.value = null
-  dissolveSchedule.value = {
-    startAtLocal:        defaultStartLocal(),
-    cadenceDays:         7,
-    pokemonPerCadence:   2,
-    crazyRarePerCadence: 1,
-    otherPerCadence:     10,
-  }
+  dissolveCategoryCounts.value = null
+  dissolveSchedule.value = defaultDissolveSchedule()
   showDissolveModal.value = true
+  try {
+    dissolveCategoryCounts.value = await $fetch(`/api/admin/users/${u.id}/ctoon-categories`)
+  } catch {
+    // non-fatal — counts will show '…'
+  }
 }
 function closeDissolveModal() {
   if (dissolvePoller) { clearInterval(dissolvePoller); dissolvePoller = null }
@@ -1009,13 +1056,8 @@ function closeDissolveModal() {
   dissolvePct.value = 0
   dissolveStep.value = ''
   dissolveSummary.value = null
-  dissolveSchedule.value = {
-    startAtLocal:        defaultStartLocal(),
-    cadenceDays:         7,
-    pokemonPerCadence:   2,
-    crazyRarePerCadence: 1,
-    otherPerCadence:     10,
-  }
+  dissolveCategoryCounts.value = null
+  dissolveSchedule.value = defaultDissolveSchedule()
 }
 function parseDissolveError(e) {
   const statusMessage = e?.data?.statusMessage || ''
@@ -1067,11 +1109,13 @@ async function confirmDissolve() {
       method: 'POST',
       body: {
         scheduleConfig: {
-          startAtUtc:          new Date(s.startAtLocal).toISOString(),
-          cadenceDays:         s.cadenceDays,
-          pokemonPerCadence:   s.pokemonPerCadence,
-          crazyRarePerCadence: s.crazyRarePerCadence,
-          otherPerCadence:     s.otherPerCadence,
+          startAtUtc:            new Date(s.startAtLocal).toISOString(),
+          pokemonCadenceDays:    s.pokemonCadenceDays,
+          pokemonPerCadence:     s.pokemonPerCadence,
+          crazyRareCadenceDays:  s.crazyRareCadenceDays,
+          crazyRarePerCadence:   s.crazyRarePerCadence,
+          otherCadenceDays:      s.otherCadenceDays,
+          otherPerCadence:       s.otherPerCadence,
         }
       }
     })

--- a/server/api/admin/users/[id]/ctoon-categories.get.js
+++ b/server/api/admin/users/[id]/ctoon-categories.get.js
@@ -1,0 +1,38 @@
+// server/api/admin/users/[id]/ctoon-categories.get.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const { id } = event.context.params || {}
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing user id' })
+
+  const ctoons = await prisma.userCtoon.findMany({
+    where: { userId: id, burnedAt: null },
+    select: {
+      ctoon: { select: { series: true, rarity: true } }
+    }
+  })
+
+  let pokemon = 0, crazyRare = 0, other = 0
+
+  for (const uc of ctoons) {
+    const isPokemon   = (uc.ctoon?.series || '').toLowerCase() === 'pokemon'
+    const isCrazyRare = (uc.ctoon?.rarity || '').toLowerCase() === 'crazy rare'
+    if (isPokemon)        pokemon++
+    else if (isCrazyRare) crazyRare++
+    else                  other++
+  }
+
+  return { pokemon, crazyRare, other, total: ctoons.length }
+})

--- a/server/workers/dissolve.worker.js
+++ b/server/workers/dissolve.worker.js
@@ -256,13 +256,24 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
   // ── Step 9: Schedule dissolve auction launches ───────────────────────────
   const { scheduleConfig } = job.data
   if (scheduleConfig && queuedEntries.length) {
-    const { startAtUtc, cadenceDays, pokemonPerCadence, crazyRarePerCadence, otherPerCadence } = scheduleConfig
+    const {
+      startAtUtc,
+      pokemonCadenceDays,   pokemonPerCadence,
+      crazyRareCadenceDays, crazyRarePerCadence,
+      otherCadenceDays,     otherPerCadence,
+    } = scheduleConfig
     const startMs = new Date(startAtUtc).getTime()
 
     const perCategory = {
-      POKEMON:    Number(pokemonPerCadence)    || 0,
-      CRAZY_RARE: Number(crazyRarePerCadence)  || 0,
-      OTHER:      Number(otherPerCadence)      || 0,
+      POKEMON:    Number(pokemonPerCadence)   || 0,
+      CRAZY_RARE: Number(crazyRarePerCadence) || 0,
+      OTHER:      Number(otherPerCadence)     || 0,
+    }
+
+    const cadenceDaysPerCategory = {
+      POKEMON:    Number(pokemonCadenceDays)   || 0,
+      CRAZY_RARE: Number(crazyRareCadenceDays) || 0,
+      OTHER:      Number(otherCadenceDays)     || 0,
     }
 
     const grouped = { POKEMON: [], CRAZY_RARE: [], OTHER: [] }
@@ -270,8 +281,9 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
 
     for (const [cat, ids] of Object.entries(grouped)) {
       const countPerCadence = perCategory[cat]
-      if (!countPerCadence || !ids.length) continue
-      const intervalMs = (Number(cadenceDays) * 24 * 3600 * 1000) / countPerCadence
+      const cadenceDays     = cadenceDaysPerCategory[cat]
+      if (!countPerCadence || !cadenceDays || !ids.length) continue
+      const intervalMs = (cadenceDays * 24 * 3600 * 1000) / countPerCadence
 
       for (let i = 0; i < ids.length; i++) {
         const scheduledFor = new Date(startMs + i * intervalMs)


### PR DESCRIPTION
Replaces the daily 50-per-day cron with a BullMQ-based system where admins
configure the release schedule (per-category counts + cadence) directly in
the dissolve modal. Pokémon and Crazy Rare toons are automatically marked as
featured auctions.

- Adds category, isFeatured, scheduledFor fields to DissolveAuctionQueue schema
- Dissolve worker now detects Pokemon/CR/Other category and sets isFeatured
- Schedule config (startAtUtc, cadenceDays, per-category counts) flows from
  the dissolve modal → API → worker → BullMQ delayed jobs per toon
- New dissolveAuctionLaunch worker creates the live Auction at scheduled time
- Removes the old processDissolveAuctionQueue daily cron entirely
- Admin dissolve modal now includes release schedule form with sensible defaults
- New /admin/dissolve-queue page for post-hoc management (view, reschedule, cancel)
- New admin API endpoints: GET /dissolve-queue, POST /dissolve-queue/schedule,
  DELETE /dissolve-queue/[id]

https://claude.ai/code/session_011UEs5eFQAH93mCmxe1Bg7V