### PR TITLE
Add News page and Other tab to admin Manage Homepage

### DIFF
--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -23,6 +23,10 @@
             class="px-3 py-2 border-b-2"
             :class="activeTab==='Release Settings' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Release Settings'">Release Settings</button>
+          <button
+            class="px-3 py-2 border-b-2"
+            :class="activeTab==='Other' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
+            @click="activeTab='Other'">Other</button>
 
         </nav>
       </div>
@@ -312,6 +316,38 @@
 
 
 
+      <!-- Other tab -->
+      <section v-if="activeTab==='Other'" class="space-y-6">
+        <p class="text-sm text-gray-600">
+          Configure additional page images.
+        </p>
+
+        <!-- News image -->
+        <div class="border rounded p-4 space-y-3">
+          <h2 class="font-semibold">News</h2>
+          <p class="text-xs text-gray-500">Image displayed on the News page.</p>
+          <div class="flex items-center gap-4">
+            <div class="w-48 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
+              <img v-if="previewUrls.news || newsPath" :src="previewUrls.news || newsPath" alt="News" class="max-h-full max-w-full object-contain" />
+              <span v-else class="text-gray-400 text-xs">No image</span>
+            </div>
+            <div class="space-y-2 flex-1 min-w-0">
+              <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
+                @change="onNewsFile($event)" class="block w-full text-sm" />
+              <div v-if="newsFile" class="text-xs text-gray-600 truncate">Selected: {{ newsFile.name }}</div>
+              <button type="button" class="px-3 py-1 text-sm rounded border"
+                      v-if="newsPath" @click="clearNews()">Clear</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-2">
+          <button class="btn-primary" :disabled="saving" @click="saveOther">
+            <span v-if="!saving">Save</span><span v-else>Saving…</span>
+          </button>
+        </div>
+      </section>
+
       <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded',
                                  toast.type==='error'?'bg-red-100 text-red-700':'bg-green-100 text-green-700']">
         {{ toast.msg }}
@@ -341,7 +377,10 @@ const activeTab = ref('Homepage')
 
 const paths = ref({ topLeft:'', bottomLeft:'', topRight:'', bottomRight:'' })
 const files = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null })
-const previewUrls = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null, showcase:null, homeImage1:null, homeImage2:null, homeImage3:null, homeImage4:null, middleSidebar1:null, middleSidebar2:null, middleSidebar3:null })
+const previewUrls = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null, showcase:null, homeImage1:null, homeImage2:null, homeImage3:null, homeImage4:null, middleSidebar1:null, middleSidebar2:null, middleSidebar3:null, news:null })
+
+const newsPath = ref('')
+const newsFile = ref(null)
 
 const showcasePath = ref('')
 const showcaseFile = ref(null)
@@ -459,6 +498,19 @@ function clearMiddleSidebar(n) {
   middleSidebarFiles[n] = null
 }
 
+function onNewsFile(e) {
+  const f = e.target.files?.[0] || null
+  try { if (previewUrls.value.news) { URL.revokeObjectURL(previewUrls.value.news); previewUrls.value.news = null } } catch (e) {}
+  newsFile.value = f
+  if (f) previewUrls.value.news = URL.createObjectURL(f)
+}
+
+function clearNews() {
+  newsPath.value = ''
+  if (previewUrls.value.news) { try { URL.revokeObjectURL(previewUrls.value.news) } catch (e) {} ; previewUrls.value.news = null }
+  newsFile.value = null
+}
+
 function onMiddleSidebarPresetChange(n) {
   const preset = middleSidebarImages[n].linkPreset
   if (preset === '') {
@@ -501,6 +553,8 @@ async function loadConfig() {
     middleSidebarImages[n].link = rawLink
     middleSidebarImages[n].linkPreset = detectPreset(rawLink)
   }
+
+  newsPath.value = cfg.newsImagePath || ''
 }
 
 
@@ -598,6 +652,23 @@ async function saveSidebar() {
     }
 
     toast.value = { type: 'ok', msg: 'Sidebar saved.' }
+  } catch (e) {
+    console.error(e); toast.value = { type: 'error', msg: e?.statusMessage || 'Save failed' }
+  } finally {
+    saving.value = false; setTimeout(() => { toast.value = null }, 2500)
+  }
+}
+
+async function saveOther() {
+  saving.value = true; toast.value = null
+  try {
+    const fd = new FormData()
+    fd.append('newsPath', newsPath.value || '')
+    if (newsFile.value) fd.append('news', newsFile.value)
+    const res = await $fetch('/api/admin/homepage', { method: 'POST', body: fd })
+    newsPath.value = res.newsImagePath || ''
+    newsFile.value = null
+    toast.value = { type: 'ok', msg: 'News image saved.' }
   } catch (e) {
     console.error(e); toast.value = { type: 'error', msg: e?.statusMessage || 'Save failed' }
   } finally {

--- a/pages/newsite/news.vue
+++ b/pages/newsite/news.vue
@@ -1,0 +1,74 @@
+<template>
+  <NuxtLayout name="newsite-template">
+    <template #sidebar-top>
+      <UserInfo />
+    </template>
+    <template #sidebar-bottom>
+      <WinballAd />
+    </template>
+    <template #main-content>
+      <div class="news-content">
+        <img v-if="newsImagePath" :src="newsImagePath" alt="News" class="news-image" />
+        <div v-else class="news-placeholder"></div>
+      </div>
+    </template>
+  </NuxtLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
+useHead({ htmlAttrs: { class: 'newsite-news' } })
+
+const newsImagePath = ref(null)
+
+onMounted(async () => {
+  try {
+    const cfg = await $fetch('/api/homepage')
+    newsImagePath.value = cfg.newsImagePath || null
+  } catch {}
+})
+</script>
+
+<style>
+html.newsite-news {
+  min-height: 100vh;
+  background: linear-gradient(
+    to bottom,
+    #000000 0px,
+    #000000 65px,
+    #003466 115px,
+    #003466 100%
+  ) no-repeat fixed !important;
+}
+
+html.newsite-news body {
+  background: transparent !important;
+  min-height: 100vh;
+}
+</style>
+
+<style scoped>
+.news-content {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+.news-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.news-placeholder {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/prisma/migrations/20260506000000_add_news_image_path/migration.sql
+++ b/prisma/migrations/20260506000000_add_news_image_path/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "HomepageConfig" ADD COLUMN "newsImagePath" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1562,6 +1562,7 @@ model HomepageConfig {
   middleSidebar2Link       String?
   middleSidebar3ImagePath  String?
   middleSidebar3Link       String?
+  newsImagePath            String?
   createdAt                DateTime @default(now())
   updatedAt                DateTime @updatedAt
 }

--- a/server/api/admin/homepage/index.get.js
+++ b/server/api/admin/homepage/index.get.js
@@ -37,6 +37,7 @@ export default defineEventHandler(async (event) => {
     middleSidebar2Link: null,
     middleSidebar3ImagePath: null,
     middleSidebar3Link: null,
+    newsImagePath: null,
     updatedAt: null
   }
 

--- a/server/api/admin/homepage/index.post.js
+++ b/server/api/admin/homepage/index.post.js
@@ -53,7 +53,8 @@ export default defineEventHandler(async (event) => {
     middleSidebar2ImagePath: null,
     middleSidebar2Link:      null,
     middleSidebar3ImagePath: null,
-    middleSidebar3Link:      null
+    middleSidebar3Link:      null,
+    newsImagePath:           null
   }
 
   // fs prep
@@ -104,7 +105,8 @@ export default defineEventHandler(async (event) => {
     homeImage4:       await saveIfPresent('homeImage4'),
     middleSidebar1:   await saveIfPresent('middleSidebar1'),
     middleSidebar2:   await saveIfPresent('middleSidebar2'),
-    middleSidebar3:   await saveIfPresent('middleSidebar3')
+    middleSidebar3:   await saveIfPresent('middleSidebar3'),
+    news:             await saveIfPresent('news')
   }
 
   // helper: update one slot without touching others unless provided
@@ -151,7 +153,8 @@ export default defineEventHandler(async (event) => {
     middleSidebar2ImagePath:  resolveSlot('middleSidebar2ImagePath',  'middleSidebar2',  'middleSidebar2Path',  current.middleSidebar2ImagePath),
     middleSidebar2Link:       resolveLink('middleSidebar2Link', current.middleSidebar2Link),
     middleSidebar3ImagePath:  resolveSlot('middleSidebar3ImagePath',  'middleSidebar3',  'middleSidebar3Path',  current.middleSidebar3ImagePath),
-    middleSidebar3Link:       resolveLink('middleSidebar3Link', current.middleSidebar3Link)
+    middleSidebar3Link:       resolveLink('middleSidebar3Link', current.middleSidebar3Link),
+    newsImagePath:            resolveSlot('newsImagePath',            'news',            'newsPath',            current.newsImagePath)
   }
 
   const cfg = await db.homepageConfig.upsert({
@@ -170,7 +173,8 @@ export default defineEventHandler(async (event) => {
       'homeImage3Path', 'homeImage3Link', 'homeImage4Path', 'homeImage4Link',
       'middleSidebar1ImagePath', 'middleSidebar1Link',
       'middleSidebar2ImagePath', 'middleSidebar2Link',
-      'middleSidebar3ImagePath', 'middleSidebar3Link'
+      'middleSidebar3ImagePath', 'middleSidebar3Link',
+      'newsImagePath'
     ]
     for (const key of fields) {
       const prev = current[key] ?? null
@@ -201,6 +205,7 @@ export default defineEventHandler(async (event) => {
     middleSidebar2ImagePath: cfg.middleSidebar2ImagePath,
     middleSidebar2Link:      cfg.middleSidebar2Link,
     middleSidebar3ImagePath: cfg.middleSidebar3ImagePath,
-    middleSidebar3Link:      cfg.middleSidebar3Link
+    middleSidebar3Link:      cfg.middleSidebar3Link,
+    newsImagePath:           cfg.newsImagePath
   }
 })

--- a/server/api/homepage/index.get.js
+++ b/server/api/homepage/index.get.js
@@ -24,5 +24,6 @@ export default defineEventHandler(async () => {
     middleSidebar2Link:      cfg?.middleSidebar2Link      ?? null,
     middleSidebar3ImagePath: cfg?.middleSidebar3ImagePath ?? null,
     middleSidebar3Link:      cfg?.middleSidebar3Link      ?? null,
+    newsImagePath:           cfg?.newsImagePath           ?? null,
   }
 })


### PR DESCRIPTION
- New pages/newsite/news.vue that displays a single image in the main content area
- New "Other" tab in admin/manage-homepage.vue with a News section (image upload + clear)
- Added newsImagePath field to HomepageConfig Prisma model and migration
- Updated admin GET/POST homepage API endpoints to handle newsImagePath
- Updated public homepage API to expose newsImagePath

https://claude.ai/code/session_01DeqNWwDw7ZMZKDh3siktVU