### PR TITLE
Improve responsive grid layout and add user profile navigation

### DIFF
--- a/components/newsite/MyCollection.vue
+++ b/components/newsite/MyCollection.vue
@@ -157,13 +157,19 @@ onMounted(async () => {
   scrollbar-width: thin;
   scrollbar-color: var(--OrbitLightBlue) transparent;
   display: grid;
-  grid-template-columns: repeat(4, var(--shortcard-width));
+  grid-template-columns: repeat(6, 1fr);
   grid-auto-rows: var(--shortcard-height);
   grid-auto-flow: row;
   gap: 4px;
   padding: 4px;
-  justify-content: center;
   box-sizing: border-box;
+  --shortcard-width: 100%;
+}
+
+@media (max-width: 768px) {
+  .mc-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 /* ── Status ──────────────────────────────────────────────────── */

--- a/components/newsite/UserInfo.vue
+++ b/components/newsite/UserInfo.vue
@@ -16,7 +16,7 @@
           <div class="skel skel-stat" />
         </template>
         <template v-else>
-          <span class="user-info-username" ref="usernameEl">{{ user.username }}</span>
+          <NuxtLink :to="`/newsite/czone/${user.username}`" class="user-info-username" ref="usernameEl">{{ user.username }}</NuxtLink>
           <span class="user-info-stat">{{ (user.points ?? 0).toLocaleString() }} Points</span>
           <span class="user-info-stat">{{ (collectionSummary.uniqueCount ?? 0).toLocaleString() }} Unique cToons</span>
           <span class="user-info-stat">{{ (collectionSummary.totalCount ?? 0).toLocaleString() }} Total cToons</span>

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -487,7 +487,7 @@ const scaleStyle = computed(() => {
   background: var(--OrbitDarkBlue);
   color: white;
   border: none;
-  border-radius: 0;
+  border-radius: var(--sidebar-radius) var(--sidebar-radius) 0 0;
   cursor: pointer;
   font-size: 0.8rem;
   font-weight: bold;


### PR DESCRIPTION
## Summary
This PR enhances the collection grid layout with better responsiveness and adds navigation to user profiles from the user info section.

## Key Changes
- **MyCollection.vue**: Refactored grid layout from fixed 4-column to flexible 6-column responsive design
  - Changed `grid-template-columns` from `repeat(4, var(--shortcard-width))` to `repeat(6, 1fr)` for better flexibility
  - Removed `justify-content: center` to allow natural grid distribution
  - Added `--shortcard-width: 100%` to make cards fill available space
  - Added mobile breakpoint (`@media (max-width: 768px)`) to switch to 2-column layout on smaller screens

- **UserInfo.vue**: Made username clickable by converting it to a NuxtLink
  - Changed username from static `<span>` to `<NuxtLink>` pointing to `/newsite/czone/{username}`
  - Allows users to navigate to other user profiles directly from the user info section

- **newsite-template.vue**: Improved sidebar button styling
  - Updated border-radius from `0` to `var(--sidebar-radius) var(--sidebar-radius) 0 0` for rounded top corners
  - Creates better visual consistency with the sidebar design

## Implementation Details
The grid layout now uses fractional units (`1fr`) instead of fixed widths, providing better responsiveness across different screen sizes. The mobile breakpoint ensures the layout remains usable on smaller devices by reducing to 2 columns.

https://claude.ai/code/session_01FjkXJSm1xN9uWh7mph4fwK