### PR TITLE
Refactor mobile layout and fix navigation routes

### DIFF
--- a/components/newsite/MyCworld.vue
+++ b/components/newsite/MyCworld.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="mycworld">
     <div class="mcw-nav">
-      <GreenButton @click="$router.push('/myczone')">My cZone</GreenButton>
-      <GreenButton @click="$router.push('/MyCollection')">My Collection</GreenButton>
-      <GreenButton @click="$router.push('/myachievements')">Achievements</GreenButton>
+      <GreenButton @click="$router.push('/newsite/myczone')">My cZone</GreenButton>
+      <GreenButton @click="$router.push('/newsite/MyCollection')">My Collection</GreenButton>
+      <GreenButton @click="$router.push('/newsite/myachievements')">Achievements</GreenButton>
       <GreenButton>Placeholder</GreenButton>
     </div>
     <div class="mcw-content">

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -270,7 +270,7 @@ const showNav = computed(() => route.meta.showNav !== false)
 const showSidebar = computed(() => route.meta.showSidebar !== false)
 const showFooter = computed(() => route.meta.showFooter !== false)
 const mainContentBorder = computed(() => route.meta.mainContentBorder === false ? 'none' : undefined)
-const mobileSidebarCollapsed = ref(false)
+const mobileSidebarCollapsed = ref(true)
 
 const gridColumns = computed(() =>
   isMobile.value ? '1fr' : 'var(--sidebar-width) var(--main-content-width)'
@@ -286,7 +286,7 @@ const gridRows = computed(() => {
 const SITE_WIDTH = 800
 const SITE_HEIGHT = 670
 const SITE_PADDING = 20
-const MOBILE_BREAKPOINT = 415
+const MOBILE_BREAKPOINT = 768
 const MAIN_CONTENT_WIDTH = 590
 const MAIN_CONTENT_HEIGHT = 480
 const scale = ref(1)
@@ -566,7 +566,7 @@ const scaleStyle = computed(() => {
   align-self: stretch;
 }
 
-@media (max-width: 415px) {
+@media (max-width: 768px) {
   .site-container,
   .topbar,
   .topbar-adbar,

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -294,9 +294,7 @@ const isMobile = ref(false)
 
 const computeLayout = () => {
   isMobile.value = window.innerWidth < MOBILE_BREAKPOINT
-  if (isMobile.value) {
-    scale.value = Math.min((window.innerWidth - SITE_PADDING) / MOBILE_BREAKPOINT, 1)
-  } else {
+  if (!isMobile.value) {
     const scaleX = (window.innerWidth - SITE_PADDING) / SITE_WIDTH
     const scaleY = (window.innerHeight - SITE_PADDING) / SITE_HEIGHT
     scale.value = Math.min(scaleX, scaleY, 1)
@@ -314,21 +312,17 @@ onUnmounted(() => {
 
 const mainContentMobileStyle = computed(() => {
   if (!isMobile.value) return {}
-  const baseWidth = showSidebar.value ? MAIN_CONTENT_WIDTH : SITE_WIDTH
   return {
-    width: `${baseWidth}px`,
+    width: '100%',
     height: `${MAIN_CONTENT_HEIGHT}px`,
-    zoom: MOBILE_BREAKPOINT / baseWidth,
   }
 })
 
 const scaleStyle = computed(() => {
   if (isMobile.value) {
     return {
-      width: `${MOBILE_BREAKPOINT}px`,
+      width: '100%',
       height: 'auto',
-      transform: `scale(${scale.value})`,
-      transformOrigin: 'top center',
     }
   }
   return {
@@ -587,6 +581,15 @@ const scaleStyle = computed(() => {
     flex-shrink: 1;
     min-width: unset;
     min-height: unset;
+  }
+
+  .site-container {
+    overflow: visible;
+  }
+
+  .main-content {
+    overflow-x: auto;
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR refactors the mobile responsive layout in the newsite template and corrects navigation routes in the MyCworld component to use the proper `/newsite/` path prefix.

## Key Changes

### Layout Refactoring (newsite-template.vue)
- **Mobile sidebar state**: Changed default `mobileSidebarCollapsed` from `false` to `true` to collapse sidebar on mobile by default
- **Mobile breakpoint**: Increased `MOBILE_BREAKPOINT` from 415px to 768px for better tablet support
- **Simplified mobile scaling**: Removed complex zoom-based scaling logic in favor of responsive width/height approach
  - Changed `mainContentMobileStyle` to use `width: 100%` instead of conditional width with zoom transform
  - Simplified `scaleStyle` for mobile to use `width: 100%` without transform scaling
- **Improved mobile overflow handling**: Added `overflow: visible` to `.site-container` and `overflow-x/y: auto` to `.main-content` in mobile media query
- **Updated media query**: Changed `@media (max-width: 415px)` to `@media (max-width: 768px)` to match new breakpoint

### Navigation Routes (MyCworld.vue)
- Fixed router navigation paths to include `/newsite/` prefix:
  - `/myczone` → `/newsite/myczone`
  - `/MyCollection` → `/newsite/MyCollection`
  - `/myachievements` → `/newsite/myachievements`

## Implementation Details
The mobile layout changes shift from a scaling-based approach (using CSS `zoom` and `transform: scale()`) to a more standard responsive design pattern with percentage-based widths and overflow handling. This should provide better compatibility and more predictable behavior across different mobile devices.

https://claude.ai/code/session_01U8iPhNSHNoACzAs1LaWXTw