### PR TITLE
Show submitted cToon images at actual size on admin page

### DIFF
--- a/pages/admin/submitted-ctoons.vue
+++ b/pages/admin/submitted-ctoons.vue
@@ -74,7 +74,7 @@
             <div class="shrink-0">
               <img
                 :src="sub.assetPath"
-                class="w-24 h-24 object-contain border rounded bg-gray-50"
+                class="max-w-full h-auto border rounded bg-gray-50"
                 :alt="sub.name"
               />
               <div class="mt-2 text-center">

--- a/pages/admin/submitted-ctoons.vue
+++ b/pages/admin/submitted-ctoons.vue
@@ -74,7 +74,7 @@
             <div class="shrink-0">
               <img
                 :src="sub.assetPath"
-                class="max-w-full h-auto border rounded bg-gray-50"
+                class="border rounded bg-gray-50"
                 :alt="sub.name"
               />
               <div class="mt-2 text-center">


### PR DESCRIPTION
Replace fixed 96x96px box with max-w-full/h-auto so images
render at their natural dimensions on all devices.

https://claude.ai/code/session_01Ugd1ooyAPFeKsem8vyHmvF