### PR TITLE
Fix audio context initialization timing in wheel spin

### DIFF
--- a/pages/newsite/winwheel.vue
+++ b/pages/newsite/winwheel.vue
@@ -298,8 +298,7 @@ const canSpin = computed(() =>
 async function spinWheel() {
   if (!canSpin.value) return
   hasShownResult.value = false
-  // Unlock / pre-load AudioContext while still inside the user-gesture call stack
-  void prepareSpinSoundBuffer()
+  startSpinSound()
   user.value.points -= spinCost.value
   spinsLeft.value--
   isSpinning.value = true
@@ -310,7 +309,6 @@ async function spinWheel() {
     await scavenger.maybeTrigger('winwheel_spin', { open: false })
     const fullTurns = 5
     const wedgeMid  = startOffset + sliceAngle / 2 + sliceIndex * sliceAngle
-    startSpinSound()
     rotation.value  = fullTurns * 360 - wedgeMid
     setTimeout(async () => {
       stopSpinSound()


### PR DESCRIPTION
## Summary
Adjusted the timing of spin sound initialization to ensure the AudioContext is properly prepared within the user gesture call stack, improving audio playback reliability.

## Key Changes
- Moved `startSpinSound()` call from after animation setup to the beginning of `spinWheel()` function
- Replaced `prepareSpinSoundBuffer()` with direct `startSpinSound()` call for simpler audio initialization
- This ensures audio context is unlocked and pre-loaded while still within the user interaction event handler

## Implementation Details
The AudioContext API requires initialization within a user gesture (click, tap, etc.) to function properly. By moving `startSpinSound()` to the start of the spin handler, we guarantee it executes within the user gesture call stack before any async operations, preventing potential audio playback failures that could occur if called after animation delays.

https://claude.ai/code/session_01XsuZbf67mbTUyR6F4S8Mwv