### PR TITLE
fix: enforce auth on all protected routes

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -11,13 +11,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     return
   }
 
-  // Only guard protected pages
-  const needsAuth =
-    to.meta?.requiresAuth ||
-    to.path.startsWith('/dashboard')
-
-  if (!needsAuth) return
-
+  // All non-home routes using this middleware require authentication
   if (!user.value) {
     try { await fetchSelf() } catch {}
   }

--- a/pages/achievements.vue
+++ b/pages/achievements.vue
@@ -80,7 +80,7 @@
 </template>
 
 <script setup>
-definePageMeta({ title: 'Achievements' })
+definePageMeta({ title: 'Achievements', middleware: 'auth' })
 
 const { data: achievements, pending } = await useFetch('/api/achievements')
 

--- a/pages/czone-contest/[id].vue
+++ b/pages/czone-contest/[id].vue
@@ -381,6 +381,8 @@
 </template>
 
 <script setup>
+definePageMeta({ middleware: 'auth', layout: 'default' })
+
 const route = useRoute()
 const contestId = route.params.id
 

--- a/pages/games/clash/tournaments/[id].vue
+++ b/pages/games/clash/tournaments/[id].vue
@@ -177,6 +177,7 @@ import { useAuth } from '@/composables/useAuth'
 
 definePageMeta({
   title: 'gToons Clash Tournament',
+  middleware: 'auth',
   layout: 'default'
 })
 

--- a/pages/games/clash/tournaments/index.vue
+++ b/pages/games/clash/tournaments/index.vue
@@ -62,6 +62,7 @@ import Nav from '@/components/Nav.vue'
 
 definePageMeta({
   title: 'gToons Clash Tournaments',
+  middleware: 'auth',
   layout: 'default'
 })
 


### PR DESCRIPTION
The auth middleware had a short-circuit that only enforced the auth
check when to.meta.requiresAuth was true or the path started with
/dashboard. This meant most pages with middleware: 'auth' in their
definePageMeta were actually accessible to unauthenticated users.

Removed the needsAuth guard so the middleware enforces authentication
for all non-home routes it is applied to.

Also added missing middleware: 'auth' to achievements, czone-contest,
and both clash tournament pages that had no auth guard at all.

https://claude.ai/code/session_01DXeDdq3sE4iBKKgkTSuxaq