### PR TITLE
Add URL-based filtering and sorting for cmart page

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -358,8 +358,6 @@ async function fetchPacks() {
 }
 
 onMounted(async () => {
-  filter.value.sortField = 'releaseDate'
-  filter.value.sortAsc   = false
   try {
     allCtoons.value = await $fetch('/api/cmart')
     scheduleNextRefresh()

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -285,27 +285,37 @@ const ctoons = computed(() => {
   if (f.hideUnavailable)
     list = list.filter(c => !c.nextReleaseAt && !(c.quantity != null && c.totalMinted >= c.quantity))
 
+  const byReleaseDateDesc = (a, b) => {
+    const at = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
+    const bt = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
+    return bt - at
+  }
+  const byRarity = (a, b) => {
+    const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99
+    const br = RARITY_ORDER[(b.rarity || '').toLowerCase()] ?? 99
+    return ar - br
+  }
+  const byName = (a, b) => (a.name || '').localeCompare(b.name || '')
+  const tieBrk = (a, b) => byReleaseDateDesc(a, b) || byRarity(a, b) || byName(a, b)
+
   list = [...list].sort((a, b) => {
     if (f.sortField === 'releaseDate') {
       const ad = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
       const bd = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
       const dateCmp = (f.sortAsc ? 1 : -1) * (ad - bd)
-      if (dateCmp !== 0) return dateCmp
-      const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99
-      const br = RARITY_ORDER[(b.rarity || '').toLowerCase()] ?? 99
-      return ar - br
+      return dateCmp !== 0 ? dateCmp : byRarity(a, b) || byName(a, b)
     }
-    let cmp = 0
     if (f.sortField === 'price') {
-      cmp = a.price - b.price
-    } else if (f.sortField === 'rarity') {
-      const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99
-      const br = RARITY_ORDER[(b.rarity || '').toLowerCase()] ?? 99
-      cmp = ar - br
-    } else {
-      cmp = a.name.localeCompare(b.name)
+      const cmp = a.price - b.price
+      return (f.sortAsc ? cmp : -cmp) || tieBrk(a, b)
     }
-    return f.sortAsc ? cmp : -cmp
+    if (f.sortField === 'rarity') {
+      const cmp = byRarity(a, b)
+      return (f.sortAsc ? cmp : -cmp) || byReleaseDateDesc(a, b) || byName(a, b)
+    }
+    // name
+    const cmp = byName(a, b)
+    return (f.sortAsc ? cmp : -cmp) || tieBrk(a, b)
   })
 
   return list

--- a/pages/newsite/cmart.vue
+++ b/pages/newsite/cmart.vue
@@ -37,6 +37,9 @@
 definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
 
 const cmartTab = useState('newSiteCmartTab', () => 'ctoons')
+const filter   = useNewSiteCtoonFilter()
+const route    = useRoute()
+const router   = useRouter()
 
 const cmartSortOptions = [
   { value: 'releaseDate', label: 'Release Date' },
@@ -44,6 +47,58 @@ const cmartSortOptions = [
   { value: 'price',       label: 'Price'        },
   { value: 'rarity',      label: 'Rarity'       },
 ]
+
+// ── Initialize filter state (reset then apply URL params) ──────────────────
+Object.assign(filter.value, {
+  name:            '',
+  rarities:        [],
+  series:          '',
+  set:             '',
+  priceMin:        '',
+  priceMax:        '',
+  sortField:       'releaseDate',
+  sortAsc:         false,
+  hideUnavailable: false,
+})
+
+const q = route.query
+if (typeof q.q      === 'string' && q.q)      filter.value.name      = q.q
+if (q.rarity) {
+  filter.value.rarities = Array.isArray(q.rarity)
+    ? q.rarity.filter(Boolean)
+    : String(q.rarity).split(',').map(s => s.trim()).filter(Boolean)
+}
+if (typeof q.series   === 'string' && q.series)   filter.value.series   = q.series
+if (typeof q.set      === 'string' && q.set)      filter.value.set      = q.set
+if (typeof q.priceMin === 'string' && q.priceMin) filter.value.priceMin = q.priceMin
+if (typeof q.priceMax === 'string' && q.priceMax) filter.value.priceMax = q.priceMax
+if (typeof q.sort     === 'string' && q.sort)     filter.value.sortField = q.sort
+if (q.sortDir === 'asc') filter.value.sortAsc = true
+if (q.available === 'true') filter.value.hideUnavailable = true
+if (q.tab === 'packs') cmartTab.value = 'packs'
+
+// ── Sync filter + tab → URL ────────────────────────────────────────────────
+function updateUrl() {
+  const f        = filter.value
+  const newQuery = {}
+
+  if (f.name)              newQuery.q        = f.name
+  if (f.rarities.length)   newQuery.rarity   = f.rarities.join(',')
+  if (f.series)            newQuery.series   = f.series
+  if (f.set)               newQuery.set      = f.set
+  if (f.priceMin !== '')   newQuery.priceMin = String(f.priceMin)
+  if (f.priceMax !== '')   newQuery.priceMax = String(f.priceMax)
+  if (f.sortField && f.sortField !== 'releaseDate') newQuery.sort = f.sortField
+  if (f.sortAsc)           newQuery.sortDir  = 'asc'
+  if (f.hideUnavailable)   newQuery.available = 'true'
+  if (cmartTab.value !== 'ctoons') newQuery.tab = cmartTab.value
+
+  const current = JSON.stringify(route.query)
+  const next    = JSON.stringify(newQuery)
+  if (current !== next) router.replace({ path: route.path, query: newQuery })
+}
+
+watch([filter, cmartTab], updateUrl, { deep: true })
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
This PR adds URL query parameter support for the cmart (collectibles mart) page, allowing users to share filtered and sorted views via URLs. Filter state is now synchronized bidirectionally with URL parameters, and sorting logic has been refactored for consistency.

## Key Changes

- **URL Parameter Initialization**: On page load, filter state is reset to defaults then populated from URL query parameters (`q`, `rarity`, `series`, `set`, `priceMin`, `priceMax`, `sort`, `sortDir`, `available`, `tab`)

- **URL Synchronization**: Added `updateUrl()` function that watches filter and tab state changes and updates the URL accordingly, only modifying the URL when the query actually changes

- **Sorting Logic Refactor**: Extracted sorting comparators (`byReleaseDateDesc`, `byRarity`, `byName`) as reusable functions and unified the sort direction handling across all sort fields (releaseDate, price, rarity, name) with consistent tie-breaking rules

- **Removed Initialization Code**: Removed redundant filter initialization from `onMounted()` hook since it's now handled during setup

## Implementation Details

- Filter state is initialized with empty/default values, then URL parameters override those defaults
- The `rarity` parameter supports both array and comma-separated string formats for flexibility
- URL updates use JSON comparison to avoid unnecessary router calls
- Tie-breaking order is consistent: releaseDate (desc) → rarity → name (asc)
- Sort direction is applied uniformly across all sort fields using ternary operators

https://claude.ai/code/session_01YPCBpXepcJZJr3o89vfvc7