### PR TITLE
Add top padding to wheel container for improved spacing

### DIFF
--- a/pages/newsite/winwheel.vue
+++ b/pages/newsite/winwheel.vue
@@ -529,6 +529,7 @@ body {
   align-items: flex-start;
   overflow: hidden;
   position: relative;
+  padding-top: 48px;
 }
 
 .wheel-img {


### PR DESCRIPTION
## Summary
Added top padding to the wheel container to improve visual spacing and layout.

## Changes
- Added `padding-top: 48px;` to the wheel container styling to provide additional spacing from the top of the viewport

## Details
This adjustment ensures better visual hierarchy and prevents content from appearing too close to the top edge of the container. The 48px padding value aligns with the spacing requirements for the wheel component layout.

https://claude.ai/code/session_01HDjmGfJtfaaobxdn9decb4