### PR TITLE
Adjust sidebar and main content height CSS variables

### DIFF
--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -140,7 +140,7 @@ html, body {
   --topbar-nav-right-pr:             0px;
 
   --sidebar-bg:                      var(--OrbitLightBlue);
-  --sidebar-height:                  677px;
+  --sidebar-height:                  682px;
   --sidebar-width:                   232px;
   --sidebar-radius:                  8px;
   --sidebar-border-thickness:        0px;
@@ -166,7 +166,7 @@ html, body {
   --sidebar-top-mr:                  0px;
 
   --sidebar-middle-bg:               var(--OrbitDarkBlue);
-  --sidebar-middle-height:           490px;
+  --sidebar-middle-height:           495px;
   --sidebar-middle-width:            224px;
   --sidebar-middle-radius:           8px;
   --sidebar-middle-border-thickness: 0px;
@@ -196,7 +196,7 @@ html, body {
   --sidebar-bottom-mr:               0px;
 
   --main-content-bg:                 transparent;
-  --main-content-height:             677px;
+  --main-content-height:             682px;
   --main-content-width:              800px;
   --main-content-radius:             8px;
   --main-content-border-thickness:   4px;


### PR DESCRIPTION
## Summary
Updated CSS custom properties in the newsite template layout to increase the heights of sidebar and main content sections for better visual spacing and layout proportions.

## Key Changes
- Increased `--sidebar-height` from 677px to 682px (+5px)
- Increased `--sidebar-middle-height` from 490px to 495px (+5px)
- Increased `--main-content-height` from 677px to 682px (+5px)

## Details
These adjustments maintain consistent proportional spacing across the layout components. The sidebar and main content heights are now aligned at 682px, while the middle sidebar section was increased by the same 5px increment to maintain visual balance within the overall sidebar structure.

https://claude.ai/code/session_01Qtnahh71VLuVqEs694oyZB