### PR TITLE
Add bulk approve/reject for cToon suggestions

### DIFF
--- a/pages/admin/ctoon-suggestions.vue
+++ b/pages/admin/ctoon-suggestions.vue
@@ -40,9 +40,17 @@
       </div>
 
       <div v-else>
+        <!-- Mobile cards -->
         <div class="space-y-3 md:hidden">
           <div v-for="s in suggestions" :key="s.id" class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
             <div class="flex items-start gap-3">
+              <input
+                v-if="activeTab === 'IN_REVIEW'"
+                type="checkbox"
+                class="mt-1 h-4 w-4 flex-shrink-0 rounded border-gray-300 text-blue-600 cursor-pointer"
+                :checked="selectedIds.has(s.id)"
+                @change="toggleSelection(s.id)"
+              />
               <img
                 v-if="s.ctoon?.assetPath"
                 :src="s.ctoon.assetPath"
@@ -73,10 +81,20 @@
           </div>
         </div>
 
+        <!-- Desktop table -->
         <div class="hidden md:block overflow-x-auto">
           <table class="min-w-full table-auto border-collapse">
             <thead>
               <tr class="bg-gray-100">
+                <th v-if="activeTab === 'IN_REVIEW'" class="px-4 py-2 w-10">
+                  <input
+                    ref="selectAllCheckboxRef"
+                    type="checkbox"
+                    class="h-4 w-4 rounded border-gray-300 text-blue-600 cursor-pointer"
+                    :checked="allSelected"
+                    @change="toggleAll"
+                  />
+                </th>
                 <th class="px-4 py-2 text-left">cToon</th>
                 <th class="px-4 py-2 text-left">Suggested By</th>
                 <th class="px-4 py-2 text-left">Submitted</th>
@@ -86,6 +104,14 @@
             </thead>
             <tbody>
               <tr v-for="s in suggestions" :key="s.id" class="border-b">
+                <td v-if="activeTab === 'IN_REVIEW'" class="px-4 py-2 w-10">
+                  <input
+                    type="checkbox"
+                    class="h-4 w-4 rounded border-gray-300 text-blue-600 cursor-pointer"
+                    :checked="selectedIds.has(s.id)"
+                    @change="toggleSelection(s.id)"
+                  />
+                </td>
                 <td class="px-4 py-2">
                   <div class="flex items-center gap-3">
                     <img
@@ -143,6 +169,7 @@
       </div>
     </div>
 
+    <!-- Individual review modal -->
     <Modal
       v-if="selectedSuggestion"
       :hide-close-button="true"
@@ -228,23 +255,23 @@
         <div class="pt-4 border-t border-white/10 flex items-center justify-end gap-3 shrink-0">
           <button
             class="bg-gray-600 hover:bg-gray-700 text-white px-3 py-2 rounded text-sm"
-            @click="closeReview"
             :disabled="actionLoading"
+            @click="closeReview"
           >
             Close
           </button>
           <template v-if="canReview">
             <button
               class="bg-red-600 hover:bg-red-700 text-white px-3 py-2 rounded text-sm disabled:opacity-50"
-              @click="rejectSuggestion"
               :disabled="actionLoading"
+              @click="rejectSuggestion"
             >
               {{ actionLoading ? 'Working...' : 'Reject' }}
             </button>
             <button
               class="bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded text-sm disabled:opacity-50"
-              @click="acceptSuggestion"
               :disabled="actionLoading"
+              @click="acceptSuggestion"
             >
               {{ actionLoading ? 'Working...' : 'Accept' }}
             </button>
@@ -252,13 +279,93 @@
         </div>
       </div>
     </Modal>
+
+    <!-- Bulk reject modal -->
+    <Modal
+      v-if="bulkRejectModalOpen"
+      :hide-close-button="true"
+      :close-on-backdrop="!bulkActionLoading"
+      @close="closeBulkRejectModal"
+    >
+      <div class="text-white flex flex-col">
+        <div class="pb-4 border-b border-white/10">
+          <h3 class="text-xl font-semibold">
+            Bulk Reject {{ selectedIds.size }} Suggestion{{ selectedIds.size !== 1 ? 's' : '' }}
+          </h3>
+          <p class="text-sm text-gray-300 mt-1">This rejection reason will be sent to each user via Discord.</p>
+        </div>
+        <div class="py-4">
+          <label class="block text-xs uppercase text-gray-300 mb-2" for="bulk-reject-reason">
+            Rejection reason (required)
+          </label>
+          <textarea
+            id="bulk-reject-reason"
+            v-model="bulkRejectReason"
+            class="w-full rounded bg-gray-900/70 text-gray-100 p-2 text-sm border border-gray-600 focus:outline-none focus:ring-2 focus:ring-red-400/60"
+            rows="4"
+            placeholder="Share the key reason for rejection..."
+            :disabled="bulkActionLoading"
+          />
+          <div v-if="bulkActionError" class="text-sm text-red-300 mt-2">{{ bulkActionError }}</div>
+        </div>
+        <div class="pt-4 border-t border-white/10 flex items-center justify-end gap-3">
+          <button
+            class="bg-gray-600 hover:bg-gray-700 text-white px-3 py-2 rounded text-sm disabled:opacity-50"
+            :disabled="bulkActionLoading"
+            @click="closeBulkRejectModal"
+          >
+            Cancel
+          </button>
+          <button
+            class="bg-red-600 hover:bg-red-700 text-white px-3 py-2 rounded text-sm disabled:opacity-50"
+            :disabled="bulkActionLoading"
+            @click="confirmBulkReject"
+          >
+            {{ bulkActionLoading ? 'Rejecting...' : `Reject ${selectedIds.size}` }}
+          </button>
+        </div>
+      </div>
+    </Modal>
+
+    <!-- Floating bulk action bar -->
+    <Transition name="slide-up">
+      <div
+        v-if="activeTab === 'IN_REVIEW' && selectedIds.size > 0"
+        class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-xl bg-gray-900 px-5 py-3 shadow-2xl border border-gray-700"
+      >
+        <span class="text-sm text-white font-medium whitespace-nowrap">
+          {{ selectedIds.size }} selected
+        </span>
+        <button
+          class="text-xs text-gray-400 hover:text-gray-200 underline whitespace-nowrap"
+          @click="clearSelection"
+        >
+          Clear
+        </button>
+        <div class="w-px h-5 bg-gray-600" />
+        <button
+          class="bg-green-600 hover:bg-green-700 text-white px-4 py-1.5 rounded-md text-sm font-medium disabled:opacity-50 whitespace-nowrap"
+          :disabled="bulkActionLoading"
+          @click="bulkAccept"
+        >
+          {{ bulkActionLoading ? 'Working...' : 'Approve' }}
+        </button>
+        <button
+          class="bg-red-600 hover:bg-red-700 text-white px-4 py-1.5 rounded-md text-sm font-medium disabled:opacity-50 whitespace-nowrap"
+          :disabled="bulkActionLoading"
+          @click="openBulkRejectModal"
+        >
+          Reject
+        </button>
+      </div>
+    </Transition>
   </div>
 </template>
 
 <script setup>
 definePageMeta({ title: 'Admin - cToon Suggestions', middleware: ['auth', 'admin'], layout: 'default' })
 
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watchEffect } from 'vue'
 import Nav from '~/components/Nav.vue'
 import Modal from '~/components/Modal.vue'
 
@@ -273,8 +380,22 @@ const selectedSuggestion = ref(null)
 const actionLoading = ref(false)
 const actionError = ref('')
 const rejectReason = ref('')
+
+// Bulk selection state
+const selectedIds = ref(new Set())
+const selectAllCheckboxRef = ref(null)
+const bulkRejectModalOpen = ref(false)
+const bulkRejectReason = ref('')
+const bulkActionLoading = ref(false)
+const bulkActionError = ref('')
+
 const canReview = computed(() => selectedSuggestion.value?.status === 'IN_REVIEW')
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const allSelected = computed(() =>
+  suggestions.value.length > 0 && suggestions.value.every(s => selectedIds.value.has(s.id))
+)
+const someSelected = computed(() => selectedIds.value.size > 0 && !allSelected.value)
+
 const showingRange = computed(() => {
   if (!total.value) return '0-0 of 0'
   const start = (page.value - 1) * pageSize + 1
@@ -286,6 +407,32 @@ const headerDescription = computed(() => (
     ? 'Browse accepted and rejected cToon suggestion history.'
     : 'Review community-submitted updates that are in review.'
 ))
+
+// Keep the select-all checkbox indeterminate when only some rows are checked
+watchEffect(() => {
+  if (selectAllCheckboxRef.value) {
+    selectAllCheckboxRef.value.indeterminate = someSelected.value
+  }
+})
+
+function clearSelection() {
+  selectedIds.value = new Set()
+}
+
+function toggleSelection(id) {
+  const next = new Set(selectedIds.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selectedIds.value = next
+}
+
+function toggleAll() {
+  if (allSelected.value) {
+    clearSelection()
+  } else {
+    selectedIds.value = new Set(suggestions.value.map(s => s.id))
+  }
+}
 
 async function fetchSuggestions() {
   loading.value = true
@@ -339,6 +486,7 @@ function setTab(tab) {
   if (activeTab.value === tab) return
   activeTab.value = tab
   page.value = 1
+  clearSelection()
   closeReview()
   fetchSuggestions()
 }
@@ -346,12 +494,14 @@ function setTab(tab) {
 function nextPage() {
   if (page.value >= totalPages.value) return
   page.value += 1
+  clearSelection()
   fetchSuggestions()
 }
 
 function prevPage() {
   if (page.value <= 1) return
   page.value -= 1
+  clearSelection()
   fetchSuggestions()
 }
 
@@ -408,6 +558,74 @@ async function rejectSuggestion() {
   }
 }
 
+function openBulkRejectModal() {
+  bulkActionError.value = ''
+  bulkRejectReason.value = ''
+  bulkRejectModalOpen.value = true
+}
+
+function closeBulkRejectModal() {
+  if (bulkActionLoading.value) return
+  bulkRejectModalOpen.value = false
+  bulkRejectReason.value = ''
+  bulkActionError.value = ''
+}
+
+async function bulkAccept() {
+  if (!selectedIds.value.size || bulkActionLoading.value) return
+  bulkActionLoading.value = true
+  bulkActionError.value = ''
+  try {
+    const res = await fetch('/api/admin/ctoon-suggestions/bulk-accept', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [...selectedIds.value] })
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data?.statusMessage || 'Failed to accept suggestions')
+    }
+    clearSelection()
+    await fetchSuggestions()
+  } catch (err) {
+    bulkActionError.value = err?.message || 'Failed to accept suggestions'
+  } finally {
+    bulkActionLoading.value = false
+  }
+}
+
+async function confirmBulkReject() {
+  if (!selectedIds.value.size || bulkActionLoading.value) return
+  const reason = bulkRejectReason.value.trim()
+  if (!reason) {
+    bulkActionError.value = 'Please enter a rejection reason.'
+    return
+  }
+  bulkActionLoading.value = true
+  bulkActionError.value = ''
+  try {
+    const res = await fetch('/api/admin/ctoon-suggestions/bulk-reject', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [...selectedIds.value], reason })
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data?.statusMessage || 'Failed to reject suggestions')
+    }
+    bulkRejectModalOpen.value = false
+    bulkRejectReason.value = ''
+    clearSelection()
+    await fetchSuggestions()
+  } catch (err) {
+    bulkActionError.value = err?.message || 'Failed to reject suggestions'
+  } finally {
+    bulkActionLoading.value = false
+  }
+}
+
 function formatValue(value) {
   if (value === null || value === undefined || value === '') return 'N/A'
   return value
@@ -441,3 +659,15 @@ function formatStatus(value) {
 
 onMounted(fetchSuggestions)
 </script>
+
+<style scoped>
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.slide-up-enter-from,
+.slide-up-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(0.75rem);
+}
+</style>

--- a/server/api/admin/ctoon-suggestions/bulk-accept.post.js
+++ b/server/api/admin/ctoon-suggestions/bulk-accept.post.js
@@ -1,0 +1,102 @@
+import { defineEventHandler, getRequestHeader, createError, readBody } from 'h3'
+import { prisma } from '@/server/prisma'
+import { sendDiscordDMByDiscordId } from '@/server/utils/discord'
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeCharacters(value) {
+  if (!Array.isArray(value)) return []
+  return value
+    .map(v => String(v || '').trim())
+    .filter(Boolean)
+}
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event).catch(() => ({}))
+  const ids = Array.isArray(body?.ids)
+    ? body.ids.filter(id => typeof id === 'string' && id.trim())
+    : []
+
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  if (!ids.length) throw createError({ statusCode: 400, statusMessage: 'No suggestion IDs provided' })
+
+  // Fetch all IN_REVIEW candidates up front
+  const candidates = await prisma.ctoonUserSuggestion.findMany({
+    where: { id: { in: ids }, status: 'IN_REVIEW' },
+    include: {
+      user: { select: { id: true, discordId: true } },
+      ctoon: { select: { id: true, name: true } }
+    }
+  })
+
+  // Map: userId -> { discordId, count }
+  const userAccepted = new Map()
+
+  for (const suggestion of candidates) {
+    const newValues = suggestion.newValues || {}
+    const name = normalizeString(newValues.name)
+    const series = normalizeString(newValues.series)
+    const set = normalizeString(newValues.set)
+    const characters = normalizeCharacters(newValues.characters)
+    const descriptionProvided = Object.prototype.hasOwnProperty.call(newValues, 'description')
+    const descriptionValue = descriptionProvided && typeof newValues.description === 'string'
+      ? newValues.description.trim()
+      : ''
+    const description = descriptionProvided ? (descriptionValue || null) : null
+
+    // Skip suggestions with incomplete data
+    if (!name || !series || !set || !characters.length) continue
+
+    const updateData = { name, series, set, characters }
+    if (descriptionProvided) updateData.description = description
+
+    try {
+      const accepted = await prisma.$transaction(async (tx) => {
+        // Re-check status inside the transaction to guard against concurrent processing
+        const current = await tx.ctoonUserSuggestion.findUnique({
+          where: { id: suggestion.id },
+          select: { status: true }
+        })
+        if (!current || current.status !== 'IN_REVIEW') return false
+
+        await tx.ctoon.update({ where: { id: suggestion.ctoonId }, data: updateData })
+        await tx.ctoonUserSuggestion.update({
+          where: { id: suggestion.id },
+          data: { status: 'ACCEPTED' }
+        })
+        return true
+      })
+
+      if (!accepted) continue
+
+      const userId = suggestion.user?.id
+      const discordId = suggestion.user?.discordId
+      if (userId) {
+        if (!userAccepted.has(userId)) {
+          userAccepted.set(userId, { discordId, count: 0 })
+        }
+        userAccepted.get(userId).count++
+      }
+    } catch {
+      // Skip this suggestion if the transaction fails (e.g., concurrent modification)
+      continue
+    }
+  }
+
+  // Send one Discord DM per unique user summarising how many were accepted
+  for (const { discordId, count } of userAccepted.values()) {
+    if (!discordId) continue
+    const were = count !== 1 ? 'were' : 'was'
+    const plural = count !== 1 ? 's' : ''
+    const message = `✅ ${count} of your cToon suggestion${plural} ${were} accepted! We appreciate you contributing to the community.`
+    await sendDiscordDMByDiscordId(discordId, message).catch(() => {})
+  }
+
+  const processed = [...userAccepted.values()].reduce((sum, u) => sum + u.count, 0)
+  return { success: true, processed }
+})

--- a/server/api/admin/ctoon-suggestions/bulk-reject.post.js
+++ b/server/api/admin/ctoon-suggestions/bulk-reject.post.js
@@ -1,0 +1,78 @@
+import { defineEventHandler, getRequestHeader, createError, readBody } from 'h3'
+import { prisma } from '@/server/prisma'
+import { sendDiscordDMByDiscordId } from '@/server/utils/discord'
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event).catch(() => ({}))
+  const ids = Array.isArray(body?.ids)
+    ? body.ids.filter(id => typeof id === 'string' && id.trim())
+    : []
+  const reason = normalizeString(body?.reason)
+
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  if (!ids.length) throw createError({ statusCode: 400, statusMessage: 'No suggestion IDs provided' })
+  if (!reason) throw createError({ statusCode: 400, statusMessage: 'Rejection reason required' })
+
+  // Fetch all IN_REVIEW candidates up front
+  const candidates = await prisma.ctoonUserSuggestion.findMany({
+    where: { id: { in: ids }, status: 'IN_REVIEW' },
+    include: {
+      user: { select: { id: true, discordId: true } }
+    }
+  })
+
+  // Map: userId -> { discordId, count }
+  const userRejected = new Map()
+
+  for (const suggestion of candidates) {
+    try {
+      const rejected = await prisma.$transaction(async (tx) => {
+        // Re-check status inside the transaction to guard against concurrent processing
+        const current = await tx.ctoonUserSuggestion.findUnique({
+          where: { id: suggestion.id },
+          select: { status: true }
+        })
+        if (!current || current.status !== 'IN_REVIEW') return false
+
+        await tx.ctoonUserSuggestion.update({
+          where: { id: suggestion.id },
+          data: { status: 'REJECTED', rejectionReason: reason }
+        })
+        return true
+      })
+
+      if (!rejected) continue
+
+      const userId = suggestion.user?.id
+      const discordId = suggestion.user?.discordId
+      if (userId) {
+        if (!userRejected.has(userId)) {
+          userRejected.set(userId, { discordId, count: 0 })
+        }
+        userRejected.get(userId).count++
+      }
+    } catch {
+      // Skip this suggestion if the transaction fails (e.g., concurrent modification)
+      continue
+    }
+  }
+
+  // Send one Discord DM per unique user summarising how many were rejected
+  for (const { discordId, count } of userRejected.values()) {
+    if (!discordId) continue
+    const were = count !== 1 ? 'were' : 'was'
+    const plural = count !== 1 ? 's' : ''
+    const message = `${count} of your cToon suggestion${plural} ${were} reviewed and couldn't be accepted.\nReason: ${reason}\nWe appreciate you contributing to the community!`
+    await sendDiscordDMByDiscordId(discordId, message).catch(() => {})
+  }
+
+  const processed = [...userRejected.values()].reduce((sum, u) => sum + u.count, 0)
+  return { success: true, processed }
+})


### PR DESCRIPTION
- Checkboxes on each row (In Review tab only) with select-all in table header
- Floating sticky action bar appears when any suggestions are selected
- Bulk approve sends one Discord DM per user with count of accepted suggestions
- Bulk reject opens a modal for a shared rejection reason, sends one Discord DM per user with count
- Both bulk endpoints re-check IN_REVIEW status inside each transaction to safely skip already-processed suggestions
- Selections clear on tab/page change and after successful bulk actions

https://claude.ai/code/session_01SPUdTZG4YTEf1WdTKx6M7b