### PR TITLE
Add Winball prize display overlay to middle sidebar images

### DIFF
--- a/components/newsite/MiddleSidebarImages.vue
+++ b/components/newsite/MiddleSidebarImages.vue
@@ -8,6 +8,12 @@
         class="middle-sidebar-item"
       >
         <img :src="imageSrc(n)" :alt="'Middle sidebar image ' + n" class="middle-sidebar-img" />
+        <img
+          v-if="isWinballLink(n) && prizeUrl"
+          :src="prizeUrl"
+          alt="Current Winball prize"
+          class="middle-sidebar-prize"
+        />
       </component>
     </template>
   </div>
@@ -15,6 +21,9 @@
 
 <script setup>
 const { data: hp } = await useAsyncData('homepage-public', () => $fetch('/api/homepage'))
+const { data: prizeData } = await useAsyncData('winball-prize', () => $fetch('/api/winball-prize'))
+
+const prizeUrl = computed(() => prizeData.value?.prize?.ctoon?.imageUrl || '')
 
 function imageSrc(n) {
   return hp.value?.[`middleSidebar${n}ImagePath`] || null
@@ -22,6 +31,12 @@ function imageSrc(n) {
 
 function configuredLink(n) {
   return hp.value?.[`middleSidebar${n}Link`] || null
+}
+
+function isWinballLink(n) {
+  const link = configuredLink(n)
+  if (!link) return false
+  return /winball/i.test(link)
 }
 
 function linkTag(n) {
@@ -50,6 +65,7 @@ function linkProps(n) {
 
 .middle-sidebar-item {
   display: block;
+  position: relative;
   width: 100%;
   text-decoration: none;
   overflow: hidden;
@@ -59,5 +75,16 @@ function linkProps(n) {
   width: 100%;
   height: auto;
   display: block;
+}
+
+.middle-sidebar-prize {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 60%;
+  max-height: 60%;
+  object-fit: contain;
+  pointer-events: none;
 }
 </style>


### PR DESCRIPTION
## Summary
This PR adds functionality to display the current Winball prize as an overlay on middle sidebar images that link to Winball. The prize image is fetched from a new API endpoint and positioned centrally over the sidebar image.

## Key Changes
- Fetch Winball prize data from `/api/winball-prize` endpoint on component mount
- Add `isWinballLink()` function to detect if a sidebar link points to Winball (case-insensitive regex match)
- Conditionally render prize image overlay when the sidebar item is a Winball link and prize data is available
- Update `.middle-sidebar-item` styling to use `position: relative` to enable absolute positioning of the overlay
- Add `.middle-sidebar-prize` styles to center and constrain the prize image overlay with `max-width: 60%` and `max-height: 60%`

## Implementation Details
- Prize URL is extracted from the API response via computed property: `prizeData.value?.prize?.ctoon?.imageUrl`
- The overlay image uses `object-fit: contain` to maintain aspect ratio and `pointer-events: none` to prevent interaction interference
- The prize image is centered using CSS `transform: translate(-50%, -50%)` with `top: 50%` and `left: 50%`

https://claude.ai/code/session_01GV1NPR99aWMQKFCY9qo3m3