### PR TITLE
Adjust layout dimensions and add box-sizing to main content

### DIFF
--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -24,7 +24,7 @@ html, body {
   --font-family:                     'Nunito', sans-serif;
 
   --site-container-bg:               transparent;
-  --site-container-height:           854px;
+  --site-container-height:           862px;
   --site-container-width:            1040px;
   --site-container-radius:           0px;
   --site-container-border-thickness: 0px;
@@ -140,7 +140,7 @@ html, body {
   --topbar-nav-right-pr:             0px;
 
   --sidebar-bg:                      var(--OrbitLightBlue);
-  --sidebar-height:                  669px;
+  --sidebar-height:                  677px;
   --sidebar-width:                   232px;
   --sidebar-radius:                  8px;
   --sidebar-border-thickness:        0px;
@@ -196,7 +196,7 @@ html, body {
   --sidebar-bottom-mr:               0px;
 
   --main-content-bg:                 transparent;
-  --main-content-height:             669px;
+  --main-content-height:             677px;
   --main-content-width:              800px;
   --main-content-radius:             8px;
   --main-content-border-thickness:   4px;
@@ -284,7 +284,7 @@ const gridRows = computed(() => {
 })
 
 const SITE_WIDTH = 1040
-const SITE_HEIGHT = 854
+const SITE_HEIGHT = 862
 const SITE_PADDING = 20
 const MOBILE_BREAKPOINT = 768
 const MAIN_CONTENT_WIDTH = 800
@@ -542,6 +542,7 @@ const scaleStyle = computed(() => {
 .main-content {
   width: var(--main-content-width);
   height: var(--main-content-height);
+  box-sizing: border-box;
   flex-shrink: 0;
   background: var(--main-content-bg);
   border-radius: var(--main-content-radius);


### PR DESCRIPTION
## Summary
Updated the newsite template layout to accommodate larger content dimensions and ensure proper box-sizing behavior for the main content area.

## Key Changes
- Increased `--site-container-height` from 854px to 862px (8px increase)
- Increased `--sidebar-height` from 669px to 677px (8px increase)
- Increased `--main-content-height` from 669px to 677px (8px increase)
- Updated the `SITE_HEIGHT` constant from 854 to 862 to match the CSS variable
- Added `box-sizing: border-box` to the `.main-content` class to ensure padding and borders are included in the height/width calculations

## Implementation Details
The height adjustments appear to be coordinated across the layout hierarchy, with the main content and sidebar both growing by 8px to accommodate the overall container height increase. The addition of `box-sizing: border-box` is particularly important given the main content has a 4px border, ensuring the total rendered height matches the specified dimension.

https://claude.ai/code/session_01UqwBPqD1BMm1ao8ZqgAf2P