### PR TITLE
Redesign onboarding panel with dark theme and improve collection UI

### DIFF
--- a/components/Onboarding.vue
+++ b/components/Onboarding.vue
@@ -3,27 +3,27 @@
     <transition name="daily-drawer">
       <div
         v-show="isOpen"
-        class="w-72 sm:w-80 rounded-2xl border border-[var(--reorbit-border)] bg-white/95 shadow-xl backdrop-blur overflow-hidden"
+        class="ob-panel w-72 sm:w-80 rounded-2xl border border-white/15 shadow-xl backdrop-blur overflow-hidden"
         style="--panel-max: 300px;"
       >
-        <div class="h-1 w-full bg-gradient-to-r from-[var(--reorbit-purple)] via-[var(--reorbit-cyan)] to-[var(--reorbit-lime)]"></div>
+        <div class="h-1 w-full bg-gradient-to-r from-[var(--OrbitDarkBlue)] via-[var(--OrbitLightBlue)] to-[#66CC00]"></div>
         <div class="px-4 py-3">
           <div class="flex items-center justify-between">
             <div>
-              <p class="text-[11px] uppercase tracking-widest text-slate-500">Onboarding</p>
-              <h3 class="text-sm font-semibold text-[var(--reorbit-blue)]">
+              <p class="text-[11px] uppercase tracking-widest text-white/50">Onboarding</p>
+              <h3 class="text-sm font-semibold text-white">
                 {{ activeTab === 'daily' ? 'Daily Checklist' : 'Events' }}
               </h3>
             </div>
             <button
               type="button"
-              class="text-xs font-semibold text-[var(--reorbit-blue)]/80 hover:text-[var(--reorbit-purple)]"
+              class="text-xs font-semibold text-white/60 hover:text-white transition"
               @click="isOpen = false"
             >
               Hide
             </button>
           </div>
-          <div class="mt-3 flex rounded-full bg-[var(--reorbit-tint)] p-1 text-xs font-semibold">
+          <div class="mt-3 flex rounded-full bg-white/10 p-1 text-xs font-semibold">
             <button
               type="button"
               :class="tabButtonClass('daily')"
@@ -43,11 +43,11 @@
         <div class="px-4 pb-4">
           <div v-if="activeTab === 'daily'">
             <div v-if="dailyPending || (!dailyData && !dailyError)" class="space-y-3 animate-pulse">
-              <div class="h-4 bg-[var(--reorbit-tint)] rounded w-5/6"></div>
-              <div class="h-4 bg-[var(--reorbit-tint)] rounded w-4/6"></div>
-              <div class="h-4 bg-[var(--reorbit-tint)] rounded w-3/6"></div>
+              <div class="h-4 bg-white/10 rounded w-5/6"></div>
+              <div class="h-4 bg-white/10 rounded w-4/6"></div>
+              <div class="h-4 bg-white/10 rounded w-3/6"></div>
             </div>
-            <div v-else-if="dailyError" class="text-sm text-slate-600">
+            <div v-else-if="dailyError" class="text-sm text-white/55">
               Sign in to view your daily activities.
             </div>
             <ul v-else class="space-y-3 max-h-[220px] overflow-y-auto pr-1">
@@ -56,15 +56,15 @@
                   :class="[
                     'mt-0.5 flex h-6 w-6 flex-none shrink-0 items-center justify-center rounded-full border',
                     item.done
-                      ? 'border-transparent bg-gradient-to-br from-[var(--reorbit-lime)] to-[var(--reorbit-green-2)] shadow'
-                      : 'border-slate-300 bg-white'
+                      ? 'border-transparent bg-gradient-to-br from-[#66CC00] to-[#3399CC] shadow'
+                      : 'border-white/25 bg-white/10'
                   ]"
                 >
                   <svg
                     v-if="item.done"
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 24 24"
-                    class="h-4 w-4 text-[var(--reorbit-deep)]"
+                    class="h-4 w-4 text-white"
                     fill="none"
                     stroke="currentColor"
                     stroke-width="3"
@@ -78,7 +78,7 @@
                     v-else
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 24 24"
-                    class="h-4 w-4 text-slate-300"
+                    class="h-4 w-4 text-white/30"
                     fill="none"
                     stroke="currentColor"
                     stroke-width="2"
@@ -89,81 +89,81 @@
                     <circle cx="12" cy="12" r="7" />
                   </svg>
                 </span>
-                <p class="text-sm text-slate-700">{{ item.text }}</p>
+                <p class="text-sm text-white/85">{{ item.text }}</p>
               </li>
             </ul>
           </div>
           <div v-else>
             <div v-if="eventsPending || (!eventsData && !eventsError)" class="space-y-3 animate-pulse">
-              <div class="h-4 bg-[var(--reorbit-tint)] rounded w-5/6"></div>
-              <div class="h-4 bg-[var(--reorbit-tint)] rounded w-4/6"></div>
-              <div class="h-4 bg-[var(--reorbit-tint)] rounded w-3/6"></div>
+              <div class="h-4 bg-white/10 rounded w-5/6"></div>
+              <div class="h-4 bg-white/10 rounded w-4/6"></div>
+              <div class="h-4 bg-white/10 rounded w-3/6"></div>
             </div>
-            <div v-else-if="eventsError" class="text-sm text-slate-600">
+            <div v-else-if="eventsError" class="text-sm text-white/55">
               Sign in to view active events.
             </div>
             <div v-else class="space-y-4 max-h-[220px] overflow-y-auto pr-1">
               <div>
-                <p class="text-[11px] uppercase tracking-widest text-slate-500">Holiday Events</p>
-                <div class="mt-1 text-[11px] text-slate-400 leading-snug">Check the cMart Holiday tab to purchase Holiday cToons.</div>
+                <p class="text-[11px] uppercase tracking-widest text-white/50">Holiday Events</p>
+                <div class="mt-1 text-[11px] text-white/40 leading-snug">Check the cMart Holiday tab to purchase Holiday cToons.</div>
                 <div v-if="holidayEvents.length" class="mt-2 space-y-2">
                   <div
                     v-for="event in holidayEvents"
                     :key="`holiday-${event.id}`"
-                    class="rounded-lg border border-[var(--reorbit-border)] bg-white/80 px-3 py-2"
+                    class="ob-event-card rounded-lg border border-white/10 px-3 py-2"
                   >
-                    <p class="text-sm font-semibold text-slate-700">
+                    <p class="text-sm font-semibold text-white/90">
                       {{ displayName(event.name, 'Holiday Event') }}
                     </p>
-                    <p class="text-xs text-slate-500">
+                    <p class="text-xs text-white/50">
                       Active {{ formatDateRange(event.startsAt, event.endsAt) }}
                     </p>
                   </div>
                 </div>
-                <p v-else class="mt-2 text-xs text-slate-500">No holiday events are active right now.</p>
+                <p v-else class="mt-2 text-xs text-white/45">No holiday events are active right now.</p>
               </div>
               <div>
-                <p class="text-[11px] uppercase tracking-widest text-slate-500">cZone Searches</p>
-                <div class="mt-1 text-[11px] text-slate-400 leading-snug">Look on other user's cZones to capture "shiny" cToons.</div>
+                <p class="text-[11px] uppercase tracking-widest text-white/50">cZone Searches</p>
+                <div class="mt-1 text-[11px] text-white/40 leading-snug">Look on other user's cZones to capture "shiny" cToons.</div>
                 <div v-if="czoneSearches.length" class="mt-2 space-y-2">
                   <div
                     v-for="search in czoneSearches"
                     :key="`czone-${search.id}`"
-                    class="rounded-lg border border-[var(--reorbit-border)] bg-white/80 px-3 py-2 text-sm font-semibold"
+                    class="ob-event-card rounded-lg border border-white/10 px-3 py-2"
                   >
                     <NuxtLink
                       v-if="search.linkInOnboarding"
                       :to="`/czonesearch/${search.id}`"
-                      class="text-sm font-semibold text-[var(--reorbit-blue)] hover:text-[var(--reorbit-purple)]"
+                      class="text-sm font-semibold text-[var(--OrbitLightBlue)] hover:text-white transition"
                     >
                       {{ displayName(search.name, 'cZone Search') }}
                     </NuxtLink>
-                    <p v-else class="text-sm font-semibold text-slate-700">
+                    <p v-else class="text-sm font-semibold text-white/90">
                       {{ displayName(search.name, 'cZone Search') }}
                     </p>
-                    <p class="text-xs text-slate-500">
+                    <p class="text-xs text-white/50">
                       Active {{ formatDateRange(search.startAt, search.endAt) }}
                     </p>
                   </div>
                 </div>
-                <p v-else class="mt-2 text-xs text-slate-500">No cZone searches are active right now.</p>
+                <p v-else class="mt-2 text-xs text-white/45">No cZone searches are active right now.</p>
               </div>
               <div>
-                <p class="text-[11px] uppercase tracking-widest text-slate-500">cZone Contests</p>
-                <div class="mt-1 text-[11px] text-slate-400 leading-snug">Submit your cZone and vote on others during active contests.</div>
+                <p class="text-[11px] uppercase tracking-widest text-white/50">cZone Contests</p>
+                <div class="mt-1 text-[11px] text-white/40 leading-snug">Submit your cZone and vote on others during active contests.</div>
                 <div v-if="czoneContests.length" class="mt-2 space-y-2">
                   <div
                     v-for="contest in czoneContests"
                     :key="`contest-${contest.id}`"
-                    class="rounded-lg border border-[var(--reorbit-border)] bg-white/80 px-3 py-2 text-sm font-semibold"
+                    class="ob-event-card rounded-lg border border-white/10 px-3 py-2"
                   >
                     <NuxtLink
                       :to="`/czone-contest/${contest.id}`"
-                      class="text-sm font-semibold text-[var(--reorbit-blue)] hover:text-[var(--reorbit-purple)]"
+                      class="text-sm font-semibold text-[var(--OrbitLightBlue)] hover:text-white transition"
                     >
                       {{ displayName(contest.name, 'cZone Contest') }}
                     </NuxtLink>
-                    <p class="text-xs text-slate-500">
+                    <p class="text-xs text-white/50">
                       <template v-if="contest.endVotingDate && new Date() > new Date(contest.endDate)">
                         Voting open until {{ formatDate(contest.endVotingDate) }}
                       </template>
@@ -173,7 +173,7 @@
                     </p>
                   </div>
                 </div>
-                <p v-else class="mt-2 text-xs text-slate-500">No cZone contests are active right now.</p>
+                <p v-else class="mt-2 text-xs text-white/45">No cZone contests are active right now.</p>
               </div>
             </div>
           </div>
@@ -183,10 +183,10 @@
 
     <button
       type="button"
-      class="group inline-flex items-center gap-2 rounded-full border border-[var(--reorbit-border)] bg-white/95 px-4 py-2 text-sm font-semibold text-[var(--reorbit-blue)] shadow-lg backdrop-blur transition hover:shadow-xl"
+      class="ob-toggle group inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white shadow-lg backdrop-blur transition hover:shadow-xl hover:border-white/35"
       @click="toggleOpen"
     >
-      <span class="h-2 w-2 rounded-full bg-[var(--reorbit-lime)] shadow-[0_0_12px_var(--reorbit-lime)]"></span>
+      <span class="h-2 w-2 rounded-full bg-[#66CC00] shadow-[0_0_10px_#66CC00]"></span>
       Daily
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -321,8 +321,8 @@ const toggleOpen = () => {
 const tabButtonClass = (tab) => ([
   'flex-1 rounded-full px-3 py-1.5 transition',
   activeTab.value === tab
-    ? 'bg-white text-[var(--reorbit-blue)] shadow-sm'
-    : 'text-slate-500 hover:text-[var(--reorbit-blue)]'
+    ? 'bg-[var(--OrbitDarkBlue)] text-white shadow-sm'
+    : 'text-white/50 hover:text-white'
 ])
 
 const displayName = (value, fallback) => {
@@ -369,6 +369,18 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+.ob-panel {
+  background: rgba(10, 25, 55, 0.96);
+}
+
+.ob-toggle {
+  background: rgba(10, 25, 55, 0.92);
+}
+
+.ob-event-card {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 .daily-drawer-enter-active,
 .daily-drawer-leave-active {
   transition: max-height 0.25s ease, opacity 0.25s ease, transform 0.25s ease;

--- a/components/newsite/MyCollection.vue
+++ b/components/newsite/MyCollection.vue
@@ -19,7 +19,7 @@
       <template v-else>
         <ShortCard v-for="c in ctoons" :key="c.id" :style="{ '--footer-left-width': '50%', '--footer-right-width': '50%' }">
           <template #header>
-            <img v-if="c.assetPath" :src="c.assetPath" :alt="c.name" class="card-img" />
+            <img v-if="c.assetPath" :src="c.assetPath" :alt="c.name" class="card-img card-img--clickable" @click="openInfo(c)" />
           </template>
           <template #middle>
             <span class="card-mint">#{{ c.mintNumber ?? '?' }}</span>
@@ -40,6 +40,12 @@
 </template>
 
 <script setup>
+const { open: openCtoonModal } = useCtoonModal()
+
+function openInfo(c) {
+  openCtoonModal({ ctoonId: c.ctoonId, userCtoonId: c.id, assetPath: c.assetPath, name: c.name })
+}
+
 const RARITY_ORDER = {
   'common': 0, 'uncommon': 1, 'rare': 2, 'very rare': 3,
   'crazy rare': 4, 'prize only': 5, 'code only': 6, 'auction only': 7,
@@ -103,6 +109,10 @@ const ctoons = computed(() => {
       const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99
       const br = RARITY_ORDER[(b.rarity || '').toLowerCase()] ?? 99
       cmp = ar - br
+    } else if (f.sortField === 'acquiredAt') {
+      const at = a.acquiredAt ? new Date(a.acquiredAt).getTime() : 0
+      const bt = b.acquiredAt ? new Date(b.acquiredAt).getTime() : 0
+      cmp = at - bt
     } else {
       cmp = a.name.localeCompare(b.name)
     }
@@ -196,6 +206,13 @@ onMounted(async () => {
   height: 100%;
   object-fit: contain;
   transform: scale(var(--img-scale));
+}
+
+.card-img--clickable {
+  cursor: pointer;
+}
+.card-img--clickable:hover {
+  filter: brightness(1.12);
 }
 
 .card-btn {

--- a/composables/useNewSiteCtoonFilter.js
+++ b/composables/useNewSiteCtoonFilter.js
@@ -5,7 +5,7 @@ export const useNewSiteCtoonFilter = () => useState('newSiteCtoonFilter', () => 
   set:             '',
   priceMin:        '',
   priceMax:        '',
-  sortField:       'name',
-  sortAsc:         true,
+  sortField:       'acquiredAt',
+  sortAsc:         false,
   hideUnavailable: false,
 }))

--- a/pages/czone/[username].vue
+++ b/pages/czone/[username].vue
@@ -845,7 +845,7 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
       @click.self="closeCaptureModal"
     >
-      <div class="relative bg-white rounded-lg shadow-lg w-full max-w-md max-h-[90vh] flex flex-col">
+      <div class="relative bg-white text-gray-900 rounded-lg shadow-lg w-full max-w-md max-h-[90vh] flex flex-col">
         <div class="px-4 py-3 border-b flex items-center justify-between flex-shrink-0">
           <h2 class="text-lg font-semibold">cToon Captured</h2>
           <button class="text-gray-500 hover:text-black" @click="closeCaptureModal">✕</button>
@@ -1824,6 +1824,7 @@ watch(isOwnerViewing, async (val) => {
   .booster-bg .border-gray-300    { border-color: #444 !important; }
   .booster-bg .border-blue-500    { border-color: #555 !important; }
   .booster-bg .text-black         { color: #ccc !important; }
+  .booster-bg .text-gray-900      { color: #e0e0e0 !important; }
   .booster-bg .text-gray-600      { color: #aaa !important; }
   .booster-bg .bg-gray-200        { background-color: #2a2a2a !important; }
   .booster-bg .bg-gray-300        { background-color: #333 !important; }

--- a/pages/newsite/MyCollection.vue
+++ b/pages/newsite/MyCollection.vue
@@ -6,6 +6,9 @@
     <template #sidebar-middle>
       <CtoonFilter />
     </template>
+    <template #sidebar-bottom>
+      <WinballAd />
+    </template>
     <template #main-content>
       <MyCollection />
     </template>
@@ -17,7 +20,5 @@ definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav:
 </script>
 
 <style>
-body.page-mycollection .sidebar-bottom { display: none; }
-body.page-mycollection .sidebar { --sidebar-middle-height: 504px; }
 body.page-mycollection .main-content { overflow-y: auto !important; scrollbar-width: thin; }
 </style>

--- a/pages/newsite/myachievements.vue
+++ b/pages/newsite/myachievements.vue
@@ -4,7 +4,7 @@
       <UserInfo />
     </template>
     <template #sidebar-bottom>
-      <NavRight />
+      <WinballAd />
     </template>
     <template #main-content>
       <MyAchievements />


### PR DESCRIPTION
## Summary
This PR updates the onboarding panel component with a dark theme redesign and makes several improvements to the collection and cZone pages, including better modal styling and default sort order changes.

## Key Changes

### Onboarding Panel Redesign
- **Dark theme styling**: Changed from light theme with CSS variables to a dark blue/transparent background (`rgba(10, 25, 55, 0.96)`)
- **Color palette updates**: 
  - Replaced `var(--reorbit-*)` CSS variables with direct color values and white opacity scales
  - Updated gradient colors in header bar to use `var(--OrbitDarkBlue)`, `var(--OrbitLightBlue)`, and `#66CC00`
  - Changed text colors from slate grays to white with varying opacity levels (white/30 to white/90)
- **Component styling**: Added new CSS classes (`.ob-panel`, `.ob-toggle`, `.ob-event-card`) for better organization
- **Border and background updates**: Changed borders from `var(--reorbit-border)` to `white/10` and `white/15`, updated card backgrounds to `rgba(255, 255, 255, 0.06)`
- **Interactive elements**: Updated button hover states and added transition effects

### Collection Page Improvements
- **Image interactivity**: Made collection card images clickable to open cToon modal with `.card-img--clickable` class and hover brightness effect
- **Default sort order**: Changed default sort from `name` (ascending) to `acquiredAt` (descending) to show recently acquired items first
- **New sort field**: Added support for sorting by `acquiredAt` date
- **Layout adjustments**: Removed hardcoded sidebar height and bottom sidebar hiding styles, replaced with `WinballAd` component in sidebar-bottom

### Modal and Page Styling
- **cZone capture modal**: Added `text-gray-900` class to ensure proper text color in light modal
- **Dark mode support**: Added `.booster-bg .text-gray-900` rule for dark theme compatibility
- **Achievements page**: Replaced `NavRight` component with `WinballAd` in sidebar-bottom

### Composable Updates
- Updated `useNewSiteCtoonFilter` default values to sort by `acquiredAt` in descending order

## Implementation Details
- All color changes maintain visual hierarchy and accessibility with appropriate opacity levels
- New CSS classes provide better separation of concerns for the onboarding component
- The dark theme uses a consistent color scheme with the Orbit design system
- Collection filtering now defaults to showing most recently acquired items first

https://claude.ai/code/session_019uUovoSwtnyMyZNifpJuqQ