### PR TITLE
Fix topbar nav right layout to be responsive and flexible

### DIFF
--- a/components/newsite/NavRight.vue
+++ b/components/newsite/NavRight.vue
@@ -47,7 +47,7 @@ const props = defineProps({
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 6px;
+  justify-content: space-evenly;
   width: 100%;
   height: 100%;
   padding: 0 6px;

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -460,13 +460,13 @@ const scaleStyle = computed(() => {
 }
 
 .topbar-nav-right {
-  width: var(--topbar-nav-right-width);
+  flex: 1;
+  min-width: 0;
   height: var(--topbar-nav-right-height);
   background: var(--topbar-nav-right-bg);
   border-radius: var(--topbar-nav-right-radius);
   border: var(--topbar-nav-right-border-thickness) solid var(--topbar-nav-right-border-color);
   padding: var(--topbar-nav-right-pt) var(--topbar-nav-right-pr) var(--topbar-nav-right-pb) var(--topbar-nav-right-pl);
-  flex-shrink: 0;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
Updated the topbar navigation right section to use flexible layout instead of fixed width, improving responsiveness and content distribution.

## Key Changes
- **newsite-template.vue**: Modified `.topbar-nav-right` styling:
  - Changed from fixed `width: var(--topbar-nav-right-width)` to `flex: 1` to allow the element to grow and fill available space
  - Added `min-width: 0` to ensure flex items can shrink below their content size
  - Removed `flex-shrink: 0` to allow the element to shrink when needed

- **NavRight.vue**: Updated layout alignment:
  - Replaced `gap: 6px` with `justify-content: space-evenly` for more balanced spacing of child elements
  - Maintains `width: 100%` and `height: 100%` to fill the parent container

## Implementation Details
These changes enable the topbar navigation right section to be truly responsive - it will now expand to fill available space and distribute its content evenly, rather than being constrained to a fixed width. This improves the layout's adaptability across different screen sizes and viewport widths.

https://claude.ai/code/session_01PareCHCUka3Wzd6QQUmLod