### PR TITLE
Redirect dashboard to new design when feature flag enabled

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -37,4 +37,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
   if (!user.value.inGuild && to.path !== '/join-discord') {
     return navigateTo('/join-discord')
   }
+
+  if (to.path === '/dashboard') {
+    const { public: { viewNewDesign } } = useRuntimeConfig()
+    if (viewNewDesign === '1') return navigateTo('/newsite/home')
+  }
 })


### PR DESCRIPTION
## Summary
Added a feature flag check in the auth middleware to conditionally redirect users from the `/dashboard` route to the new design at `/newsite/home` when the `viewNewDesign` feature flag is enabled.

## Key Changes
- Added a runtime config check in the auth middleware for the `viewNewDesign` feature flag
- When accessing `/dashboard` and the feature flag is set to `'1'`, users are automatically redirected to `/newsite/home`
- This allows for gradual rollout of the new design without requiring code changes

## Implementation Details
- The check is performed after existing authentication and guild membership validations
- Uses `useRuntimeConfig()` to access the public `viewNewDesign` configuration value
- The redirect only applies to the `/dashboard` route, leaving other routes unaffected

https://claude.ai/code/session_01LrksU7MMnAQyaADsgNUtPy