### PR TITLE
Schedule auction close when creating daily featured auctions

### DIFF
--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -6,7 +6,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { prisma } from '../prisma.js'
 import cron from 'node-cron'
-import { achievementsQueue } from '../../server/utils/queues.js'
+import { achievementsQueue, scheduleAuctionClose } from '../../server/utils/queues.js'
 import { runTournamentScheduler } from '../../server/utils/gtoonTournament.js'
 
 const BOT_TOKEN   = process.env.BOT_TOKEN
@@ -1087,6 +1087,8 @@ async function createDailyFeaturedAuction() {
 
     if (!result) continue
     createdCount += 1
+
+    await scheduleAuctionClose(result.auctionId, endAt)
 
     const isHolidayItem = !!(await prisma.holidayEventItem.findFirst({
       where: { ctoonId: result.ctoonId },


### PR DESCRIPTION
## Summary
Added automatic scheduling of auction closure when daily featured auctions are created, ensuring auctions are properly closed at their designated end time.

## Key Changes
- Imported `scheduleAuctionClose` function from the queues utility module
- Added a call to `scheduleAuctionClose()` in the `createDailyFeaturedAuction()` function to schedule closure for each newly created auction with its calculated end time

## Implementation Details
The auction close scheduling is now triggered immediately after an auction is successfully created, passing the auction ID and end time to the queue system. This ensures that all daily featured auctions have their closure events properly scheduled without requiring manual intervention.

https://claude.ai/code/session_01PHkSKWcB769aKGpsG3zgQz