### PR TITLE
Implement admin-scheduled dissolve auction queue release

### DIFF
--- a/components/Nav.vue
+++ b/components/Nav.vue
@@ -333,6 +333,7 @@ const adminGroups = [
       { label: 'Manage Scavenger Hunt', to: '/admin/scavenger' },
           { label: 'Manage Holiday Events', to: '/admin/holidayevents' },
           { label: 'Manage Auction Only', to: '/admin/manage-auctions' },
+          { label: 'Dissolved Queue', to: '/admin/dissolved-queue' },
       { label: 'Manage Achievements', to: '/admin/achievements' },
       { label: 'Manage cZone Contests', to: '/admin/czone-contest' }
     ]


### PR DESCRIPTION
Replaces the daily 50-per-day cron with a BullMQ-based system where admins
configure the release schedule (per-category counts + cadence) directly in
the dissolve modal. Pokémon and Crazy Rare toons are automatically marked as
featured auctions.

- Adds category, isFeatured, scheduledFor fields to DissolveAuctionQueue schema
- Dissolve worker now detects Pokemon/CR/Other category and sets isFeatured
- Schedule config (startAtUtc, cadenceDays, per-category counts) flows from
  the dissolve modal → API → worker → BullMQ delayed jobs per toon
- New dissolveAuctionLaunch worker creates the live Auction at scheduled time
- Removes the old processDissolveAuctionQueue daily cron entirely
- Admin dissolve modal now includes release schedule form with sensible defaults
- New /admin/dissolve-queue page for post-hoc management (view, reschedule, cancel)
- New admin API endpoints: GET /dissolve-queue, POST /dissolve-queue/schedule,
  DELETE /dissolve-queue/[id]

https://claude.ai/code/session_011UEs5eFQAH93mCmxe1Bg7V