### PR TITLE
Fix mobile navigation layout to use auto height instead of fixed calculation

### DIFF
--- a/components/newsite/NavLeft.vue
+++ b/components/newsite/NavLeft.vue
@@ -44,4 +44,12 @@ const { isAdmin, logout } = useAuth()
   padding: 0 6px;
   box-sizing: border-box;
 }
+
+@media (max-width: 768px) {
+  .nav-left {
+    flex-wrap: wrap;
+    height: auto;
+    padding: 4px 6px;
+  }
+}
 </style>

--- a/components/newsite/NavRight.vue
+++ b/components/newsite/NavRight.vue
@@ -51,4 +51,12 @@ const props = defineProps({
   padding: 0 6px;
   box-sizing: border-box;
 }
+
+@media (max-width: 768px) {
+  .nav-right {
+    flex-wrap: wrap;
+    height: auto;
+    padding: 4px 6px;
+  }
+}
 </style>

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -235,7 +235,7 @@ html.newsite-active body {
       <div class="topbar-nav"
         :style="[
           { visibility: showNav ? 'visible' : 'hidden' },
-          isMobile ? { flexDirection: 'column', height: 'calc(var(--topbar-nav-height) * 2 + 4px)', overflow: 'visible', gap: '4px', width: '100%' } : {}
+          isMobile ? { flexDirection: 'column', height: 'auto', overflow: 'visible', gap: '4px', width: '100%' } : {}
         ]"
       >
         <div class="topbar-nav-left" :style="isMobile ? { width: '100%' } : {}"><NavLeft :isMobile="isMobile" /></div>
@@ -609,6 +609,17 @@ const scaleStyle = computed(() => {
     width: 100%;
     overflow: visible;
     box-sizing: border-box;
+  }
+
+  .topbar-primary {
+    overflow: visible;
+    height: auto;
+  }
+
+  .topbar-nav-left,
+  .topbar-nav-right {
+    overflow: visible;
+    height: auto;
   }
 
   .main-content {


### PR DESCRIPTION
## Summary
Fixed mobile navigation layout issues by replacing fixed height calculations with `auto` height and adding responsive styles to ensure proper wrapping and spacing on smaller screens.

## Key Changes
- Changed `.topbar-nav` mobile height from `calc(var(--topbar-nav-height) * 2 + 4px)` to `auto` to accommodate dynamic content
- Added responsive styles to `.topbar-primary`, `.topbar-nav-left`, and `.topbar-nav-right` with `overflow: visible` and `height: auto`
- Added mobile media query (`max-width: 768px`) to `NavLeft.vue` with `flex-wrap: wrap` and `height: auto`
- Added mobile media query (`max-width: 768px`) to `NavRight.vue` with `flex-wrap: wrap` and `height: auto`

## Implementation Details
The changes ensure that navigation components properly adapt to mobile viewports by:
- Allowing flexible height based on content rather than fixed calculations
- Enabling flex items to wrap on smaller screens
- Maintaining consistent padding (`4px 6px`) on mobile devices
- Ensuring overflow is visible to prevent content clipping

https://claude.ai/code/session_01RPE6A8cgPbcx6d75QCZ1mQ