### PR TITLE
Add pack opening feature to cMart with animated reveal overlay

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -8,11 +8,50 @@
       </div>
     </Teleport>
 
+    <!-- ── Pack opening overlay ─────────────────────────────────── -->
+    <Teleport to="body">
+      <div v-if="overlayVisible" class="pack-overlay" @click.self="revealComplete && closeOverlay()">
+        <div class="pack-overlay-card">
+          <button v-if="revealComplete" class="pack-overlay-close" @click="closeOverlay">✕</button>
+
+          <!-- Pack image (during animation) -->
+          <template v-if="openingStep === 'pack'">
+            <img :src="openingPack?.imagePath" class="pack-overlay-img" alt="Pack" />
+          </template>
+
+          <!-- Reveal grid -->
+          <template v-if="openingStep === 'reveal'">
+            <div class="pack-reveal-grid">
+              <div
+                v-for="item in packContents"
+                :key="item.id"
+                class="pack-reveal-card"
+                :class="{ 'pack-reveal-new': !originalOwnedSet.has(item.id) }"
+              >
+                <span v-if="!originalOwnedSet.has(item.id)" class="pack-new-badge">New!</span>
+                <img
+                  v-if="item.assetPath"
+                  :src="item.assetPath"
+                  :alt="item.name"
+                  class="pack-reveal-img"
+                />
+                <p class="pack-reveal-name">{{ item.name }}</p>
+                <p class="pack-reveal-rarity">{{ item.rarity }}</p>
+                <p class="pack-reveal-mint">Mint #{{ item.mintNumber }}</p>
+              </div>
+            </div>
+            <button v-if="revealComplete" class="pack-reveal-close-btn" @click="closeOverlay">Close</button>
+          </template>
+        </div>
+      </div>
+      <div v-if="showGlow" class="pack-glow" :class="glowStage" />
+    </Teleport>
+
     <!-- ── Header bar ────────────────────────────────────────────── -->
     <div class="cmart-header">Cartoon Reorbit cMart</div>
 
-    <!-- ── Card grid ─────────────────────────────────────────────── -->
-    <div class="cmart-grid">
+    <!-- ── cToons grid ───────────────────────────────────────────── -->
+    <div v-if="cmartTab === 'ctoons'" class="cmart-grid">
       <template v-if="loading">
         <ShortCard v-for="n in 100" :key="'skel-' + n" class="skel-card">
           <template #header><div class="skel-img" /></template>
@@ -51,7 +90,7 @@
           </template>
           <template #footer-left>
             <span v-if="isSoldOut(c) && !hasCountdown(c)" class="card-sold-out">Sold Out</span>
-            <span v-else class="card-price">{{ c.price }} pts</span>
+            <span v-else class="card-price">{{ c.price.toLocaleString() }} pts</span>
           </template>
           <template #footer-right>
             <template v-if="!isSoldOut(c) || hasCountdown(c)">
@@ -73,6 +112,42 @@
             </template>
           </template>
         </ShortCard>
+      </template>
+    </div>
+
+    <!-- ── Packs grid ────────────────────────────────────────────── -->
+    <div v-else-if="cmartTab === 'packs'" class="packs-grid">
+      <template v-if="packsLoading">
+        <div v-for="n in 6" :key="'pskel-' + n" class="pack-card pack-card-skel">
+          <div class="skel-line" style="height:14px;width:70%;margin-bottom:8px" />
+          <div class="skel-img" style="height:100px;border-radius:6px;margin-bottom:8px" />
+          <div class="skel-line" style="height:10px;width:90%;margin-bottom:4px" />
+          <div class="skel-line" style="height:10px;width:80%;margin-bottom:4px" />
+          <div class="skel-line" style="height:24px;width:100%;margin-top:auto;border-radius:4px" />
+        </div>
+      </template>
+      <div v-else-if="!packs.length" class="cmart-status">No packs available.</div>
+      <template v-else>
+        <div
+          v-for="pack in packs"
+          :key="pack.id"
+          class="pack-card"
+        >
+          <p class="pack-name">{{ pack.name }}</p>
+          <img v-if="pack.imagePath" :src="pack.imagePath" class="pack-img" :alt="pack.name" />
+          <ul class="pack-rarity-list">
+            <li v-for="r in pack.rarityConfigs" :key="r.rarity">
+              <strong>{{ r.rarity }}:</strong> {{ r.probabilityPercent }}% — {{ r.count }} cToon(s)
+            </li>
+          </ul>
+          <GreenButton
+            class="pack-buy-btn"
+            :disabled="buyingPackIds.includes(pack.id)"
+            @click="buyPack(pack)"
+          >
+            {{ buyingPackIds.includes(pack.id) ? 'Purchasing…' : `Buy for ${pack.price.toLocaleString()} pts` }}
+          </GreenButton>
+        </div>
       </template>
     </div>
 
@@ -105,11 +180,30 @@ function openInfo(c) {
   ctoonModal.open({ ctoonId: c.id, assetPath: c.assetPath, name: c.name })
 }
 
-const allCtoons = useState('cmartCtoons', () => [])
-const loading   = ref(true)
-const buyingIds = ref([])
-const cmartEl   = ref(null)
-const filter    = useNewSiteCtoonFilter()
+const { user, fetchSelf } = useAuth()
+const cmartTab   = useState('newSiteCmartTab', () => 'ctoons')
+const allCtoons  = useState('cmartCtoons', () => [])
+const loading    = ref(true)
+const buyingIds  = ref([])
+const cmartEl    = ref(null)
+const filter     = useNewSiteCtoonFilter()
+
+// ── Packs state ──────────────────────────────────────────────
+const packs          = ref([])
+const packsLoading   = ref(false)
+const buyingPackIds  = ref([])
+
+// ── Pack opening state ────────────────────────────────────────
+const overlayVisible  = ref(false)
+const showGlow        = ref(false)
+const openingStep     = ref('pack')
+const glowStage       = ref('hidden')
+const revealComplete  = ref(false)
+const openingPack     = ref(null)
+const packContents    = ref([])
+const ownedCtoonIds   = ref([])
+
+const originalOwnedSet = computed(() => new Set(ownedCtoonIds.value))
 
 // ── Reactive clock for countdowns ────────────────────────────
 const nowTs = ref(Date.now())
@@ -133,19 +227,16 @@ function formatCountdown(c) {
   const totalSec = Math.floor(ms / 1000)
 
   if (ms >= 60 * 60 * 1000) {
-    // >= 60 minutes: show "Xh Ym"
     const h = Math.floor(totalSec / 3600)
     const m = Math.floor((totalSec % 3600) / 60)
     return `${h}h ${m}m`
   } else {
-    // < 60 minutes: show "Xm Ys"
     const m = Math.floor(totalSec / 60)
     const s = totalSec % 60
     return `${m}m ${s}s`
   }
 }
 
-// Schedule a data refresh when the next countdown expires
 function scheduleNextRefresh() {
   if (_refreshTimer) clearTimeout(_refreshTimer)
 
@@ -200,7 +291,6 @@ const ctoons = computed(() => {
       const bd = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
       const dateCmp = (f.sortAsc ? 1 : -1) * (ad - bd)
       if (dateCmp !== 0) return dateCmp
-      // Secondary: rarity ascending (common → uncommon → rare → very rare → crazy rare → others)
       const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99
       const br = RARITY_ORDER[(b.rarity || '').toLowerCase()] ?? 99
       return ar - br
@@ -237,6 +327,26 @@ function showToast(message, type = 'success') {
   toastTimer = setTimeout(() => { toast.visible = false }, 2000)
 }
 
+async function loadOwnedCtoonIds() {
+  try {
+    const res = await $fetch('/api/cmart/self/owned', { credentials: 'include' })
+    ownedCtoonIds.value = Array.isArray(res?.ownedCtoonIds) ? res.ownedCtoonIds : []
+  } catch {
+    ownedCtoonIds.value = []
+  }
+}
+
+async function fetchPacks() {
+  packsLoading.value = true
+  try {
+    packs.value = await $fetch('/api/cmart/packs')
+  } catch (err) {
+    console.error('Cmart: failed to load packs', err)
+  } finally {
+    packsLoading.value = false
+  }
+}
+
 onMounted(async () => {
   filter.value.sortField = 'releaseDate'
   filter.value.sortAsc   = false
@@ -248,6 +358,8 @@ onMounted(async () => {
   } finally {
     loading.value = false
   }
+  await fetchPacks()
+  await loadOwnedCtoonIds()
   _tick = setInterval(() => { nowTs.value = Date.now() }, 1000)
 })
 
@@ -266,7 +378,6 @@ async function buy(ctoon) {
       body: { ctoonId: ctoon.id },
     })
     showToast(`${ctoon.name} purchased!`, 'success')
-    // Refresh listing so sold-out states update
     allCtoons.value = await $fetch('/api/cmart')
     scheduleNextRefresh()
   } catch (err) {
@@ -275,6 +386,72 @@ async function buy(ctoon) {
   } finally {
     buyingIds.value = buyingIds.value.filter(id => id !== ctoon.id)
   }
+}
+
+// ── Pack buying ───────────────────────────────────────────────
+function resetPackSequence() {
+  openingStep.value   = 'pack'
+  glowStage.value     = 'hidden'
+  revealComplete.value = false
+  showGlow.value      = false
+  packContents.value  = []
+}
+
+async function buyPack(pack) {
+  if (buyingPackIds.value.includes(pack.id)) return
+  if (user.value && user.value.points < pack.price) {
+    showToast("You don't have enough points", 'error')
+    return
+  }
+  buyingPackIds.value = [...buyingPackIds.value, pack.id]
+
+  try {
+    const res = await $fetch('/api/cmart/packs/buy', {
+      method: 'POST',
+      body: { packId: pack.id },
+    })
+
+    openingPack.value    = pack
+    resetPackSequence()
+    overlayVisible.value = true
+    showGlow.value       = true
+
+    setTimeout(() => { glowStage.value = 'expand' }, 2000)
+
+    setTimeout(async () => {
+      try {
+        packContents.value = await $fetch('/api/cmart/open-pack', {
+          query: { id: res.userPackId }
+        })
+      } catch (e) {
+        console.error('Failed to open pack', e)
+        showToast('Failed to open pack', 'error')
+      }
+      openingStep.value    = 'reveal'
+      revealComplete.value = true
+      glowStage.value      = 'fade'
+    }, 3000)
+
+    setTimeout(() => {
+      showGlow.value  = false
+      glowStage.value = 'hidden'
+    }, 5000)
+
+    await fetchSelf({ force: true })
+    await loadOwnedCtoonIds()
+  } catch (err) {
+    const msg = err?.data?.statusMessage || err?.message || 'Purchase failed.'
+    showToast(msg, 'error')
+  } finally {
+    buyingPackIds.value = buyingPackIds.value.filter(id => id !== pack.id)
+  }
+}
+
+async function closeOverlay() {
+  overlayVisible.value = false
+  resetPackSequence()
+  await fetchPacks()
+  await loadOwnedCtoonIds()
 }
 </script>
 
@@ -307,6 +484,7 @@ async function buy(ctoon) {
   box-sizing: border-box;
 }
 
+/* ── cToons grid ─────────────────────────────────────────────── */
 .cmart-grid {
   flex: 1;
   overflow-y: auto;
@@ -325,6 +503,233 @@ async function buy(ctoon) {
   width: 100%;
 }
 
+/* ── Packs grid ──────────────────────────────────────────────── */
+.packs-grid {
+  flex: 1;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--OrbitLightBlue) transparent;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  padding: 10px;
+  box-sizing: border-box;
+  align-content: start;
+}
+
+.pack-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--OrbitDarkBlue);
+  border-radius: 8px;
+  padding: 10px 8px;
+  box-sizing: border-box;
+  gap: 6px;
+}
+
+.pack-card-skel {
+  background: #1a3a58;
+}
+
+.pack-name {
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: #fff;
+  text-align: center;
+  margin: 0;
+}
+
+.pack-img {
+  width: 100%;
+  max-height: 90px;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
+.pack-rarity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  font-size: 0.6rem;
+  color: #cce0ff;
+  line-height: 1.4;
+}
+
+.pack-buy-btn {
+  width: 100%;
+  margin-top: auto;
+  font-size: 0.7rem;
+  padding: 4px 6px;
+  white-space: nowrap;
+}
+
+/* ── Pack opening overlay ────────────────────────────────────── */
+:global(.pack-overlay) {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  overflow-y: auto;
+}
+
+:global(.pack-overlay-card) {
+  position: relative;
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  width: 100%;
+  max-width: 640px;
+  max-height: 90vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+:global(.pack-overlay-close) {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: #555;
+  line-height: 1;
+}
+
+:global(.pack-overlay-img) {
+  max-width: 100%;
+  max-height: 60vh;
+  object-fit: contain;
+}
+
+:global(.pack-reveal-grid) {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  width: 100%;
+}
+
+:global(.pack-reveal-card) {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #f5f8ff;
+  border: 2px solid #c7d8f0;
+  border-radius: 8px;
+  padding: 10px 8px;
+  gap: 4px;
+}
+
+:global(.pack-reveal-new) {
+  border-color: #16a34a;
+  animation: cardGlow 1.5s ease-in-out infinite alternate;
+}
+
+:global(.pack-new-badge) {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  background: #16a34a;
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: bold;
+  padding: 2px 5px;
+  border-radius: 10px;
+}
+
+:global(.pack-reveal-img) {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  margin-top: 16px;
+}
+
+:global(.pack-reveal-name) {
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-align: center;
+  color: #1a2a40;
+  margin: 0;
+}
+
+:global(.pack-reveal-rarity) {
+  font-size: 0.65rem;
+  color: #556;
+  margin: 0;
+  text-transform: capitalize;
+}
+
+:global(.pack-reveal-mint) {
+  font-size: 0.6rem;
+  color: #889;
+  margin: 0;
+}
+
+:global(.pack-reveal-close-btn) {
+  margin-top: 8px;
+  padding: 8px 24px;
+  background: var(--OrbitDarkBlue, #336699);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: bold;
+  cursor: pointer;
+  align-self: stretch;
+}
+
+:global(.pack-reveal-close-btn:hover) {
+  background: var(--OrbitLightBlue, #3399CC);
+}
+
+/* ── Glow effect ─────────────────────────────────────────────── */
+:global(.pack-glow) {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 1vw;
+  height: 1vh;
+  background: white;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 1100;
+}
+
+:global(.pack-glow.expand) {
+  animation: expandGlow 2s ease-out forwards;
+}
+
+:global(.pack-glow.fade) {
+  animation:
+    expandGlow 2s ease-out forwards,
+    fadeGlow   1s ease-in 2s forwards;
+}
+
+@keyframes expandGlow {
+  from { width: 1vw; height: 1vh; opacity: 1; }
+  to   { width: 300vw; height: 300vh; opacity: 0.9; }
+}
+
+@keyframes fadeGlow {
+  from { opacity: 0.9; }
+  to   { opacity: 0; }
+}
+
+@keyframes cardGlow {
+  from { box-shadow: 0 0 4px #16a34a; }
+  to   { box-shadow: 0 0 16px #16a34a; }
+}
 
 /* ── Toast ───────────────────────────────────────────────────── */
 :global(.cmart-toast) {
@@ -369,6 +774,14 @@ async function buy(ctoon) {
     width: 100%;
     height: auto;
     aspect-ratio: 3 / 4;
+  }
+
+  .packs-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  :global(.pack-reveal-grid) {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 

--- a/components/newsite/UserInfo.vue
+++ b/components/newsite/UserInfo.vue
@@ -17,9 +17,9 @@
         </template>
         <template v-else>
           <span class="user-info-username" ref="usernameEl">{{ user.username }}</span>
-          <span class="user-info-stat">{{ user.points }} Points</span>
-          <span class="user-info-stat">{{ collectionSummary.uniqueCount }} Unique cToons</span>
-          <span class="user-info-stat">{{ collectionSummary.totalCount }} Total cToons</span>
+          <span class="user-info-stat">{{ (user.points ?? 0).toLocaleString() }} Points</span>
+          <span class="user-info-stat">{{ (collectionSummary.uniqueCount ?? 0).toLocaleString() }} Unique cToons</span>
+          <span class="user-info-stat">{{ (collectionSummary.totalCount ?? 0).toLocaleString() }} Total cToons</span>
         </template>
       </div>
     </div>

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -119,7 +119,7 @@ html, body {
 
   --topbar-nav-left-bg:              var(--OrbitLightBlue);
   --topbar-nav-left-height:          var(--topbar-nav-height);
-  --topbar-nav-left-width:           295px;
+  --topbar-nav-left-width:           330px;
   --topbar-nav-left-radius:          8px;
   --topbar-nav-left-border-thickness: 0px;
   --topbar-nav-left-border-color:    var(--OrbitLightBlue);
@@ -130,7 +130,7 @@ html, body {
 
   --topbar-nav-right-bg:             var(--OrbitDarkBlue);
   --topbar-nav-right-height:         var(--topbar-nav-height);
-  --topbar-nav-right-width:          735px;
+  --topbar-nav-right-width:          700px;
   --topbar-nav-right-radius:         8px;
   --topbar-nav-right-border-thickness: 0px;
   --topbar-nav-right-border-color:   var(--OrbitDarkBlue);
@@ -490,6 +490,15 @@ const scaleStyle = computed(() => {
   font-family: inherit;
   text-align: center;
   flex-shrink: 0;
+  box-sizing: border-box;
+}
+
+@media (max-width: 768px) {
+  .sidebar-toggle {
+    margin-left: -5px;
+    margin-right: -5px;
+    width: calc(100% + 10px);
+  }
 }
 
 .sidebar-toggle:hover {

--- a/pages/newsite/cmart.vue
+++ b/pages/newsite/cmart.vue
@@ -4,7 +4,25 @@
       <UserInfo />
     </template>
     <template #sidebar-middle>
-      <CtoonFilter :show-hide-unavailable="true" :sort-options="cmartSortOptions" />
+      <div class="cmart-sidebar-middle">
+        <div class="cmart-tab-bar">
+          <button
+            class="cmart-tab"
+            :class="{ active: cmartTab === 'ctoons' }"
+            @click="cmartTab = 'ctoons'"
+          >cToons</button>
+          <button
+            class="cmart-tab"
+            :class="{ active: cmartTab === 'packs' }"
+            @click="cmartTab = 'packs'"
+          >Packs</button>
+        </div>
+        <CtoonFilter
+          v-if="cmartTab === 'ctoons'"
+          :show-hide-unavailable="true"
+          :sort-options="cmartSortOptions"
+        />
+      </div>
     </template>
     <template #main-content>
       <Cmart />
@@ -17,6 +35,8 @@
 
 <script setup>
 definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
+
+const cmartTab = useState('newSiteCmartTab', () => 'ctoons')
 
 const cmartSortOptions = [
   { value: 'releaseDate', label: 'Release Date' },
@@ -31,4 +51,45 @@ body.page-cmart { --shortcard-width: 154px; }
 body.page-cmart .sidebar-bottom { display: none; }
 body.page-cmart .sidebar { --sidebar-middle-height: 504px; }
 body.page-cmart .main-content { overflow-y: auto !important; scrollbar-width: thin; }
+</style>
+
+<style scoped>
+.cmart-sidebar-middle {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.cmart-tab-bar {
+  display: flex;
+  flex-direction: row;
+  flex-shrink: 0;
+  width: 100%;
+}
+
+.cmart-tab {
+  flex: 1;
+  padding: 5px 4px;
+  font-size: 0.75rem;
+  font-weight: bold;
+  font-family: inherit;
+  color: rgba(255, 255, 255, 0.55);
+  background: rgba(0, 0, 0, 0.2);
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.cmart-tab:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.cmart-tab.active {
+  color: #ffffff;
+  background: rgba(0, 0, 0, 0.1);
+  border-bottom-color: var(--OrbitLightBlue, #3399CC);
+}
 </style>


### PR DESCRIPTION
## Summary
This PR adds a complete pack purchasing and opening system to the cMart component, including an animated overlay experience for revealing pack contents. Users can now browse and purchase packs in addition to individual cToons, with visual feedback during the opening sequence.

## Key Changes

- **Pack browsing and purchasing**: Added a new "Packs" tab in the cMart sidebar that displays available packs in a 3-column grid layout with rarity information and purchase buttons
- **Pack opening overlay**: Implemented a full-screen overlay with two-stage animation:
  - Pack image display during the opening animation
  - Grid reveal of pack contents with "New!" badges for newly acquired items
- **Animated glow effect**: Added a white expanding glow animation that plays during pack opening (2-3 second sequence)
- **State management**: 
  - Track owned cToon IDs to highlight new acquisitions
  - Manage pack purchasing state and loading states
  - Handle pack opening sequence with timed transitions
- **API integration**: 
  - Fetch available packs from `/api/cmart/packs`
  - Purchase packs via `/api/cmart/packs/buy`
  - Open packs and retrieve contents from `/api/cmart/open-pack`
  - Load user's owned cToons from `/api/cmart/self/owned`
- **UI improvements**:
  - Added tab bar to switch between cToons and Packs views
  - Formatted price displays with `toLocaleString()` for better readability
  - Responsive grid layouts (3 columns on desktop, 2 on tablet)
  - Adjusted sidebar widths to accommodate new tab bar
  - Added skeleton loaders for packs grid

## Notable Implementation Details

- Pack opening uses a timed sequence: glow expands at 2s, contents reveal at 3s, glow fades at 5s
- New items are identified by comparing pack contents against the user's previously owned set
- The overlay can be closed by clicking the background (after reveal completes) or the close button
- User points are refreshed after successful pack purchase via `fetchSelf()`
- Filter component is conditionally rendered only when viewing cToons tab

https://claude.ai/code/session_01XdRi6c9xvLZXdcFmWWA5Gq