### PR TITLE
Add owned/unowned badge to card headers and Escape key support

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -70,13 +70,18 @@
             : {}"
         >
           <template #header>
-            <img
-              v-if="c.assetPath"
-              :src="c.assetPath"
-              :alt="c.name"
-              class="card-img"
-              @click.stop="openInfo(c)"
-            />
+            <div class="card-header-wrap" @click.stop="openInfo(c)">
+              <img
+                v-if="c.assetPath"
+                :src="c.assetPath"
+                :alt="c.name"
+                class="card-img"
+              />
+              <span
+                class="owned-badge"
+                :class="originalOwnedSet.has(c.id) ? 'owned-badge--owned' : 'owned-badge--unowned'"
+              >{{ originalOwnedSet.has(c.id) ? 'Owned' : 'Unowned' }}</span>
+            </div>
           </template>
           <template #middle>
             <div class="card-middle-row">
@@ -863,12 +868,40 @@ async function closeOverlay() {
   line-height: 1.2;
 }
 
+.card-header-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
 .card-img {
   width: 100%;
   height: 100%;
   object-fit: contain;
   transform: scale(var(--img-scale));
-  cursor: pointer;
+}
+
+.owned-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  font-size: 0.5rem;
+  font-weight: bold;
+  padding: 1px 4px;
+  border-radius: 3px;
+  line-height: 1.4;
+  pointer-events: none;
+}
+
+.owned-badge--owned {
+  background: #16a34a;
+  color: #fff;
+}
+
+.owned-badge--unowned {
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .card-name {

--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -333,7 +333,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch, onBeforeUnmount, nextTick } from 'vue'
+import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import AddToWishlist from '@/components/AddToWishlist.vue'
 import abilities from '@/data/abilities.json'
 import { useCtoonModal } from '@/composables/useCtoonModal'
@@ -581,7 +581,16 @@ watch(suggestSet, (next) => {
   }, 250)
 })
 
+function onKeydown(e) {
+  if (e.key === 'Escape') close()
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', onKeydown)
+})
+
 onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKeydown)
   if (seriesSuggestTimer) clearTimeout(seriesSuggestTimer)
   if (setSuggestTimer) clearTimeout(setSuggestTimer)
   if (audioEl.value) audioEl.value.pause()


### PR DESCRIPTION
## Summary
This PR enhances the card display in the Cmart component by adding a visual badge indicating ownership status, and improves the info card modal by adding keyboard support for closing.

## Key Changes

**Cmart.vue:**
- Wrapped card header image in a new `card-header-wrap` div to serve as a clickable container
- Added an "Owned/Unowned" badge that displays in the top-right corner of each card header
  - Green badge (#16a34a) for owned items
  - Dark semi-transparent badge for unowned items
- Moved click handler from image element to the wrapper div for better UX
- Added corresponding CSS styles for the new badge component with proper positioning and styling

**CtoonInfoCard.vue:**
- Added `onMounted` import from Vue
- Implemented keyboard event listener for the Escape key to close the modal
- Properly cleaned up the event listener in `onBeforeUnmount` to prevent memory leaks

## Implementation Details
- The owned badge uses `originalOwnedSet.has(c.id)` to determine ownership status
- Badge is positioned absolutely within the card header with `pointer-events: none` to avoid interfering with interactions
- Keyboard handler is attached to the document and properly removed on component unmount

https://claude.ai/code/session_019RCmXVaJLPCuz9GLbDWg2o