### PR TITLE
Add CtoonInfoCard newsite component for cmart page

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -76,8 +76,6 @@
       </template>
     </div>
 
-    <CtoonInfoCard v-if="ctoonModal.isOpen.value" />
-
   </div>
 </template>
 

--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -645,7 +645,7 @@ function formatDate(value) {
 <style scoped>
 /* ── Overlay ─────────────────────────────────────────────────── */
 .ctic-overlay {
-  position: absolute;
+  position: fixed;
   inset: 0;
   background: rgba(0, 20, 50, 0.75);
   display: flex;

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -254,11 +254,13 @@ html, body {
     <div class="main-content" :class="{ 'main-content-full': !showSidebar && !isMobile, 'main-content-expand': !showFooter }" :style="[{ border: mainContentBorder }, mainContentMobileStyle]"><slot name="main-content" /></div>
     <div class="footer" :style="[{ display: showFooter ? '' : 'none' }, isMobile ? { width: '100%', height: 'auto', aspectRatio: '800 / 60' } : {}]"><slot name="footer" /></div>
     <slot />
+    <CtoonInfoCard v-if="ctoonModalIsOpen" />
   </div>
 </template>
 
 <script setup>
 const route = useRoute()
+const { isOpen: ctoonModalIsOpen } = useCtoonModal()
 const czoneState = useState('newSiteCzoneState', () => ({ buildMode: false }))
 useHead({ bodyAttrs: { class: computed(() => {
   const pageClass  = route.name ? `page-${String(route.name).toLowerCase()}` : ''


### PR DESCRIPTION
- New components/newsite/CtoonInfoCard.vue: self-contained overlay panel
  adapted from CtoonInfoModal with newsite color tokens, scoped ctic-*
  CSS, and holiday features removed
- Updated Cmart.vue: clicking a cToon image opens the info card via
  useCtoonModal, overlay mounted inside .cmart, position:relative added

https://claude.ai/code/session_01KmyPNdG27iS5D1uhcoqTGj