### PR TITLE
Remove Footer template from layout and unused placeholder button

### DIFF
--- a/components/newsite/MyCworld.vue
+++ b/components/newsite/MyCworld.vue
@@ -4,7 +4,6 @@
       <GreenButton @click="goToCzone">My cZone</GreenButton>
       <GreenButton @click="$router.push('/newsite/MyCollection')">My Collection</GreenButton>
       <GreenButton @click="$router.push('/newsite/myachievements')">Achievements</GreenButton>
-      <GreenButton>Placeholder</GreenButton>
     </div>
     <div class="mcw-content">
       <CzoneContest />

--- a/pages/newsite/AuctionHouse.vue
+++ b/pages/newsite/AuctionHouse.vue
@@ -9,9 +9,6 @@
     <template #main-content>
       <AuctionHouse />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/Games.vue
+++ b/pages/newsite/Games.vue
@@ -9,9 +9,6 @@
     <template #main-content>
       <GamesHome />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/MyCollection.vue
+++ b/pages/newsite/MyCollection.vue
@@ -9,9 +9,6 @@
     <template #main-content>
       <MyCollection />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/MycWorld.vue
+++ b/pages/newsite/MycWorld.vue
@@ -9,9 +9,6 @@
     <template #main-content>
       <MyCworld />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/cmart.vue
+++ b/pages/newsite/cmart.vue
@@ -27,9 +27,6 @@
     <template #main-content>
       <Cmart />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/czone/[username].vue
+++ b/pages/newsite/czone/[username].vue
@@ -12,9 +12,6 @@
     <template #main-content>
       <MyCzone ref="czoneRef" />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/home.vue
+++ b/pages/newsite/home.vue
@@ -20,9 +20,6 @@
         </template>
       </div>
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/myachievements.vue
+++ b/pages/newsite/myachievements.vue
@@ -9,9 +9,6 @@
     <template #main-content>
       <MyAchievements />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/myczone.vue
+++ b/pages/newsite/myczone.vue
@@ -12,9 +12,6 @@
     <template #main-content>
       <MyCzone ref="czoneRef" />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/newcmart.vue
+++ b/pages/newsite/newcmart.vue
@@ -9,9 +9,6 @@
     <template #main-content>
       <Cmart />
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 

--- a/pages/newsite/settings.vue
+++ b/pages/newsite/settings.vue
@@ -108,9 +108,6 @@
         </div>
       </div>
     </template>
-    <template #footer>
-      <Footer />
-    </template>
   </NuxtLayout>
 </template>
 


### PR DESCRIPTION
## Summary
This PR removes redundant Footer template declarations from multiple page components and cleans up an unused placeholder button from the MyCworld component.

## Key Changes
- Removed `<template #footer>` blocks from 11 page components in the `pages/newsite/` directory:
  - AuctionHouse.vue
  - Games.vue
  - MyCollection.vue
  - MycWorld.vue
  - cmart.vue
  - czone/[username].vue
  - home.vue
  - myachievements.vue
  - myczone.vue
  - newcmart.vue
  - settings.vue
- Removed unused placeholder button (`<GreenButton>Placeholder</GreenButton>`) from MyCworld.vue component

## Implementation Details
The Footer template removal suggests that footer rendering is now handled at the layout level (NuxtLayout) rather than being explicitly declared in each page component. This is a cleaner approach that reduces code duplication and centralizes footer management.

The placeholder button removal is a simple cleanup of unused UI elements.

https://claude.ai/code/session_012eJvyuPLuVavMb9LBrDF3m