### PR TITLE
Simplify AdSpot link handling logic

### DIFF
--- a/components/newsite/AdSpot.vue
+++ b/components/newsite/AdSpot.vue
@@ -1,28 +1,17 @@
 <template>
-  <a v-if="isExternal" :href="linkHref" target="_blank" rel="noopener noreferrer" class="adspot">
-    <img v-if="currentSrc" :src="currentSrc" alt="Advertisement" />
-  </a>
-  <NuxtLink v-else :to="linkHref" class="adspot">
+  <NuxtLink v-if="!hasAdUrl" to="/newsite/home" class="adspot">
     <img v-if="currentSrc" :src="currentSrc" alt="Advertisement" />
   </NuxtLink>
+  <a v-else :href="currentUrl" target="_blank" rel="noopener noreferrer" class="adspot">
+    <img v-if="currentSrc" :src="currentSrc" alt="Advertisement" />
+  </a>
 </template>
 
 <script setup>
 const currentSrc = ref('')
 const currentUrl = ref('')
-const siteOrigin = ref('')
 
-const isExternal = computed(() => {
-  const url = currentUrl.value
-  if (!url) return false
-  try {
-    return new URL(url).origin !== siteOrigin.value
-  } catch {
-    return false
-  }
-})
-
-const linkHref = computed(() => currentUrl.value || '/newsite/home')
+const hasAdUrl = computed(() => !!currentUrl.value)
 
 let adOrder = []
 let adIdx = 0
@@ -147,7 +136,6 @@ async function initAds() {
 }
 
 onMounted(() => {
-  siteOrigin.value = window.location.origin
   initAds()
 })
 onUnmounted(() => {


### PR DESCRIPTION
## Summary
Refactored the AdSpot component to simplify the logic for determining whether to render an internal or external link. The changes remove unnecessary URL origin detection and streamline the conditional rendering.

## Key Changes
- Replaced `isExternal` computed property (which checked if URL origin matched site origin) with simpler `hasAdUrl` computed property that only checks if a URL exists
- Inverted the template logic: now uses `NuxtLink` when there's NO ad URL (defaulting to home), and external `<a>` tag when there IS an ad URL
- Removed `siteOrigin` ref and the associated `window.location.origin` initialization in `onMounted`
- Removed `linkHref` computed property, using `currentUrl` directly in the external link

## Implementation Details
The new approach assumes that if `currentUrl` is set, it should be treated as an external link. This simplifies the component by removing the need to detect whether a URL is internal or external based on origin comparison. The fallback behavior (linking to `/newsite/home`) is now explicit and only occurs when no ad URL is configured.

https://claude.ai/code/session_01MBTbjERCM9rfv34AAnF1Ac