### PR TITLE
Fix burned cToon inventory leak (trade, auction, trade-list)

### DIFF
--- a/prisma/fixBurnedCtoonAuctionsAndTrades.js
+++ b/prisma/fixBurnedCtoonAuctionsAndTrades.js
@@ -1,0 +1,141 @@
+// prisma/fixBurnedCtoonAuctionsAndTrades.js
+//
+// Cleans up data left behind when a holiday cToon was burned but its delete
+// failed (FK constraint, etc.), leaving the burned UserCtoon still visible to
+// trade and auction endpoints.
+//
+// For each burned UserCtoon (burnedAt IS NOT NULL):
+//   - ACTIVE auctions  → status set to CANCELLED; bids and auto-bids deleted
+//   - PENDING trades   → status set to WITHDRAWN; initiator's locked points released
+//
+// Usage:
+//   node prisma/fixBurnedCtoonAuctionsAndTrades.js           # dry run (no writes)
+//   node prisma/fixBurnedCtoonAuctionsAndTrades.js --commit  # apply changes
+
+import { prisma } from '../server/prisma.js'
+
+const COMMIT = process.argv.includes('--commit')
+
+async function main() {
+  console.log(`[fixBurnedCtoonAuctionsAndTrades] start. commit=${COMMIT}\n`)
+
+  // ── 1. Collect all burned UserCtoon IDs ──────────────────────────────────
+  const burnedCtoons = await prisma.userCtoon.findMany({
+    where: { burnedAt: { not: null } },
+    select: { id: true, burnedAt: true }
+  })
+  const burnedIds = burnedCtoons.map((uc) => uc.id)
+  console.log(`Burned UserCtoons: ${burnedIds.length}`)
+
+  if (burnedIds.length === 0) {
+    console.log('Nothing to do.')
+    return
+  }
+
+  // ── 2. Find active auctions on burned cToons ──────────────────────────────
+  const activeAuctions = await prisma.auction.findMany({
+    where: { userCtoonId: { in: burnedIds }, status: 'ACTIVE' },
+    select: {
+      id: true,
+      userCtoonId: true,
+      _count: { select: { bids: true, autoBids: true } }
+    }
+  })
+  console.log(`Active auctions on burned cToons: ${activeAuctions.length}`)
+  for (const a of activeAuctions) {
+    console.log(
+      `  auction ${a.id}  userCtoonId=${a.userCtoonId}` +
+      `  bids=${a._count.bids}  autoBids=${a._count.autoBids}`
+    )
+  }
+
+  // ── 3. Find pending trades involving burned cToons ────────────────────────
+  const pendingTrades = await prisma.tradeOffer.findMany({
+    where: {
+      status: 'PENDING',
+      ctoons: { some: { userCtoonId: { in: burnedIds } } }
+    },
+    select: {
+      id: true,
+      initiatorId: true,
+      ctoons: { select: { userCtoonId: true, role: true } }
+    }
+  })
+  console.log(`\nPending trades involving burned cToons: ${pendingTrades.length}`)
+  for (const t of pendingTrades) {
+    const burned = t.ctoons
+      .filter((c) => burnedIds.includes(c.userCtoonId))
+      .map((c) => `${c.userCtoonId}[${c.role}]`)
+      .join(', ')
+    console.log(`  trade ${t.id}  initiator=${t.initiatorId}  burned cToons: ${burned}`)
+  }
+
+  if (!COMMIT) {
+    console.log('\n[fixBurnedCtoonAuctionsAndTrades] dry-run complete. Use --commit to apply.')
+    return
+  }
+
+  // ── 4. Cancel active auctions + delete their bids ─────────────────────────
+  let auctionsCancelled = 0
+  let bidsDeleted = 0
+  let autoBidsDeleted = 0
+
+  for (const auction of activeAuctions) {
+    await prisma.$transaction(async (tx) => {
+      const ab = await tx.auctionAutoBid.deleteMany({ where: { auctionId: auction.id } })
+      autoBidsDeleted += ab.count
+
+      const b = await tx.bid.deleteMany({ where: { auctionId: auction.id } })
+      bidsDeleted += b.count
+
+      await tx.auction.update({
+        where: { id: auction.id },
+        data: { status: 'CANCELLED' }
+      })
+    })
+    auctionsCancelled++
+    console.log(`  Cancelled auction ${auction.id}`)
+  }
+  console.log(`\nAuctions cancelled:  ${auctionsCancelled}`)
+  console.log(`Bids deleted:        ${bidsDeleted}`)
+  console.log(`Auto-bids deleted:   ${autoBidsDeleted}`)
+
+  // ── 5. Withdraw pending trades + release locked points ───────────────────
+  let tradesWithdrawn = 0
+  let lockedReleased = 0
+
+  for (const trade of pendingTrades) {
+    await prisma.$transaction(async (tx) => {
+      await tx.tradeOffer.update({
+        where: { id: trade.id },
+        data: { status: 'WITHDRAWN' }
+      })
+
+      const lp = await tx.lockedPoints.updateMany({
+        where: {
+          userId: trade.initiatorId,
+          status: 'ACTIVE',
+          contextType: 'TRADE',
+          contextId: trade.id
+        },
+        data: { status: 'RELEASED' }
+      })
+      lockedReleased += lp.count
+    })
+    tradesWithdrawn++
+    console.log(`  Withdrew trade ${trade.id}`)
+  }
+  console.log(`\nTrades withdrawn:          ${tradesWithdrawn}`)
+  console.log(`Locked point records released: ${lockedReleased}`)
+
+  console.log('\n[fixBurnedCtoonAuctionsAndTrades] done.')
+}
+
+main()
+  .catch((err) => {
+    console.error('[fixBurnedCtoonAuctionsAndTrades] fatal:', err)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/server/api/auctions.post.js
+++ b/server/api/auctions.post.js
@@ -54,12 +54,16 @@ export default defineEventHandler(async (event) => {
     select: {
       userId: true,
       ctoonId: true, // needed to check Holiday flag
+      burnedAt: true,
       mintNumber: true,
       ctoon: { select: { rarity: true, name: true, assetPath: true } }
     }
   })
   if (!userCtoonRec || userCtoonRec.userId !== userId) {
     throw createError({ statusCode: 403, statusMessage: 'You do not own this cToon' })
+  }
+  if (userCtoonRec.burnedAt) {
+    throw createError({ statusCode: 400, statusMessage: 'This cToon has been burned and cannot be auctioned' })
   }
 
   // Helper: map rarity -> insta-bid floor (must match client)

--- a/server/api/trade-list.get.js
+++ b/server/api/trade-list.get.js
@@ -15,12 +15,15 @@ export default defineEventHandler(async (event) => {
   await prisma.userTradeListItem.deleteMany({
     where: {
       userId,
-      userCtoon: { userId: { not: userId } }
+      OR: [
+        { userCtoon: { userId: { not: userId } } },
+        { userCtoon: { burnedAt: { not: null } } }
+      ]
     }
   })
 
   return prisma.userTradeListItem.findMany({
-    where: { userId, userCtoon: { userId } },
+    where: { userId, userCtoon: { userId, burnedAt: null } },
     select: { userCtoonId: true }
   })
 })

--- a/server/api/trade-list/[userCtoonId].post.js
+++ b/server/api/trade-list/[userCtoonId].post.js
@@ -16,7 +16,7 @@ export default defineEventHandler(async (event) => {
   if (!userCtoonId) throw createError({ statusCode: 400, statusMessage: 'Missing userCtoonId' })
 
   const owned = await prisma.userCtoon.findFirst({
-    where: { id: userCtoonId, userId },
+    where: { id: userCtoonId, userId, burnedAt: null },
     select: { id: true }
   })
   if (!owned) {

--- a/server/api/trade/offers.post.js
+++ b/server/api/trade/offers.post.js
@@ -55,7 +55,7 @@ export default defineEventHandler(async (event) => {
   // 4) Verify ownership of offered cToons
   if (ctoonIdsOffered.length) {
     const ownedByInitiator = await prisma.userCtoon.findMany({
-      where: { id: { in: ctoonIdsOffered }, userId: initiatorId },
+      where: { id: { in: ctoonIdsOffered }, userId: initiatorId, burnedAt: null },
       select: { id: true }
     })
     if (ownedByInitiator.length !== ctoonIdsOffered.length) {
@@ -109,7 +109,7 @@ export default defineEventHandler(async (event) => {
   // 5) Verify ownership of requested cToons
   if (ctoonIdsRequested.length) {
     const ownedByRecipient = await prisma.userCtoon.findMany({
-      where: { id: { in: ctoonIdsRequested }, userId: recipient.id },
+      where: { id: { in: ctoonIdsRequested }, userId: recipient.id, burnedAt: null },
       select: { id: true }
     })
     if (ownedByRecipient.length !== ctoonIdsRequested.length) {


### PR DESCRIPTION
## Summary

- **Root cause:** When a holiday cToon is burned via `/api/holiday/redeem`, the final `prisma.userCtoon.delete()` is wrapped in a silent try/catch. If it fails (e.g. FK constraint from trade list entries), the record stays in the DB with `burnedAt` set but not deleted. Trade, auction, and trade-list endpoints were not checking `burnedAt`, so users could still offer, request, and auction these burned cToons.
- Added `burnedAt: null` guards to all endpoints that gate on cToon ownership (trade offers, auctions, trade-list add, trade-list fetch).
- Added a one-off cleanup script to cancel/withdraw any existing dirty data.

## Changes

### Endpoint fixes
- **`server/api/trade/offers.post.js`** — add `burnedAt: null` to the offered-cToons and requested-cToons ownership queries (steps 4 & 5)
- **`server/api/auctions.post.js`** — select `burnedAt` in the ownership fetch and reject with 400 if set
- **`server/api/trade-list/[userCtoonId].post.js`** — add `burnedAt: null` to the ownership check so burned cToons cannot be added to a trade list
- **`server/api/trade-list.get.js`** — filter burned cToons out of the stale-entry cleanup and the results query

### Cleanup script
- **`prisma/fixBurnedCtoonAuctionsAndTrades.js`** — dry-run by default (`--commit` to apply); cancels active auctions on burned cToons (deletes bids + auto-bids), marks pending trades as `WITHDRAWN`, and releases initiator locked points

## Test plan

- [ ] Open a holiday cToon successfully — reward is granted, burned cToon is removed from inventory
- [ ] Attempt to offer a burned cToon in a trade — should receive "not owned" error
- [ ] Attempt to request a burned cToon in a trade — should receive "not owned" error
- [ ] Attempt to auction a burned cToon — should receive "burned" error
- [ ] Attempt to add a burned cToon to trade list — should receive "not owned" error
- [ ] Run `node prisma/fixBurnedCtoonAuctionsAndTrades.js` (dry run) and verify output lists any existing dirty data
- [ ] Run with `--commit` and confirm auctions are cancelled and trades are withdrawn

https://claude.ai/code/session_01QWLtp7VP4zL561ZTNHS7aM