### PR TITLE
feat: add Terms of Use page with IP disclaimer and footer link

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -248,6 +248,7 @@
           <p>© {{ new Date().getFullYear() }} Cartoon ReOrbit</p>
           <nav class="flex items-center gap-6">
             <NuxtLink to="/privacy" class="hover:text-[var(--reorbit-blue)]">Privacy</NuxtLink>
+            <NuxtLink to="/terms" class="hover:text-[var(--reorbit-blue)]">Terms of Use</NuxtLink>
           </nav>
         </div>
         <p class="mt-4 text-xs text-slate-500">

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -1,0 +1,154 @@
+<template>
+  <div class="p-6 max-w-4xl mx-auto text-gray-800">
+    <h1 class="text-3xl font-bold mb-4">Terms of Use</h1>
+    <p class="mb-2"><strong>Effective Date:</strong> May 3, 2025</p>
+
+    <p class="mb-4">
+      Welcome to <strong>Cartoon ReOrbit</strong> ("we", "our", or "us"). By accessing or using this platform, you agree to these Terms of Use. If you do not agree, do not use the platform.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">1. Fan Project — No Affiliation</h2>
+    <p class="mb-4">
+      Cartoon ReOrbit is an independent, fan-made, non-commercial project. It is <strong>not affiliated with, endorsed by, sponsored by, or in any way officially connected to</strong> any of the intellectual property holders whose characters may appear on this platform. This project exists as a tribute to classic animated programming and operates in the spirit of fan creativity.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">2. Third-Party Intellectual Property</h2>
+    <p class="mb-4">
+      All characters, shows, logos, and related imagery featured on this platform are the exclusive property of their respective owners and networks. Cartoon ReOrbit claims no ownership over any third-party intellectual property. Rights holders include, but are not limited to:
+    </p>
+    <ul class="list-disc list-inside mb-4 space-y-1">
+      <li><strong>Warner Bros. Discovery</strong> — Cartoon Network, Adult Swim, Boomerang, Hanna-Barbera, Turner Entertainment, DC Comics</li>
+      <li><strong>Paramount Global / Nickelodeon</strong> — Nickelodeon, Nick Jr., Noggin, MTV Networks, Comedy Central, VH1</li>
+      <li><strong>The Walt Disney Company</strong> — Disney Channel, Disney XD, Disney Junior, ABC, Marvel Entertainment, Lucasfilm (Star Wars), Pixar</li>
+      <li><strong>Fox Entertainment Group / Fox Kids</strong> — Fox Broadcasting, Fox Kids Network</li>
+      <li><strong>NBCUniversal / DreamWorks Animation</strong> — Universal Pictures, Illumination Entertainment, DreamWorks Animation</li>
+      <li><strong>Sony Pictures Entertainment</strong> — Sony Pictures Animation, Sony Pictures Television</li>
+      <li><strong>Hasbro Studios</strong> — Transformers, My Little Pony, G.I. Joe, Power Rangers (in partnership with Saban)</li>
+      <li><strong>Mattel</strong> — He-Man, Masters of the Universe, Barbie, Hot Wheels</li>
+      <li><strong>Saban Brands / Saban Entertainment</strong> — Power Rangers franchise and related properties</li>
+      <li><strong>4Kids Entertainment</strong> — Licensed properties distributed through 4Kids</li>
+      <li><strong>Toei Animation</strong> — Dragon Ball, Sailor Moon, One Piece, Digimon (in partnership with Bandai)</li>
+      <li><strong>Bandai Namco Entertainment</strong> — Digimon, Pac-Man, and related franchises</li>
+      <li><strong>Viz Media</strong> — Naruto, Bleach, and other licensed manga/anime properties</li>
+      <li><strong>Funimation / Crunchyroll (Sony)</strong> — Various licensed anime properties</li>
+      <li><strong>Studio Ghibli / GKIDS</strong> — Studio Ghibli films and characters</li>
+      <li><strong>Netflix, Inc.</strong> — Netflix original animated series and acquired properties</li>
+      <li><strong>MGM / United Artists</strong> — Tom and Jerry (original productions), other classic animation</li>
+      <li><strong>Klasky Csupo</strong> — Rugrats, Rocket Power, As Told by Ginger, and related shows</li>
+      <li><strong>Frederator Studios</strong> — Adventure Time (in partnership with Cartoon Network), Castlevania, and related works</li>
+      <li><strong>Sesame Workshop</strong> — Sesame Street and related characters</li>
+      <li><strong>PBS / PBS Kids</strong> — PBS Kids programming and characters</li>
+      <li><strong>All other rights holders</strong> not named above whose characters, artwork, or intellectual property may appear on the platform</li>
+    </ul>
+    <p class="mb-4">
+      If you are a rights holder and believe content on this platform infringes your intellectual property, please see Section 10 (Intellectual Property Takedown Requests).
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">3. No Real Money Exchange</h2>
+    <p class="mb-4">
+      Cartoon ReOrbit is entirely free to play. No real money is accepted by the platform, its owner, or its moderators in exchange for in-game items, currency, or benefits.
+    </p>
+    <p class="mb-4">
+      Some cosmetic account perks are available to users who boost the Cartoon ReOrbit Discord server. Those boosts are a transaction exclusively between the user and <strong>Discord, Inc.</strong> — no funds from Discord boosts are received by or paid to the Cartoon ReOrbit owner, moderators, or volunteers. Cartoon ReOrbit makes no guarantees regarding Discord's services or policies.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">4. Virtual Items Have No Real-World Value</h2>
+    <p class="mb-4">
+      All cToons, in-game currency, cZone items, and any other virtual goods or assets on this platform have <strong>no real-world monetary value</strong>. They cannot be redeemed for real money, transferred outside the platform, or sold for real currency. Loss of virtual items due to trades, bans, account termination, server issues, or any other reason does not entitle any user to compensation of any kind.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">5. User-Submitted Content</h2>
+    <p class="mb-4">
+      Users may submit custom cToons and other content ("User Content") to the platform. By submitting content, you grant Cartoon ReOrbit a non-exclusive, royalty-free license to display, reproduce, and use that content within the platform.
+    </p>
+    <p class="mb-4">
+      You are <strong>solely responsible</strong> for any User Content you submit. You must not submit content that:
+    </p>
+    <ul class="list-disc list-inside mb-4 space-y-1">
+      <li>Violates the intellectual property rights of any third party</li>
+      <li>Contains offensive, hateful, or illegal material</li>
+      <li>Misrepresents official characters or brands in a defamatory or harmful way</li>
+      <li>Includes personal information of real individuals without their consent</li>
+    </ul>
+    <p class="mb-4">
+      Cartoon ReOrbit reserves the right to remove any User Content at any time without notice. Submission of User Content does not create any ownership claim over third-party intellectual property depicted within it.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">6. Acceptable Use</h2>
+    <p class="mb-4">You agree not to:</p>
+    <ul class="list-disc list-inside mb-4 space-y-1">
+      <li>Exploit bugs, glitches, or unintended platform behavior for personal gain</li>
+      <li>Use scripts, bots, or automation tools to interact with the platform</li>
+      <li>Harass, threaten, or harm other users</li>
+      <li>Attempt to sell, trade, or exchange in-game items for real money</li>
+      <li>Create multiple accounts to evade bans or gain unfair advantages</li>
+      <li>Attempt to gain unauthorized access to the platform or other users' accounts</li>
+      <li>Share, distribute, or reproduce platform content outside of its intended use</li>
+    </ul>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">7. Account Suspension and Termination</h2>
+    <p class="mb-4">
+      The Cartoon ReOrbit owner and any designated moderator may suspend, restrict, or permanently ban any account <strong>at any time, for any reason, with or without prior notice</strong>. This includes but is not limited to violations of these Terms of Use, community rules, or behavior deemed harmful to the platform or its users.
+    </p>
+    <p class="mb-4">
+      Upon termination of an account, all associated virtual items, currency, cZones, and progress are forfeited. No compensation or appeal is guaranteed.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">8. Age Requirements</h2>
+    <p class="mb-4">
+      Cartoon ReOrbit is intended for users aged <strong>13 and older</strong> (or 16 and older where required by local law, such as in certain European Union member states). By using the platform, you confirm that you meet the minimum age requirement for your jurisdiction. If we learn that a user does not meet the minimum age requirement, their account will be removed.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">9. Moderator and Volunteer Disclaimer</h2>
+    <p class="mb-4">
+      Moderators, content creators, developers, and all other volunteers who assist in operating Cartoon ReOrbit are <strong>unpaid community volunteers</strong>. They are not employees, agents, or legal representatives of any business entity. No moderator, volunteer, content creator, or developer is personally liable for any losses, damages, disputes, or negative experiences arising from their actions taken in good faith while serving the community.
+    </p>
+    <p class="mb-4">
+      The owner of Cartoon ReOrbit is likewise not liable for the independent actions of community volunteers, moderators, or contributors beyond what is directly within their control.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">10. Intellectual Property Takedown Requests</h2>
+    <p class="mb-4">
+      Cartoon ReOrbit respects the intellectual property rights of all rights holders and is committed to cooperating with legitimate takedown requests. If you are a copyright or trademark owner (or authorized agent) and believe that content on this platform infringes your rights, please contact us through our Discord server with the following information:
+    </p>
+    <ul class="list-disc list-inside mb-4 space-y-1">
+      <li>Identification of the copyrighted or trademarked work claimed to be infringed</li>
+      <li>Identification of the specific content on the platform you believe is infringing</li>
+      <li>Your contact information</li>
+      <li>A statement that you have a good faith belief that the use is not authorized</li>
+      <li>A statement that the information provided is accurate and, under penalty of perjury, that you are authorized to act on behalf of the rights holder</li>
+    </ul>
+    <p class="mb-4">
+      We will review all legitimate requests and take appropriate action, which may include removing the identified content.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">11. Disclaimer of Warranties</h2>
+    <p class="mb-4">
+      Cartoon ReOrbit is provided <strong>"as is"</strong> and <strong>"as available"</strong> without warranty of any kind, express or implied. We do not guarantee that the platform will be uninterrupted, error-free, or free of data loss. Use the platform at your own risk.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">12. Limitation of Liability</h2>
+    <p class="mb-4">
+      To the fullest extent permitted by applicable law, <strong>no owner, developer, moderator, content creator, or community volunteer</strong> involved with Cartoon ReOrbit shall be liable for any direct, indirect, incidental, special, consequential, or punitive damages arising from your use of or inability to use the platform, including but not limited to loss of virtual items, account bans, data loss, or disputes with other users.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">13. Governing Law</h2>
+    <p class="mb-4">
+      These Terms of Use are governed by and construed in accordance with the laws of the <strong>State of Arkansas, United States of America</strong>, without regard to its conflict of law provisions. Any disputes arising under these terms shall be subject to the exclusive jurisdiction of the courts located in Arkansas.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">14. Changes to These Terms</h2>
+    <p class="mb-4">
+      We may update these Terms of Use at any time. Significant changes will be announced through the Discord server. Continued use of the platform after changes are posted constitutes acceptance of the updated terms.
+    </p>
+
+    <h2 class="text-2xl font-semibold mt-6 mb-2">15. Contact</h2>
+    <p class="mb-4">
+      For questions, concerns, or intellectual property takedown requests, please <strong>contact our moderators through the Cartoon ReOrbit Discord server</strong>. Discord is our sole support channel.
+    </p>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({ title: 'Terms of Use' })
+</script>


### PR DESCRIPTION
Creates /terms page modeled after the privacy policy, covering Arkansas governing law, third-party IP ownership for all major animation studios/networks, no real-money exchange (Discord boosts go to Discord not the site), user-submitted cToon content policy, virtual item value disclaimer, mod/volunteer liability disclaimer, and DMCA takedown cooperation. Adds Terms of Use link to the homepage footer next to Privacy.

https://claude.ai/code/session_01HEWVmyvRJwiy27b2DXSDu1