### PR TITLE
Fix auction win condition to include highest bidder when no winner assigned

### DIFF
--- a/server/api/auction/mybids.get.js
+++ b/server/api/auction/mybids.get.js
@@ -226,7 +226,10 @@ export default defineEventHandler(async (event) => {
       myBid,
       highestBid,
       bidCount,
-      didWin: ended && !!a.winner && a.winner.id === userId
+      didWin: ended && (
+        (!!a.winner && a.winner.id === userId) ||
+        (!a.winner && myBid != null && myBid === highestFromBids)
+      )
     }
   })
 


### PR DESCRIPTION
## Summary
Updated the auction win detection logic to correctly identify winners in cases where the auction has ended but no winner has been explicitly assigned in the database.

## Key Changes
- Modified the `didWin` calculation in the mybids endpoint to handle auctions without an assigned winner
- Now checks if the current user's bid matches the highest bid amount when no winner record exists
- This ensures users who placed the highest bid are correctly identified as winners even if the winner field hasn't been populated

## Implementation Details
The win condition now uses an OR operator to cover two scenarios:
1. **Traditional case**: Auction has an explicitly assigned winner and it matches the current user
2. **Fallback case**: Auction has ended with no assigned winner, but the user's bid equals the highest bid amount

This change prevents edge cases where auctions end without explicit winner assignment while still maintaining the integrity of the win detection logic.

https://claude.ai/code/session_01M65dchHnuK4K1adU1R9Kyw