### PR TITLE
Add CtoonInfoCard newsite component for cmart page

### DIFF
--- a/components/newsite/GetcToons.vue
+++ b/components/newsite/GetcToons.vue
@@ -24,6 +24,8 @@
 }
 
 .quadrant {
+  width: 100%;
+  height: 100%;
   border: none;
   border-radius: 10px;
   font-size: 1rem;


### PR DESCRIPTION
- New components/newsite/CtoonInfoCard.vue: self-contained overlay panel
  adapted from CtoonInfoModal with newsite color tokens, scoped ctic-*
  CSS, and holiday features removed
- Updated Cmart.vue: clicking a cToon image opens the info card via
  useCtoonModal, overlay mounted inside .cmart, position:relative added

https://claude.ai/code/session_01KmyPNdG27iS5D1uhcoqTGj