### PR TITLE
Add Earn Points page with configurable image support

### DIFF
--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -168,6 +168,8 @@
                       <option value="lottery">Lottery</option>
                       <option value="auctions">Auctions</option>
                       <option value="gtoons-clash">gToons Clash</option>
+                      <option value="news">News</option>
+                      <option value="earn-points">Earn Points</option>
                       <option value="custom">Custom URL…</option>
                     </select>
                     <input v-if="homeImages[n].linkPreset === 'custom'"
@@ -274,6 +276,8 @@
                       <option value="lottery">Lottery</option>
                       <option value="auctions">Auctions</option>
                       <option value="gtoons-clash">gToons Clash</option>
+                      <option value="news">News</option>
+                      <option value="earn-points">Earn Points</option>
                       <option value="custom">Custom URL…</option>
                     </select>
                     <input v-if="middleSidebarImages[n].linkPreset === 'custom'"
@@ -389,7 +393,9 @@ const PAGE_LINKS = {
   'winball':     '/newsite/winball',
   'lottery':     '/newsite/lottery',
   'auctions':    '/newsite/auctions',
-  'gtoons-clash':'/newsite/gtoons-clash'
+  'gtoons-clash':'/newsite/gtoons-clash',
+  'news':        '/newsite/news',
+  'earn-points': '/newsite/earnpoints'
 }
 
 const activeTab = ref('Homepage')

--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -341,6 +341,25 @@
           </div>
         </div>
 
+        <!-- Earn Points image -->
+        <div class="border rounded p-4 space-y-3">
+          <h2 class="font-semibold">Earn Points</h2>
+          <p class="text-xs text-gray-500">Image displayed on the Earn Points page.</p>
+          <div class="flex items-center gap-4">
+            <div class="w-48 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
+              <img v-if="previewUrls.earnPoints || earnPointsPath" :src="previewUrls.earnPoints || earnPointsPath" alt="Earn Points" class="max-h-full max-w-full object-contain" />
+              <span v-else class="text-gray-400 text-xs">No image</span>
+            </div>
+            <div class="space-y-2 flex-1 min-w-0">
+              <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
+                @change="onEarnPointsFile($event)" class="block w-full text-sm" />
+              <div v-if="earnPointsFile" class="text-xs text-gray-600 truncate">Selected: {{ earnPointsFile.name }}</div>
+              <button type="button" class="px-3 py-1 text-sm rounded border"
+                      v-if="earnPointsPath" @click="clearEarnPoints()">Clear</button>
+            </div>
+          </div>
+        </div>
+
         <div class="mt-2">
           <button class="btn-primary" :disabled="saving" @click="saveOther">
             <span v-if="!saving">Save</span><span v-else>Saving…</span>
@@ -377,10 +396,13 @@ const activeTab = ref('Homepage')
 
 const paths = ref({ topLeft:'', bottomLeft:'', topRight:'', bottomRight:'' })
 const files = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null })
-const previewUrls = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null, showcase:null, homeImage1:null, homeImage2:null, homeImage3:null, homeImage4:null, middleSidebar1:null, middleSidebar2:null, middleSidebar3:null, news:null })
+const previewUrls = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null, showcase:null, homeImage1:null, homeImage2:null, homeImage3:null, homeImage4:null, middleSidebar1:null, middleSidebar2:null, middleSidebar3:null, news:null, earnPoints:null })
 
 const newsPath = ref('')
 const newsFile = ref(null)
+
+const earnPointsPath = ref('')
+const earnPointsFile = ref(null)
 
 const showcasePath = ref('')
 const showcaseFile = ref(null)
@@ -511,6 +533,19 @@ function clearNews() {
   newsFile.value = null
 }
 
+function onEarnPointsFile(e) {
+  const f = e.target.files?.[0] || null
+  try { if (previewUrls.value.earnPoints) { URL.revokeObjectURL(previewUrls.value.earnPoints); previewUrls.value.earnPoints = null } } catch (e) {}
+  earnPointsFile.value = f
+  if (f) previewUrls.value.earnPoints = URL.createObjectURL(f)
+}
+
+function clearEarnPoints() {
+  earnPointsPath.value = ''
+  if (previewUrls.value.earnPoints) { try { URL.revokeObjectURL(previewUrls.value.earnPoints) } catch (e) {} ; previewUrls.value.earnPoints = null }
+  earnPointsFile.value = null
+}
+
 function onMiddleSidebarPresetChange(n) {
   const preset = middleSidebarImages[n].linkPreset
   if (preset === '') {
@@ -555,6 +590,7 @@ async function loadConfig() {
   }
 
   newsPath.value = cfg.newsImagePath || ''
+  earnPointsPath.value = cfg.earnPointsImagePath || ''
 }
 
 
@@ -665,10 +701,14 @@ async function saveOther() {
     const fd = new FormData()
     fd.append('newsPath', newsPath.value || '')
     if (newsFile.value) fd.append('news', newsFile.value)
+    fd.append('earnPointsPath', earnPointsPath.value || '')
+    if (earnPointsFile.value) fd.append('earnPoints', earnPointsFile.value)
     const res = await $fetch('/api/admin/homepage', { method: 'POST', body: fd })
     newsPath.value = res.newsImagePath || ''
     newsFile.value = null
-    toast.value = { type: 'ok', msg: 'News image saved.' }
+    earnPointsPath.value = res.earnPointsImagePath || ''
+    earnPointsFile.value = null
+    toast.value = { type: 'ok', msg: 'Images saved.' }
   } catch (e) {
     console.error(e); toast.value = { type: 'error', msg: e?.statusMessage || 'Save failed' }
   } finally {

--- a/pages/newsite/earnpoints.vue
+++ b/pages/newsite/earnpoints.vue
@@ -1,0 +1,74 @@
+<template>
+  <NuxtLayout name="newsite-template">
+    <template #sidebar-top>
+      <UserInfo />
+    </template>
+    <template #sidebar-bottom>
+      <WinballAd />
+    </template>
+    <template #main-content>
+      <div class="earnpoints-content">
+        <img v-if="earnPointsImagePath" :src="earnPointsImagePath" alt="Earn Points" class="earnpoints-image" />
+        <div v-else class="earnpoints-placeholder"></div>
+      </div>
+    </template>
+  </NuxtLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
+useHead({ htmlAttrs: { class: 'newsite-earnpoints' } })
+
+const earnPointsImagePath = ref(null)
+
+onMounted(async () => {
+  try {
+    const cfg = await $fetch('/api/homepage')
+    earnPointsImagePath.value = cfg.earnPointsImagePath || null
+  } catch {}
+})
+</script>
+
+<style>
+html.newsite-earnpoints {
+  min-height: 100vh;
+  background: linear-gradient(
+    to bottom,
+    #000000 0px,
+    #000000 65px,
+    #003466 115px,
+    #003466 100%
+  ) no-repeat fixed !important;
+}
+
+html.newsite-earnpoints body {
+  background: transparent !important;
+  min-height: 100vh;
+}
+</style>
+
+<style scoped>
+.earnpoints-content {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+.earnpoints-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.earnpoints-placeholder {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/prisma/migrations/20260507000000_add_earn_points_image_path/migration.sql
+++ b/prisma/migrations/20260507000000_add_earn_points_image_path/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "HomepageConfig" ADD COLUMN "earnPointsImagePath" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1563,6 +1563,7 @@ model HomepageConfig {
   middleSidebar3ImagePath  String?
   middleSidebar3Link       String?
   newsImagePath            String?
+  earnPointsImagePath      String?
   createdAt                DateTime @default(now())
   updatedAt                DateTime @updatedAt
 }

--- a/server/api/admin/homepage/index.get.js
+++ b/server/api/admin/homepage/index.get.js
@@ -38,6 +38,7 @@ export default defineEventHandler(async (event) => {
     middleSidebar3ImagePath: null,
     middleSidebar3Link: null,
     newsImagePath: null,
+    earnPointsImagePath: null,
     updatedAt: null
   }
 

--- a/server/api/admin/homepage/index.post.js
+++ b/server/api/admin/homepage/index.post.js
@@ -54,7 +54,8 @@ export default defineEventHandler(async (event) => {
     middleSidebar2Link:      null,
     middleSidebar3ImagePath: null,
     middleSidebar3Link:      null,
-    newsImagePath:           null
+    newsImagePath:           null,
+    earnPointsImagePath:     null
   }
 
   // fs prep
@@ -106,7 +107,8 @@ export default defineEventHandler(async (event) => {
     middleSidebar1:   await saveIfPresent('middleSidebar1'),
     middleSidebar2:   await saveIfPresent('middleSidebar2'),
     middleSidebar3:   await saveIfPresent('middleSidebar3'),
-    news:             await saveIfPresent('news')
+    news:             await saveIfPresent('news'),
+    earnPoints:       await saveIfPresent('earnPoints')
   }
 
   // helper: update one slot without touching others unless provided
@@ -154,7 +156,8 @@ export default defineEventHandler(async (event) => {
     middleSidebar2Link:       resolveLink('middleSidebar2Link', current.middleSidebar2Link),
     middleSidebar3ImagePath:  resolveSlot('middleSidebar3ImagePath',  'middleSidebar3',  'middleSidebar3Path',  current.middleSidebar3ImagePath),
     middleSidebar3Link:       resolveLink('middleSidebar3Link', current.middleSidebar3Link),
-    newsImagePath:            resolveSlot('newsImagePath',            'news',            'newsPath',            current.newsImagePath)
+    newsImagePath:            resolveSlot('newsImagePath',            'news',            'newsPath',            current.newsImagePath),
+    earnPointsImagePath:      resolveSlot('earnPointsImagePath',      'earnPoints',      'earnPointsPath',      current.earnPointsImagePath)
   }
 
   const cfg = await db.homepageConfig.upsert({
@@ -174,7 +177,8 @@ export default defineEventHandler(async (event) => {
       'middleSidebar1ImagePath', 'middleSidebar1Link',
       'middleSidebar2ImagePath', 'middleSidebar2Link',
       'middleSidebar3ImagePath', 'middleSidebar3Link',
-      'newsImagePath'
+      'newsImagePath',
+      'earnPointsImagePath'
     ]
     for (const key of fields) {
       const prev = current[key] ?? null
@@ -206,6 +210,7 @@ export default defineEventHandler(async (event) => {
     middleSidebar2Link:      cfg.middleSidebar2Link,
     middleSidebar3ImagePath: cfg.middleSidebar3ImagePath,
     middleSidebar3Link:      cfg.middleSidebar3Link,
-    newsImagePath:           cfg.newsImagePath
+    newsImagePath:           cfg.newsImagePath,
+    earnPointsImagePath:     cfg.earnPointsImagePath
   }
 })

--- a/server/api/homepage/index.get.js
+++ b/server/api/homepage/index.get.js
@@ -25,5 +25,6 @@ export default defineEventHandler(async () => {
     middleSidebar3ImagePath: cfg?.middleSidebar3ImagePath ?? null,
     middleSidebar3Link:      cfg?.middleSidebar3Link      ?? null,
     newsImagePath:           cfg?.newsImagePath           ?? null,
+    earnPointsImagePath:     cfg?.earnPointsImagePath     ?? null,
   }
 })


### PR DESCRIPTION
## Summary
This PR adds a new "Earn Points" page to the newsite section with admin-configurable image support, similar to the existing News page functionality.

## Key Changes
- **New Page**: Created `pages/newsite/earnpoints.vue` - a new page that displays a configurable image fetched from the homepage API
- **Admin Interface**: Extended `pages/admin/manage-homepage.vue` to include:
  - File upload UI for the Earn Points image
  - Image preview functionality
  - Clear button to remove the image
  - Navigation link preset option ("earn-points") in homepage image link dropdowns
- **Backend API**: Updated `server/api/admin/homepage/index.post.js` to:
  - Handle earnPoints file uploads
  - Store and retrieve earnPointsImagePath configuration
- **Public API**: Updated `server/api/homepage/index.get.js` to expose earnPointsImagePath to frontend
- **Admin API**: Updated `server/api/admin/homepage/index.get.js` to include earnPointsImagePath in config retrieval
- **Database**: 
  - Added `earnPointsImagePath` field to HomepageConfig model in `prisma/schema.prisma`
  - Created migration to add the new column

## Implementation Details
- The Earn Points page follows the same pattern as the News page for consistency
- Uses the newsite-template layout with UserInfo sidebar and WinballAd
- Supports the same image formats as other homepage images (SVG, PNG, JPEG, GIF)
- Image is fetched on component mount from `/api/homepage` endpoint
- Includes fallback placeholder when no image is configured
- Added "News" and "Earn Points" as preset link options in homepage image management

https://claude.ai/code/session_01PJVy8aon2NbcofyyS1h2mH