### PR TITLE
Add text-gray-800 color class to modal and card components

### DIFF
--- a/components/ClashCToonCard.vue
+++ b/components/ClashCToonCard.vue
@@ -35,7 +35,7 @@
     <!-- name only when large -->
     <span
       v-if="!isSmall"
-      class="font-semibold truncate w-full px-1 mt-1 leading-none text-[11px]"
+      class="font-semibold truncate w-full px-1 mt-1 leading-none text-[11px] text-gray-800"
     >
       {{ card.name }}
     </span>

--- a/components/ClashGameBoard.vue
+++ b/components/ClashGameBoard.vue
@@ -10,7 +10,7 @@
         @click="onLaneClick(idx)"
         :class="[
           'relative', // so we can show a small 'Full' badge
-          'flex flex-row md:flex-col items-center bg-white rounded-lg shadow-lg p-4 transition',
+          'flex flex-row md:flex-col items-center bg-white rounded-lg shadow-lg p-4 transition text-gray-800',
           'w-full md:w-1/3',
           (phase!=='select' || confirmed)
             ? 'pointer-events-none opacity-70'

--- a/components/gtoons/ClashDecks.vue
+++ b/components/gtoons/ClashDecks.vue
@@ -125,7 +125,7 @@
         v-if="deckToDelete"
         class="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
       >
-        <div class="bg-white rounded-lg shadow-lg p-6 w-80">
+        <div class="bg-white rounded-lg shadow-lg p-6 w-80 text-gray-800">
           <h3 class="text-xl font-bold mb-4 text-gray-800">Delete Deck?</h3>
           <p class="mb-6 text-gray-700">
             Are you sure you want to delete "{{ deckToDelete.name }}"? This cannot be undone.

--- a/components/gtoons/ClashMeta.vue
+++ b/components/gtoons/ClashMeta.vue
@@ -151,7 +151,7 @@
     >
       <div class="absolute inset-0 bg-black/50" @click="closeDeckModal"></div>
       <div
-        class="relative w-full max-w-4xl max-h-[90vh] bg-white rounded-lg shadow-lg flex flex-col overflow-hidden"
+        class="relative w-full max-w-4xl max-h-[90vh] bg-white rounded-lg shadow-lg flex flex-col overflow-hidden text-gray-800"
         role="dialog"
         aria-modal="true"
       >

--- a/components/gtoons/ClashRooms.vue
+++ b/components/gtoons/ClashRooms.vue
@@ -59,7 +59,7 @@
     >
       <div class="absolute inset-0 bg-black/40" @click="closeStakeModal"></div>
 
-      <div class="relative w-full max-w-md bg-white rounded-xl shadow-xl p-5">
+      <div class="relative w-full max-w-md bg-white rounded-xl shadow-xl p-5 text-gray-800">
         <div class="flex items-start justify-between">
           <h2 class="text-lg font-semibold text-gray-800">Stake Points (optional)</h2>
           <button @click="closeStakeModal" class="text-gray-500 hover:text-gray-700" aria-label="Close">✕</button>

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -124,7 +124,7 @@
           class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
           @click.self="closeCaptureModal"
         >
-          <div class="relative bg-white rounded-lg shadow-lg w-full max-w-md max-h-[90vh] flex flex-col">
+          <div class="relative bg-white rounded-lg shadow-lg w-full max-w-md max-h-[90vh] flex flex-col text-gray-800">
             <div class="px-4 py-3 border-b flex items-center justify-between flex-shrink-0">
               <h2 class="text-lg font-semibold">cToon Captured</h2>
               <button class="text-gray-500 hover:text-black" @click="closeCaptureModal">✕</button>


### PR DESCRIPTION
## Summary
This PR adds explicit text color styling to several modal dialogs and card components by applying the `text-gray-800` Tailwind CSS class to ensure consistent dark text rendering across the application.

## Key Changes
- **ClashCToonCard.vue**: Added `text-gray-800` to the card name display span
- **ClashGameBoard.vue**: Added `text-gray-800` to the lane container div
- **ClashDecks.vue**: Added `text-gray-800` to the delete confirmation modal
- **ClashMeta.vue**: Added `text-gray-800` to the deck modal dialog
- **ClashRooms.vue**: Added `text-gray-800` to the stake points modal
- **MyCzone.vue**: Added `text-gray-800` to the capture confirmation modal

## Implementation Details
These changes ensure that text within modal dialogs and card components inherits a consistent dark gray color (`#1f2937`), improving readability and visual consistency across the application. The class is applied at the container level, allowing child elements to inherit the color unless explicitly overridden.

https://claude.ai/code/session_01Fm3pTzDQh5JqHQd63PQ7K6