### PR TITLE
fix: prevent premature auction close when anti-snipe extends endAt mid-job

### DIFF
--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -3056,7 +3056,23 @@ async function performAuctionClose(auctionId) {
     select: { userId: true, amount: true }
   })
 
+  // Will be set inside the transaction if endAt was extended after our initial read.
+  let extendedEndAt = null
+
   await db.$transaction(async tx => {
+    // Re-check inside the transaction to close the TOCTOU gap: a concurrent bid
+    // with anti-snipe may have extended endAt after our initial read above, but
+    // scheduleAuctionClose skips rescheduling when the job is already 'active'.
+    const current = await tx.auction.findUnique({
+      where: { id },
+      select: { status: true, endAt: true }
+    })
+    if (!current || current.status !== 'ACTIVE') return
+    if (new Date(current.endAt) > now) {
+      extendedEndAt = current.endAt
+      return
+    }
+
     await tx.auction.update({
       where: { id },
       data: {
@@ -3137,6 +3153,12 @@ async function performAuctionClose(auctionId) {
       })
     }
   })
+
+  // endAt was extended by a concurrent anti-snipe bid; reschedule and bail out.
+  if (extendedEndAt) {
+    await scheduleAuctionClose(auctionId, extendedEndAt)
+    return
+  }
 
   io.to(`auction_${id}`).emit('auction-ended', {
     winnerId:   winningBid?.userId ?? null,


### PR DESCRIPTION
performAuctionClose had a TOCTOU race: it read endAt outside the
transaction, then the close transaction ran with no re-check. A
concurrent bid with anti-snipe could extend endAt after the initial
read, but scheduleAuctionClose silently skips rescheduling when the
close job is already 'active', so the auction was marked CLOSED while
endAt was still in the future — causing "Auction not active" errors
on active auctions.

Fix: re-read status and endAt inside the transaction before writing
CLOSED. If endAt has moved forward, set extendedEndAt and return
without closing; after the transaction, reschedule the close job to
the updated endAt.

https://claude.ai/code/session_018JDRUz2AnkMTx5JdbMcUmH