### PR TITLE
fix: fall back to natural image dimensions when toon width/height are…

### DIFF
--- a/components/newsite/CzoneContest.vue
+++ b/components/newsite/CzoneContest.vue
@@ -412,7 +412,9 @@ async function doSubmit() {
     for (const toon of (zone?.toons || [])) {
       try {
         const img = await loadImage(toon.assetPath)
-        ctx.drawImage(img, toon.x, toon.y, toon.width, toon.height)
+        const w = toon.width  || img.naturalWidth
+        const h = toon.height || img.naturalHeight
+        ctx.drawImage(img, toon.x, toon.y, w, h)
       } catch { /* skip toons that fail to load */ }
     }
 


### PR DESCRIPTION
… missing

The save endpoint only persists x and y for each toon — width and height are never stored. ctx.drawImage with undefined dimensions draws nothing, so toons were invisible. Use img.naturalWidth/naturalHeight as the fallback, matching how the czone canvas renders toons via unsized <img> elements.

https://claude.ai/code/session_018Ad1yzVADTnM7CwRGjmXsd