### PR TITLE
Refactor canvas styling and background selection logic

### DIFF
--- a/components/newsite/CzoneEdit.vue
+++ b/components/newsite/CzoneEdit.vue
@@ -52,11 +52,11 @@
       <div class="czew-bg-grid">
         <img
           v-for="bg in cz.backgrounds" :key="bg.id"
-          :src="`/backgrounds/${bg.filename}`"
-          :alt="bg.filename"
+          :src="bg.imagePath"
+          :alt="bg.label || bg.filename"
           class="czew-bg-item"
-          :class="{ 'czew-bg-active': currentZoneBg === bg.filename }"
-          @click="selectBg(bg.filename)"
+          :class="{ 'czew-bg-active': (currentZoneBg || '').split('/').pop() === bg.filename }"
+          @click="selectBg(bg)"
         />
         <div v-if="!cz.backgrounds.length" class="czew-empty" style="grid-column:1/-1">No backgrounds available.</div>
       </div>
@@ -133,8 +133,8 @@ function startDrag(ctoon, e) {
   cz.value.ghostY     = e.clientY
 }
 
-function selectBg(filename) {
-  cz.value.zones[cz.value.activeZone].background = filename
+function selectBg(bg) {
+  cz.value.zones[cz.value.activeZone].background = bg.imagePath
 }
 </script>
 

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -28,7 +28,7 @@
         <div
           class="cz-canvas"
           ref="canvasEl"
-          :style="{ backgroundImage: currentBg }"
+          :style="canvasStyle"
           @contextmenu.prevent="onContextMenu"
           @mousedown="onCanvasMouseDown"
         >
@@ -133,11 +133,24 @@ function bgUrl(v) {
   return `/backgrounds/${s}`
 }
 
-const currentBg = computed(() => {
-  const src  = bgUrl(currentZone.value.background)
-  const grid = `linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px)`
-  return src ? `${grid}, url('${src}')` : grid
+const canvasStyle = computed(() => {
+  const src   = bgUrl(currentZone.value.background)
+  const gridH = 'linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px)'
+  const gridV = 'linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px)'
+  if (src) {
+    return {
+      backgroundImage:    `${gridH}, ${gridV}, url('${src}')`,
+      backgroundSize:     '40px 40px, 40px 40px, cover',
+      backgroundPosition: '0 0, 0 0, center',
+      backgroundRepeat:   'repeat, repeat, no-repeat',
+    }
+  }
+  return {
+    backgroundImage:    `${gridH}, ${gridV}`,
+    backgroundSize:     '40px 40px',
+    backgroundPosition: '0 0',
+    backgroundRepeat:   'repeat',
+  }
 })
 
 // ── Lifecycle ─────────────────────────────────────────────────
@@ -405,9 +418,6 @@ defineExpose({ save, clearZone })
   height: 600px;
   overflow: hidden;
   background-color: var(--OrbitDarkBlue);
-  background-size: 40px 40px, 40px 40px, 100% 100%;
-  background-position: 0 0, 0 0, top left;
-  background-repeat: repeat, repeat, no-repeat;
   cursor: default;
 }
 


### PR DESCRIPTION
## Summary
This PR refactors the canvas styling approach and improves the background selection system by moving style definitions from CSS to computed properties and updating background object handling.

## Key Changes

- **Canvas Styling Refactor (MyCzone.vue)**
  - Moved `background-size`, `background-position`, and `background-repeat` CSS properties from static styles to a computed `canvasStyle` object
  - Renamed `currentBg` computed property to `canvasStyle` and changed it to return a style object instead of a string
  - Updated the template to use `:style="canvasStyle"` instead of `:style="{ backgroundImage: currentBg }"`
  - Improved grid gradient definitions by separating horizontal and vertical gradients into named variables for better readability

- **Background Selection Enhancement (CzoneEdit.vue)**
  - Changed `selectBg()` function to accept the full background object instead of just the filename
  - Updated background image source binding to use `bg.imagePath` property instead of constructing the path
  - Updated alt text to use `bg.label` with fallback to `bg.filename`
  - Improved active background detection by extracting filename from the full path using `.split('/').pop()`

## Implementation Details

The canvas styling now properly handles multiple background layers with explicit sizing and positioning for each layer:
- Grid patterns use `40px 40px` sizing with `repeat`
- Background images use `cover` sizing with `center` positioning and `no-repeat`

The background selection now works with background objects that contain `imagePath` and optional `label` properties, providing better data structure consistency.

https://claude.ai/code/session_01Ya3CYUCHemokKeQGFFAJkS