### PR TITLE
Add search, autocomplete, and pagination to dissolve queue admin page

### DIFF
--- a/pages/admin/dissolve-queue.vue
+++ b/pages/admin/dissolve-queue.vue
@@ -62,6 +62,118 @@
         <div v-else class="p-6 text-center text-sm text-gray-400">No upcoming scheduled auctions</div>
       </div>
 
+      <!-- All Queue Entries (search + pagination) -->
+      <div class="bg-white rounded-lg shadow">
+        <div class="p-4 border-b">
+          <h2 class="font-semibold">All Queue Entries</h2>
+          <p class="text-xs text-gray-500 mt-0.5">
+            <template v-if="searchQuery.length > 0">
+              {{ filteredEntries.length }} of {{ allEntries.length }} entries match
+            </template>
+            <template v-else>
+              {{ allEntries.length }} total entries
+            </template>
+          </p>
+        </div>
+
+        <!-- Search bar with autocomplete -->
+        <div class="p-4 border-b" ref="searchContainer">
+          <div class="relative w-full sm:w-80">
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="Search by cToon name…"
+              class="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 pr-8 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              @focus="showSuggestions = searchQuery.trim().length >= 3"
+              @keydown.escape="showSuggestions = false"
+            />
+            <button
+              v-if="searchQuery"
+              @click="clearSearch"
+              class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 text-xl leading-none"
+            >×</button>
+
+            <!-- Autocomplete dropdown -->
+            <div
+              v-if="showSuggestions && searchSuggestions.length"
+              class="absolute z-20 top-full mt-1 left-0 w-full sm:w-96 bg-white border border-gray-200 rounded-lg shadow-lg max-h-72 overflow-y-auto"
+            >
+              <button
+                v-for="suggestion in searchSuggestions"
+                :key="suggestion.id"
+                @mousedown.prevent="selectSuggestion(suggestion)"
+                class="w-full flex items-center gap-3 px-3 py-2 hover:bg-gray-50 text-left"
+              >
+                <div class="shrink-0 w-9 h-9 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
+                  <img v-if="suggestion.ctoonImage" :src="suggestion.ctoonImage" :alt="suggestion.ctoonName"
+                       class="w-full h-full object-contain" loading="lazy" />
+                  <span v-else class="text-gray-300 text-sm">?</span>
+                </div>
+                <div class="min-w-0 flex-1">
+                  <div class="text-sm font-medium truncate">{{ suggestion.ctoonName || '—' }}</div>
+                  <div class="text-xs text-gray-500">Mint #{{ suggestion.mintNumber ?? '?' }}</div>
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Entries list -->
+        <div v-if="paginatedEntries.length" class="divide-y">
+          <div v-for="entry in paginatedEntries" :key="entry.id" class="px-4 py-3 text-sm">
+            <div class="flex items-start gap-3">
+              <div class="shrink-0 w-10 h-10 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
+                <img v-if="entry.ctoonImage" :src="entry.ctoonImage" :alt="entry.ctoonName"
+                     class="w-full h-full object-contain" loading="lazy" />
+                <span v-else class="text-gray-300 text-lg">?</span>
+              </div>
+              <div class="flex-1 min-w-0">
+                <div class="font-medium truncate" :title="entry.ctoonName">{{ entry.ctoonName || '—' }}</div>
+                <div class="text-xs text-gray-500 mt-0.5">
+                  {{ entry.rarity }}
+                  <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>
+                  <span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium"
+                        :class="categoryChip(entry.category)">{{ entry.category }}</span>
+                  <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
+                </div>
+                <div class="text-xs text-gray-500 mt-1">
+                  {{ entry.scheduledFor ? fmtCST(entry.scheduledFor) : 'Not scheduled' }}
+                </div>
+              </div>
+              <div class="shrink-0">
+                <button
+                  v-if="entry.scheduledFor"
+                  @click="cancelEntry(entry.id)"
+                  class="text-xs text-red-500 hover:text-red-700"
+                  :disabled="cancellingId === entry.id"
+                >{{ cancellingId === entry.id ? '…' : 'Unschedule' }}</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div v-else class="p-6 text-center text-sm text-gray-400">
+          {{ searchQuery.length > 0 ? 'No entries match your search' : 'No entries in the dissolve queue' }}
+        </div>
+
+        <!-- Pagination -->
+        <div v-if="totalPages > 1" class="p-4 border-t flex items-center justify-between">
+          <div class="text-xs text-gray-500">
+            Showing {{ (currentPage - 1) * pageSize + 1 }}–{{ Math.min(currentPage * pageSize, filteredEntries.length) }} of {{ filteredEntries.length }}
+          </div>
+          <div class="flex items-center gap-1">
+            <button @click="goToPage(1)" :disabled="currentPage === 1"
+                    class="px-2 py-1 text-xs rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50 disabled:cursor-not-allowed">«</button>
+            <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1"
+                    class="px-2 py-1 text-xs rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50 disabled:cursor-not-allowed">‹</button>
+            <span class="px-3 text-xs text-gray-600">{{ currentPage }} / {{ totalPages }}</span>
+            <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages"
+                    class="px-2 py-1 text-xs rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50 disabled:cursor-not-allowed">›</button>
+            <button @click="goToPage(totalPages)" :disabled="currentPage === totalPages"
+                    class="px-2 py-1 text-xs rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50 disabled:cursor-not-allowed">»</button>
+          </div>
+        </div>
+      </div>
+
       <!-- Reschedule All form -->
       <div class="bg-white rounded-lg shadow p-4 sm:p-5">
         <h2 class="font-semibold mb-1">Reschedule All</h2>
@@ -120,7 +232,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useRequestHeaders } from '#app'
 import Nav from '~/components/Nav.vue'
 
@@ -128,14 +240,72 @@ definePageMeta({ title: 'Admin - Dissolve Queue', middleware: ['auth', 'admin'],
 
 const headers = process.server ? useRequestHeaders(['cookie']) : undefined
 
-const stats    = ref(null)
-const upcoming = ref([])
+const stats      = ref(null)
+const upcoming   = ref([])
+const allEntries = ref([])
+
+// Search
+const searchQuery     = ref('')
+const showSuggestions = ref(false)
+const searchContainer = ref(null)
+
+// Pagination
+const currentPage = ref(1)
+const pageSize    = 50
 
 const categories = [
   { key: 'POKEMON',    label: 'Pokémon' },
   { key: 'CRAZY_RARE', label: 'Crazy Rare' },
   { key: 'OTHER',      label: 'Other' },
 ]
+
+// Filter across all entries (not just current page)
+const filteredEntries = computed(() => {
+  if (!searchQuery.value.trim()) return allEntries.value
+  const q = searchQuery.value.trim().toLowerCase()
+  return allEntries.value.filter(e => (e.ctoonName || '').toLowerCase().includes(q))
+})
+
+// Autocomplete suggestions: up to 8 results, only shown at 3+ chars
+const searchSuggestions = computed(() => {
+  if (searchQuery.value.trim().length < 3) return []
+  return filteredEntries.value.slice(0, 8)
+})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(filteredEntries.value.length / pageSize)))
+
+const paginatedEntries = computed(() => {
+  const start = (currentPage.value - 1) * pageSize
+  return filteredEntries.value.slice(start, start + pageSize)
+})
+
+// Reset to page 1 and manage suggestion visibility when search changes
+watch(searchQuery, (val) => {
+  currentPage.value = 1
+  showSuggestions.value = val.trim().length >= 3
+})
+
+function handleDocumentClick(e) {
+  if (searchContainer.value && !searchContainer.value.contains(e.target)) {
+    showSuggestions.value = false
+  }
+}
+
+function clearSearch() {
+  searchQuery.value     = ''
+  showSuggestions.value = false
+  currentPage.value     = 1
+}
+
+function selectSuggestion(suggestion) {
+  searchQuery.value     = suggestion.ctoonName || ''
+  showSuggestions.value = false
+  currentPage.value     = 1
+}
+
+function goToPage(page) {
+  currentPage.value = Math.max(1, Math.min(page, totalPages.value))
+}
 
 function defaultStartLocal() {
   const d = new Date()
@@ -154,22 +324,30 @@ const form = ref({
   reschedule:          false,
 })
 
-const scheduling    = ref(false)
-const scheduleError = ref('')
+const scheduling      = ref(false)
+const scheduleError   = ref('')
 const scheduleSuccess = ref('')
-const cancellingId  = ref(null)
+const cancellingId    = ref(null)
 
 async function loadData() {
   try {
     const data = await $fetch('/api/admin/dissolve-queue', { headers })
-    stats.value    = data
-    upcoming.value = data.upcoming || []
+    stats.value      = data
+    upcoming.value   = data.upcoming || []
+    allEntries.value = data.entries  || []
   } catch (e) {
     console.error('Failed to load dissolve queue', e)
   }
 }
 
-onMounted(loadData)
+onMounted(() => {
+  loadData()
+  document.addEventListener('click', handleDocumentClick)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleDocumentClick)
+})
 
 async function applySchedule() {
   scheduling.value    = true

--- a/server/api/admin/dissolve-queue/index.get.js
+++ b/server/api/admin/dissolve-queue/index.get.js
@@ -38,26 +38,32 @@ export default defineEventHandler(async (event) => {
     else cat.unscheduled++
   }
 
+  const mapEntry = (e) => ({
+    id:           e.id,
+    category:     e.category,
+    isFeatured:   e.isFeatured,
+    scheduledFor: e.scheduledFor,
+    createdAt:    e.createdAt,
+    ctoonName:    e.userCtoon?.ctoon?.name ?? null,
+    ctoonImage:   e.userCtoon?.ctoon?.assetPath ?? null,
+    rarity:       e.userCtoon?.ctoon?.rarity ?? null,
+    series:       e.userCtoon?.ctoon?.series ?? null,
+    mintNumber:   e.userCtoon?.mintNumber ?? null,
+  })
+
   // Next 20 scheduled entries
   const upcoming = allEntries
     .filter(e => e.scheduledFor)
     .slice(0, 20)
-    .map(e => ({
-      id:          e.id,
-      category:    e.category,
-      isFeatured:  e.isFeatured,
-      scheduledFor: e.scheduledFor,
-      createdAt:   e.createdAt,
-      ctoonName:   e.userCtoon?.ctoon?.name,
-      ctoonImage:  e.userCtoon?.ctoon?.assetPath,
-      rarity:      e.userCtoon?.ctoon?.rarity,
-      series:      e.userCtoon?.ctoon?.series,
-      mintNumber:  e.userCtoon?.mintNumber,
-    }))
+    .map(mapEntry)
+
+  // All entries for search/pagination on the frontend
+  const entries = allEntries.map(mapEntry)
 
   return {
     total: allEntries.length,
     byCategory,
     upcoming,
+    entries,
   }
 })


### PR DESCRIPTION
- API now returns all queue entries in an `entries` array (in addition to the existing upcoming/stats) so the frontend can do client-side search and pagination without extra round-trips
- Added "All Queue Entries" section with a search bar that filters by cToon name across all entries (not just the current page)
- Autocomplete dropdown appears after 3+ characters are typed, showing up to 8 matching suggestions with the cToon image, name, and mint number
- Paginated the full entry list to 50 per page with first/prev/next/last controls and a "X of Y" count
- Clicking a suggestion or clearing the search resets to page 1; page also resets when search query changes

https://claude.ai/code/session_012qFWLKhQjY3QZZXRKih5s2