### PR TITLE
Scope newsite styles with HTML class selectors

### DIFF
--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -1,7 +1,8 @@
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@300..700&display=swap');
 
-html, body {
+html.newsite-active,
+html.newsite-active body {
   background: var(--bg-color);
   margin: 0;
   padding: 0;
@@ -262,11 +263,14 @@ html, body {
 const route = useRoute()
 const { isOpen: ctoonModalIsOpen } = useCtoonModal()
 const czoneState = useState('newSiteCzoneState', () => ({ buildMode: false }))
-useHead({ bodyAttrs: { class: computed(() => {
-  const pageClass  = route.name ? `page-${String(route.name).toLowerCase()}` : ''
-  const buildClass = czoneState.value.buildMode ? 'czone-build' : ''
-  return [pageClass, buildClass].filter(Boolean).join(' ')
-}) } })
+useHead({
+  htmlAttrs: { class: 'newsite-active' },
+  bodyAttrs: { class: computed(() => {
+    const pageClass  = route.name ? `page-${String(route.name).toLowerCase()}` : ''
+    const buildClass = czoneState.value.buildMode ? 'czone-build' : ''
+    return [pageClass, buildClass].filter(Boolean).join(' ')
+  })
+} })
 const showAdbar = computed(() => route.meta.showAdbar !== false)
 const showNav = computed(() => route.meta.showNav !== false)
 const showSidebar = computed(() => route.meta.showSidebar !== false)

--- a/pages/newsite/home.vue
+++ b/pages/newsite/home.vue
@@ -14,10 +14,11 @@
 
 <script setup>
 definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
+useHead({ htmlAttrs: { class: 'newsite-home' } })
 </script>
 
 <style>
-html {
+html.newsite-home {
   min-height: 100vh;
   background: linear-gradient(
     to bottom,
@@ -28,7 +29,7 @@ html {
   ) no-repeat fixed !important;
 }
 
-body {
+html.newsite-home body {
   background: transparent !important;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
This PR refactors the newsite template styling to use scoped HTML class selectors instead of global `html` and `body` selectors. This prevents style conflicts with other parts of the application and provides better style isolation.

## Key Changes
- Modified `newsite-template.vue` to add `newsite-active` class to the `html` element via `useHead()` and scoped all global styles to `html.newsite-active`
- Updated `home.vue` to add `newsite-home` class to the `html` element and scoped its styles to `html.newsite-home` and `html.newsite-home body`
- Improved CSS specificity by targeting scoped class selectors instead of bare `html` and `body` elements

## Implementation Details
- The `htmlAttrs` configuration in `useHead()` is now used to dynamically apply scoping classes to the HTML element
- All stylesheet rules that previously targeted global `html` or `body` elements are now prefixed with the appropriate scoped class selector
- This approach ensures that newsite styles only apply when the corresponding layout or page is active, preventing unintended style leakage to other parts of the application

https://claude.ai/code/session_01DDLq1hpFUtE28wwnamnn6m