### PR TITLE
Improve card layout with better rarity badge positioning

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -27,12 +27,14 @@
             <img v-if="c.assetPath" :src="c.assetPath" :alt="c.name" class="card-img" />
           </template>
           <template #middle>
-            <span class="card-name">{{ c.name }}</span>
-            <span
-              class="rarity-badge"
-              :style="{ background: rarityInfo(c.rarity).bg, color: rarityInfo(c.rarity).fg }"
-              :title="c.rarity"
-            >{{ rarityInfo(c.rarity).label }}</span>
+            <div class="card-middle-row">
+              <span class="card-name">{{ c.name }}</span>
+              <span
+                class="rarity-badge"
+                :style="{ background: rarityInfo(c.rarity).bg, color: rarityInfo(c.rarity).fg }"
+                :title="c.rarity"
+              >{{ rarityInfo(c.rarity).label }}</span>
+            </div>
           </template>
           <template #footer-left>
             <span v-if="isSoldOut(c) && !hasCountdown(c)" class="card-sold-out">Sold Out</span>
@@ -346,14 +348,27 @@ async function buy(ctoon) {
 }
 
 /* ── Card contents ───────────────────────────────────────────── */
+:deep(.sc) {
+  cursor: default;
+}
+
+.card-middle-row {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .rarity-badge {
+  position: absolute;
+  right: 0;
   font-size: 0.55rem;
   font-weight: bold;
   padding: 1px 3px;
   border-radius: 3px;
   white-space: nowrap;
   flex-shrink: 0;
-  margin-left: 3px;
   line-height: 1.2;
 }
 
@@ -362,6 +377,7 @@ async function buy(ctoon) {
   height: 100%;
   object-fit: contain;
   transform: scale(var(--img-scale));
+  cursor: pointer;
 }
 
 .card-name {
@@ -371,8 +387,8 @@ async function buy(ctoon) {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  min-width: 0;
   text-align: center;
+  max-width: calc(100% - 24px);
 }
 
 .card-price {


### PR DESCRIPTION
## Summary
Refactored the card middle section layout to improve the positioning and styling of the rarity badge relative to the card name, while enhancing cursor feedback and text overflow handling.

## Key Changes
- Wrapped card name and rarity badge in a new `card-middle-row` container with flexbox layout for better alignment control
- Changed rarity badge from relative positioning to absolute positioning within the middle row, anchored to the right
- Replaced left margin on rarity badge with absolute positioning for more precise control
- Added `max-width: calc(100% - 24px)` to card name to prevent overlap with the absolutely positioned badge
- Removed `min-width: 0` from card name (no longer needed with new layout)
- Added `cursor: pointer` to card image to indicate interactivity
- Added `cursor: default` to the card container (`:deep(.sc)`) to override any inherited cursor styles
- Centered card name text alignment for better visual balance

## Implementation Details
The layout change uses absolute positioning for the rarity badge within a flex container, allowing the card name to remain centered while the badge stays fixed to the right edge. The `max-width` constraint on the card name ensures text truncation occurs before overlapping with the badge, maintaining the ellipsis behavior.

https://claude.ai/code/session_01MpjXJGuZJieSSMVWtCD6a1