### PR TITLE
Make canvas responsive and remove hardcoded dimensions

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -23,7 +23,7 @@
     </div>
 
     <!-- ── Canvas ──────────────────────────────────────────── -->
-    <div class="cz-canvas-outer" :style="{ width: CANVAS_W + 'px', height: CANVAS_H + 'px' }">
+    <div class="cz-canvas-outer">
       <div
         class="cz-canvas"
         ref="canvasEl"
@@ -74,10 +74,12 @@
 
 <script setup>
 // ── Canvas size variables ─────────────────────────────────────
-const CANVAS_W    = 560   // canvas width in px
-const CANVAS_H    = 400   // canvas height in px
 const TOON_SIZE   = 80    // default toon size in px when dropped
 const BOTTOMBAR_H = 35    // bottom bar height in px
+
+// Reactive canvas dimensions — read from the DOM element at drag time
+function canvasW() { return canvasEl.value?.offsetWidth  ?? 560 }
+function canvasH() { return canvasEl.value?.offsetHeight ?? 400 }
 
 const { user } = useAuth()
 const cz = useNewSiteCzoneState()
@@ -223,8 +225,8 @@ function onGlobalMove(e) {
   if (localDrag.value) {
     const { x, y } = toCanvasCoords(e.clientX, e.clientY)
     const t = localDrag.value.toon
-    t.x = clamp(x - localDrag.value.offsetX, 0, CANVAS_W - (t.width  || TOON_SIZE))
-    t.y = clamp(y - localDrag.value.offsetY, 0, CANVAS_H - (t.height || TOON_SIZE))
+    t.x = clamp(x - localDrag.value.offsetX, 0, canvasW() - (t.width  || TOON_SIZE))
+    t.y = clamp(y - localDrag.value.offsetY, 0, canvasH() - (t.height || TOON_SIZE))
   }
 }
 
@@ -241,8 +243,8 @@ function onGlobalUp(e) {
         const h = img.naturalHeight
         currentZone.value.toons.push({
           id: c.id, assetPath: c.assetPath, name: c.name,
-          x: clamp(x - w / 2, 0, CANVAS_W - w),
-          y: clamp(y - h / 2, 0, CANVAS_H - h),
+          x: clamp(x - w / 2, 0, canvasW() - w),
+          y: clamp(y - h / 2, 0, canvasH() - h),
           width: w, height: h,
         })
       }
@@ -339,7 +341,9 @@ defineExpose({ save, clearZone })
 
 /* ── Canvas ── */
 .cz-canvas-outer {
-  flex-shrink: 0;
+  flex: 1;
+  width: 100%;
+  min-height: 0;
   overflow: hidden;
   position: relative;
   background: var(--OrbitDarkBlue);

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -166,7 +166,7 @@ html, body {
   --sidebar-top-mr:                  0px;
 
   --sidebar-middle-bg:               var(--OrbitDarkBlue);
-  --sidebar-middle-height:           425px;
+  --sidebar-middle-height:           421px;
   --sidebar-middle-width:            224px;
   --sidebar-middle-radius:           8px;
   --sidebar-middle-border-thickness: 0px;
@@ -176,7 +176,7 @@ html, body {
   --sidebar-middle-pl:               0px;
   --sidebar-middle-pr:               0px;
   --sidebar-middle-mt:               0px;
-  --sidebar-middle-mb:               0px;
+  --sidebar-middle-mb:               4px;
   --sidebar-middle-ml:               0px;
   --sidebar-middle-mr:               0px;
 


### PR DESCRIPTION
## Summary
Refactored the canvas component to be responsive by removing hardcoded width/height values and instead reading dimensions dynamically from the DOM element. This allows the canvas to adapt to its container size while maintaining proper boundary constraints for dragged elements.

## Key Changes
- **Removed hardcoded canvas dimensions**: Replaced static `CANVAS_W` and `CANVAS_H` constants with reactive `canvasW()` and `canvasH()` functions that read actual dimensions from the DOM element at runtime
- **Updated canvas styling**: Changed `.cz-canvas-outer` from `flex-shrink: 0` with inline styles to use `flex: 1`, `width: 100%`, and `min-height: 0` for proper flex container behavior
- **Updated drag boundary calculations**: Modified `onGlobalMove()` and `onGlobalUp()` functions to use the new canvas dimension functions instead of constants
- **Fine-tuned layout spacing**: Adjusted `--sidebar-middle-height` from 425px to 421px and added 4px bottom margin to `--sidebar-middle-mb` for better visual alignment

## Implementation Details
- Canvas dimensions now default to 560x400px if the DOM element is not yet available (via nullish coalescing operator)
- The responsive approach allows the canvas to fill available space while maintaining proper constraints for toon positioning
- All drag-and-drop boundary logic automatically adapts to the actual rendered canvas size

https://claude.ai/code/session_0121iD9ibJEFH6WRHS9hkjDD