### PR TITLE
Fix mobile layout for winball game on tablets and smaller screens

### DIFF
--- a/pages/newsite/winball.vue
+++ b/pages/newsite/winball.vue
@@ -957,6 +957,15 @@ body {
   background: transparent !important;
   min-height: 100vh;
 }
+
+@media (max-width: 768px) {
+  body.page-newsite-winball .main-content {
+    min-height: calc(100svh - 190px);
+    max-width: 100% !important;
+    overflow: hidden !important;
+    box-sizing: border-box !important;
+  }
+}
 </style>
 
 <style scoped>
@@ -971,6 +980,14 @@ body {
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
   touch-action: none;
+}
+
+@media (max-width: 768px) {
+  .game-container {
+    min-height: calc(100svh - 190px);
+    max-width: 100%;
+    box-sizing: border-box;
+  }
 }
 
 .game-canvas {


### PR DESCRIPTION
## Summary
Added responsive design fixes for the winball game page to properly handle mobile and tablet viewports (max-width: 768px).

## Key Changes
- Added media query for `.main-content` on mobile devices to:
  - Set minimum height to `calc(100svh - 190px)` using small viewport height units
  - Ensure full width with `max-width: 100%`
  - Prevent overflow with `overflow: hidden`
  - Apply proper box-sizing for consistent layout calculations

- Added media query for `.game-container` on mobile devices to:
  - Match the same minimum height calculation (`calc(100svh - 190px)`)
  - Set maximum width to 100% for full mobile width
  - Apply border-box sizing for accurate dimension calculations

## Implementation Details
- Uses `100svh` (small viewport height) instead of `100vh` to account for mobile browser UI elements
- Subtracts 190px to accommodate the page header/navigation on mobile
- Applied consistent styling across both the global body styles and scoped game container styles
- Ensures the game canvas properly fills available space without overflow on smaller screens

https://claude.ai/code/session_01DU7cmo7EjUjCn3CKScoAhq