### PR TITLE
Add CtoonInfoCard newsite component for cmart page

### DIFF
--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -45,4 +45,10 @@
 .quadrant--collection { background: #1a3e8a; }
 .quadrant--games      { background: #7c2d8a; }
 .quadrant--profile    { background: #8a4a1a; }
+
+@media (max-width: 768px) {
+  .gameshome {
+    height: max(200px, calc(100dvh - 240px));
+  }
+}
 </style>

--- a/components/newsite/GetcToons.vue
+++ b/components/newsite/GetcToons.vue
@@ -52,6 +52,12 @@
   text-decoration: none;
 }
 
+@media (max-width: 768px) {
+  .getctoons {
+    height: max(200px, calc(100dvh - 240px));
+  }
+}
+
 .quadrant--shop       { background: #1a6e3c; }
 .quadrant--collection { background: #1a3e8a; }
 .quadrant--games      { background: #7c2d8a; }


### PR DESCRIPTION
- New components/newsite/CtoonInfoCard.vue: self-contained overlay panel
  adapted from CtoonInfoModal with newsite color tokens, scoped ctic-*
  CSS, and holiday features removed
- Updated Cmart.vue: clicking a cToon image opens the info card via
  useCtoonModal, overlay mounted inside .cmart, position:relative added

https://claude.ai/code/session_01KmyPNdG27iS5D1uhcoqTGj