### PR TITLE
Add viewport meta tag to prevent mobile zoom

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,11 @@
 export default defineNuxtConfig({
+  app: {
+    head: {
+      meta: [
+        { name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' }
+      ]
+    }
+  },
   server: {
     port: process.env.NUXT_PORT || 3000,
     host: '0.0.0.0'


### PR DESCRIPTION
## Summary
Added viewport meta tag configuration to the Nuxt app head to disable user scaling and set fixed viewport dimensions on mobile devices.

## Key Changes
- Added `app.head.meta` configuration in `nuxt.config.js`
- Configured viewport meta tag with the following properties:
  - `width=device-width`: Sets viewport width to device width
  - `initial-scale=1`: Sets initial zoom level to 100%
  - `maximum-scale=1`: Prevents users from zooming beyond 100%
  - `user-scalable=no`: Disables user pinch-to-zoom functionality

## Implementation Details
This viewport configuration is commonly used to ensure consistent layout behavior across mobile devices and prevent unintended zoom interactions. The meta tag is now automatically included in the HTML head for all pages served by the Nuxt application.

https://claude.ai/code/session_018j2mZLPGYtFsQkiEnaWGh6