### PR TITLE
Add card view to Auction House and refactor filters to sidebar

### DIFF
--- a/components/ScavengerHuntModal.vue
+++ b/components/ScavengerHuntModal.vue
@@ -1,22 +1,23 @@
 <template>
-  <div v-if="story && sessionId" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" @click.self="onBackdrop">
-    <div class="bg-white rounded-lg shadow-lg w-full max-w-md overflow-hidden">
+  <div v-if="story && sessionId" class="sh-backdrop" @click.self="onBackdrop">
+    <div class="sh-modal">
+
       <!-- Header -->
-      <div class="p-4 border-b">
-        <h2 class="text-xl font-bold">{{ story?.title || 'Scavenger Hunt' }}</h2>
+      <div class="sh-header">
+        <span class="sh-title">{{ story?.title || 'Scavenger Hunt' }}</span>
       </div>
 
       <!-- Body -->
-      <div class="p-4 space-y-4">
+      <div class="sh-body">
         <template v-if="!result">
-          <div v-if="step">
-            <img v-if="step.imagePath" :src="step.imagePath" alt="" class="w-full h-40 object-cover rounded" />
-            <p class="text-gray-800 whitespace-pre-line">{{ step.description }}</p>
-            <div class="mt-4 flex gap-2">
-              <button :disabled="loading" class="flex-1 px-4 py-2 rounded bg-indigo-600 text-white disabled:opacity-50" @click="choose('A')">
+          <div v-if="step" class="sh-step">
+            <img v-if="step.imagePath" :src="step.imagePath" alt="" class="sh-step-img" />
+            <p class="sh-desc">{{ step.description }}</p>
+            <div class="sh-choices">
+              <button :disabled="loading" class="sh-btn sh-btn-primary" @click="choose('A')">
                 {{ step.optionA }}
               </button>
-              <button :disabled="loading" class="flex-1 px-4 py-2 rounded bg-gray-200 text-gray-900 disabled:opacity-50" @click="choose('B')">
+              <button :disabled="loading" class="sh-btn sh-btn-secondary" @click="choose('B')">
                 {{ step.optionB }}
               </button>
             </div>
@@ -24,31 +25,32 @@
         </template>
 
         <template v-else>
-          <div class="text-center">
+          <div class="sh-result">
             <template v-if="result.type === 'NOTHING'">
-              <p class="text-lg font-semibold">You found nothing this time.</p>
-              <p v-if="result.text" class="mt-2 text-sm text-gray-700">{{ result.text }}</p>
+              <p class="sh-result-title">You found nothing this time.</p>
+              <p v-if="result.text" class="sh-result-sub">{{ result.text }}</p>
             </template>
             <template v-else-if="result.type === 'POINTS'">
-              <p class="text-lg font-semibold">You won {{ Number(result.points).toLocaleString() }} points! 🎉</p>
-              <p v-if="result.text" class="mt-2 text-sm text-gray-700">{{ result.text }}</p>
+              <p class="sh-result-title">You won {{ Number(result.points).toLocaleString() }} points! 🎉</p>
+              <p v-if="result.text" class="sh-result-sub">{{ result.text }}</p>
             </template>
             <template v-else>
-              <p class="text-lg font-semibold">You found an exclusive cToon! 🎉</p>
-              <div v-if="result.ctoon" class="mt-3">
-                <img :src="result.ctoon.assetPath" :alt="result.ctoon.name" class="w-24 h-24 object-contain mx-auto mb-2" />
-                <div class="font-medium">{{ result.ctoon.name }}</div>
+              <p class="sh-result-title">You found an exclusive cToon! 🎉</p>
+              <div v-if="result.ctoon" class="sh-ctoon">
+                <img :src="result.ctoon.assetPath" :alt="result.ctoon.name" class="sh-ctoon-img" />
+                <div class="sh-ctoon-name">{{ result.ctoon.name }}</div>
               </div>
-              <p v-if="result.text" class="mt-2 text-sm text-gray-700">{{ result.text }}</p>
+              <p v-if="result.text" class="sh-result-sub">{{ result.text }}</p>
             </template>
           </div>
         </template>
       </div>
 
       <!-- Footer -->
-      <div class="p-4 border-t text-right">
-        <button class="px-4 py-2 rounded bg-indigo-600 text-white" @click="close">{{ result ? 'Close' : 'Cancel' }}</button>
+      <div class="sh-footer">
+        <button class="sh-btn sh-btn-primary" @click="close">{{ result ? 'Close' : 'Cancel' }}</button>
       </div>
+
     </div>
   </div>
 </template>
@@ -64,5 +66,147 @@ function onBackdrop() { close() }
 </script>
 
 <style scoped>
-/* Tailwind handles the styling */
+.sh-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.75);
+  padding: 16px;
+}
+
+.sh-modal {
+  background: #001f3f;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  width: 100%;
+  max-width: 420px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header */
+.sh-header {
+  background: #336699;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sh-title {
+  font-size: 1rem;
+  font-weight: bold;
+  color: #fff;
+  letter-spacing: 0.03em;
+}
+
+/* Body */
+.sh-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: #002244;
+}
+
+.sh-step { display: flex; flex-direction: column; gap: 12px; }
+
+.sh-step-img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sh-desc {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.85);
+  white-space: pre-line;
+  line-height: 1.5;
+}
+
+.sh-choices {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* Result */
+.sh-result {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.sh-result-title {
+  font-size: 1rem;
+  font-weight: bold;
+  color: #fff;
+}
+
+.sh-result-sub {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.sh-ctoon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.sh-ctoon-img {
+  width: 96px;
+  height: 96px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.sh-ctoon-name {
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: #fff;
+}
+
+/* Footer */
+.sh-footer {
+  padding: 10px 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  text-align: right;
+  background: #001f3f;
+}
+
+/* Buttons */
+.sh-btn {
+  flex: 1;
+  padding: 7px 14px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: bold;
+  cursor: pointer;
+  border: none;
+  transition: background 0.12s, opacity 0.12s;
+}
+.sh-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.sh-btn-primary {
+  background: #3399cc;
+  color: #fff;
+}
+.sh-btn-primary:not(:disabled):hover { background: #2288bb; }
+
+.sh-btn-secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+.sh-btn-secondary:not(:disabled):hover { background: rgba(255, 255, 255, 0.18); }
 </style>

--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -11,7 +11,7 @@
     <!-- ── List view ─────────────────────────────────────────────── -->
     <template v-if="!selectedAuctionId">
 
-    <!-- ── Tabs + Sort ─────────────────────────────────────────── -->
+    <!-- ── Tabs + View toggle ─────────────────────────────────── -->
     <div class="ah-topbar">
       <div class="ah-tabs">
         <button
@@ -20,22 +20,14 @@
           @click="switchTab(t.id)"
         >{{ t.label }}</button>
       </div>
-    </div>
-
-    <!-- ── Auction-specific filters ───────────────────────────── -->
-    <div class="ah-xfilters">
-      <button class="ah-pill" :class="{ active: featuredOnly  }" @click="featuredOnly  = !featuredOnly" >★ Feat.</button>
-      <button class="ah-pill" :class="{ active: hasBidsOnly   }" @click="hasBidsOnly   = !hasBidsOnly"  >Has Bids</button>
-      <button class="ah-pill" :class="{ active: gtoonsOnly    }" @click="gtoonsOnly    = !gtoonsOnly"   >gToons</button>
-      <button class="ah-pill" :class="{ active: wishlistOnly  }" @click="toggleWishlist">Wishlist</button>
-      <div class="ah-owned">
-        <button class="ah-owned-opt" :class="{ active: selectedOwned === 'all'     }" @click="selectedOwned = 'all'"    >All</button>
-        <button class="ah-owned-opt" :class="{ active: selectedOwned === 'owned'   }" @click="selectedOwned = 'owned'"  >Owned</button>
-        <button class="ah-owned-opt" :class="{ active: selectedOwned === 'unowned' }" @click="selectedOwned = 'unowned'">Unowned</button>
+      <div class="ah-view-toggle">
+        <button class="ah-vt-btn" :class="{ active: viewMode === 'list' }" @click="setView('list')">&#9776; List</button>
+        <button class="ah-vt-btn" :class="{ active: viewMode === 'card' }" @click="setView('card')">&#8859; Cards</button>
       </div>
     </div>
 
-    <!-- ── Auction list ────────────────────────────────────────── -->
+    <!-- ── List view ─────────────────────────────────────────── -->
+    <template v-if="viewMode === 'list'">
     <div class="ah-list">
 
       <!-- Loading skeletons -->
@@ -97,6 +89,56 @@
         </div>
       </template>
     </div>
+    </template>
+
+    <!-- ── Card view ─────────────────────────────────────────── -->
+    <template v-else>
+    <div class="ah-card-grid">
+
+      <!-- Loading skeletons -->
+      <template v-if="isLoadingActive">
+        <div v-for="n in 15" :key="n" class="ah-card-skeleton" />
+      </template>
+
+      <!-- Empty state -->
+      <div v-else-if="paginatedItems.length === 0" class="ah-empty ah-card-empty">
+        {{ hasActiveFilters ? 'No auctions match your filters.' : emptyMessage }}
+      </div>
+
+      <!-- Cards -->
+      <template v-else>
+        <ShortCard
+          v-for="item in paginatedItems" :key="item.id"
+          :style="{ '--footer-left-width': '60%', '--footer-right-width': '40%' }"
+          @click="selectedAuctionId = item.id"
+        >
+          <template #header>
+            <div class="ah-card-header">
+              <img v-if="item.assetPath" :src="item.assetPath" :alt="item.name" class="ah-card-img" draggable="false" />
+              <div class="ah-card-time-badge" :class="{ ended: isEnded(item.endAt) }">
+                <template v-if="!isEnded(item.endAt)">{{ formatRemaining(item.endAt) }}</template>
+                <template v-else>Ended</template>
+              </div>
+            </div>
+          </template>
+          <template #middle>
+            <div class="ah-card-middle">
+              <span class="ah-card-name">{{ item.name }}</span>
+              <span class="ah-rarity ah-card-rarity" :class="`r-${rarityKey(item.rarity)}`">{{ rarityShort(item.rarity) }}</span>
+            </div>
+          </template>
+          <template #footer-left>
+            <span class="ah-card-bid-val">
+              {{ Number(item.bidCount ?? 0) > 0 ? formatHighestBid(item) : (item.initialBid != null ? item.initialBid + ' pts' : '—') }}
+            </span>
+          </template>
+          <template #footer-right>
+            <button class="ah-card-view-btn" @click.stop="selectedAuctionId = item.id">View</button>
+          </template>
+        </ShortCard>
+      </template>
+    </div>
+    </template>
 
     <!-- ── Pagination ───────────────────────────────────────────── -->
     <div class="ah-pagination">
@@ -111,7 +153,8 @@
 </template>
 
 <script setup>
-const filter      = useNewSiteCtoonFilter()
+const filter   = useNewSiteCtoonFilter()
+const aFilters = useAuctionHouseFilters()
 const cmartCtoons = useState('cmartCtoons', () => [])
 
 const selectedAuctionId = ref(null)
@@ -124,6 +167,14 @@ const TABS = [
 ]
 
 const PAGE_SIZE = 20
+
+// ── View mode ─────────────────────────────────────────────────────
+const viewMode = ref('list')
+
+function setView(mode) {
+  viewMode.value = mode
+  if (import.meta.client) localStorage.setItem('auctionHouseView', mode)
+}
 
 // ── Tab ──────────────────────────────────────────────────────────
 const activeTab = ref('current')
@@ -153,13 +204,6 @@ const allTotalPages    = ref(1)
 // ── Client-side pagination (current) ─────────────────────────────
 const currentPage = ref(1)
 
-// ── Auction-specific filters ──────────────────────────────────────
-const featuredOnly  = ref(false)
-const wishlistOnly  = ref(false)
-const hasBidsOnly   = ref(false)
-const gtoonsOnly    = ref(false)
-const selectedOwned = ref('all')
-
 // ── Wishlist ──────────────────────────────────────────────────────
 const wishlistCtoonIds  = ref([])
 const isLoadingWishlist = ref(false)
@@ -171,6 +215,9 @@ const now = ref(new Date())
 let timer = null
 
 onMounted(() => {
+  if (import.meta.client) {
+    viewMode.value = localStorage.getItem('auctionHouseView') || 'list'
+  }
   timer = setInterval(() => { now.value = new Date() }, 1000)
   loadAuctions()
   loadTrendingAuctions()
@@ -181,22 +228,22 @@ onUnmounted(() => clearInterval(timer))
 function buildFilterParams() {
   const params = new URLSearchParams()
   const q = String(filter.value.name || '').trim()
-  if (q)                              params.set('q',        q)
-  if (filter.value.rarities.length)   params.set('rarity',   filter.value.rarities.join(','))
-  if (filter.value.series)            params.set('series',   filter.value.series)
-  if (filter.value.set)               params.set('set',      filter.value.set)
-  if (selectedOwned.value !== 'all')  params.set('owned',    selectedOwned.value)
-  if (featuredOnly.value)             params.set('featured', '1')
-  if (wishlistOnly.value)             params.set('wishlist', '1')
-  if (hasBidsOnly.value)              params.set('hasBids',  '1')
-  if (gtoonsOnly.value)               params.set('gtoon',    '1')
+  if (q)                                          params.set('q',        q)
+  if (filter.value.rarities.length)               params.set('rarity',   filter.value.rarities.join(','))
+  if (filter.value.series)                        params.set('series',   filter.value.series)
+  if (filter.value.set)                           params.set('set',      filter.value.set)
+  if (aFilters.value.selectedOwned !== 'all')     params.set('owned',    aFilters.value.selectedOwned)
+  if (aFilters.value.featuredOnly)                params.set('featured', '1')
+  if (aFilters.value.wishlistOnly)                params.set('wishlist', '1')
+  if (aFilters.value.hasBidsOnly)                 params.set('hasBids',  '1')
+  if (aFilters.value.gtoonsOnly)                  params.set('gtoon',    '1')
   return params
 }
 
 function loadAuctions() {
   isLoading.value = true
   const params = new URLSearchParams()
-  if (hasBidsOnly.value) params.set('hasBids', '1')
+  if (aFilters.value.hasBidsOnly) params.set('hasBids', '1')
   const qs = params.toString()
   $fetch(qs ? `/api/auctions?${qs}` : '/api/auctions')
     .then(data => { auctions.value = Array.isArray(data) ? data : []; syncCmartCtoons() })
@@ -285,11 +332,6 @@ function syncCmartCtoons() {
 
 // ── Watchers ──────────────────────────────────────────────────────
 
-watch(hasBidsOnly, () => {
-  loadAuctions()
-  loadTrendingAuctions()
-})
-
 watch(() => filter.value.sortField, () => {
   if (activeTab.value === 'mine')   { myPage.value = 1;      loadMyAuctions() }
   if (activeTab.value === 'mybids') { myBidsPage.value = 1;  loadMyBids()     }
@@ -300,11 +342,23 @@ watch(myPage,     () => { if (activeTab.value === 'mine')   loadMyAuctions() })
 watch(myBidsPage, () => { if (activeTab.value === 'mybids') loadMyBids()     })
 watch(allPage,    () => { if (activeTab.value === 'all')    loadAllAuctions()})
 
+watch(() => aFilters.value.hasBidsOnly, () => {
+  loadAuctions()
+  loadTrendingAuctions()
+})
+
+watch(() => aFilters.value.wishlistOnly, val => {
+  if (val) loadWishlist()
+})
+
 // Sidebar filter changes → reset + reload server-side tabs, reset client page
 watch(
-  [() => filter.value.name, () => filter.value.rarities, () => filter.value.series, () => filter.value.set,
-   () => filter.value.priceMin, () => filter.value.priceMax,
-   featuredOnly, wishlistOnly, gtoonsOnly, selectedOwned],
+  [
+    () => filter.value.name, () => filter.value.rarities, () => filter.value.series, () => filter.value.set,
+    () => filter.value.priceMin, () => filter.value.priceMax,
+    () => aFilters.value.featuredOnly, () => aFilters.value.wishlistOnly,
+    () => aFilters.value.gtoonsOnly,   () => aFilters.value.selectedOwned,
+  ],
   () => {
     currentPage.value = 1
     if (activeTab.value === 'mine')   { myPage.value = 1;     loadMyAuctions() }
@@ -329,16 +383,16 @@ function applyFilters(items) {
           !chars.some(c => String(c || '').toLowerCase().includes(term))) return false
     }
     if (rarities.length && !rarities.includes((item.rarity || '').toLowerCase()))    return false
-    if (series && item.series !== series)                       return false
-    if (set    && item.set    !== set)                          return false
-    if (featuredOnly.value  && !item.isFeatured)               return false
-    if (selectedOwned.value === 'owned'   && !item.isOwned)    return false
-    if (selectedOwned.value === 'unowned' && item.isOwned)     return false
-    if (wishlistOnly.value) {
+    if (series && item.series !== series)                                             return false
+    if (set    && item.set    !== set)                                                return false
+    if (aFilters.value.featuredOnly  && !item.isFeatured)                            return false
+    if (aFilters.value.selectedOwned === 'owned'   && !item.isOwned)                 return false
+    if (aFilters.value.selectedOwned === 'unowned' && item.isOwned)                  return false
+    if (aFilters.value.wishlistOnly) {
       if (!hasLoadedWishlist.value || !wishlistCtoonIdSet.value.has(item.ctoonId)) return false
     }
-    if (hasBidsOnly.value && Number(item.bidCount ?? 0) < 1) return false
-    if (gtoonsOnly.value  && !item.isGtoon)                  return false
+    if (aFilters.value.hasBidsOnly && Number(item.bidCount ?? 0) < 1)               return false
+    if (aFilters.value.gtoonsOnly  && !item.isGtoon)                                 return false
     const currentPrice = Number(item.highestBid > 0 ? item.highestBid : item.initialBid) || 0
     if (filter.value.priceMin !== '' && currentPrice < Number(filter.value.priceMin)) return false
     if (filter.value.priceMax !== '' && currentPrice > Number(filter.value.priceMax)) return false
@@ -411,8 +465,8 @@ const emptyMessage = computed(() => ({
 
 const hasActiveFilters = computed(() => !!(
   filter.value.name || filter.value.rarities.length || filter.value.series || filter.value.set ||
-  featuredOnly.value || wishlistOnly.value || hasBidsOnly.value || gtoonsOnly.value ||
-  selectedOwned.value !== 'all'
+  aFilters.value.featuredOnly || aFilters.value.wishlistOnly || aFilters.value.hasBidsOnly ||
+  aFilters.value.gtoonsOnly   || aFilters.value.selectedOwned !== 'all'
 ))
 
 // ── Actions ───────────────────────────────────────────────────────
@@ -422,11 +476,6 @@ function switchTab(id) {
   else if (id === 'mybids') { myBidsPage.value = 1; loadMyBids() }
   else if (id === 'mine')   { myPage.value = 1;     loadMyAuctions() }
   else if (id === 'all')    { allPage.value = 1;     loadAllAuctions() }
-}
-
-function toggleWishlist() {
-  wishlistOnly.value = !wishlistOnly.value
-  if (wishlistOnly.value) loadWishlist()
 }
 
 function prevPage() {
@@ -515,51 +564,28 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
 .ah-tab.active { background: var(--OrbitLightBlue); color: #fff; }
 .ah-tab:not(.active):hover { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.75); }
 
-/* ── Extra filters ── */
-.ah-xfilters {
+/* ── View toggle ── */
+.ah-view-toggle {
   display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 6px;
-  background: rgba(0,0,0,0.12);
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 6px;
+  overflow: hidden;
   flex-shrink: 0;
 }
 
-.ah-pill {
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 10px;
-  background: transparent;
-  color: rgba(255,255,255,0.5);
-  font-size: 0.58rem;
-  font-weight: bold;
-  padding: 1px 7px;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: all 0.15s;
-}
-.ah-pill.active { background: var(--OrbitLightBlue); border-color: var(--OrbitLightBlue); color: #fff; }
-.ah-pill:not(.active):hover { color: rgba(255,255,255,0.85); }
-
-.ah-owned {
-  display: flex;
-  margin-left: auto;
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 10px;
-  overflow: hidden;
-}
-.ah-owned-opt {
+.ah-vt-btn {
   border: none;
-  background: transparent;
+  background: rgba(0,0,0,0.2);
   color: rgba(255,255,255,0.45);
-  font-size: 0.58rem;
+  font-size: 0.6rem;
   font-weight: bold;
-  padding: 1px 6px;
+  padding: 3px 8px;
   cursor: pointer;
   white-space: nowrap;
   transition: background 0.15s, color 0.15s;
 }
-.ah-owned-opt.active { background: var(--OrbitLightBlue); color: #fff; }
+.ah-vt-btn.active  { background: var(--OrbitLightBlue); color: #fff; }
+.ah-vt-btn:not(.active):hover { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.75); }
 
 /* ── List ── */
 .ah-list {
@@ -702,6 +728,114 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
   transition: background 0.12s;
 }
 .ah-view:hover { background: var(--OrbitLightBlue); }
+
+/* ── Card grid ── */
+.ah-card-grid {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--OrbitDarkBlue) transparent;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-auto-rows: var(--shortcard-height);
+  gap: 4px;
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+.ah-card-grid :deep(.sc) { width: 100%; cursor: pointer; }
+
+.ah-card-skeleton {
+  border-radius: 8px;
+  background: rgba(255,255,255,0.06);
+  animation: ah-pulse 1.2s ease-in-out infinite;
+}
+
+.ah-card-empty {
+  grid-column: 1 / -1;
+}
+
+/* Card internals */
+.ah-card-header {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.ah-card-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transform: scale(0.7);
+  image-rendering: pixelated;
+}
+
+.ah-card-time-badge {
+  position: absolute;
+  bottom: 3px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.52rem;
+  font-weight: bold;
+  background: rgba(0,0,0,0.65);
+  color: #fca5a5;
+  padding: 1px 5px;
+  border-radius: 10px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+.ah-card-time-badge.ended { color: rgba(255,255,255,0.45); }
+
+.ah-card-middle {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  gap: 3px;
+}
+
+.ah-card-name {
+  font-size: 0.6rem;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  text-align: center;
+}
+
+.ah-card-rarity {
+  flex-shrink: 0;
+}
+
+.ah-card-bid-val {
+  font-size: 0.62rem;
+  font-weight: bold;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.ah-card-view-btn {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  background: rgba(0,0,0,0.3);
+  border: 1px solid var(--OrbitLightBlue);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.ah-card-view-btn:hover { background: var(--OrbitLightBlue); }
 
 /* ── Pagination ── */
 .ah-pagination {

--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -284,11 +284,6 @@ function syncCmartCtoons() {
 }
 
 // ── Watchers ──────────────────────────────────────────────────────
-watch(activeTab, tab => {
-  if (tab === 'mine')   loadMyAuctions()
-  if (tab === 'mybids') loadMyBids()
-  if (tab === 'all')    loadAllAuctions()
-})
 
 watch(hasBidsOnly, () => {
   loadAuctions()
@@ -421,7 +416,13 @@ const hasActiveFilters = computed(() => !!(
 ))
 
 // ── Actions ───────────────────────────────────────────────────────
-function switchTab(id) { activeTab.value = id }
+function switchTab(id) {
+  activeTab.value = id
+  if (id === 'current') { loadAuctions(); loadTrendingAuctions() }
+  else if (id === 'mybids') { myBidsPage.value = 1; loadMyBids() }
+  else if (id === 'mine')   { myPage.value = 1;     loadMyAuctions() }
+  else if (id === 'all')    { allPage.value = 1;     loadAllAuctions() }
+}
 
 function toggleWishlist() {
   wishlistOnly.value = !wishlistOnly.value
@@ -574,7 +575,7 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
 }
 
 .ah-skeleton {
-  height: 38px;
+  height: 106px;
   border-radius: 4px;
   background: rgba(255,255,255,0.06);
   animation: ah-pulse 1.2s ease-in-out infinite;
@@ -602,7 +603,7 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
   background: rgba(0,0,0,0.2);
   border: 1px solid rgba(255,255,255,0.06);
   border-radius: 4px;
-  min-height: 38px;
+  min-height: 106px;
   flex-shrink: 0;
   transition: background 0.12s;
 }
@@ -610,8 +611,8 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
 .ah-row.trending { border-color: rgba(251,191,36,0.35); }
 
 .ah-img {
-  width: 34px;
-  height: 34px;
+  width: 102px;
+  height: 102px;
   object-fit: contain;
   flex-shrink: 0;
   image-rendering: pixelated;

--- a/components/newsite/CtoonFilter.vue
+++ b/components/newsite/CtoonFilter.vue
@@ -68,6 +68,25 @@
       </div>
     </div>
 
+    <!-- Auction-specific filters -->
+    <template v-if="showAuctionFilters">
+      <hr class="cf-divider" />
+      <div>
+        <div class="cf-section-label">Filters</div>
+        <div class="cf-pill-row">
+          <button class="cf-pill" :class="{ active: aFilters.featuredOnly }" @click="aFilters.featuredOnly = !aFilters.featuredOnly">★ Feat.</button>
+          <button class="cf-pill" :class="{ active: aFilters.hasBidsOnly  }" @click="aFilters.hasBidsOnly  = !aFilters.hasBidsOnly" >Has Bids</button>
+          <button class="cf-pill" :class="{ active: aFilters.gtoonsOnly   }" @click="aFilters.gtoonsOnly   = !aFilters.gtoonsOnly"  >gToons</button>
+          <button class="cf-pill" :class="{ active: aFilters.wishlistOnly }" @click="aFilters.wishlistOnly = !aFilters.wishlistOnly">Wishlist</button>
+        </div>
+        <div class="cf-owned-row">
+          <button class="cf-owned-btn" :class="{ active: aFilters.selectedOwned === 'all'     }" @click="aFilters.selectedOwned = 'all'"    >All</button>
+          <button class="cf-owned-btn" :class="{ active: aFilters.selectedOwned === 'owned'   }" @click="aFilters.selectedOwned = 'owned'"  >Owned</button>
+          <button class="cf-owned-btn" :class="{ active: aFilters.selectedOwned === 'unowned' }" @click="aFilters.selectedOwned = 'unowned'">Unowned</button>
+        </div>
+      </div>
+    </template>
+
     <template v-if="showHideUnavailable">
       <hr class="cf-divider" />
       <div class="cf-page-filters">
@@ -87,7 +106,8 @@
 <script setup>
 const props = defineProps({
   showHideUnavailable: { type: Boolean, default: false },
-  showSortDir: { type: Boolean, default: true },
+  showSortDir:         { type: Boolean, default: true  },
+  showAuctionFilters:  { type: Boolean, default: false },
   sortOptions: {
     type: Array,
     default: () => [
@@ -98,8 +118,9 @@ const props = defineProps({
   },
 })
 
-const filter = useNewSiteCtoonFilter()
-const ctoons = useState('cmartCtoons', () => [])
+const filter   = useNewSiteCtoonFilter()
+const aFilters = useAuctionHouseFilters()
+const ctoons   = useState('cmartCtoons', () => [])
 
 const RARITIES = [
   { value: 'common',       label: 'C',  cls: 'cf-rb-common'        },
@@ -138,6 +159,15 @@ function clearFilters() {
     sortAsc:         true,
     hideUnavailable: false,
   })
+  if (props.showAuctionFilters) {
+    Object.assign(aFilters.value, {
+      featuredOnly:  false,
+      hasBidsOnly:   false,
+      gtoonsOnly:    false,
+      wishlistOnly:  false,
+      selectedOwned: 'all',
+    })
+  }
 }
 </script>
 
@@ -318,4 +348,50 @@ function clearFilters() {
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   margin: 0;
 }
+
+/* ── Auction filter pills ── */
+.cf-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.cf-pill {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.58rem;
+  font-weight: bold;
+  padding: 2px 7px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+.cf-pill.active                { background: var(--OrbitLightBlue); border-color: var(--OrbitLightBlue); color: #fff; }
+.cf-pill:not(.active):hover    { color: rgba(255, 255, 255, 0.85); }
+
+.cf-owned-row {
+  display: flex;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.cf-owned-btn {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.58rem;
+  font-weight: bold;
+  padding: 2px 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  text-align: center;
+  transition: background 0.15s, color 0.15s;
+}
+.cf-owned-btn.active { background: var(--OrbitLightBlue); color: #fff; }
 </style>

--- a/components/newsite/MyCollection.vue
+++ b/components/newsite/MyCollection.vue
@@ -97,7 +97,9 @@ const ctoons = computed(() => {
 
   list = [...list].sort((a, b) => {
     let cmp = 0
-    if (f.sortField === 'price') {
+    if (f.sortField === 'acquiredDate') {
+      cmp = new Date(a.acquiredAt) - new Date(b.acquiredAt)
+    } else if (f.sortField === 'price') {
       cmp = a.price - b.price
     } else if (f.sortField === 'rarity') {
       const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99

--- a/composables/useAuctionHouseFilters.js
+++ b/composables/useAuctionHouseFilters.js
@@ -1,0 +1,7 @@
+export const useAuctionHouseFilters = () => useState('auctionHouseFilters', () => ({
+  featuredOnly:  false,
+  hasBidsOnly:   false,
+  gtoonsOnly:    false,
+  wishlistOnly:  false,
+  selectedOwned: 'all',
+}))

--- a/pages/newsite/AuctionHouse.vue
+++ b/pages/newsite/AuctionHouse.vue
@@ -4,7 +4,7 @@
       <UserInfo />
     </template>
     <template #sidebar-middle>
-      <CtoonFilter :sort-options="auctionSortOptions" :show-sort-dir="false" />
+      <CtoonFilter :sort-options="auctionSortOptions" :show-sort-dir="false" :show-auction-filters="true" />
     </template>
     <template #sidebar-bottom>
       <WinballAd />

--- a/pages/newsite/AuctionHouse.vue
+++ b/pages/newsite/AuctionHouse.vue
@@ -6,6 +6,9 @@
     <template #sidebar-middle>
       <CtoonFilter :sort-options="auctionSortOptions" :show-sort-dir="false" />
     </template>
+    <template #sidebar-bottom>
+      <WinballAd />
+    </template>
     <template #main-content>
       <AuctionHouse />
     </template>
@@ -45,6 +48,5 @@ body {
   min-height: 100vh;
 }
 
-body.page-auctionhouse .sidebar-bottom { display: none; }
-body.page-auctionhouse .sidebar { --sidebar-middle-height: 504px; }
+body.page-auctionhouse .sidebar { --sidebar-middle-height: 495px; }
 </style>

--- a/pages/newsite/MyCollection.vue
+++ b/pages/newsite/MyCollection.vue
@@ -4,7 +4,7 @@
       <UserInfo />
     </template>
     <template #sidebar-middle>
-      <CtoonFilter />
+      <CtoonFilter :sort-options="myCollectionSortOptions" />
     </template>
     <template #main-content>
       <MyCollection />
@@ -14,6 +14,26 @@
 
 <script setup>
 definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
+
+const myCollectionSortOptions = [
+  { value: 'acquiredDate', label: 'Acquired Date' },
+  { value: 'name',         label: 'Name'          },
+  { value: 'price',        label: 'Price'         },
+  { value: 'rarity',       label: 'Rarity'        },
+]
+
+const filter = useNewSiteCtoonFilter()
+Object.assign(filter.value, {
+  name:            '',
+  rarities:        [],
+  series:          '',
+  set:             '',
+  priceMin:        '',
+  priceMax:        '',
+  sortField:       'acquiredDate',
+  sortAsc:         false,
+  hideUnavailable: false,
+})
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
This PR refactors the Auction House UI to improve layout and usability by moving auction-specific filters to the sidebar and adding a card grid view option alongside the existing list view.

## Key Changes

- **View Mode Toggle**: Added list/card view switcher in the top bar with localStorage persistence for user preference
- **Card Grid View**: Implemented a new 5-column card grid layout displaying auctions with image, name, rarity, bid value, and quick view button
- **Filter Refactoring**: Moved auction-specific filters (Featured, Has Bids, gToons, Wishlist, Owned/Unowned) from inline bar to the sidebar filter panel
- **Composable Extraction**: Created `useAuctionHouseFilters()` composable to centralize auction filter state management
- **CtoonFilter Component Enhancement**: Added `showAuctionFilters` prop to conditionally display auction-specific filter controls in the sidebar
- **ScavengerHuntModal Styling**: Replaced Tailwind classes with custom scoped CSS for consistent theming with the rest of the application
- **Tab Switching Logic**: Improved `switchTab()` function to properly initialize page numbers and load data when switching between tabs
- **Watcher Refactoring**: Updated watchers to reference filters through the new `aFilters` composable instead of local refs

## Implementation Details

- Card view uses CSS Grid with responsive column layout and maintains consistent styling with existing components
- Filters are now reactive through the composable, ensuring state consistency across the application
- View preference is persisted to localStorage and restored on page load
- The sidebar filter panel now serves as the primary interface for all filtering options
- Removed the separate filter bar UI in favor of a cleaner top bar with just tabs and view toggle

https://claude.ai/code/session_01WAvk3eiB9BapaGyn5uLt5x