### PR TITLE
Reorganize Redeem button placement for mobile responsiveness

### DIFF
--- a/components/newsite/NavLeft.vue
+++ b/components/newsite/NavLeft.vue
@@ -9,6 +9,9 @@
     <NuxtLink v-if="isMobile" to="/newsite/settings" class="nav-link">
       <BlueButton :style="{ height: buttonHeight }">Settings</BlueButton>
     </NuxtLink>
+    <NuxtLink v-if="isMobile" to="/newsite/redeem" class="nav-link">
+      <BlueButton :style="{ height: buttonHeight }">Redeem</BlueButton>
+    </NuxtLink>
     <GreenButton :style="{ height: buttonHeight }" @click="logout">Logout</GreenButton>
   </div>
 </template>

--- a/components/newsite/NavRight.vue
+++ b/components/newsite/NavRight.vue
@@ -13,7 +13,7 @@
     <NuxtLink to="/newsite/Games" class="nav-link">
       <BlueButton :style="{ height: buttonHeight }">Games</BlueButton>
     </NuxtLink>
-    <NuxtLink to="/newsite/redeem" class="nav-link">
+    <NuxtLink v-if="!isMobile" to="/newsite/redeem" class="nav-link">
       <BlueButton :style="{ height: buttonHeight }">Redeem</BlueButton>
     </NuxtLink>
     <NuxtLink v-if="!isMobile" to="/newsite/settings" class="nav-link">


### PR DESCRIPTION
## Summary
This PR reorganizes the navigation layout to improve mobile responsiveness by moving the Redeem button from the right navigation to the left navigation on mobile devices.

## Key Changes
- **NavLeft.vue**: Added a mobile-only Redeem button that displays between Settings and Logout on mobile devices
- **NavRight.vue**: Added `v-if="!isMobile"` condition to the Redeem button to hide it on mobile, preventing duplication

## Implementation Details
The changes implement a responsive navigation pattern where the Redeem button is conditionally rendered based on screen size:
- On mobile: Redeem appears in the left navigation alongside other mobile-specific options
- On desktop: Redeem remains in the right navigation as before

This ensures the navigation remains clean and organized across different device sizes without duplicating the Redeem functionality.

https://claude.ai/code/session_01JJSjfS4W8yf6RcMN8zYJhK