### PR TITLE
Fix ad vertical alignment and mobile sidebar/cMart layout

### DIFF
--- a/components/newsite/AdSpot.vue
+++ b/components/newsite/AdSpot.vue
@@ -146,7 +146,9 @@ onUnmounted(() => {
 
 <style scoped>
 .adspot {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 100%;
   overflow: hidden;

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -239,7 +239,14 @@ async function buy(ctoon) {
 
 @media (max-width: 768px) {
   .cmart-grid {
-    grid-template-columns: repeat(2, var(--shortcard-width));
+    grid-template-columns: repeat(2, 1fr);
+    grid-auto-rows: auto;
+  }
+
+  .cmart-grid :deep(.sc) {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 3 / 4;
   }
 }
 

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -237,6 +237,12 @@ async function buy(ctoon) {
   to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
 
+@media (max-width: 768px) {
+  .cmart-grid {
+    grid-template-columns: repeat(2, var(--shortcard-width));
+  }
+}
+
 /* ── Status ──────────────────────────────────────────────────── */
 .cmart-status {
   grid-column: 1 / -1;

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -241,14 +241,14 @@ html, body {
         <div class="topbar-nav-right" :style="isMobile ? { width: '100%' } : {}"><NavRight :isMobile="isMobile" /></div>
       </div>
     </div>
-    <div class="sidebar" :style="[{ display: showSidebar ? '' : 'none' }, isMobile ? { width: '100%', height: 'auto' } : {}]">
+    <div class="sidebar" :style="[{ display: showSidebar ? '' : 'none' }, isMobile ? { width: '100%', height: 'auto', boxSizing: 'border-box', paddingLeft: '5px', paddingRight: '5px' } : {}]">
       <button v-if="isMobile" class="sidebar-toggle" @click="mobileSidebarCollapsed = !mobileSidebarCollapsed">
         {{ mobileSidebarCollapsed ? '▼ Show Sidebar' : '▲ Hide Sidebar' }}
       </button>
       <template v-if="!isMobile || !mobileSidebarCollapsed">
-        <div class="sidebar-top"    :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', aspectRatio: '186 / 85' } : {}"><slot name="sidebar-top" /></div>
-        <div class="sidebar-middle" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', aspectRatio: '186 / 300', marginTop: 'var(--sidebar-middle-mt)', marginBottom: 'var(--sidebar-middle-mb)' } : {}"><slot name="sidebar-middle" /></div>
-        <div class="sidebar-bottom" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', aspectRatio: '186 / 64', marginTop: 'var(--sidebar-bottom-mt)' } : {}"><slot name="sidebar-bottom" /></div>
+        <div class="sidebar-top"    :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto' } : {}"><slot name="sidebar-top" /></div>
+        <div class="sidebar-middle" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', marginTop: 'var(--sidebar-middle-mt)', marginBottom: 'var(--sidebar-middle-mb)' } : {}"><slot name="sidebar-middle" /></div>
+        <div class="sidebar-bottom" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', marginTop: 'var(--sidebar-bottom-mt)' } : {}"><slot name="sidebar-bottom" /></div>
       </template>
     </div>
     <div class="main-content" :class="{ 'main-content-full': !showSidebar && !isMobile, 'main-content-expand': !showFooter }" :style="[{ border: mainContentBorder }, mainContentMobileStyle]"><slot name="main-content" /></div>
@@ -314,7 +314,7 @@ const mainContentMobileStyle = computed(() => {
   if (!isMobile.value) return {}
   return {
     width: '100%',
-    height: `${MAIN_CONTENT_HEIGHT}px`,
+    height: 'auto',
   }
 })
 


### PR DESCRIPTION
## Summary

- Vertically center the ad image in the newsite ad bar using flexbox on `AdSpot.vue`
- Remove forced aspect-ratio heights from mobile sidebar sections so they shrink to content instead of leaving dead space under the timer and in the sidebar middle
- Remove fixed 480px height from main content on mobile so it sizes to its content
- Add 5px left/right padding to the sidebar on mobile
- Show 2 cMart items per row on mobile (down from 4) with cards expanding via `1fr` columns and `aspect-ratio: 3/4` to fill the available width