### PR TITLE
Fix MyCzone height calculation to prevent layout overflow

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="myczone" ref="wrapperEl">
+  <div class="myczone" ref="wrapperEl" :style="wrapperStyle">
     <div class="myczone-content" :style="contentScaleStyle">
 
     <!-- ── Top bar ─────────────────────────────────────────── -->
@@ -99,7 +99,7 @@ const contentScale = ref(1)
 function updateContentScale() {
   if (!wrapperEl.value) return
   const w = wrapperEl.value.offsetWidth
-  contentScale.value = w > 0 ? w / DESIGN_W : 1
+  contentScale.value = w > 0 ? Math.min(w / DESIGN_W, 1) : 1
 }
 
 const contentScaleStyle = computed(() => {
@@ -107,6 +107,12 @@ const contentScaleStyle = computed(() => {
   if (s >= 1) return {}
   return { transform: `scale(${s})`, transformOrigin: 'top left' }
 })
+
+// Wrapper height = scaled design height, so the element self-sizes correctly
+// instead of relying on height:100% which breaks when parent has height:auto
+const wrapperStyle = computed(() => ({
+  height: Math.round(contentScale.value * DESIGN_H) + 'px'
+}))
 
 let resizeObserver = null
 
@@ -331,7 +337,7 @@ defineExpose({ save, clearZone })
 <style scoped>
 .myczone {
   width: 100%;
-  height: 100%;
+  /* height set dynamically via wrapperStyle (scale × DESIGN_H) */
   overflow: hidden;
   user-select: none;
   position: relative;

--- a/pages/newsite/czone/[username].vue
+++ b/pages/newsite/czone/[username].vue
@@ -29,16 +29,6 @@ onUnmounted(() => { cz.value.buildMode = false })
 </script>
 
 <style>
-/* ── Base page styles ── */
-body.page-newsite-czone-username .main-content { overflow: auto !important; scrollbar-width: thin; }
-
-@media (max-width: 768px) {
-  body.page-newsite-czone-username .main-content {
-    aspect-ratio: 800 / 669;
-    min-height: 300px;
-  }
-}
-
 /* ── Build mode: CzoneEdit fills entire sidebar with 4px border ── */
 body.page-newsite-czone-username.czone-build .sidebar-top    { display: none !important; }
 body.page-newsite-czone-username.czone-build .sidebar-bottom { display: none !important; }


### PR DESCRIPTION
## Summary
Fixed a layout issue in the MyCzone component where the container height was not properly constrained, causing content to overflow. The component now dynamically calculates its height based on the scaled design dimensions instead of relying on `height: 100%`.

## Key Changes
- **MyCzone.vue**: 
  - Added dynamic `wrapperStyle` computed property that sets the wrapper height to `contentScale × DESIGN_H` pixels
  - Applied `wrapperStyle` binding to the wrapper div
  - Modified `updateContentScale()` to cap the scale at 1.0 using `Math.min()`, preventing upscaling on larger screens
  - Replaced static `height: 100%` CSS rule with a comment explaining the dynamic height behavior

- **[username].vue**:
  - Removed obsolete page-level styles that attempted to manage the container height via `aspect-ratio` and `min-height` properties
  - These styles are no longer needed since the MyCzone component now self-sizes correctly

## Implementation Details
The fix addresses a fundamental issue where `height: 100%` doesn't work reliably when the parent container has `height: auto`. By calculating the exact pixel height needed based on the content scale factor and design height, the component now properly sizes itself and prevents layout overflow issues, particularly on mobile devices where the previous `aspect-ratio` workaround was insufficient.

https://claude.ai/code/session_01KW46UVn7v9SFv3ACuvkt7e