### PR TITLE
Remove mobile sidebar auto-expand logic from czone build

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -191,7 +191,6 @@ function canvasH() { return CANVAS_H }
 const { user } = useAuth()
 const cz = useNewSiteCzoneState()
 const { open: openCtoonModal } = useCtoonModal()
-const { mobileSidebarCollapsed } = useNewsiteLayout()
 const route  = useRoute()
 const router = useRouter()
 
@@ -379,10 +378,6 @@ async function toggleBuild() {
       buildLoading.value = false
     }
     cz.value.buildMode = true
-    // On mobile, expand the sidebar so the ctoons/backgrounds panel is visible
-    if (typeof window !== 'undefined' && window.innerWidth < 768) {
-      mobileSidebarCollapsed.value = false
-    }
   }
 }
 

--- a/pages/newsite/czone/[username].vue
+++ b/pages/newsite/czone/[username].vue
@@ -29,4 +29,12 @@ body.page-newsite-czone-username.czone-build .sidebar-middle {
   overflow: hidden !important;
   padding: 0 !important;
 }
+
+@media (max-width: 768px) {
+  body.page-newsite-czone-username.czone-build .sidebar-middle {
+    flex: none !important;
+    min-height: unset !important;
+    overflow: visible !important;
+  }
+}
 </style>

--- a/pages/newsite/myczone.vue
+++ b/pages/newsite/myczone.vue
@@ -25,4 +25,10 @@ body.page-myczone.czone-build .sidebar-middle {
   width: calc(100% - 8px) !important;
   box-sizing: border-box;
 }
+
+@media (max-width: 768px) {
+  body.page-myczone.czone-build .sidebar-middle {
+    flex: none !important;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary
Removed the automatic mobile sidebar expansion logic that was triggered when entering build mode in the czone component. Instead, responsive CSS media queries now handle sidebar behavior on mobile devices.

## Key Changes
- Removed the `mobileSidebarCollapsed` state management from the build mode toggle in `MyCzone.vue`
- Removed the conditional logic that automatically expanded the sidebar when entering build mode on mobile devices (width < 768px)
- Added responsive CSS media queries to both `[username].vue` and `myczone.vue` that adjust sidebar styling for mobile viewports:
  - Set `flex: none` to prevent flex growth
  - Reset `min-height` and `overflow` properties for proper mobile layout

## Implementation Details
The change shifts from imperative JavaScript-based sidebar control to declarative CSS-based responsive design. This approach is cleaner and more maintainable, as the mobile sidebar behavior is now defined entirely in the stylesheet rather than being scattered across component logic. The media query breakpoint (768px) matches the existing mobile detection threshold in the removed JavaScript code.

https://claude.ai/code/session_0154y1Aq8ECR6yRcjVsbAxyC