### PR TITLE
Refactor mobile sidebar state to composable and auto-expand on build

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -191,6 +191,7 @@ function canvasH() { return CANVAS_H }
 const { user } = useAuth()
 const cz = useNewSiteCzoneState()
 const { open: openCtoonModal } = useCtoonModal()
+const { mobileSidebarCollapsed } = useNewsiteLayout()
 const route  = useRoute()
 const router = useRouter()
 
@@ -378,6 +379,10 @@ async function toggleBuild() {
       buildLoading.value = false
     }
     cz.value.buildMode = true
+    // On mobile, expand the sidebar so the ctoons/backgrounds panel is visible
+    if (typeof window !== 'undefined' && window.innerWidth < 768) {
+      mobileSidebarCollapsed.value = false
+    }
   }
 }
 

--- a/composables/useNewsiteLayout.js
+++ b/composables/useNewsiteLayout.js
@@ -1,5 +1,6 @@
 export const useNewsiteLayout = () => {
   const sidebarMiddleComponent = useState('newsiteSidebarMiddle', () => null)
+  const mobileSidebarCollapsed = useState('newsiteMobileSidebarCollapsed', () => true)
 
   const setSidebarMiddle = (componentName) => {
     sidebarMiddleComponent.value = componentName
@@ -9,5 +10,5 @@ export const useNewsiteLayout = () => {
     sidebarMiddleComponent.value = null
   }
 
-  return { sidebarMiddleComponent, setSidebarMiddle, clearSidebarMiddle }
+  return { sidebarMiddleComponent, setSidebarMiddle, clearSidebarMiddle, mobileSidebarCollapsed }
 }

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -270,7 +270,7 @@ html.newsite-active body {
 <script setup>
 const route = useRoute()
 const { isOpen: ctoonModalIsOpen } = useCtoonModal()
-const { sidebarMiddleComponent } = useNewsiteLayout()
+const { sidebarMiddleComponent, mobileSidebarCollapsed } = useNewsiteLayout()
 const czoneState = useState('newSiteCzoneState', () => ({ buildMode: false }))
 useHead({
   htmlAttrs: { class: 'newsite-active' },
@@ -285,7 +285,7 @@ const showNav = computed(() => route.meta.showNav !== false)
 const showSidebar = computed(() => route.meta.showSidebar !== false)
 const showFooter = computed(() => route.meta.showFooter !== false)
 const mainContentBorder = computed(() => route.meta.mainContentBorder === false ? 'none' : undefined)
-const mobileSidebarCollapsed = ref(true)
+
 
 const gridColumns = computed(() =>
   isMobile.value ? '1fr' : 'var(--sidebar-width) var(--main-content-width)'


### PR DESCRIPTION
## Summary
This PR refactors the mobile sidebar collapsed state from a local component ref into a shared composable state, and adds logic to automatically expand the sidebar when entering build mode on mobile devices.

## Key Changes
- **Moved mobile sidebar state to composable**: Migrated `mobileSidebarCollapsed` from a local ref in `newsite-template.vue` to a shared state in `useNewsiteLayout()` composable, making it accessible across components
- **Auto-expand sidebar on build mode**: Added logic in `MyCzone.vue` to automatically collapse the mobile sidebar (set `mobileSidebarCollapsed` to `false`) when entering build mode on devices with width < 768px, ensuring the ctoons/backgrounds panel is visible
- **Updated state management**: Modified `useNewsiteLayout()` to export the new `mobileSidebarCollapsed` state alongside existing sidebar utilities
- **Updated layout template**: Removed local `mobileSidebarCollapsed` ref and imported it from the composable instead

## Implementation Details
- The sidebar auto-expansion uses a runtime check (`typeof window !== 'undefined' && window.innerWidth < 768`) to safely detect mobile viewports
- The state is initialized to `true` (collapsed) by default in the composable
- All components now reference the same shared state instance, ensuring consistent sidebar behavior across the application

https://claude.ai/code/session_01PFrQ7FdLY7bCsrWr9GfGPV