### PR TITLE
Add cZone Search: capture items feature for visitors

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -42,6 +42,7 @@
             :style="{ left: toon.x + 'px', top: toon.y + 'px', width: toonW(toon) + 'px', height: toonH(toon) + 'px' }"
             @click.stop="onToonClick(toon)"
           >
+
             <img
               :src="toon.assetPath" :alt="toon.name"
               class="cz-item-img"
@@ -72,6 +73,21 @@
               </svg>
             </button>
           </div>
+
+          <!-- ── cZone Search items (zone 0 only, visitor only) ── -->
+          <template v-if="!cz.buildMode && cz.activeZone === 0">
+            <button
+              v-for="item in czoneSearchItems"
+              :key="item.key"
+              type="button"
+              class="czone-search-ctoon"
+              :class="{ 'opacity-70 cursor-wait': item.isCapturing }"
+              :style="{ position: 'absolute', top: item.y + 'px', left: item.x + 'px', width: item.size + 'px', height: item.size + 'px', zIndex: 60 }"
+              @click="captureCzoneSearchItem(item)"
+            >
+              <img :src="item.assetPath" :alt="item.name" class="czone-search-image" loading="lazy" />
+            </button>
+          </template>
         </div>
       </div>
     </div>
@@ -100,6 +116,51 @@
         :style="{ left: cz.ghostX + 'px', top: cz.ghostY + 'px' }"
         draggable="false"
       />
+
+      <!-- ── cZone Search: capture modal ── -->
+      <transition name="cz-fade">
+        <div
+          v-if="captureModalVisible"
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          @click.self="closeCaptureModal"
+        >
+          <div class="relative bg-white rounded-lg shadow-lg w-full max-w-md max-h-[90vh] flex flex-col">
+            <div class="px-4 py-3 border-b flex items-center justify-between flex-shrink-0">
+              <h2 class="text-lg font-semibold">cToon Captured</h2>
+              <button class="text-gray-500 hover:text-black" @click="closeCaptureModal">✕</button>
+            </div>
+            <div class="p-4 overflow-y-auto flex-1">
+              <div v-if="capturedCtoon" class="space-y-4">
+                <img
+                  :src="capturedCtoon.assetPath"
+                  :alt="capturedCtoon.name || 'Captured cToon'"
+                  class="w-full max-h-56 object-contain rounded"
+                  loading="lazy"
+                />
+                <div class="space-y-1">
+                  <p class="font-semibold text-base">You've captured {{ capturedCtoon.captureCount.toLocaleString() }} {{ capturedCtoon.name }}s</p>
+                  <p class="text-sm text-gray-600">You now own {{ capturedCtoon.ownedCount.toLocaleString() }} {{ capturedCtoon.name }}s</p>
+                </div>
+                <div class="space-y-1 text-sm">
+                  <div><span class="text-gray-500">Rarity:</span> <span class="font-medium">{{ capturedCtoon.rarity || '—' }}</span></div>
+                  <div><span class="text-gray-500">Series:</span> <span class="font-medium">{{ capturedCtoon.series || '—' }}</span></div>
+                  <div><span class="text-gray-500">Set:</span> <span class="font-medium">{{ capturedCtoon.set || '—' }}</span></div>
+                </div>
+              </div>
+            </div>
+            <div class="px-4 py-3 border-t flex justify-end gap-2 flex-shrink-0">
+              <button class="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700" @click="closeCaptureModal">Close</button>
+            </div>
+          </div>
+        </div>
+      </transition>
+
+      <!-- ── cZone Search: toast ── -->
+      <transition name="cz-fade">
+        <div v-if="searchToast.visible" class="cz-search-toast" :class="searchToast.type">
+          {{ searchToast.message }}
+        </div>
+      </transition>
     </Teleport>
 
   </div>
@@ -107,12 +168,13 @@
 
 <script setup>
 // ── Canvas size variables ─────────────────────────────────────
-const TOON_SIZE   = 80    // default toon size in px when dropped
-const TOPBAR_H    = 34    // top bar height in px
-const BOTTOMBAR_H = 35    // bottom bar height in px
-const CANVAS_W    = 800   // design-space canvas width
-const CANVAS_H    = 600   // design-space canvas height
-const SIZE_CYCLE  = [1, 0.5, 2]  // sizeScale cycle: default → half → double
+const TOON_SIZE        = 80    // default toon size in px when dropped
+const TOPBAR_H         = 34    // top bar height in px
+const BOTTOMBAR_H      = 35    // bottom bar height in px
+const CANVAS_W         = 800   // design-space canvas width
+const CANVAS_H         = 600   // design-space canvas height
+const SIZE_CYCLE       = [1, 0.5, 2]  // sizeScale cycle: default → half → double
+const SEARCH_TOON_SIZE = 140   // cZone search toon size in px
 
 function toonW(t) { return (t.width  || TOON_SIZE) * (t.sizeScale || 1) }
 function toonH(t) { return (t.height || TOON_SIZE) * (t.sizeScale || 1) }
@@ -152,12 +214,19 @@ const innerScaleStyle = computed(() => ({
   height:          `${CANVAS_H}px`,
 }))
 
-const canvasEl   = ref(null)
+const canvasEl       = ref(null)
 const viewedOwner    = ref(null)   // { username, avatar } of the displayed zone owner
 const viewedUsername = ref(null)   // username whose zone is currently displayed
 
 // Local drag: repositioning toons already on the canvas
 const localDrag = ref(null)  // { toon, offsetX, offsetY }
+
+// ── cZone Search state ────────────────────────────────────────
+const czoneSearchItems  = ref([])
+const captureModalVisible = ref(false)
+const capturedCtoon       = ref(null)
+const searchToast         = reactive({ visible: false, message: '', type: 'success' })
+let   searchToastTimer    = null
 
 const currentZone = computed(() => cz.value.zones[cz.value.activeZone] ?? { background: '', toons: [] })
 const isOwnZone   = computed(() => !!user.value && viewedUsername.value === user.value.username)
@@ -224,10 +293,20 @@ async function loadZone(username) {
     cz.value.activeZone  = firstActive >= 0 ? firstActive : 0
     viewedUsername.value = target
     viewedOwner.value    = { username: data.ownerName, avatar: data.avatar }
+    loadCzoneSearchItems()
   } catch (e) {
     console.error('MyCzone: failed to load zone', e)
   }
 }
+
+// Reload search items when switching to zone 0; clear them on other zones
+watch(() => cz.value.activeZone, (newZone) => {
+  if (newZone === 0) {
+    loadCzoneSearchItems()
+  } else {
+    czoneSearchItems.value = []
+  }
+})
 
 async function navigate(type) {
   const from = viewedUsername.value ?? user.value?.username
@@ -415,6 +494,100 @@ function cycleToonSize(idx) {
 function onToonImgLoad(e, toon) {
   if (!toon.width)  toon.width  = e.target.naturalWidth
   if (!toon.height) toon.height = e.target.naturalHeight
+}
+
+// ── cZone Search helpers ──────────────────────────────────────
+function showSearchToast(message, type = 'success') {
+  if (searchToastTimer) clearTimeout(searchToastTimer)
+  searchToast.message = message
+  searchToast.type    = type
+  searchToast.visible = true
+  searchToastTimer = setTimeout(() => { searchToast.visible = false }, 2500)
+}
+
+function randomSearchPosition(size) {
+  const maxX = Math.max(0, CANVAS_W - size)
+  const maxY = Math.max(0, CANVAS_H - size)
+  return {
+    x: Math.floor(Math.random() * (maxX + 1)),
+    y: Math.floor(Math.random() * (maxY + 1))
+  }
+}
+
+function buildSearchItems(items) {
+  return items.map((entry) => {
+    const size = SEARCH_TOON_SIZE
+    const pos  = randomSearchPosition(size)
+    return {
+      appearanceId: entry.appearanceId,
+      cZoneSearchId: entry.cZoneSearchId,
+      ctoonId: entry.ctoon?.id,
+      name: entry.ctoon?.name || 'cToon',
+      assetPath: entry.ctoon?.assetPath,
+      rarity: entry.ctoon?.rarity,
+      series: entry.ctoon?.series,
+      set: entry.ctoon?.set,
+      x: pos.x,
+      y: pos.y,
+      size,
+      isCapturing: false,
+      key: `search-${entry.appearanceId}`
+    }
+  }).filter(item => item.ctoonId && item.assetPath)
+}
+
+async function loadCzoneSearchItems() {
+  czoneSearchItems.value = []
+  if (!user.value?.id || !viewedUsername.value) return
+  if (user.value.username === viewedUsername.value) return
+  try {
+    const tz  = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+    const res = await $fetch(`/api/czone/${viewedUsername.value}/searches`, {
+      query: { tz, zoneIndex: 0 }
+    })
+    const items = Array.isArray(res?.items) ? res.items : []
+    czoneSearchItems.value = buildSearchItems(items)
+  } catch (err) {
+    console.error('MyCzone: failed to load cZone search items', err)
+    czoneSearchItems.value = []
+  }
+}
+
+async function captureCzoneSearchItem(item) {
+  if (!item || item.isCapturing) return
+  item.isCapturing = true
+  try {
+    const res  = await $fetch('/api/czone/searches/capture', {
+      method: 'POST',
+      body: { appearanceId: item.appearanceId }
+    })
+    const name = res?.ctoon?.name || item.name
+    showSearchToast(`Captured ${name}!`, 'success')
+    capturedCtoon.value = res?.ctoon ? { ...res.ctoon } : {
+      name: item.name,
+      assetPath: item.assetPath,
+      rarity: item.rarity,
+      series: item.series,
+      set: item.set,
+      captureCount: 1,
+      ownedCount: 1
+    }
+    captureModalVisible.value = true
+    czoneSearchItems.value = czoneSearchItems.value.filter(i => i.appearanceId !== item.appearanceId)
+  } catch (err) {
+    const message = err?.data?.statusMessage || 'Failed to capture cToon.'
+    showSearchToast(message, 'error')
+    if (String(message).toLowerCase().includes('already')) {
+      czoneSearchItems.value = czoneSearchItems.value.filter(i => i.appearanceId !== item.appearanceId)
+      return
+    }
+    item.isCapturing = false
+  }
+}
+
+function closeCaptureModal() {
+  captureModalVisible.value = false
+  capturedCtoon.value = null
 }
 
 // ── Save / Clear (called from CzoneEdit emits via page) ───────
@@ -644,4 +817,66 @@ defineExpose({ save, clearZone })
   z-index: 9999;
   image-rendering: pixelated;
 }
+
+/* ── cZone Search ── */
+.czone-search-ctoon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+}
+.czone-search-ctoon::before {
+  content: '';
+  position: absolute;
+  inset: -14px;
+  background: radial-gradient(circle, rgba(255, 215, 0, 0.75) 0%, rgba(255, 215, 0, 0.15) 55%, rgba(255, 215, 0, 0) 70%);
+  border-radius: 50%;
+  filter: blur(2px);
+  animation: czone-search-pulse 2.6s ease-in-out infinite;
+  z-index: 0;
+}
+.czone-search-image {
+  position: relative;
+  z-index: 1;
+  width: auto;
+  height: auto;
+  max-width: none;
+  max-height: none;
+  filter: drop-shadow(0 0 8px rgba(255, 215, 0, 0.6));
+}
+@keyframes czone-search-pulse {
+  0%   { transform: scale(0.9); opacity: 0.65; }
+  50%  { transform: scale(1.06); opacity: 1; }
+  100% { transform: scale(0.9); opacity: 0.65; }
+}
+
+/* ── cZone Search: toast ── */
+.cz-search-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #fff;
+  pointer-events: none;
+  white-space: nowrap;
+}
+.cz-search-toast.success { background: #16a34a; }
+.cz-search-toast.error   { background: #dc2626; }
+
+/* ── cZone Search: capture modal fade ── */
+.cz-fade-enter-active,
+.cz-fade-leave-active { transition: opacity 0.2s; }
+.cz-fade-enter-from,
+.cz-fade-leave-to    { opacity: 0; }
 </style>

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -257,6 +257,7 @@ html.newsite-active body {
     <slot />
     <CtoonInfoCard v-if="ctoonModalIsOpen" />
   </div>
+  <Onboarding />
 </template>
 
 <script setup>


### PR DESCRIPTION
## Summary
This PR adds a new "cZone Search" feature that allows visitors to discover and capture cToons in zone 0 of other users' cZones. When viewing another user's zone 0, visitors see interactive search items that can be clicked to capture cToons, with a modal displaying capture results and a toast notification system for feedback.

## Key Changes
- **Search Items Display**: Added rendering of search items as clickable buttons with pulsing golden glow animation, positioned randomly on the canvas (zone 0 only, visitor mode)
- **Capture Functionality**: Implemented `captureCzoneSearchItem()` to handle POST requests to `/api/czone/searches/capture` endpoint with loading state management
- **Capture Modal**: Added a modal dialog displaying captured cToon details including name, rarity, series, set, and capture/owned counts
- **Toast Notifications**: Implemented a toast notification system (`showSearchToast()`) for success/error feedback with auto-dismiss after 2.5 seconds
- **Data Loading**: Added `loadCzoneSearchItems()` to fetch search items from `/api/czone/{username}/searches` with timezone support
- **Zone Switching**: Added watcher to reload search items when switching to zone 0 and clear them when leaving
- **Styling**: Added CSS for search item buttons with radial gradient pulse animation, modal styling, and toast notifications with fade transitions

## Implementation Details
- Search items are only visible when `!cz.buildMode && cz.activeZone === 0` (visitor viewing zone 0)
- Items are positioned randomly within canvas bounds using `randomSearchPosition()` helper
- Captured items are removed from the list immediately after successful capture
- Modal and toast use Vue transitions (`cz-fade`) for smooth appearance/disappearance
- Search items include metadata (rarity, series, set) fetched from the API for display in the capture modal
- Items with missing `ctoonId` or `assetPath` are filtered out during build phase

https://claude.ai/code/session_01B7ywmCpGMDT7GRVXvM11Pq