### PR TITLE
Add customizable label image and improve touch handling

### DIFF
--- a/components/newsite/CzoneEdit.vue
+++ b/components/newsite/CzoneEdit.vue
@@ -38,7 +38,8 @@
             class="czew-toon-wrap"
             :class="{ 'in-zone': currentZoneToonIds.has(c.id) }"
             @mousedown.prevent="!currentZoneToonIds.has(c.id) && startDrag(c, $event)"
-            @touchstart.prevent="!currentZoneToonIds.has(c.id) && startDrag(c, $event)"
+            @touchstart.prevent="!currentZoneToonIds.has(c.id) && onToonTouchStart(c, $event)"
+            @touchend="!currentZoneToonIds.has(c.id) && onToonTouchEnd(c, $event)"
           >
             <img :src="c.assetPath" :alt="c.name" :title="c.name" draggable="false" class="czew-toon" />
             <div v-if="currentZoneToonIds.has(c.id)" class="czew-toon-overlay" />
@@ -133,6 +134,59 @@ function startDrag(ctoon, e) {
   const point = e.touches ? e.touches[0] : e
   cz.value.ghostX = point.clientX
   cz.value.ghostY = point.clientY
+}
+
+const isMobile = ref(false)
+let touchStartX = 0
+let touchStartY = 0
+
+function updateMobile() {
+  isMobile.value = window.innerWidth <= 768
+}
+
+onMounted(() => {
+  updateMobile()
+  window.addEventListener('resize', updateMobile)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateMobile)
+})
+
+function onToonTouchStart(c, e) {
+  touchStartX = e.touches[0].clientX
+  touchStartY = e.touches[0].clientY
+  if (!isMobile.value) {
+    startDrag(c, e)
+  }
+}
+
+function onToonTouchEnd(c, e) {
+  if (!isMobile.value) return
+  const touch = e.changedTouches[0]
+  const dx = Math.abs(touch.clientX - touchStartX)
+  const dy = Math.abs(touch.clientY - touchStartY)
+  if (dx < 10 && dy < 10) {
+    addToonToTopLeft(c)
+  }
+}
+
+function addToonToTopLeft(c) {
+  const zone = cz.value.zones[cz.value.activeZone]
+  if (!zone || zone.toons.some(t => t.id === c.id)) return
+  const img = new Image()
+  img.onload = () => {
+    zone.toons.push({
+      id: c.id,
+      assetPath: c.assetPath,
+      name: c.name,
+      x: 0,
+      y: 0,
+      width: img.naturalWidth,
+      height: img.naturalHeight,
+    })
+  }
+  img.src = c.assetPath
 }
 
 function selectBg(bg) {

--- a/components/newsite/PromoLabel.vue
+++ b/components/newsite/PromoLabel.vue
@@ -1,8 +1,13 @@
 <template>
   <div class="orbit-label">
-    <img src="/images/newsite/orbit-label.gif" alt="" />
+    <img :src="labelSrc" alt="" />
   </div>
 </template>
+
+<script setup>
+const { data } = await useFetch('/api/homepage')
+const labelSrc = computed(() => data.value?.labelImagePath || '/images/newsite/orbit-label.gif')
+</script>
 
 <style scoped>
 .orbit-label {

--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -364,6 +364,25 @@
           </div>
         </div>
 
+        <!-- Label image -->
+        <div class="border rounded p-4 space-y-3">
+          <h2 class="font-semibold">Label Image</h2>
+          <p class="text-xs text-gray-500">Image displayed as the orbit label on the newsite template (replaces the default orbit-label.gif).</p>
+          <div class="flex items-center gap-4">
+            <div class="w-48 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
+              <img v-if="previewUrls.label || labelPath" :src="previewUrls.label || labelPath" alt="Label" class="max-h-full max-w-full object-contain" />
+              <span v-else class="text-gray-400 text-xs">No image (uses default)</span>
+            </div>
+            <div class="space-y-2 flex-1 min-w-0">
+              <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
+                @change="onLabelFile($event)" class="block w-full text-sm" />
+              <div v-if="labelFile" class="text-xs text-gray-600 truncate">Selected: {{ labelFile.name }}</div>
+              <button type="button" class="px-3 py-1 text-sm rounded border"
+                      v-if="labelPath" @click="clearLabel()">Clear</button>
+            </div>
+          </div>
+        </div>
+
         <div class="mt-2">
           <button class="btn-primary" :disabled="saving" @click="saveOther">
             <span v-if="!saving">Save</span><span v-else>Saving…</span>
@@ -402,13 +421,16 @@ const activeTab = ref('Homepage')
 
 const paths = ref({ topLeft:'', bottomLeft:'', topRight:'', bottomRight:'' })
 const files = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null })
-const previewUrls = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null, showcase:null, homeImage1:null, homeImage2:null, homeImage3:null, homeImage4:null, middleSidebar1:null, middleSidebar2:null, middleSidebar3:null, news:null, earnPoints:null })
+const previewUrls = ref({ topLeft:null, bottomLeft:null, topRight:null, bottomRight:null, showcase:null, homeImage1:null, homeImage2:null, homeImage3:null, homeImage4:null, middleSidebar1:null, middleSidebar2:null, middleSidebar3:null, news:null, earnPoints:null, label:null })
 
 const newsPath = ref('')
 const newsFile = ref(null)
 
 const earnPointsPath = ref('')
 const earnPointsFile = ref(null)
+
+const labelPath = ref('')
+const labelFile = ref(null)
 
 const showcasePath = ref('')
 const showcaseFile = ref(null)
@@ -552,6 +574,19 @@ function clearEarnPoints() {
   earnPointsFile.value = null
 }
 
+function onLabelFile(e) {
+  const f = e.target.files?.[0] || null
+  try { if (previewUrls.value.label) { URL.revokeObjectURL(previewUrls.value.label); previewUrls.value.label = null } } catch (e) {}
+  labelFile.value = f
+  if (f) previewUrls.value.label = URL.createObjectURL(f)
+}
+
+function clearLabel() {
+  labelPath.value = ''
+  if (previewUrls.value.label) { try { URL.revokeObjectURL(previewUrls.value.label) } catch (e) {} ; previewUrls.value.label = null }
+  labelFile.value = null
+}
+
 function onMiddleSidebarPresetChange(n) {
   const preset = middleSidebarImages[n].linkPreset
   if (preset === '') {
@@ -597,6 +632,7 @@ async function loadConfig() {
 
   newsPath.value = cfg.newsImagePath || ''
   earnPointsPath.value = cfg.earnPointsImagePath || ''
+  labelPath.value = cfg.labelImagePath || ''
 }
 
 
@@ -709,11 +745,15 @@ async function saveOther() {
     if (newsFile.value) fd.append('news', newsFile.value)
     fd.append('earnPointsPath', earnPointsPath.value || '')
     if (earnPointsFile.value) fd.append('earnPoints', earnPointsFile.value)
+    fd.append('labelPath', labelPath.value || '')
+    if (labelFile.value) fd.append('label', labelFile.value)
     const res = await $fetch('/api/admin/homepage', { method: 'POST', body: fd })
     newsPath.value = res.newsImagePath || ''
     newsFile.value = null
     earnPointsPath.value = res.earnPointsImagePath || ''
     earnPointsFile.value = null
+    labelPath.value = res.labelImagePath || ''
+    labelFile.value = null
     toast.value = { type: 'ok', msg: 'Images saved.' }
   } catch (e) {
     console.error(e); toast.value = { type: 'error', msg: e?.statusMessage || 'Save failed' }

--- a/prisma/migrations/20260508000000_add_label_image_path/migration.sql
+++ b/prisma/migrations/20260508000000_add_label_image_path/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "HomepageConfig" ADD COLUMN "labelImagePath" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1564,6 +1564,7 @@ model HomepageConfig {
   middleSidebar3Link       String?
   newsImagePath            String?
   earnPointsImagePath      String?
+  labelImagePath           String?
   createdAt                DateTime @default(now())
   updatedAt                DateTime @updatedAt
 }

--- a/server/api/admin/homepage/index.get.js
+++ b/server/api/admin/homepage/index.get.js
@@ -39,6 +39,7 @@ export default defineEventHandler(async (event) => {
     middleSidebar3Link: null,
     newsImagePath: null,
     earnPointsImagePath: null,
+    labelImagePath: null,
     updatedAt: null
   }
 

--- a/server/api/admin/homepage/index.post.js
+++ b/server/api/admin/homepage/index.post.js
@@ -55,7 +55,8 @@ export default defineEventHandler(async (event) => {
     middleSidebar3ImagePath: null,
     middleSidebar3Link:      null,
     newsImagePath:           null,
-    earnPointsImagePath:     null
+    earnPointsImagePath:     null,
+    labelImagePath:          null
   }
 
   // fs prep
@@ -108,7 +109,8 @@ export default defineEventHandler(async (event) => {
     middleSidebar2:   await saveIfPresent('middleSidebar2'),
     middleSidebar3:   await saveIfPresent('middleSidebar3'),
     news:             await saveIfPresent('news'),
-    earnPoints:       await saveIfPresent('earnPoints')
+    earnPoints:       await saveIfPresent('earnPoints'),
+    label:            await saveIfPresent('label')
   }
 
   // helper: update one slot without touching others unless provided
@@ -157,7 +159,8 @@ export default defineEventHandler(async (event) => {
     middleSidebar3ImagePath:  resolveSlot('middleSidebar3ImagePath',  'middleSidebar3',  'middleSidebar3Path',  current.middleSidebar3ImagePath),
     middleSidebar3Link:       resolveLink('middleSidebar3Link', current.middleSidebar3Link),
     newsImagePath:            resolveSlot('newsImagePath',            'news',            'newsPath',            current.newsImagePath),
-    earnPointsImagePath:      resolveSlot('earnPointsImagePath',      'earnPoints',      'earnPointsPath',      current.earnPointsImagePath)
+    earnPointsImagePath:      resolveSlot('earnPointsImagePath',      'earnPoints',      'earnPointsPath',      current.earnPointsImagePath),
+    labelImagePath:           resolveSlot('labelImagePath',           'label',           'labelPath',           current.labelImagePath)
   }
 
   const cfg = await db.homepageConfig.upsert({
@@ -178,7 +181,8 @@ export default defineEventHandler(async (event) => {
       'middleSidebar2ImagePath', 'middleSidebar2Link',
       'middleSidebar3ImagePath', 'middleSidebar3Link',
       'newsImagePath',
-      'earnPointsImagePath'
+      'earnPointsImagePath',
+      'labelImagePath'
     ]
     for (const key of fields) {
       const prev = current[key] ?? null
@@ -211,6 +215,7 @@ export default defineEventHandler(async (event) => {
     middleSidebar3ImagePath: cfg.middleSidebar3ImagePath,
     middleSidebar3Link:      cfg.middleSidebar3Link,
     newsImagePath:           cfg.newsImagePath,
-    earnPointsImagePath:     cfg.earnPointsImagePath
+    earnPointsImagePath:     cfg.earnPointsImagePath,
+    labelImagePath:          cfg.labelImagePath
   }
 })

--- a/server/api/homepage/index.get.js
+++ b/server/api/homepage/index.get.js
@@ -26,5 +26,6 @@ export default defineEventHandler(async () => {
     middleSidebar3Link:      cfg?.middleSidebar3Link      ?? null,
     newsImagePath:           cfg?.newsImagePath           ?? null,
     earnPointsImagePath:     cfg?.earnPointsImagePath     ?? null,
+    labelImagePath:          cfg?.labelImagePath          ?? null,
   }
 })


### PR DESCRIPTION
## Summary
This PR adds support for customizable orbit label images on the newsite template and improves touch interaction handling for the zone editor on mobile devices.

## Key Changes

### Label Image Customization
- Added `labelImagePath` field to `HomepageConfig` model in Prisma schema
- Created database migration to add the new column
- Updated admin homepage management page to include label image upload UI with preview
- Modified `PromoLabel.vue` component to use custom label image when available, falling back to default `orbit-label.gif`
- Extended API endpoints (`/api/admin/homepage` and `/api/homepage`) to handle label image path configuration

### Touch Interaction Improvements
- Enhanced `CzoneEdit.vue` with mobile-aware touch handling:
  - Added `isMobile` ref that tracks viewport width (≤768px)
  - Implemented `onToonTouchStart()` to capture touch coordinates and initiate drag on desktop
  - Implemented `onToonTouchEnd()` to detect tap gestures (< 10px movement) on mobile and add toons to the zone
  - Added `addToonToTopLeft()` function to place toons at coordinates (0, 0) with natural image dimensions
  - Added window resize listener to update mobile state dynamically

## Implementation Details
- Touch handling distinguishes between desktop (drag-to-add) and mobile (tap-to-add) behaviors
- Label image upload accepts SVG, PNG, JPEG, and GIF formats
- Toon placement on mobile uses image natural dimensions to maintain aspect ratio
- Preview URLs are properly managed with cleanup to prevent memory leaks

https://claude.ai/code/session_01Fd3RTSoYwCrGaYhx2jc6qK