### PR TITLE
Add toon click interaction to view character details in czone

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -38,8 +38,9 @@
           <div
             v-for="(toon, toonIdx) in currentZone.toons" :key="toon.id"
             class="cz-item"
-            :class="{ 'is-dragging': localDrag?.toon?.id === toon.id }"
+            :class="{ 'is-dragging': localDrag?.toon?.id === toon.id, 'is-viewable': !cz.buildMode }"
             :style="{ left: toon.x + 'px', top: toon.y + 'px', width: toonW(toon) + 'px', height: toonH(toon) + 'px' }"
+            @click.stop="onToonClick(toon)"
           >
             <img
               :src="toon.assetPath" :alt="toon.name"
@@ -122,6 +123,7 @@ function canvasH() { return CANVAS_H }
 
 const { user } = useAuth()
 const cz = useNewSiteCzoneState()
+const { open: openCtoonModal } = useCtoonModal()
 const route  = useRoute()
 const router = useRouter()
 
@@ -295,6 +297,12 @@ function toCanvasCoords(cx, cy) {
 function isOverCanvas(cx, cy) {
   const r = canvasRect()
   return r && cx >= r.left && cx <= r.right && cy >= r.top && cy <= r.bottom
+}
+
+// ── Toon click: open info modal in view mode ──────────────────
+function onToonClick(toon) {
+  if (cz.value.buildMode || !toon.ctoonId) return
+  openCtoonModal({ ctoonId: toon.ctoonId, assetPath: toon.assetPath, name: toon.name })
 }
 
 // ── Canvas mousedown: reposition placed toons ─────────────────
@@ -526,6 +534,8 @@ defineExpose({ save, clearZone })
 }
 
 .cz-item.is-dragging { opacity: 0.5; }
+.cz-item.is-viewable { pointer-events: auto; cursor: pointer; }
+.cz-item.is-viewable:hover { filter: brightness(1.1); }
 
 .cz-item-img {
   width: 100%;


### PR DESCRIPTION
## Summary
Added interactivity to character (toon) items in the custom zone view mode, allowing users to click on toons to open a character information modal.

## Key Changes
- Added click handler (`onToonClick`) to toon elements that opens the character modal in view mode (disabled in build mode)
- Integrated `useCtoonModal()` composable to manage character detail modal state
- Added `is-viewable` CSS class to enable pointer events and visual feedback (cursor and hover brightness) on toons when not in build mode
- Updated toon element binding to include click handler with stop propagation

## Implementation Details
- The click handler checks two conditions before opening the modal: build mode must be disabled and the toon must have a valid `ctoonId`
- Character modal is opened with toon metadata (ctoonId, assetPath, name)
- Visual feedback includes pointer cursor and 1.1x brightness filter on hover for better UX
- Pointer events are disabled on toons during build mode to prevent accidental interactions while editing

https://claude.ai/code/session_01GVci9sLECxPqJYCrz1nBPm