### PR TITLE
Fix case-insensitive discordTag check for MattShull trade filtering

### DIFF
--- a/server/api/admin/official-collection.get.js
+++ b/server/api/admin/official-collection.get.js
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Admin with discordTag "mattshull" can see ALL official cToons including non-tradeable ones
-  const isMattShull = me.discordTag === 'mattshull'
+  const isMattShull = me.discordTag?.toLowerCase() === 'mattshull'
 
   const officialUsername = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
   const userWithCtoons = await prisma.user.findUnique({


### PR DESCRIPTION
The isMattShull check used strict equality against 'mattshull', which
fails when the stored discordTag has mixed casing (e.g. 'MattShull').
Switching to a toLowerCase() comparison ensures all rarities (including
code-only and prize-only toons) are returned regardless of tag casing.

https://claude.ai/code/session_012XoLZymQgYPBaD5nxGKkUX