### PR TITLE
Rename newcmart page to cmart and update grid layout

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -282,7 +282,7 @@ async function buy(ctoon) {
   scrollbar-width: thin;
   scrollbar-color: var(--OrbitLightBlue) transparent;
   display: grid;
-  grid-template-columns: repeat(4, var(--shortcard-width));
+  grid-template-columns: repeat(5, var(--shortcard-width));
   grid-auto-rows: var(--shortcard-height);
   grid-auto-flow: row;
   gap: 4px;

--- a/components/newsite/GetcToons.vue
+++ b/components/newsite/GetcToons.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="getctoons">
-    <NuxtLink to="/newsite/newcmart" class="quadrant-link">
+    <NuxtLink to="/newsite/cmart" class="quadrant-link">
       <button class="quadrant quadrant--shop">cMart</button>
     </NuxtLink>
     <NuxtLink to="/newsite/AuctionHouse" class="quadrant-link">

--- a/pages/newsite/cmart.vue
+++ b/pages/newsite/cmart.vue
@@ -20,7 +20,8 @@ definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav:
 </script>
 
 <style>
-body.page-newcmart .sidebar-bottom { display: none; }
-body.page-newcmart .sidebar { --sidebar-middle-height: 504px; }
-body.page-newcmart .main-content { overflow-y: auto !important; scrollbar-width: thin; }
+body.page-cmart { --shortcard-width: 154px; }
+body.page-cmart .sidebar-bottom { display: none; }
+body.page-cmart .sidebar { --sidebar-middle-height: 504px; }
+body.page-cmart .main-content { overflow-y: auto !important; scrollbar-width: thin; }
 </style>


### PR DESCRIPTION
## Summary
This PR renames the newcmart page to cmart and updates the product grid layout to display 5 columns instead of 4.

## Key Changes
- Renamed `pages/newsite/cmart.vue` (previously `newcmart.vue`) to align with simplified naming convention
- Updated all CSS selectors from `body.page-newcmart` to `body.page-cmart` in the page styles
- Added new CSS variable `--shortcard-width: 154px` to the cmart page body selector for consistent card sizing
- Updated the cMart grid layout in `components/newsite/Cmart.vue` from 4 columns to 5 columns
- Fixed navigation link in `components/newsite/GetcToons.vue` to point to the renamed `/newsite/cmart` route

## Implementation Details
- The grid layout change from `repeat(4, var(--shortcard-width))` to `repeat(5, var(--shortcard-width))` allows for more products to be displayed per row
- The new `--shortcard-width` CSS variable (154px) is defined at the page level to ensure consistent card dimensions across the grid
- All internal references and routing have been updated to reflect the new page name

https://claude.ai/code/session_01L6rurZz3BZfQC7bqTF4km4