### PR TITLE
Implement admin-scheduled dissolve auction queue release

### DIFF
--- a/pages/admin/dissolve-queue.vue
+++ b/pages/admin/dissolve-queue.vue
@@ -32,8 +32,13 @@
           <div v-for="entry in upcoming" :key="entry.id"
                class="px-4 py-3 text-sm">
             <div class="flex items-start gap-3">
+              <div class="shrink-0 w-10 h-10 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
+                <img v-if="entry.ctoonImage" :src="entry.ctoonImage" :alt="entry.ctoonName"
+                     class="w-full h-full object-contain" loading="lazy" />
+                <span v-else class="text-gray-300 text-lg">?</span>
+              </div>
               <div class="flex-1 min-w-0">
-                <div class="font-medium truncate">{{ entry.ctoonName || '—' }}</div>
+                <div class="font-medium truncate" :title="entry.ctoonName">{{ entry.ctoonName || '—' }}</div>
                 <div class="text-xs text-gray-500 mt-0.5">
                   {{ entry.rarity }}
                   <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>

--- a/pages/admin/dissolve-queue.vue
+++ b/pages/admin/dissolve-queue.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gray-50 p-6 mt-16 md:mt-20">
+  <div class="min-h-screen bg-gray-50 p-3 sm:p-6 mt-16 md:mt-20">
     <Nav />
 
     <div class="max-w-5xl mx-auto mt-6 space-y-6">
@@ -30,60 +30,65 @@
         </div>
         <div v-if="upcoming.length" class="divide-y">
           <div v-for="entry in upcoming" :key="entry.id"
-               class="flex items-center gap-3 px-4 py-3 text-sm">
-            <div class="flex-1 min-w-0">
-              <div class="font-medium truncate">{{ entry.ctoonName || '—' }}</div>
-              <div class="text-xs text-gray-500">
-                {{ entry.rarity }}
-                <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>
-                <span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium"
-                      :class="categoryChip(entry.category)">{{ entry.category }}</span>
-                <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
+               class="px-4 py-3 text-sm">
+            <div class="flex items-start gap-3">
+              <div class="flex-1 min-w-0">
+                <div class="font-medium truncate">{{ entry.ctoonName || '—' }}</div>
+                <div class="text-xs text-gray-500 mt-0.5">
+                  {{ entry.rarity }}
+                  <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>
+                  <span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium"
+                        :class="categoryChip(entry.category)">{{ entry.category }}</span>
+                  <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
+                </div>
+                <div class="text-xs text-gray-500 mt-1 sm:hidden">{{ fmtCST(entry.scheduledFor) }}</div>
+              </div>
+              <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 shrink-0">
+                <div class="hidden sm:block text-xs text-gray-600">{{ fmtCST(entry.scheduledFor) }}</div>
+                <button
+                  @click="cancelEntry(entry.id)"
+                  class="text-xs text-red-500 hover:text-red-700"
+                  :disabled="cancellingId === entry.id"
+                >{{ cancellingId === entry.id ? '…' : 'Unschedule' }}</button>
               </div>
             </div>
-            <div class="text-xs text-gray-600 shrink-0">{{ fmtCST(entry.scheduledFor) }}</div>
-            <button
-              @click="cancelEntry(entry.id)"
-              class="text-xs text-red-500 hover:text-red-700 shrink-0"
-              :disabled="cancellingId === entry.id"
-            >{{ cancellingId === entry.id ? '…' : 'Unschedule' }}</button>
           </div>
         </div>
         <div v-else class="p-6 text-center text-sm text-gray-400">No upcoming scheduled auctions</div>
       </div>
 
       <!-- Reschedule All form -->
-      <div class="bg-white rounded-lg shadow p-5">
+      <div class="bg-white rounded-lg shadow p-4 sm:p-5">
         <h2 class="font-semibold mb-1">Reschedule All</h2>
         <p class="text-xs text-gray-500 mb-4">
           Set a new schedule for all unscheduled entries. Toggle "Reschedule all" to also reset existing scheduled entries.
         </p>
 
-        <div class="space-y-3 max-w-sm">
-          <div class="flex items-center gap-2">
-            <label class="w-40 text-xs text-gray-600 shrink-0">Start date (local)</label>
+        <div class="space-y-3">
+          <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+            <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Start date (local)</label>
             <input v-model="form.startAtLocal" type="datetime-local"
-                   class="flex-1 text-xs border rounded px-2 py-1" />
+                   class="w-full sm:flex-1 text-xs border rounded px-2 py-1.5" />
           </div>
-          <div class="flex items-center gap-2">
-            <label class="w-40 text-xs text-gray-600 shrink-0">Cadence (days)</label>
+          <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+            <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Cadence (days)</label>
             <input v-model.number="form.cadenceDays" type="number" min="1"
-                   class="w-24 text-xs border rounded px-2 py-1" />
+                   class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
           </div>
-          <div class="flex items-center gap-2">
-            <label class="w-40 text-xs text-gray-600 shrink-0">Pokémon / cadence</label>
+          <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+            <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Pokémon / cadence</label>
             <input v-model.number="form.pokemonPerCadence" type="number" min="1"
-                   class="w-24 text-xs border rounded px-2 py-1" />
+                   class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
           </div>
-          <div class="flex items-center gap-2">
-            <label class="w-40 text-xs text-gray-600 shrink-0">Crazy Rare / cadence</label>
+          <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+            <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Crazy Rare / cadence</label>
             <input v-model.number="form.crazyRarePerCadence" type="number" min="1"
-                   class="w-24 text-xs border rounded px-2 py-1" />
+                   class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
           </div>
-          <div class="flex items-center gap-2">
-            <label class="w-40 text-xs text-gray-600 shrink-0">Other / cadence</label>
+          <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+            <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Other / cadence</label>
             <input v-model.number="form.otherPerCadence" type="number" min="1"
-                   class="w-24 text-xs border rounded px-2 py-1" />
+                   class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
           </div>
           <div class="flex items-center gap-2">
             <input v-model="form.reschedule" type="checkbox" id="reschedule-all"
@@ -101,7 +106,7 @@
           <button
             @click="applySchedule"
             :disabled="scheduling"
-            class="px-4 py-2 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+            class="w-full sm:w-auto px-4 py-2 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
           >{{ scheduling ? 'Scheduling…' : 'Apply Schedule' }}</button>
         </div>
       </div>

--- a/server/api/admin/dissolve-queue/index.get.js
+++ b/server/api/admin/dissolve-queue/index.get.js
@@ -18,7 +18,7 @@ export default defineEventHandler(async (event) => {
         select: {
           id: true,
           mintNumber: true,
-          ctoon: { select: { name: true, rarity: true, series: true } }
+          ctoon: { select: { name: true, rarity: true, series: true, assetPath: true } }
         }
       }
     },
@@ -49,6 +49,7 @@ export default defineEventHandler(async (event) => {
       scheduledFor: e.scheduledFor,
       createdAt:   e.createdAt,
       ctoonName:   e.userCtoon?.ctoon?.name,
+      ctoonImage:  e.userCtoon?.ctoon?.assetPath,
       rarity:      e.userCtoon?.ctoon?.rarity,
       series:      e.userCtoon?.ctoon?.series,
       mintNumber:  e.userCtoon?.mintNumber,


### PR DESCRIPTION
Replaces the daily 50-per-day cron with a BullMQ-based system where admins
configure the release schedule (per-category counts + cadence) directly in
the dissolve modal. Pokémon and Crazy Rare toons are automatically marked as
featured auctions.

- Adds category, isFeatured, scheduledFor fields to DissolveAuctionQueue schema
- Dissolve worker now detects Pokemon/CR/Other category and sets isFeatured
- Schedule config (startAtUtc, cadenceDays, per-category counts) flows from
  the dissolve modal → API → worker → BullMQ delayed jobs per toon
- New dissolveAuctionLaunch worker creates the live Auction at scheduled time
- Removes the old processDissolveAuctionQueue daily cron entirely
- Admin dissolve modal now includes release schedule form with sensible defaults
- New /admin/dissolve-queue page for post-hoc management (view, reschedule, cancel)
- New admin API endpoints: GET /dissolve-queue, POST /dissolve-queue/schedule,
  DELETE /dissolve-queue/[id]

https://claude.ai/code/session_011UEs5eFQAH93mCmxe1Bg7V