### PR TITLE
Add header background styling to auction house card grid

### DIFF
--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -744,7 +744,7 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
   box-sizing: border-box;
 }
 
-.ah-card-grid :deep(.sc) { width: 100%; cursor: pointer; }
+.ah-card-grid :deep(.sc) { width: 100%; cursor: pointer; --header-bg: url('/images/newsite/infocardSplash.png') top / 100% 100% no-repeat; }
 
 .ah-card-skeleton {
   border-radius: 8px;


### PR DESCRIPTION
## Summary
Updated the auction house card grid styling to include a custom header background image with proper positioning and sizing.

## Key Changes
- Added `--header-bg` CSS custom property to `.ah-card-grid :deep(.sc)` selector
- Set background image to `/images/newsite/infocardSplash.png` with `top / 100% 100% no-repeat` positioning
- This applies consistent header styling across all info cards in the auction house grid

## Implementation Details
The change uses CSS custom properties to define the header background, allowing for flexible theming and reusability. The background is positioned at the top with full coverage (100% width and height) and no repetition, creating a clean header appearance for the card components.

https://claude.ai/code/session_01DifPvhJkbKEGb2KdS8Sgxz