### PR TITLE
fix: cZone Build sidebar blank on first load with ad blocker

### DIFF
--- a/components/newsite/CzoneEdit.vue
+++ b/components/newsite/CzoneEdit.vue
@@ -201,7 +201,12 @@ function selectBg(bg) {
 .czew {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  /* flex:1 fills the flex-column .sidebar-middle in build mode.
+     Avoids height:100% which collapses to 0 when the parent has no
+     explicit px height (e.g. flex-grown height isn't "definite" for
+     percentage resolution in all browsers). */
+  flex: 1 1 0;
+  min-height: 0;
   overflow: hidden;
   padding: 4px;
   box-sizing: border-box;
@@ -379,6 +384,7 @@ function selectBg(bg) {
 
 @media (max-width: 768px) {
   .czew {
+    flex: none;  /* revert to content-height on mobile */
     height: auto;
   }
   .czew-panel {

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -395,9 +395,15 @@ async function toggleBuild() {
       cz.value.activeZone = firstActive
     }
   } else {
-    // If the background prefetch is still in flight, wait for it so we don't
-    // start duplicate requests and so data is ready when the sidebar renders.
-    if (prefetchPromise.value) await prefetchPromise.value
+    // If the prefetch is still in flight, wait for it (max 5 s) so we don't
+    // start duplicate requests. The timeout prevents an ad-blocker-stalled
+    // prefetch from blocking build mode indefinitely.
+    if (prefetchPromise.value) {
+      await Promise.race([
+        prefetchPromise.value,
+        new Promise(resolve => setTimeout(resolve, 5000))
+      ])
+    }
 
     if (!cz.value.collection.length) {
       cz.value.loadingCollection = true

--- a/pages/newsite/czone/[username].vue
+++ b/pages/newsite/czone/[username].vue
@@ -26,16 +26,23 @@ onUnmounted(() => { cz.value.buildMode = false })
 </script>
 
 <style>
-/* ── Build mode: CzoneEdit fills entire sidebar with 4px border ── */
+/* ── Build mode: CzoneEdit fills entire sidebar ── */
 body.page-newsite-czone-username.czone-build .sidebar-top    { display: none !important; }
 body.page-newsite-czone-username.czone-build .sidebar-bottom { display: none !important; }
 body.page-newsite-czone-username.czone-build .sidebar-middle {
-  flex: 1 !important;
-  height: auto !important;
+  /* Grow to fill the full sidebar height once top/bottom are hidden */
+  flex: 1 1 0 !important;
+  /* Turn into a flex column so CzoneEdit (.czew) can use flex:1 reliably.
+     height:auto is NOT used here — it breaks height:100% on children because
+     the browser won't treat a flex-grown height as "definite" for % resolution. */
+  display: flex !important;
+  flex-direction: column !important;
   min-height: 0 !important;
   max-height: none !important;
   margin: 4px !important;
   width: calc(100% - 8px) !important;
   box-sizing: border-box;
+  overflow: hidden !important;
+  padding: 0 !important;
 }
 </style>


### PR DESCRIPTION
## Summary

- **CSS root cause**: `.czew` used `height: 100%` to fill the sidebar, but `.sidebar-middle` in build mode had `height: auto !important`. Browsers don't treat a flex-grown height as "definite" for `%` resolution in children — so `height: 100%` collapsed to `0`. With `overflow: hidden` on the container, every element inside `.czew` became invisible (truly blank, no text, no tabs).
- **Race condition**: `prefetchEditResources()` was called without `await` in `loadZone`. If the user clicked Build before the prefetch finished, `toggleBuild` started duplicate fetches. With an ad blocker slowing requests, this window was wide enough to cause the empty state on first load.

## Changes

**`pages/newsite/czone/[username].vue`**
- Build-mode `.sidebar-middle` override now adds `display: flex; flex-direction: column` and removes `height: auto !important`
- This makes `.sidebar-middle` a proper flex column so `.czew` can size itself via `flex: 1`

**`components/newsite/CzoneEdit.vue`**
- `.czew` now uses `flex: 1 1 0; min-height: 0` instead of `height: 100%` — reliable inside a flex column regardless of whether the parent has an explicit px height
- Mobile gets `flex: none; height: auto` to preserve existing scroll behaviour
- Backgrounds panel now shows `Loading…` while fetching (same as the cToons panel), so users see a loading state instead of a misleading "No backgrounds available."

**`components/newsite/MyCzone.vue`**
- `loadZone` stores the prefetch as `prefetchPromise` so `toggleBuild` can await it instead of starting duplicate requests
- The await is raced against a 5-second timeout so an ad-blocker-stalled prefetch can never freeze build mode indefinitely
- `loadingBackgrounds` flag added and set during both prefetch and manual fetch paths

**`composables/useNewSiteCzoneState.js`**
- Added `loadingBackgrounds: false` to shared state shape

## Test plan

- [ ] Load cZone page with an ad blocker enabled — click Build on first load, verify sidebar shows ctoons and backgrounds immediately (no refresh needed)
- [ ] Verify sidebar expands to fill full height in build mode on desktop
- [ ] Verify sidebar scrolls correctly on mobile in build mode
- [ ] Verify clicking "Exit Build" restores normal sidebar layout

https://claude.ai/code/session_01CBx3X9Tw9zHcwC8PNqrthp

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBx3X9Tw9zHcwC8PNqrthp)_