### PR TITLE
Add loading state for background prefetching in Czone editor

### DIFF
--- a/components/newsite/CzoneEdit.vue
+++ b/components/newsite/CzoneEdit.vue
@@ -52,15 +52,18 @@
     <!-- ── Background panel ── -->
     <div v-show="activeTab === 'bg'" class="czew-panel">
       <div class="czew-bg-grid">
-        <img
-          v-for="bg in cz.backgrounds" :key="bg.id"
-          :src="bg.imagePath"
-          :alt="bg.label || bg.filename"
-          class="czew-bg-item"
-          :class="{ 'czew-bg-active': (currentZoneBg || '').split('/').pop() === bg.filename }"
-          @click="selectBg(bg)"
-        />
-        <div v-if="!cz.backgrounds.length" class="czew-empty" style="grid-column:1/-1">No backgrounds available.</div>
+        <div v-if="cz.loadingBackgrounds" class="czew-empty" style="grid-column:1/-1">Loading…</div>
+        <template v-else>
+          <img
+            v-for="bg in cz.backgrounds" :key="bg.id"
+            :src="bg.imagePath"
+            :alt="bg.label || bg.filename"
+            class="czew-bg-item"
+            :class="{ 'czew-bg-active': (currentZoneBg || '').split('/').pop() === bg.filename }"
+            @click="selectBg(bg)"
+          />
+          <div v-if="!cz.backgrounds.length" class="czew-empty" style="grid-column:1/-1">No backgrounds available.</div>
+        </template>
       </div>
     </div>
 

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -223,6 +223,9 @@ const canvasEl       = ref(null)
 const viewedOwner    = ref(null)   // { username, avatar } of the displayed zone owner
 const viewedUsername = ref(null)   // username whose zone is currently displayed
 
+// Track in-flight prefetch so toggleBuild can await it instead of double-fetching
+const prefetchPromise = ref(null)
+
 // Local drag: repositioning toons already on the canvas
 const localDrag = ref(null)  // { toon, offsetX, offsetY }
 
@@ -311,9 +314,11 @@ async function loadZone(username) {
     viewedUsername.value = target
     viewedOwner.value    = { username: data.ownerName, avatar: data.avatar }
     loadCzoneSearchItems()
-    // Pre-fetch edit resources so the Build sidebar is ready without a blank flash
+    // Pre-fetch edit resources so the Build sidebar is ready without a blank flash.
+    // Store the promise so toggleBuild can await it if the user clicks Build before it completes.
     if (user.value?.username && target === user.value.username) {
-      prefetchEditResources()
+      prefetchPromise.value = prefetchEditResources()
+      prefetchPromise.value.finally(() => { prefetchPromise.value = null })
     }
   } catch (e) {
     console.error('MyCzone: failed to load zone', e)
@@ -339,10 +344,13 @@ async function prefetchEditResources() {
   if (!cz.value.backgrounds.length) {
     fetches.push(
       (async () => {
+        cz.value.loadingBackgrounds = true
         try {
           cz.value.backgrounds = await $fetch('/api/czone/backgrounds-available')
         } catch (e) {
           console.error('MyCzone: failed to pre-load backgrounds', e)
+        } finally {
+          cz.value.loadingBackgrounds = false
         }
       })()
     )
@@ -387,6 +395,10 @@ async function toggleBuild() {
       cz.value.activeZone = firstActive
     }
   } else {
+    // If the background prefetch is still in flight, wait for it so we don't
+    // start duplicate requests and so data is ready when the sidebar renders.
+    if (prefetchPromise.value) await prefetchPromise.value
+
     if (!cz.value.collection.length) {
       cz.value.loadingCollection = true
       try {
@@ -398,10 +410,13 @@ async function toggleBuild() {
       }
     }
     if (!cz.value.backgrounds.length) {
+      cz.value.loadingBackgrounds = true
       try {
         cz.value.backgrounds = await $fetch('/api/czone/backgrounds-available')
       } catch (e) {
         console.error('MyCzone: failed to load backgrounds', e)
+      } finally {
+        cz.value.loadingBackgrounds = false
       }
     }
   }

--- a/composables/useNewSiteCzoneState.js
+++ b/composables/useNewSiteCzoneState.js
@@ -1,12 +1,13 @@
 export const useNewSiteCzoneState = () => useState('newSiteCzoneState', () => ({
-  buildMode:        false,
-  zones:            [{ background: '', toons: [] }],
-  activeZone:       0,
-  saving:           false,
-  collection:       [],
-  loadingCollection: false,
-  backgrounds:      [],
-  activeDrag:       null,   // { ctoon: {...} } when dragging from CzoneEdit
-  ghostX:           0,
-  ghostY:           0,
+  buildMode:          false,
+  zones:              [{ background: '', toons: [] }],
+  activeZone:         0,
+  saving:             false,
+  collection:         [],
+  loadingCollection:  false,
+  backgrounds:        [],
+  loadingBackgrounds: false,
+  activeDrag:         null,   // { ctoon: {...} } when dragging from CzoneEdit
+  ghostX:             0,
+  ghostY:             0,
 }))


### PR DESCRIPTION
## Summary
This PR improves the user experience when loading backgrounds in the Czone editor by adding a loading indicator and preventing duplicate API requests during the prefetch phase.

## Key Changes
- **Added `loadingBackgrounds` state** to track when backgrounds are being fetched, displayed as a "Loading…" message in the background panel
- **Implemented prefetch promise tracking** in `MyCzone.vue` to store the in-flight prefetch request, allowing `toggleBuild()` to await it if the user opens the Build sidebar before prefetching completes
- **Prevented duplicate requests** by awaiting the prefetch promise in `toggleBuild()` before making additional API calls
- **Improved UI feedback** with conditional rendering that shows a loading state instead of a blank panel while backgrounds are being fetched
- **Code formatting** aligned state object properties for better readability

## Implementation Details
- The `prefetchEditResources()` function now sets `loadingBackgrounds = true` before fetching and resets it in a `finally` block
- The `prefetchPromise` ref stores the promise returned by `prefetchEditResources()` and is cleared once the promise settles
- Both the prefetch path and the direct `toggleBuild()` path now properly manage the loading state
- The background grid shows "Loading…" when `cz.loadingBackgrounds` is true, preventing a jarring blank state

https://claude.ai/code/session_01CBx3X9Tw9zHcwC8PNqrthp