### PR TITLE
Fix auction close job rescheduling on early timer fire

### DIFF
--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -2832,9 +2832,13 @@ async function performAuctionClose(auctionId) {
   // Guard: already closed or cancelled (e.g. duplicate job fire)
   if (!auc || auc.status !== 'ACTIVE') return
 
-  // Re-check: if endAt is still in the future the job fired too early (shouldn't
-  // normally happen, but guard against clock skew)
-  if (new Date(auc.endAt) > new Date()) return
+  // Re-check: if endAt is still in the future the job fired too early (can happen
+  // due to timer imprecision or clock skew). Reschedule rather than silently
+  // completing — a bare `return` would drop the job and leave the auction stuck.
+  if (new Date(auc.endAt) > new Date()) {
+    await scheduleAuctionClose(auctionId, auc.endAt)
+    return
+  }
 
   const { id, creatorId, userCtoonId } = auc
   const now = new Date()


### PR DESCRIPTION
## Summary
Fixed a bug where auction close jobs that fired early due to timer imprecision or clock skew would silently return without rescheduling, leaving auctions stuck in an ACTIVE state indefinitely.

## Changes
- **Rescheduling logic**: When `performAuctionClose` detects that the auction's `endAt` time is still in the future, it now reschedules the job instead of silently returning
- **Improved comments**: Updated the guard clause comment to clarify that early job fires can happen due to timer imprecision (not just clock skew) and explain why rescheduling is necessary

## Implementation Details
- The fix calls `scheduleAuctionClose(auctionId, auc.endAt)` to reschedule the job when the end time hasn't been reached yet
- This prevents auctions from becoming stuck when the job scheduler fires prematurely
- The change is defensive and handles a real edge case that can occur in production environments

https://claude.ai/code/session_01Es5xAeFrXWkYWdBdu4CciX