### PR TITLE
Skip inactive account check for admin routes

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -22,6 +22,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   if (!user.value) return navigateTo('/')
 
+  // Admin routes only need authentication; admin.js handles authorization
+  if (to.path.startsWith('/admin')) return
+
   // Inactive accounts are sent to join-discord with a notice
   if (user.value.active === false && to.path !== '/join-discord') {
     return navigateTo('/join-discord?inactive=1')


### PR DESCRIPTION
## Summary
Updated the authentication middleware to skip the inactive account check for admin routes, since admin authorization is handled separately by the dedicated admin middleware.

## Key Changes
- Added early return in `auth.js` middleware when the route path starts with `/admin`
- This prevents inactive users from being redirected to the join-discord page when accessing admin routes
- Admin-specific authorization logic remains in the `admin.js` middleware

## Implementation Details
The change leverages a separation of concerns where:
- `auth.js` handles general authentication requirements (user must be logged in)
- `admin.js` handles admin-specific authorization checks
- By skipping the inactive account validation for `/admin` routes, we allow the admin middleware to make its own authorization decisions without interference from the general authentication flow

https://claude.ai/code/session_01E9E9QBgBdx95JnegJAyxPN