### PR TITLE
Redesign CtoonCard with dark theme and compact layout

### DIFF
--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -227,8 +227,6 @@
                     :selected="selectedTargetCtoonsMap.has(c.id)"
                     :disabled="c.inPendingTrade"
                     :badge="selfOwnedIdsCreate.has(c.ctoonId) ? 'Owned' : 'Unowned'"
-                    badge-class-owned="bg-green-100 text-green-800"
-                    badge-class-unowned="bg-gray-200 text-gray-600"
                     @toggle="toggleTargetCtoon(c)"
                   />
                 </div>
@@ -300,8 +298,7 @@
                     :selected="selectedInitiatorCtoonsMap.has(c.id)"
                     :disabled="c.inPendingTrade"
                     :badge="targetOwnedIds.has(c.ctoonId) ? 'Owned by User' : 'Unowned by User'"
-                    badge-class-owned="bg-blue-100 text-blue-800"
-                    badge-class-unowned="bg-gray-200 text-gray-600"
+                    badge-class-owned="tc-badge--blue"
                     @toggle="toggleInitiatorCtoon(c)"
                   />
                 </div>
@@ -1247,13 +1244,12 @@ onBeforeUnmount(() => {
 .tr-cards {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: var(--shortcard-height, 176px);
   gap: 6px;
   flex-shrink: 0;
 }
 .tr-card-wrap {
-  background: white;
-  border-radius: 6px;
-  overflow: hidden;
+  min-height: 0;
 }
 
 /* ── Confirm ── */

--- a/components/trade/CtoonCard.vue
+++ b/components/trade/CtoonCard.vue
@@ -3,57 +3,37 @@
     @click="disabled ? undefined : $emit('toggle')"
     :disabled="disabled"
     :aria-pressed="selected ? 'true' : 'false'"
-    :class="[
-      'relative w-full text-left border rounded p-2 transition',
-      disabled ? 'opacity-50 cursor-not-allowed' : 'hover:shadow',
-      selected ? 'border-indigo-500 bg-indigo-50' : ''
-    ]"
+    :class="['tc', { 'tc--selected': selected, 'tc--disabled': disabled }]"
   >
-    <!-- Badge (Owned/Unowned or custom) -->
-    <span
-      v-if="badge"
-      class="absolute top-1 right-1 px-2 py-0.5 text-xs font-semibold rounded-full"
-      :class="badgeClassComputed"
-    >
-      {{ badge }}
-    </span>
+    <!-- Header: splash bg + image -->
+    <div class="tc-header">
+      <img
+        :src="ctoon.assetPath"
+        :alt="ctoon.name"
+        class="tc-img"
+        loading="lazy"
+        draggable="false"
+      />
+      <!-- Owned / Unowned badge -->
+      <span v-if="badge" class="tc-badge" :class="badgeClassComputed">{{ badge }}</span>
+      <!-- In Trade overlay -->
+      <span v-if="disabled" class="tc-in-trade">In Trade</span>
+      <!-- Selected indicator -->
+      <span v-if="selected" class="tc-selected-pip">✓</span>
+    </div>
 
-    <!-- Pending Trade overlay label -->
-    <span
-      v-if="disabled"
-      class="absolute top-1 left-1 px-2 py-0.5 text-[10px] font-semibold rounded-full bg-yellow-100 text-yellow-800 border border-yellow-300"
-    >
-      In Trade
-    </span>
+    <!-- Middle: name + rarity -->
+    <div class="tc-middle">
+      <span class="tc-name">{{ ctoon.name }}</span>
+      <span class="tc-rarity" :class="`r-${rarityKey}`">{{ rarityShort }}</span>
+    </div>
 
-    <!-- Thumb -->
-    <img
-      :src="ctoon.assetPath"
-      :alt="ctoon.name"
-      class="w-full h-28 object-contain mb-2 mt-6"
-      loading="lazy"
-      draggable="false"
-    />
-
-    <!-- Meta -->
-    <p class="text-sm font-medium leading-tight truncate">{{ ctoon.name }}</p>
-    <p class="text-xs text-gray-600">{{ ctoon.rarity }}</p>
-
-    <p v-if="ctoon.mintNumber != null" class="text-xs text-gray-600">
-      Mint #{{ ctoon.mintNumber }}
-      <template v-if="quantityDisplay"> of {{ quantityDisplay }}</template>
-    </p>
-
-    <p v-if="hasEdition" class="text-xs text-gray-600">
-      {{ editionLabel }}
-    </p>
-
-    <!-- Selected tag -->
-    <div
-      v-if="selected"
-      class="absolute -top-2 -left-2 bg-indigo-500 text-white text-xs px-2 py-0.5 rounded"
-    >
-      Selected
+    <!-- Footer: mint info -->
+    <div class="tc-footer">
+      <span v-if="ctoon.mintNumber != null" class="tc-mint">
+        #{{ ctoon.mintNumber }}<template v-if="quantityDisplay"> / {{ quantityDisplay }}</template>
+      </span>
+      <span v-if="hasEdition" class="tc-edition">{{ editionLabel }}</span>
     </div>
   </button>
 </template>
@@ -62,20 +42,13 @@
 import { computed } from 'vue'
 import { formatQuantity } from '~/utils/formatQuantity'
 
-/**
- * Expects a flattened cToon object shaped like your collection responses, e.g.:
- * {
- *   id, ctoonId, assetPath, name, rarity,
- *   mintNumber, isFirstEdition, quantity? (nullable or missing)
- * }
- */
 const props = defineProps({
   ctoon: { type: Object, required: true },
   selected: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
   badge: { type: String, default: '' },
-  badgeClassOwned: { type: String, default: 'bg-green-100 text-green-800' },
-  badgeClassUnowned: { type: String, default: 'bg-gray-200 text-gray-600' }
+  badgeClassOwned: { type: String, default: 'tc-badge--owned' },
+  badgeClassUnowned: { type: String, default: 'tc-badge--unowned' },
 })
 
 defineEmits(['toggle'])
@@ -87,16 +60,200 @@ const badgeClassComputed = computed(() => {
 
 const hasEdition = computed(() => typeof props.ctoon.isFirstEdition === 'boolean')
 const editionLabel = computed(() =>
-  props.ctoon.isFirstEdition ? 'First Edition' : 'Unlimited Edition'
+  props.ctoon.isFirstEdition ? '1st Ed' : 'Unlim'
 )
 
-/**
- * If quantity is null => Unlimited
- * If quantity is undefined => show nothing
- * Else => numeric quantity
- */
 const quantityDisplay = computed(() => {
   if (!('quantity' in props.ctoon)) return ''
   return formatQuantity(props.ctoon.quantity)
 })
+
+const RARITY_MAP = {
+  'common': 'C', 'uncommon': 'U', 'rare': 'R', 'very rare': 'VR',
+  'crazy rare': 'CR', 'prize only': 'PO', 'code only': 'CO', 'auction only': 'AO',
+}
+const rarityShort = computed(() => RARITY_MAP[(props.ctoon.rarity || '').toLowerCase()] || props.ctoon.rarity || '?')
+const rarityKey = computed(() => (props.ctoon.rarity || '').toLowerCase().replace(/\s+/g, '-'))
 </script>
+
+<style scoped>
+/* ── Card shell ── */
+.tc {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--OrbitDarkBlue, #336699);
+  border: 2px solid #1a4a7a;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  text-align: left;
+  padding: 0;
+}
+
+.tc:hover:not(.tc--disabled) {
+  border-color: rgba(51,153,204,0.6);
+}
+
+.tc--selected {
+  border-color: var(--OrbitLightBlue, #3399CC);
+  box-shadow: 0 0 0 1px var(--OrbitLightBlue, #3399CC);
+}
+
+.tc--disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* ── Header (splash + image) ── */
+.tc-header {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background: url('/images/newsite/infocardSplash.png') top / 100% 100% no-repeat;
+  overflow: hidden;
+}
+
+.tc-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transform: scale(0.7);
+  image-rendering: pixelated;
+}
+
+/* ── Overlays ── */
+.tc-badge {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  font-size: 0.52rem;
+  font-weight: bold;
+  padding: 1px 5px;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+.tc-badge--owned {
+  background: rgba(74,222,128,0.25);
+  color: #4ade80;
+  border: 1px solid rgba(74,222,128,0.4);
+}
+
+.tc-badge--unowned {
+  background: rgba(156,163,175,0.2);
+  color: #d1d5db;
+  border: 1px solid rgba(156,163,175,0.3);
+}
+
+.tc-badge--blue {
+  background: rgba(96,165,250,0.2);
+  color: #93c5fd;
+  border: 1px solid rgba(96,165,250,0.35);
+}
+
+.tc-in-trade {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  font-size: 0.52rem;
+  font-weight: bold;
+  padding: 1px 4px;
+  border-radius: 9999px;
+  background: rgba(251,191,36,0.25);
+  color: #fbbf24;
+  border: 1px solid rgba(251,191,36,0.35);
+}
+
+.tc-selected-pip {
+  position: absolute;
+  bottom: 3px;
+  left: 3px;
+  font-size: 0.65rem;
+  font-weight: bold;
+  color: #fff;
+  background: var(--OrbitLightBlue, #3399CC);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+/* ── Middle: name + rarity ── */
+.tc-middle {
+  height: 18px;
+  min-height: 18px;
+  max-height: 18px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  gap: 3px;
+  overflow: hidden;
+}
+
+.tc-name {
+  font-size: 0.6rem;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  text-align: center;
+}
+
+.tc-rarity {
+  flex-shrink: 0;
+  font-size: 0.52rem;
+  font-weight: bold;
+  padding: 1px 3px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+/* ── Footer: mint + edition ── */
+.tc-footer {
+  height: 20px;
+  min-height: 20px;
+  max-height: 20px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 4px;
+  overflow: hidden;
+}
+
+.tc-mint {
+  font-size: 0.52rem;
+  color: rgba(255,255,255,0.5);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tc-edition {
+  font-size: 0.5rem;
+  color: rgba(255,255,255,0.38);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Rarity colour badges (match AuctionHouse) ── */
+.r-common        { background: #6b7280; color: #fff; }
+.r-uncommon      { background: #e5e7eb; color: #111; }
+.r-rare          { background: #16a34a; color: #fff; }
+.r-very-rare     { background: #2563eb; color: #fff; }
+.r-crazy-rare    { background: #7c3aed; color: #fff; }
+.r-prize-only    { background: #111;    color: #e5e7eb; }
+.r-code-only     { background: #ea580c; color: #fff; }
+.r-auction-only  { background: #eab308; color: #111; }
+</style>

--- a/pages/newsite/trade.vue
+++ b/pages/newsite/trade.vue
@@ -46,6 +46,6 @@ body {
 }
 
 body.page-newsite-trade .sidebar {
-  --sidebar-middle-height: 560px;
+  --sidebar-middle-height: 490px;
 }
 </style>


### PR DESCRIPTION
## Summary
Redesigned the `CtoonCard` component with a dark theme matching the Orbit design system, restructured the layout into distinct header/middle/footer sections, and optimized spacing for a more compact card appearance.

## Key Changes

- **Visual Redesign**: Replaced light Tailwind styling with dark blue theme (`--OrbitDarkBlue #336699`) and updated border/shadow colors to match Orbit design system
- **Layout Restructuring**: Reorganized card content into three semantic sections:
  - Header: splash background image with overlays (badge, "In Trade", selected indicator)
  - Middle: character name and abbreviated rarity badge
  - Footer: mint number and edition info
- **Rarity Display**: Added `RARITY_MAP` to display rarity as short codes (C, U, R, VR, CR, PO, CO, AO) with color-coded badges matching AuctionHouse styling
- **Styling Consolidation**: Moved all inline Tailwind classes to scoped CSS with BEM-style naming (`.tc-*` classes) for better maintainability
- **Badge System**: Updated badge styling with semi-transparent backgrounds and borders; added `tc-badge--blue` variant for "Owned by User" state
- **Compact Sizing**: Reduced card dimensions with fixed heights for middle (18px) and footer (20px) sections; adjusted image scaling and font sizes
- **Trade.vue Updates**: Removed redundant `badge-class-owned/unowned` props from target ctoons (using defaults); updated initiator ctoons to use new `tc-badge--blue` class
- **Layout Adjustments**: Added `grid-auto-rows` to card grid and adjusted sidebar height from 560px to 490px

## Implementation Details

- Edition labels shortened: "First Edition" → "1st Ed", "Unlimited Edition" → "Unlim"
- Mint display format changed from "of" to "/" separator
- Image rendering set to `pixelated` for retro aesthetic
- Selected indicator changed from text label to checkmark symbol (✓) in circular pip
- All color values use CSS custom properties where applicable for theme consistency

https://claude.ai/code/session_01RF6jyj5V8dyRicwxEQFyEM