### PR TITLE
Fix newsite sidebar always hidden on desktop

### DIFF
--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -245,7 +245,7 @@ html, body {
       <button v-if="isMobile" class="sidebar-toggle" @click="mobileSidebarCollapsed = !mobileSidebarCollapsed">
         {{ mobileSidebarCollapsed ? '▼ Show Sidebar' : '▲ Hide Sidebar' }}
       </button>
-      <template v-if="!mobileSidebarCollapsed">
+      <template v-if="!isMobile || !mobileSidebarCollapsed">
         <div class="sidebar-top"    :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', aspectRatio: '186 / 85' } : {}"><slot name="sidebar-top" /></div>
         <div class="sidebar-middle" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', aspectRatio: '186 / 300', marginTop: 'var(--sidebar-middle-mt)', marginBottom: 'var(--sidebar-middle-mb)' } : {}"><slot name="sidebar-middle" /></div>
         <div class="sidebar-bottom" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', aspectRatio: '186 / 64', marginTop: 'var(--sidebar-bottom-mt)' } : {}"><slot name="sidebar-bottom" /></div>


### PR DESCRIPTION
## Summary
- The sidebar on all newsite pages was completely hidden after the mobile breakpoint change in #346
- `mobileSidebarCollapsed` defaults to `true` but the `v-if` guarding sidebar content was not scoped to mobile, so desktop users had no way to see or toggle the sidebar
- Fixed by changing the condition to `!isMobile || !mobileSidebarCollapsed` so desktop always renders the sidebar while mobile respects the collapsed toggle

## Test plan
- [ ] Visit any newsite page (e.g. `/newsite/home`) on a desktop viewport — sidebar should be visible
- [ ] Resize to mobile (< 768px) — sidebar should be collapsed by default with a "Show Sidebar" toggle button
- [ ] Click the toggle on mobile — sidebar should expand and collapse correctly

https://claude.ai/code/session_01SnhZ4mwSSRfPzpf8cCb52h