### PR TITLE
fix: cZone canvas not visible on desktop or mobile

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="myczone" ref="wrapperEl" :style="wrapperStyle">
+  <div class="myczone" ref="wrapperEl">
     <div class="myczone-content" :style="contentScaleStyle">
 
     <!-- ── Top bar ─────────────────────────────────────────── -->
@@ -107,12 +107,6 @@ const contentScaleStyle = computed(() => {
   if (s >= 1) return {}
   return { transform: `scale(${s})`, transformOrigin: 'top left' }
 })
-
-// Wrapper height = scaled design height, so the element self-sizes correctly
-// instead of relying on height:100% which breaks when parent has height:auto
-const wrapperStyle = computed(() => ({
-  height: Math.round(contentScale.value * DESIGN_H) + 'px'
-}))
 
 let resizeObserver = null
 
@@ -337,7 +331,7 @@ defineExpose({ save, clearZone })
 <style scoped>
 .myczone {
   width: 100%;
-  /* height set dynamically via wrapperStyle (scale × DESIGN_H) */
+  aspect-ratio: 800 / 669;
   overflow: hidden;
   user-select: none;
   position: relative;


### PR DESCRIPTION
## Summary

- Fixes cZone canvas not showing at all on desktop and mobile
- Root cause: JS-computed `wrapperStyle` height had a mount-order timing bug — `MyCzone` mounts before the layout, so `offsetWidth` always read `800px` (desktop CSS value) even on mobile viewports, leaving the canvas incorrectly sized/invisible
- Fix: replaced the JS height calculation with a single CSS rule `aspect-ratio: 800 / 669` on `.myczone`, letting the browser derive height from width automatically with no timing dependency
  - Desktop (`width = 800px`): height resolves to exactly `669px`
  - Mobile (`width = viewport`): height scales proportionally
- The existing `contentScaleStyle` transform on `.myczone-content` continues to handle visual scaling of inner content on mobile

## Test plan

- [ ] Desktop: visit `/newsite/czone/[username]` — canvas should be visible at 800×600 with topbar and bottombar
- [ ] Desktop narrow window (768–1040px): whole site CSS-scales, canvas still visible at correct proportions
- [ ] Mobile: canvas should scale down to fill the screen width proportionally
- [ ] Build mode: drag cToons onto canvas, right-click to remove — drag/drop still works correctly

https://claude.ai/code/session_011GB1fh8TUmKZe5M16rd2uJ