### PR TITLE
Increase layout dimensions for improved content display

### DIFF
--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -24,8 +24,8 @@ html, body {
   --font-family:                     'Nunito', sans-serif;
 
   --site-container-bg:               transparent;
-  --site-container-height:           670px;
-  --site-container-width:            800px;
+  --site-container-height:           785px;
+  --site-container-width:            1040px;
   --site-container-radius:           0px;
   --site-container-border-thickness: 0px;
   --site-container-border-color:     transparent;
@@ -38,7 +38,7 @@ html, body {
 
   --topbar-bg:                       transparent;
   --topbar-height:                   105px;
-  --topbar-width:                    800px;
+  --topbar-width:                    1040px;
   --topbar-radius:                   0px;
   --topbar-border-thickness:         0px;
   --topbar-border-color:             transparent;
@@ -130,7 +130,7 @@ html, body {
 
   --topbar-nav-right-bg:             var(--OrbitDarkBlue);
   --topbar-nav-right-height:         var(--topbar-nav-height);
-  --topbar-nav-right-width:          495px;
+  --topbar-nav-right-width:          735px;
   --topbar-nav-right-radius:         8px;
   --topbar-nav-right-border-thickness: 0px;
   --topbar-nav-right-border-color:   var(--OrbitDarkBlue);
@@ -140,8 +140,8 @@ html, body {
   --topbar-nav-right-pr:             0px;
 
   --sidebar-bg:                      var(--OrbitLightBlue);
-  --sidebar-height:                  480px;
-  --sidebar-width:                   225px;
+  --sidebar-height:                  600px;
+  --sidebar-width:                   232px;
   --sidebar-radius:                  8px;
   --sidebar-border-thickness:        0px;
   --sidebar-border-color:            var(--OrbitLightBlue);
@@ -152,7 +152,7 @@ html, body {
 
   --sidebar-top-bg:                  var(--OrbitDarkBlue);
   --sidebar-top-height:              85px;
-  --sidebar-top-width:               217px;
+  --sidebar-top-width:               224px;
   --sidebar-top-radius:              8px;
   --sidebar-top-border-thickness:    0px;
   --sidebar-top-border-color:        transparent;
@@ -166,8 +166,8 @@ html, body {
   --sidebar-top-mr:                  0px;
 
   --sidebar-middle-bg:               var(--OrbitDarkBlue);
-  --sidebar-middle-height:           300px;
-  --sidebar-middle-width:            217px;
+  --sidebar-middle-height:           425px;
+  --sidebar-middle-width:            224px;
   --sidebar-middle-radius:           8px;
   --sidebar-middle-border-thickness: 0px;
   --sidebar-middle-border-color:     transparent;
@@ -182,7 +182,7 @@ html, body {
 
   --sidebar-bottom-bg:               var(--OrbitDarkBlue);
   --sidebar-bottom-height:           78px;
-  --sidebar-bottom-width:            217px;
+  --sidebar-bottom-width:            224px;
   --sidebar-bottom-radius:           8px;
   --sidebar-bottom-border-thickness: 0px;
   --sidebar-bottom-border-color:     transparent;
@@ -196,8 +196,8 @@ html, body {
   --sidebar-bottom-mr:               0px;
 
   --main-content-bg:                 transparent;
-  --main-content-height:             480px;
-  --main-content-width:              567px;
+  --main-content-height:             600px;
+  --main-content-width:              800px;
   --main-content-radius:             8px;
   --main-content-border-thickness:   4px;
   --main-content-border-color:       var(--OrbitLightBlue);
@@ -208,7 +208,7 @@ html, body {
 
   --footer-bg:                       transparent;
   --footer-height:                   60px;
-  --footer-width:                    800px;
+  --footer-width:                    1040px;
 
   --shortcard-width:                      132px;
   --shortcard-height:                     176px;
@@ -283,12 +283,12 @@ const gridRows = computed(() => {
     : 'var(--topbar-height) 1fr'
 })
 
-const SITE_WIDTH = 800
-const SITE_HEIGHT = 670
+const SITE_WIDTH = 1040
+const SITE_HEIGHT = 785
 const SITE_PADDING = 20
 const MOBILE_BREAKPOINT = 768
-const MAIN_CONTENT_WIDTH = 590
-const MAIN_CONTENT_HEIGHT = 480
+const MAIN_CONTENT_WIDTH = 800
+const MAIN_CONTENT_HEIGHT = 600
 const scale = ref(1)
 const isMobile = ref(false)
 

--- a/pages/newsite/AuctionHouse.vue
+++ b/pages/newsite/AuctionHouse.vue
@@ -49,5 +49,5 @@ body {
 }
 
 body.page-auctionhouse .sidebar-bottom { display: none; }
-body.page-auctionhouse .sidebar { --sidebar-middle-height: 384px; }
+body.page-auctionhouse .sidebar { --sidebar-middle-height: 504px; }
 </style>

--- a/pages/newsite/MyCollection.vue
+++ b/pages/newsite/MyCollection.vue
@@ -21,6 +21,6 @@ definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav:
 
 <style>
 body.page-mycollection .sidebar-bottom { display: none; }
-body.page-mycollection .sidebar { --sidebar-middle-height: 384px; }
+body.page-mycollection .sidebar { --sidebar-middle-height: 504px; }
 body.page-mycollection .main-content { overflow-y: auto !important; scrollbar-width: thin; }
 </style>

--- a/pages/newsite/newcmart.vue
+++ b/pages/newsite/newcmart.vue
@@ -21,6 +21,6 @@ definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav:
 
 <style>
 body.page-newcmart .sidebar-bottom { display: none; }
-body.page-newcmart .sidebar { --sidebar-middle-height: 384px; }
+body.page-newcmart .sidebar { --sidebar-middle-height: 504px; }
 body.page-newcmart .main-content { overflow-y: auto !important; scrollbar-width: thin; }
 </style>


### PR DESCRIPTION
## Summary
Updated the newsite template layout dimensions to provide more space for content display. This includes increases to the overall site container, topbar, sidebar, and main content areas.

## Key Changes
- **Site container**: Increased from 800x670px to 1040x785px
- **Topbar**: Width expanded from 800px to 1040px
- **Topbar navigation right section**: Width increased from 495px to 735px
- **Sidebar**: 
  - Width increased from 225px to 232px
  - Height increased from 480px to 600px
  - Sub-sections (top, middle, bottom) widths adjusted to 224px
  - Middle section height increased from 300px to 425px
- **Main content area**: 
  - Width expanded from 567px to 800px
  - Height increased from 480px to 600px
- **Footer**: Width expanded from 800px to 1040px
- **Page-specific adjustments**: Updated sidebar-middle-height from 384px to 504px for AuctionHouse, MyCollection, and newcmart pages
- **JavaScript constants**: Updated SITE_WIDTH, SITE_HEIGHT, MAIN_CONTENT_WIDTH, and MAIN_CONTENT_HEIGHT to match new dimensions

## Implementation Details
All dimension changes maintain proportional spacing and padding relationships. The adjustments affect the responsive layout grid while preserving the visual hierarchy and component structure of the newsite template.

https://claude.ai/code/session_01959Csxb1mLNBdt7LgYzYxm