### PR TITLE
Fix cMart header capitalization and glow animation timing

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -48,7 +48,7 @@
     </Teleport>
 
     <!-- ── Header bar ────────────────────────────────────────────── -->
-    <div class="cmart-header">Cartoon Reorbit cMart</div>
+    <div class="cmart-header">Cartoon ReOrbit cMart</div>
 
     <!-- ── cToons grid ───────────────────────────────────────────── -->
     <div v-if="cmartTab === 'ctoons'" class="cmart-grid">

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -435,7 +435,7 @@ async function buyPack(pack) {
     setTimeout(() => {
       showGlow.value  = false
       glowStage.value = 'hidden'
-    }, 5000)
+    }, 6000)
 
     await fetchSelf({ force: true })
     await loadOwnedCtoonIds()
@@ -718,11 +718,11 @@ async function closeOverlay() {
 
 @keyframes expandGlow {
   from { width: 1vw; height: 1vh; opacity: 1; }
-  to   { width: 300vw; height: 300vh; opacity: 0.9; }
+  to   { width: 300vw; height: 300vh; opacity: 1; }
 }
 
 @keyframes fadeGlow {
-  from { opacity: 0.9; }
+  from { opacity: 1; }
   to   { opacity: 0; }
 }
 


### PR DESCRIPTION
## Summary
This PR includes minor fixes to the cMart component's header text capitalization and adjustments to the glow animation timing and opacity values.

## Key Changes
- Fixed header text capitalization from "Cartoon Reorbit cMart" to "Cartoon ReOrbit cMart"
- Increased glow effect duration from 5000ms to 6000ms to better align with animation timing
- Updated glow animation opacity values:
  - `expandGlow` animation: changed final opacity from 0.9 to 1
  - `fadeGlow` animation: changed initial opacity from 0.9 to 1
  
## Implementation Details
These changes improve the visual consistency of the glow effect by ensuring the opacity values remain at full intensity (1) throughout the animation sequence, and extending the timeout duration to allow the animations to complete more smoothly.

https://claude.ai/code/session_01MTe1k2T6VCPaj2htZXp2Bw