### PR TITLE
Fix responsive design and add fallback sidebar component

### DIFF
--- a/components/newsite/CzoneSidebarMiddle.vue
+++ b/components/newsite/CzoneSidebarMiddle.vue
@@ -4,6 +4,7 @@
     @save="czoneActions.save()"
     @clear="czoneActions.clearZone()"
   />
+  <MiddleSidebarImages v-else />
 </template>
 
 <script setup>

--- a/components/newsite/WinballPromo.vue
+++ b/components/newsite/WinballPromo.vue
@@ -65,6 +65,15 @@ const linkProps = computed(() => {
   object-fit: cover;
 }
 
+@media (max-width: 768px) {
+  .winball-promo {
+    height: auto;
+  }
+  .winball-promo-bg {
+    height: auto;
+  }
+}
+
 .winball-promo-prize {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
## Summary
This PR includes two UI improvements: adding responsive styling to the WinballPromo component and implementing a fallback component for the CzoneSidebarMiddle.

## Key Changes
- **WinballPromo.vue**: Added mobile responsive media query (max-width: 768px) to set height to `auto` for both `.winball-promo` and `.winball-promo-bg` classes, ensuring proper display on smaller screens
- **CzoneSidebarMiddle.vue**: Added `MiddleSidebarImages` component as a fallback when the conditional rendering condition is not met (v-else clause)

## Implementation Details
- The responsive breakpoint targets tablets and smaller devices at 768px width
- The fallback component ensures the sidebar always displays content, improving user experience when the primary condition is not satisfied

https://claude.ai/code/session_01GK1dpMq2BEDaqKjpAoVBuV