### PR TITLE
Fix onboarding links, lottery images, and winwheel layout/sound on newsite

### DIFF
--- a/pages/newsite/winwheel.vue
+++ b/pages/newsite/winwheel.vue
@@ -365,6 +365,7 @@ function prepareSpinSoundBuffer() {
 
 function playSpinSoundBuffer() {
   if (!spinBuffer || !audioCtx) return false
+  if (audioCtx.state === 'suspended') audioCtx.resume().catch(() => {})
   const src = audioCtx.createBufferSource()
   src.buffer = spinBuffer
   src.connect(audioCtx.destination)
@@ -392,6 +393,7 @@ function playSpinSoundOnce() {
 function startSpinSound() {
   if (!winWheelSoundPath.value) return
   stopSpinSound()
+  ensureAudioContext()
   void prepareSpinSoundBuffer()
   if (winWheelSoundMode.value === 'once') {
     playSpinSoundOnce()


### PR DESCRIPTION
## Summary

- **Onboarding cZone Contest links are now route-aware** — on newsite pages they link to `/newsite/MycWorld?contestId=:id`; on old-site pages they link to `/czone-contest/:id`. Mirrors the existing behavior for cZone Search links.
- **Newsite lottery prize pool and win modal images now display** — `prize-card-image` and `modal-ctoon-image` CSS classes were referenced by `CtoonAsset` but never defined, causing ctoon images to render invisibly.
- **Winwheel layout fixed** — wheel was `position: absolute; bottom: -24%`, pulling it out of document flow and overlapping the spin button. Changed to `flex: 1` so the wheel renders below the controls.
- **Winwheel sound timing fixed** — sound now starts when the wheel actually begins spinning (after the API responds), not during the server round-trip. AudioContext is pre-unlocked in the user-gesture stack via `prepareSpinSoundBuffer()`.
- **Winwheel sound suspended-context bug fixed** — after an `await`, browsers may suspend the `AudioContext`. Added `ensureAudioContext()` at the top of `startSpinSound()` and an explicit resume guard inside `playSpinSoundBuffer()` to handle this.

## Test plan

- [ ] On a newsite page, open the Onboarding panel → Events tab → verify cZone Contest links go to `/newsite/MycWorld?contestId=…`
- [ ] On an old-site page, verify cZone Contest links go to `/czone-contest/:id`
- [ ] Visit `/newsite/lottery` — confirm prize pool cToon images are visible
- [ ] Buy a lottery ticket and win a cToon — confirm the win modal shows the cToon image
- [ ] Visit `/newsite/winwheel` — confirm spin button and links appear above the wheel, not overlapping it
- [ ] Spin the wheel — confirm sound starts at the same moment the wheel begins rotating
- [ ] Spin the wheel — confirm sound plays (was silenced by suspended AudioContext)

https://claude.ai/code/session_01U22UTiwHiB7znhYZiK1rdk

---
_Generated by [Claude Code](https://claude.ai/code/session_01U22UTiwHiB7znhYZiK1rdk)_