### PR TITLE
Adjust layout dimensions and improve grid responsiveness

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -259,7 +259,6 @@ async function buy(ctoon) {
   overflow: hidden;
 
   --img-scale: 0.7;
-  --shortcard-width: 154px;
 }
 
 .cmart-header {
@@ -283,13 +282,16 @@ async function buy(ctoon) {
   scrollbar-width: thin;
   scrollbar-color: var(--OrbitLightBlue) transparent;
   display: grid;
-  grid-template-columns: repeat(5, var(--shortcard-width));
+  grid-template-columns: repeat(5, 1fr);
   grid-auto-rows: var(--shortcard-height);
   grid-auto-flow: row;
   gap: 4px;
   padding: 4px;
-  justify-content: center;
   box-sizing: border-box;
+}
+
+.cmart-grid :deep(.sc) {
+  width: 100%;
 }
 
 
@@ -328,7 +330,7 @@ async function buy(ctoon) {
 
 @media (max-width: 768px) {
   .cmart-grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     grid-auto-rows: auto;
   }
 

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -259,6 +259,7 @@ async function buy(ctoon) {
   overflow: hidden;
 
   --img-scale: 0.7;
+  --shortcard-width: 154px;
 }
 
 .cmart-header {

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -75,6 +75,7 @@
 <script setup>
 // ── Canvas size variables ─────────────────────────────────────
 const TOON_SIZE   = 80    // default toon size in px when dropped
+const TOPBAR_H    = 34    // top bar height in px
 const BOTTOMBAR_H = 35    // bottom bar height in px
 
 // Reactive canvas dimensions — read from the DOM element at drag time
@@ -314,6 +315,8 @@ defineExpose({ save, clearZone })
   align-items: center;
   justify-content: space-between;
   flex-shrink: 0;
+  height: v-bind(TOPBAR_H + 'px');
+  box-sizing: border-box;
   padding: 4px 6px;
   gap: 6px;
   background: var(--OrbitLightBlue);

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -24,7 +24,7 @@ html, body {
   --font-family:                     'Nunito', sans-serif;
 
   --site-container-bg:               transparent;
-  --site-container-height:           785px;
+  --site-container-height:           854px;
   --site-container-width:            1040px;
   --site-container-radius:           0px;
   --site-container-border-thickness: 0px;
@@ -140,7 +140,7 @@ html, body {
   --topbar-nav-right-pr:             0px;
 
   --sidebar-bg:                      var(--OrbitLightBlue);
-  --sidebar-height:                  600px;
+  --sidebar-height:                  669px;
   --sidebar-width:                   232px;
   --sidebar-radius:                  8px;
   --sidebar-border-thickness:        0px;
@@ -166,7 +166,7 @@ html, body {
   --sidebar-top-mr:                  0px;
 
   --sidebar-middle-bg:               var(--OrbitDarkBlue);
-  --sidebar-middle-height:           421px;
+  --sidebar-middle-height:           490px;
   --sidebar-middle-width:            224px;
   --sidebar-middle-radius:           8px;
   --sidebar-middle-border-thickness: 0px;
@@ -196,7 +196,7 @@ html, body {
   --sidebar-bottom-mr:               0px;
 
   --main-content-bg:                 transparent;
-  --main-content-height:             600px;
+  --main-content-height:             669px;
   --main-content-width:              800px;
   --main-content-radius:             8px;
   --main-content-border-thickness:   4px;
@@ -284,11 +284,11 @@ const gridRows = computed(() => {
 })
 
 const SITE_WIDTH = 1040
-const SITE_HEIGHT = 785
+const SITE_HEIGHT = 854
 const SITE_PADDING = 20
 const MOBILE_BREAKPOINT = 768
 const MAIN_CONTENT_WIDTH = 800
-const MAIN_CONTENT_HEIGHT = 600
+const MAIN_CONTENT_HEIGHT = 669
 const scale = ref(1)
 const isMobile = ref(false)
 


### PR DESCRIPTION
## Summary
This PR updates the newsite template layout dimensions to accommodate taller content and improves the grid layout system for better responsiveness across different screen sizes.

## Key Changes

- **Layout Height Adjustments**: Increased site container height from 785px to 854px, sidebar height from 600px to 669px, sidebar middle section from 421px to 490px, and main content height from 600px to 669px to provide more vertical space for content
- **Grid Layout Improvements**: Changed the Cmart grid from fixed-width columns to flexible `1fr` units for better responsiveness, and adjusted mobile breakpoint from 2 columns to 3 columns
- **Grid Card Sizing**: Added CSS rule to ensure grid cards (`.sc`) take full width within their grid cells
- **Topbar Height Definition**: Added explicit `TOPBAR_H` constant (34px) in MyCzone component and applied it as a fixed height with proper box-sizing to the topbar element
- **Removed Centering**: Removed `justify-content: center` from the grid container to allow full-width column distribution

## Implementation Details

- Updated both CSS custom properties and JavaScript constants to maintain consistency between styled and computed dimensions
- The grid layout now uses fractional units (`1fr`) instead of fixed widths, making it more flexible and responsive
- Added proper height constraints and box-sizing to the topbar to ensure consistent spacing and alignment

https://claude.ai/code/session_01YNk95wDazGMmzNU7tpNhzz