### PR TITLE
Fix image positioning in contest card layout

### DIFF
--- a/components/newsite/CzoneContest.vue
+++ b/components/newsite/CzoneContest.vue
@@ -599,8 +599,8 @@ async function doSubmit() {
   padding: 3px;
 }
 
-.cc-card-img-wrap { aspect-ratio: 800/600; width: 100%; overflow: hidden; }
-.cc-card-img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.cc-card-img-wrap { aspect-ratio: 800/600; width: 100%; overflow: hidden; position: relative; }
+.cc-card-img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; display: block; }
 
 .cc-card-foot {
   display: flex;


### PR DESCRIPTION
## Summary
Updated the CSS styling for contest card images to use absolute positioning, ensuring proper image containment and alignment within their wrapper containers.

## Key Changes
- Added `position: relative` to `.cc-card-img-wrap` to establish a positioning context
- Changed `.cc-card-img` from default positioning to `position: absolute` with `inset: 0` to fill the entire wrapper
- Maintained existing `object-fit: cover` behavior for proper image scaling

## Implementation Details
This change improves the layout stability by using absolute positioning instead of relying on default flow behavior. The `inset: 0` shorthand (equivalent to `top: 0; right: 0; bottom: 0; left: 0`) ensures the image precisely fills its container while respecting the aspect ratio constraint on the wrapper. This approach provides better control over image placement and prevents potential layout shifts.

https://claude.ai/code/session_01Q7H7orChAbVgEuJTLrHgf1