### PR TITLE
Add clear button for homepage images and improve sidebar docs

### DIFF
--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -239,6 +239,7 @@
         <div class="border rounded p-4 space-y-3">
           <h2 class="font-semibold">Middle Sidebar</h2>
           <p class="text-sm text-gray-500">Up to 3 images displayed in the middle sidebar area. Each can link to a page or custom URL.</p>
+          <p class="text-sm text-gray-500">Images must be 757px wide. Total height across all uploaded images must equal 1668px. Split evenly: 1 image = 1668px tall, 2 images = 834px each, 3 images = 556px each. You don't have to do evenly split heights, they just need to total up to 1668px.</p>
           <div class="space-y-4">
             <div v-for="n in 3" :key="n" class="border rounded p-3 space-y-2">
               <h3 class="font-medium text-sm">Image {{ n }}</h3>

--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -150,6 +150,8 @@
                     @change="onHomeImageFile(n, $event)" class="block w-full text-xs" />
                   <p class="text-xs text-gray-500">Max size is 374px by 292px</p>
                   <div v-if="homeImageFiles[n]" class="text-xs text-gray-600 truncate">{{ homeImageFiles[n].name }}</div>
+                  <button type="button" class="px-2 py-0.5 text-xs rounded border"
+                          v-if="homeImages[n].path" @click="clearHomeImage(n)">Clear</button>
                   <div class="space-y-1">
                     <label class="text-xs text-gray-600 font-medium">Link to</label>
                     <select v-model="homeImages[n].linkPreset" @change="onLinkPresetChange(n)" class="block w-full text-sm border rounded p-1.5">
@@ -424,6 +426,13 @@ function clearShowcase() {
   showcasePath.value = ''
   if (previewUrls.value.showcase) { try { URL.revokeObjectURL(previewUrls.value.showcase) } catch (e) {} ; previewUrls.value.showcase = null }
   showcaseFile.value = null
+}
+
+function clearHomeImage(n) {
+  homeImages[n].path = ''
+  const key = `homeImage${n}`
+  if (previewUrls.value[key]) { try { URL.revokeObjectURL(previewUrls.value[key]) } catch (e) {} ; previewUrls.value[key] = null }
+  homeImageFiles[n] = null
 }
 
 function onHomeImageFile(n, e) {


### PR DESCRIPTION
## Summary
Enhanced the homepage image management interface by adding the ability to clear individual homepage images and improved documentation for the middle sidebar image requirements.

## Key Changes
- **Added clear button for homepage images**: Users can now click a "Clear" button to remove an uploaded homepage image, which properly cleans up the file reference, preview URL, and file object
- **Improved middle sidebar documentation**: Added detailed guidance about image dimensions and height requirements (757px wide, 1668px total height across all images with specific split recommendations)

## Implementation Details
- The new `clearHomeImage(n)` function handles cleanup of:
  - The image path reference
  - The preview URL (with proper object URL revocation)
  - The file object reference
- The clear button only displays when an image path exists (`v-if="homeImages[n].path"`)
- Enhanced user guidance for the middle sidebar section with specific pixel requirements and examples for different numbers of images

https://claude.ai/code/session_012cRybf44MQ3PhTgN7txFkB