### PR TITLE
Improve marble track physics and rendering with signed miters

### DIFF
--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -284,8 +284,7 @@ function buildTrackMeshes() {
     sAngle[i] = Math.atan2(dx, dz)
   }
 
-  // Miter extension needed at the joint between segment a and segment b
-  // so their rectangular boxes overlap flush rather than leaving a triangular gap
+  // Unsigned miter for floors — fills gaps; overlapping coplanar meshes have no visible artifact
   function miterExt(a, b) {
     if (a < 0 || b >= nSegs) return 0.1
     let delta = sAngle[b] - sAngle[a]
@@ -293,49 +292,71 @@ function buildTrackMeshes() {
     if (delta < -Math.PI) delta += 2 * Math.PI
     return Math.min(COURSE_HALF_W * Math.abs(Math.tan(delta / 2)), COURSE_HALF_W)
   }
+  // Signed miter for walls: positive = extend (outer/convex corner fills gap),
+  // negative = truncate (inner/concave corner — avoids the overlapping-box spike artifact)
+  function wallMiterLeft(a, b) {
+    if (a < 0 || b >= nSegs) return 0.05
+    let delta = sAngle[b] - sAngle[a]
+    if (delta >  Math.PI) delta -= 2 * Math.PI
+    if (delta < -Math.PI) delta += 2 * Math.PI
+    return Math.max(-COURSE_HALF_W, Math.min(COURSE_HALF_W, -COURSE_HALF_W * Math.tan(delta / 2)))
+  }
+  function wallMiterRight(a, b) {
+    if (a < 0 || b >= nSegs) return 0.05
+    let delta = sAngle[b] - sAngle[a]
+    if (delta >  Math.PI) delta -= 2 * Math.PI
+    if (delta < -Math.PI) delta += 2 * Math.PI
+    return Math.max(-COURSE_HALF_W, Math.min(COURSE_HALF_W,  COURSE_HALF_W * Math.tan(delta / 2)))
+  }
 
   for (let i = 0; i < nSegs; i++) {
     const dx = sDx[i], dz = sDz[i], len = sLen[i]
     if (len < 0.001) continue
     const angle = sAngle[i]
-
-    // Extend each end to the miter plane of its neighbouring segment
-    const extBack  = miterExt(i - 1, i)
-    const extFront = miterExt(i, i + 1)
-    const totalLen = len + extBack + extFront
-
-    // Shift the box centre so it still straddles the spine segment
     const [x1, z1] = samples[i], [x2, z2] = samples[i + 1]
-    const shift = (extFront - extBack) / 2
-    const midX = (x1 + x2) / 2 + (dx / len) * shift
-    const midZ = (z1 + z2) / 2 + (dz / len) * shift
+    const rawMidX = (x1 + x2) / 2, rawMidZ = (z1 + z2) / 2
 
-    // Floor
-    const floorGeo  = new THREE.BoxGeometry(COURSE_HALF_W * 2, 1, totalLen)
-    const floorMesh = new THREE.Mesh(floorGeo, floorMat)
-    floorMesh.position.set(midX, -0.5, midZ)
+    // Floor: unsigned miter fills all corner gaps
+    const floorBk  = miterExt(i - 1, i), floorFt = miterExt(i, i + 1)
+    const floorLen  = len + floorBk + floorFt
+    const floorSh   = (floorFt - floorBk) / 2
+    const floorMesh = new THREE.Mesh(new THREE.BoxGeometry(COURSE_HALF_W * 2, 1, floorLen), floorMat)
+    floorMesh.position.set(rawMidX + (dx / len) * floorSh, -0.5, rawMidZ + (dz / len) * floorSh)
     floorMesh.rotation.y = angle
     floorMesh.receiveShadow = true
     scene.add(floorMesh)
 
-    // Left wall
-    const wallGeo = new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, totalLen)
-    const lx = midX + (-dz / len) * (COURSE_HALF_W + WALL_T)
-    const lz = midZ + ( dx / len) * (COURSE_HALF_W + WALL_T)
-    const lw = new THREE.Mesh(wallGeo, wallMat)
-    lw.position.set(lx, WALL_H, lz)
-    lw.rotation.y = angle
-    lw.castShadow = true
-    scene.add(lw)
+    // Left wall: signed miter — truncates inner concave corners, eliminating the spike overlap
+    const lBk = wallMiterLeft(i - 1, i), lFt = wallMiterLeft(i, i + 1)
+    const lTot = len + lBk + lFt
+    if (lTot > 0.1) {
+      const lSh = (lFt - lBk) / 2
+      const lw = new THREE.Mesh(new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, lTot), wallMat)
+      lw.position.set(
+        rawMidX + (dx / len) * lSh + (-dz / len) * (COURSE_HALF_W + WALL_T),
+        WALL_H,
+        rawMidZ + (dz / len) * lSh + ( dx / len) * (COURSE_HALF_W + WALL_T)
+      )
+      lw.rotation.y = angle
+      lw.castShadow = true
+      scene.add(lw)
+    }
 
-    // Right wall
-    const rx = midX + ( dz / len) * (COURSE_HALF_W + WALL_T)
-    const rz = midZ + (-dx / len) * (COURSE_HALF_W + WALL_T)
-    const rw = new THREE.Mesh(wallGeo.clone(), wallMat)
-    rw.position.set(rx, WALL_H, rz)
-    rw.rotation.y = angle
-    rw.castShadow = true
-    scene.add(rw)
+    // Right wall: signed miter — truncates inner concave corners, eliminating the spike overlap
+    const rBk = wallMiterRight(i - 1, i), rFt = wallMiterRight(i, i + 1)
+    const rTot = len + rBk + rFt
+    if (rTot > 0.1) {
+      const rSh = (rFt - rBk) / 2
+      const rw = new THREE.Mesh(new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, rTot), wallMat)
+      rw.position.set(
+        rawMidX + (dx / len) * rSh + ( dz / len) * (COURSE_HALF_W + WALL_T),
+        WALL_H,
+        rawMidZ + (dz / len) * rSh + (-dx / len) * (COURSE_HALF_W + WALL_T)
+      )
+      rw.rotation.y = angle
+      rw.castShadow = true
+      scene.add(rw)
+    }
   }
 
   // Pegs — same logic as server (denser, every 5 samples, cycling left/center/right/center)

--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -338,14 +338,15 @@ function buildTrackMeshes() {
     scene.add(rw)
   }
 
-  // Pegs — same logic as server
-  for (let i = 5; i < samples.length - 5; i += 8) {
+  // Pegs — same logic as server (denser, every 5 samples, cycling left/center/right/center)
+  const PEG_PATTERN = [-1, 0, 1, 0]
+  for (let i = 5; i < samples.length - 7; i += 5) {
     const [px, pz] = samples[i]
     const [nx, nz] = samples[Math.min(i + 1, samples.length - 1)]
     const ddx = nx - px, ddz = nz - pz
     const dlen = Math.sqrt(ddx * ddx + ddz * ddz)
     if (dlen < 0.001) continue
-    const side = ((Math.floor(i / 8)) % 3) - 1
+    const side = PEG_PATTERN[Math.floor(i / 5) % PEG_PATTERN.length]
     const off  = side * (COURSE_HALF_W * 0.45)
     const mesh = new THREE.Mesh(pegGeo, pegMat)
     mesh.position.set(px + (-ddz / dlen) * off, 1.5, pz + (ddx / dlen) * off)

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -203,7 +203,7 @@ function buildMarblesWorld() {
     segData.push({ dx, dz, len, angle: Math.atan2(dx, dz) })
   }
 
-  // Miter extension at the joint between segment a and b so boxes overlap flush
+  // Unsigned miter for floors — fills gaps; overlapping coplanar static bodies are harmless
   function miterExt(a, b) {
     if (a < 0 || b >= nSegs) return 0.1
     let delta = segData[b].angle - segData[a].angle
@@ -211,44 +211,70 @@ function buildMarblesWorld() {
     if (delta < -Math.PI) delta += 2 * Math.PI
     return Math.min(COURSE_HALF_W * Math.abs(Math.tan(delta / 2)), COURSE_HALF_W)
   }
+  // Signed miter for walls: positive = extend (outer/convex corner fills gap),
+  // negative = truncate (inner/concave corner avoids overlap pocket that traps marbles)
+  function wallMiterLeft(a, b) {
+    if (a < 0 || b >= nSegs) return 0.05
+    let delta = segData[b].angle - segData[a].angle
+    if (delta >  Math.PI) delta -= 2 * Math.PI
+    if (delta < -Math.PI) delta += 2 * Math.PI
+    return Math.max(-COURSE_HALF_W, Math.min(COURSE_HALF_W, -COURSE_HALF_W * Math.tan(delta / 2)))
+  }
+  function wallMiterRight(a, b) {
+    if (a < 0 || b >= nSegs) return 0.05
+    let delta = segData[b].angle - segData[a].angle
+    if (delta >  Math.PI) delta -= 2 * Math.PI
+    if (delta < -Math.PI) delta += 2 * Math.PI
+    return Math.max(-COURSE_HALF_W, Math.min(COURSE_HALF_W,  COURSE_HALF_W * Math.tan(delta / 2)))
+  }
 
   for (let i = 0; i < nSegs; i++) {
     const { dx, dz, len, angle } = segData[i]
     if (len < 0.001) continue
     const [x1, z1] = samples[i], [x2, z2] = samples[i + 1]
+    const rawMidX = (x1 + x2) / 2, rawMidZ = (z1 + z2) / 2
 
-    const extBack  = miterExt(i - 1, i)
-    const extFront = miterExt(i, i + 1)
-    const halfLen  = (len + extBack + extFront) / 2
-
-    const shift = (extFront - extBack) / 2
-    const midX = (x1 + x2) / 2 + (dx / len) * shift
-    const midZ = (z1 + z2) / 2 + (dz / len) * shift
-
-    // Floor
+    // Floor: unsigned miter fills all corner gaps
+    const floorBk = miterExt(i - 1, i), floorFt = miterExt(i, i + 1)
+    const floorHL = (len + floorBk + floorFt) / 2
+    const floorSh = (floorFt - floorBk) / 2
     const floor = new CANNON.Body({ mass: 0, material: trackMat })
-    floor.addShape(new CANNON.Box(new CANNON.Vec3(COURSE_HALF_W, FLOOR_H, halfLen)))
-    floor.position.set(midX, -FLOOR_H, midZ)
+    floor.addShape(new CANNON.Box(new CANNON.Vec3(COURSE_HALF_W, FLOOR_H, floorHL)))
+    floor.position.set(rawMidX + (dx / len) * floorSh, -FLOOR_H, rawMidZ + (dz / len) * floorSh)
     floor.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angle)
     world.addBody(floor)
 
-    // Left wall  (perpendicular-left: (-dz, 0, dx) / len)
-    const lx = midX + (-dz / len) * (COURSE_HALF_W + WALL_T)
-    const lz = midZ + ( dx / len) * (COURSE_HALF_W + WALL_T)
-    const lw = new CANNON.Body({ mass: 0, material: trackMat })
-    lw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, halfLen)))
-    lw.position.set(lx, WALL_H, lz)
-    lw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angle)
-    world.addBody(lw)
+    // Left wall: signed miter — truncates inner concave corners, no wedge pocket
+    const lBk = wallMiterLeft(i - 1, i), lFt = wallMiterLeft(i, i + 1)
+    const lTot = len + lBk + lFt
+    if (lTot > 0.1) {
+      const lSh = (lFt - lBk) / 2
+      const lw = new CANNON.Body({ mass: 0, material: trackMat })
+      lw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, lTot / 2)))
+      lw.position.set(
+        rawMidX + (dx / len) * lSh + (-dz / len) * (COURSE_HALF_W + WALL_T),
+        WALL_H,
+        rawMidZ + (dz / len) * lSh + ( dx / len) * (COURSE_HALF_W + WALL_T)
+      )
+      lw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angle)
+      world.addBody(lw)
+    }
 
-    // Right wall (perpendicular-right: (dz, 0, -dx) / len)
-    const rx = midX + ( dz / len) * (COURSE_HALF_W + WALL_T)
-    const rz = midZ + (-dx / len) * (COURSE_HALF_W + WALL_T)
-    const rw = new CANNON.Body({ mass: 0, material: trackMat })
-    rw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, halfLen)))
-    rw.position.set(rx, WALL_H, rz)
-    rw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angle)
-    world.addBody(rw)
+    // Right wall: signed miter — truncates inner concave corners, no wedge pocket
+    const rBk = wallMiterRight(i - 1, i), rFt = wallMiterRight(i, i + 1)
+    const rTot = len + rBk + rFt
+    if (rTot > 0.1) {
+      const rSh = (rFt - rBk) / 2
+      const rw = new CANNON.Body({ mass: 0, material: trackMat })
+      rw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, rTot / 2)))
+      rw.position.set(
+        rawMidX + (dx / len) * rSh + ( dz / len) * (COURSE_HALF_W + WALL_T),
+        WALL_H,
+        rawMidZ + (dz / len) * rSh + (-dx / len) * (COURSE_HALF_W + WALL_T)
+      )
+      rw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angle)
+      world.addBody(rw)
+    }
   }
 
   // End-cap wall at the finish line — solid physics body matching the visual cap

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -184,27 +184,50 @@ function buildMarblesWorld() {
 
   const trackMat  = new CANNON.Material('mbl_track')
   const marbleMat = new CANNON.Material('mbl_marble')
-  world.addContactMaterial(new CANNON.ContactMaterial(trackMat, marbleMat, { friction: 0.35, restitution: 0.35 }))
-  world.addContactMaterial(new CANNON.ContactMaterial(marbleMat, marbleMat, { friction: 0.1,  restitution: 0.55 }))
+  world.addContactMaterial(new CANNON.ContactMaterial(trackMat, marbleMat, { friction: 0.4, restitution: 0.3 }))
+  world.addContactMaterial(new CANNON.ContactMaterial(marbleMat, marbleMat, { friction: 0.2, restitution: 0.45 }))
 
   const WALL_H  = 3    // wall half-height (total wall = 6 units tall)
   const WALL_T  = 0.3  // wall half-thickness
   const FLOOR_H = 0.5  // floor half-height
 
   const samples = buildCourseSamples()
+  const nSegs = samples.length - 1
 
-  for (let i = 0; i < samples.length - 1; i++) {
+  // Pre-compute per-segment direction data for miter joint calculation
+  const segData = []
+  for (let i = 0; i < nSegs; i++) {
     const [x1, z1] = samples[i], [x2, z2] = samples[i + 1]
-    const midX = (x1 + x2) / 2, midZ = (z1 + z2) / 2
     const dx = x2 - x1, dz = z2 - z1
     const len = Math.sqrt(dx * dx + dz * dz)
+    segData.push({ dx, dz, len, angle: Math.atan2(dx, dz) })
+  }
+
+  // Miter extension at the joint between segment a and b so boxes overlap flush
+  function miterExt(a, b) {
+    if (a < 0 || b >= nSegs) return 0.1
+    let delta = segData[b].angle - segData[a].angle
+    if (delta >  Math.PI) delta -= 2 * Math.PI
+    if (delta < -Math.PI) delta += 2 * Math.PI
+    return Math.min(COURSE_HALF_W * Math.abs(Math.tan(delta / 2)), COURSE_HALF_W)
+  }
+
+  for (let i = 0; i < nSegs; i++) {
+    const { dx, dz, len, angle } = segData[i]
     if (len < 0.001) continue
-    const angle = Math.atan2(dx, dz)
-    const halfSeg = len / 2 + 0.08  // slight overlap to seal gaps between boxes
+    const [x1, z1] = samples[i], [x2, z2] = samples[i + 1]
+
+    const extBack  = miterExt(i - 1, i)
+    const extFront = miterExt(i, i + 1)
+    const halfLen  = (len + extBack + extFront) / 2
+
+    const shift = (extFront - extBack) / 2
+    const midX = (x1 + x2) / 2 + (dx / len) * shift
+    const midZ = (z1 + z2) / 2 + (dz / len) * shift
 
     // Floor
     const floor = new CANNON.Body({ mass: 0, material: trackMat })
-    floor.addShape(new CANNON.Box(new CANNON.Vec3(COURSE_HALF_W, FLOOR_H, halfSeg)))
+    floor.addShape(new CANNON.Box(new CANNON.Vec3(COURSE_HALF_W, FLOOR_H, halfLen)))
     floor.position.set(midX, -FLOOR_H, midZ)
     floor.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angle)
     world.addBody(floor)
@@ -213,7 +236,7 @@ function buildMarblesWorld() {
     const lx = midX + (-dz / len) * (COURSE_HALF_W + WALL_T)
     const lz = midZ + ( dx / len) * (COURSE_HALF_W + WALL_T)
     const lw = new CANNON.Body({ mass: 0, material: trackMat })
-    lw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, halfSeg)))
+    lw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, halfLen)))
     lw.position.set(lx, WALL_H, lz)
     lw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angle)
     world.addBody(lw)
@@ -222,20 +245,35 @@ function buildMarblesWorld() {
     const rx = midX + ( dz / len) * (COURSE_HALF_W + WALL_T)
     const rz = midZ + (-dx / len) * (COURSE_HALF_W + WALL_T)
     const rw = new CANNON.Body({ mass: 0, material: trackMat })
-    rw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, halfSeg)))
+    rw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, halfLen)))
     rw.position.set(rx, WALL_H, rz)
     rw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angle)
     world.addBody(rw)
   }
 
-  // Pegs – alternating sides every 8th sample point
-  for (let i = 5; i < samples.length - 5; i += 8) {
+  // End-cap wall at the finish line — solid physics body matching the visual cap
+  {
+    const lastIdx = samples.length - 1
+    const [finX, finZ] = samples[lastIdx]
+    const [prevX, prevZ] = samples[lastIdx - 1]
+    const adx = finX - prevX, adz = finZ - prevZ
+    const approachAngle = Math.atan2(adx, adz)
+    const cap = new CANNON.Body({ mass: 0, material: trackMat })
+    cap.addShape(new CANNON.Box(new CANNON.Vec3(COURSE_HALF_W + 1, WALL_H, WALL_T)))
+    cap.position.set(finX, WALL_H, finZ)
+    cap.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), approachAngle)
+    world.addBody(cap)
+  }
+
+  // Pegs – denser spacing (every 5 samples), spread throughout, cycling left/center/right/center
+  const PEG_PATTERN = [-1, 0, 1, 0]
+  for (let i = 5; i < samples.length - 7; i += 5) {
     const [px, pz] = samples[i]
     const [nx, nz] = samples[Math.min(i + 1, samples.length - 1)]
     const ddx = nx - px, ddz = nz - pz
     const dlen = Math.sqrt(ddx * ddx + ddz * ddz)
     if (dlen < 0.001) continue
-    const side = ((Math.floor(i / 8)) % 3) - 1  // -1, 0, +1
+    const side = PEG_PATTERN[Math.floor(i / 5) % PEG_PATTERN.length]
     const off  = side * (COURSE_HALF_W * 0.45)
     const b = new CANNON.Body({ mass: 0, material: trackMat })
     b.addShape(new CANNON.Cylinder(0.45, 0.45, 3, 8))
@@ -281,7 +319,7 @@ function startMarblesPhysics() {
 
   const FIXED_STEP = 1 / 60
   marblesPhysInterval = setInterval(() => {
-    world.step(FIXED_STEP)
+    world.step(FIXED_STEP, FIXED_STEP, 3)
 
     if (marblesState.phase !== 'racing') return
     for (let i = 0; i < marbleBodies.length; i++) {


### PR DESCRIPTION
## Summary
This PR refactors the marble track construction to use signed miter joints for walls, eliminating visual and physics artifacts at track corners while also improving peg placement density and physics simulation accuracy.

## Key Changes

- **Signed miter joints for walls**: Replaced unsigned miter calculation with separate `wallMiterLeft()` and `wallMiterRight()` functions that use signed values to truncate inner (concave) corners and extend outer (convex) corners. This eliminates overlapping-box spike artifacts at sharp turns and prevents marble-trapping wedge pockets in the physics simulation.

- **Pre-computed segment data**: Extracted direction vectors, lengths, and angles into a `segData` array to avoid recalculating these values and improve code clarity.

- **Denser peg placement**: Changed peg spacing from every 8 samples to every 5 samples, and replaced the alternating -1/0/+1 pattern with a 4-element cycling pattern `[-1, 0, 1, 0]` for more varied track obstacles.

- **End-cap wall at finish line**: Added a solid physics body and visual mesh at the final track position to properly contain marbles at the finish.

- **Physics tuning**: 
  - Adjusted contact material friction and restitution values (track-marble: 0.35→0.4 friction, 0.35→0.3 restitution; marble-marble: 0.1→0.2 friction, 0.55→0.45 restitution)
  - Enhanced physics solver with `world.step(FIXED_STEP, FIXED_STEP, 3)` for better stability

- **Synchronized rendering and physics**: Applied identical miter logic and peg placement to both the Three.js visualization (`marbles.vue`) and Cannon.js physics engine (`socket-server.js`) to ensure visual and physical consistency.

## Implementation Details

The signed miter calculation uses `Math.tan(delta / 2)` where `delta` is the angle difference between consecutive segments. For walls, the sign determines whether to extend (positive, outer corners) or truncate (negative, inner corners), clamped to `[-COURSE_HALF_W, COURSE_HALF_W]`. Floor miters remain unsigned to fill all gaps without visual artifacts from overlapping coplanar meshes.

https://claude.ai/code/session_01SaF8HtgUWiN5Gi2Z2CfLuK