### PR TITLE
Add responsive styles for customization zone on mobile

### DIFF
--- a/pages/newsite/czone/[username].vue
+++ b/pages/newsite/czone/[username].vue
@@ -32,6 +32,13 @@ onUnmounted(() => { cz.value.buildMode = false })
 /* ── Base page styles ── */
 body.page-newsite-czone-username .main-content { overflow: auto !important; scrollbar-width: thin; }
 
+@media (max-width: 768px) {
+  body.page-newsite-czone-username .main-content {
+    aspect-ratio: 800 / 669;
+    min-height: 300px;
+  }
+}
+
 /* ── Build mode: CzoneEdit fills entire sidebar with 4px border ── */
 body.page-newsite-czone-username.czone-build .sidebar-top    { display: none !important; }
 body.page-newsite-czone-username.czone-build .sidebar-bottom { display: none !important; }


### PR DESCRIPTION
## Summary
Added responsive design improvements to the customization zone page for mobile devices by implementing media query styles that constrain the main content area on smaller screens.

## Key Changes
- Added mobile-specific media query (`max-width: 768px`) for the customization zone main content area
- Set `aspect-ratio: 800 / 669` to maintain consistent proportions on mobile devices
- Added `min-height: 300px` to ensure adequate vertical space on smaller viewports

## Implementation Details
The new styles are applied only to devices with a maximum width of 768px, ensuring the customization zone remains usable and visually consistent on tablets and mobile phones without affecting desktop layouts. The aspect ratio constraint helps maintain the intended visual design while the minimum height ensures the content area doesn't become too cramped on very small screens.

https://claude.ai/code/session_013HVQPjbQypsp618dJNuZMh