### PR TITLE
Add daily purchase limit feature for packs

### DIFF
--- a/pages/admin/edit-pack/[id].vue
+++ b/pages/admin/edit-pack/[id].vue
@@ -113,6 +113,22 @@
             </p>
           </div>
 
+          <!-- daily purchase limit -->
+          <div class="lg:col-span-2 flex flex-col gap-1">
+            <label class="text-sm font-medium">Daily purchase limit per user</label>
+            <input
+              v-model.number="dailyPurchaseLimit"
+              type="number"
+              min="1"
+              placeholder="Leave blank for unlimited"
+              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+              @input="onDailyLimitInput"
+            />
+            <p class="text-xs text-gray-500 ml-1">
+              Max purchases per user per day (8pm–7:59pm CST window). Leave blank for unlimited.
+            </p>
+          </div>
+
           <!-- sell-out behavior -->
           <div class="lg:col-span-2 space-y-2">
             <p class="text-sm font-medium">Pack sell-out behavior</p>
@@ -262,13 +278,19 @@ const { data: packData, pending, error } = await useFetch(`/api/admin/packs/${id
 const loadedOk = computed(() => !pending.value && !error.value)
 
 /* ---------------- basic meta refs ---------------- */
-const name        = ref('')
-const price       = ref(0)
-const description = ref('')
-const inCmart     = ref(false)
-const scheduledAtLocal = ref('')
+const name               = ref('')
+const price              = ref(0)
+const description        = ref('')
+const inCmart            = ref(false)
+const scheduledAtLocal   = ref('')
 const scheduledOffAtLocal = ref('')
-const sellOutBehavior = ref('REMOVE_ON_ANY_RARITY_EMPTY')
+const sellOutBehavior    = ref('REMOVE_ON_ANY_RARITY_EMPTY')
+const dailyPurchaseLimit = ref(null)
+
+function onDailyLimitInput(e) {
+  const raw = e.target.value
+  dailyPurchaseLimit.value = raw === '' ? null : Math.max(1, Math.floor(Number(raw)))
+}
 
 /* ---------------- thumbnail upload ---------------- */
 const fileInput    = ref(null)
@@ -465,7 +487,8 @@ onMounted(async () => {
     price.value       = p.price
     description.value = p.description
     inCmart.value     = p.inCmart
-    sellOutBehavior.value = p.sellOutBehavior || 'REMOVE_ON_ANY_RARITY_EMPTY'
+    sellOutBehavior.value    = p.sellOutBehavior || 'REMOVE_ON_ANY_RARITY_EMPTY'
+    dailyPurchaseLimit.value = p.dailyPurchaseLimit ?? null
     imagePreview.value= p.imagePath
     scheduledAtLocal.value = p.scheduledAt ? centralDateTimeValue(new Date(p.scheduledAt)) : ''
     scheduledOffAtLocal.value = p.scheduledOffAt ? centralDateTimeValue(new Date(p.scheduledOffAt)) : ''
@@ -515,6 +538,7 @@ async function submit () {
     scheduledAtLocal: scheduledAtLocal.value || '',
     scheduledOffAtLocal: scheduledOffAtLocal.value || '',
     sellOutBehavior: sellOutBehavior.value,
+    dailyPurchaseLimit: dailyPurchaseLimit.value,
     rarityConfigs: rarityConfigs.value,
     ctoonOptions: selectedIds.value.map(id => ({
       ctoonId: id,

--- a/prisma/migrations/20260509000000_add_pack_daily_purchase_limit/migration.sql
+++ b/prisma/migrations/20260509000000_add_pack_daily_purchase_limit/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Pack" ADD COLUMN "dailyPurchaseLimit" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -686,18 +686,19 @@ model TradeSpectator {
 }
 
 model Pack {
-  id          String   @id @default(uuid())
-  name        String
-  description String?
-  price       Int      @default(0)
-  imagePath   String?
-  inCmart     Boolean  @default(false)
-  scheduledAt DateTime?
-  sentAt      DateTime?
-  scheduledOffAt DateTime?
-  sellOutBehavior PackSellOutBehavior @default(REMOVE_ON_ANY_RARITY_EMPTY)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id                 String   @id @default(uuid())
+  name               String
+  description        String?
+  price              Int      @default(0)
+  imagePath          String?
+  inCmart            Boolean  @default(false)
+  scheduledAt        DateTime?
+  sentAt             DateTime?
+  scheduledOffAt     DateTime?
+  sellOutBehavior    PackSellOutBehavior @default(REMOVE_ON_ANY_RARITY_EMPTY)
+  dailyPurchaseLimit Int?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
   rarityConfigs PackRarityConfig[]
   ctoonOptions  PackCtoonOption[]

--- a/server/api/admin/packs/[id].patch.js
+++ b/server/api/admin/packs/[id].patch.js
@@ -181,11 +181,12 @@ export default defineEventHandler(async (event) => {
     await tx.pack.update({
       where: { id: packId },
       data: {
-        name:        meta.name.trim(),
-        price:       meta.price ?? 0,
-        description: meta.description ?? null,
-        inCmart:     !!meta.inCmart,
-        sellOutBehavior: meta.sellOutBehavior ?? 'REMOVE_ON_ANY_RARITY_EMPTY',
+        name:               meta.name.trim(),
+        price:              meta.price ?? 0,
+        description:        meta.description ?? null,
+        inCmart:            !!meta.inCmart,
+        sellOutBehavior:    meta.sellOutBehavior ?? 'REMOVE_ON_ANY_RARITY_EMPTY',
+        dailyPurchaseLimit: meta.dailyPurchaseLimit != null ? Number(meta.dailyPurchaseLimit) : null,
         scheduledOffAt,
         scheduledAt,
         ...(imagePath ? { imagePath } : {})

--- a/server/api/cmart/packs/buy.post.js
+++ b/server/api/cmart/packs/buy.post.js
@@ -8,6 +8,8 @@
 // • user must be logged-in
 // • pack must exist + be inCmart = true
 // • user must have ≥ pack.price points
+// • if pack.dailyPurchaseLimit is set, user must not have hit the limit
+//   for the current 8pm–7:59pm CST daily window
 // • deduct points, create a UserPack row (sealed)
 
 import {
@@ -18,6 +20,58 @@ import {
 } from 'h3'
 
 import { prisma as db } from '@/server/prisma'
+
+/**
+ * Returns the start of the current 8pm–7:59pm CST daily window as a UTC Date.
+ * If it's before 8pm Chicago time, the window started yesterday at 8pm.
+ */
+function getDailyWindowStart() {
+  const now = new Date()
+
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', hour12: false
+  })
+  const parts = Object.fromEntries(
+    fmt.formatToParts(now)
+      .filter(p => p.type !== 'literal')
+      .map(p => [p.type, p.value])
+  )
+
+  let year = +parts.year, month = +parts.month - 1, day = +parts.day
+  const hour = +parts.hour
+
+  if (hour < 20) {
+    // Before 8pm Chicago — window started yesterday at 8pm
+    const d = new Date(Date.UTC(year, month, day))
+    d.setUTCDate(d.getUTCDate() - 1)
+    year  = d.getUTCFullYear()
+    month = d.getUTCMonth()
+    day   = d.getUTCDate()
+  }
+
+  // Convert "YYYY-MM-DD 20:00 Chicago" → UTC using the same offset-correction
+  // trick used elsewhere in this codebase.
+  const utcGuessMs = Date.UTC(year, month, day, 20, 0, 0)
+  const fmtCheck = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit'
+  })
+  const displayed = Object.fromEntries(
+    fmtCheck.formatToParts(new Date(utcGuessMs))
+      .filter(p => p.type !== 'literal')
+      .map(p => [p.type, p.value])
+  )
+  const zonalMs = Date.UTC(
+    +displayed.year, +displayed.month - 1, +displayed.day,
+    +displayed.hour, +displayed.minute, +displayed.second
+  )
+  const offsetMs = zonalMs - utcGuessMs
+  return new Date(utcGuessMs - offsetMs)
+}
 
 
 export default defineEventHandler(async (event) => {
@@ -38,47 +92,68 @@ export default defineEventHandler(async (event) => {
 
   /* 3.  lookup pack & user points --------------------------------------- */
   const [pack, userPts, activeLocks] = await Promise.all([
-    db.pack.findUnique({ where: { id: packId }, select: { id: true, price: true, inCmart: true } }),
+    db.pack.findUnique({
+      where:  { id: packId },
+      select: { id: true, price: true, inCmart: true, dailyPurchaseLimit: true }
+    }),
     db.userPoints.findUnique({ where: { userId: me.id }, select: { points: true } }),
     db.lockedPoints.findMany({
-      where: { userId: me.id, status: 'ACTIVE' },
+      where:  { userId: me.id, status: 'ACTIVE' },
       select: { amount: true }
     })
   ])
   if (!pack || !pack.inCmart) {
     throw createError({ statusCode: 404, statusMessage: 'Pack not found' })
   }
-  const totalPoints = userPts?.points || 0
-  const lockedSum = activeLocks.reduce((acc, lock) => acc + (lock.amount || 0), 0)
+  const totalPoints    = userPts?.points || 0
+  const lockedSum      = activeLocks.reduce((acc, lock) => acc + (lock.amount || 0), 0)
   const availablePoints = totalPoints - lockedSum
   if (availablePoints < pack.price) {
     throw createError({ statusCode: 400, statusMessage: 'Not enough available points' })
   }
 
-  /* 4.  transaction: deduct points + create sealed pack ----------------- */
+  /* 4.  daily purchase limit check --------------------------------------- */
+  if (pack.dailyPurchaseLimit != null) {
+    const windowStart = getDailyWindowStart()
+    const purchasedToday = await db.userPack.count({
+      where: {
+        userId:    me.id,
+        packId:    pack.id,
+        createdAt: { gte: windowStart }
+      }
+    })
+    if (purchasedToday >= pack.dailyPurchaseLimit) {
+      throw createError({
+        statusCode: 429,
+        statusMessage: `Daily limit reached — you can buy ${pack.dailyPurchaseLimit} of this pack per day (resets at 8pm CST)`
+      })
+    }
+  }
+
+  /* 5.  transaction: deduct points + create sealed pack ----------------- */
   const result = await db.$transaction(async (tx) => {
-    // 4-a  deduct points
+    // 5-a  deduct points
     const updated = await tx.userPoints.update({
       where: { userId: me.id },
-      data: { points: { decrement: pack.price } }
+      data:  { points: { decrement: pack.price } }
     })
 
     await tx.pointsLog.create({
       data: { userId: me.id, points: pack.price, total: updated.points, method: "Bought Pack", direction: 'decrease' }
-    });
+    })
 
-    // 4-b  create UserPack (sealed)
+    // 5-b  create UserPack (sealed)
     const userPack = await tx.userPack.create({
       data: {
         userId: me.id,
         packId: pack.id,
-        opened: false   // unopened
+        opened: false
       }
     })
 
     return userPack
   })
 
-  /* 5.  success response ------------------------------------------------- */
+  /* 6.  success response ------------------------------------------------- */
   return { success: true, userPackId: result.id }
 })


### PR DESCRIPTION
## Summary
Implements a daily purchase limit feature for packs, allowing admins to restrict how many times a user can purchase the same pack within a 24-hour window (8pm–7:59pm CST).

## Key Changes

- **Backend API (`buy.post.js`)**: 
  - Added `getDailyWindowStart()` utility function to calculate the current 8pm–7:59pm CST daily window in UTC, accounting for timezone conversions
  - Added validation check before purchase to enforce daily limits, returning a 429 status code when limit is reached
  - Updated pack lookup to include the new `dailyPurchaseLimit` field

- **Database Schema (`schema.prisma`)**:
  - Added optional `dailyPurchaseLimit` field to the `Pack` model
  - Created migration to add the column to the database

- **Admin UI (`edit-pack/[id].vue`)**:
  - Added input field for admins to set daily purchase limits per pack
  - Added `onDailyLimitInput()` handler to validate and normalize the input (ensures positive integers, allows null for unlimited)
  - Updated form submission to include the new field

- **Admin API (`packs/[id].patch.js`)**:
  - Updated pack update endpoint to handle the `dailyPurchaseLimit` field

## Implementation Details

- The daily window uses Chicago time (America/Chicago timezone) and resets at 8pm CST each day
- The `getDailyWindowStart()` function uses `Intl.DateTimeFormat` with timezone conversion to accurately determine window boundaries across DST changes
- Purchase limit validation queries `UserPack` records created within the current window for the specific user and pack
- Admins can leave the field blank to allow unlimited purchases
- Error message clearly indicates the limit and when it resets

https://claude.ai/code/session_01Q6meocsKkfDhwNxgWgXDSK