### PR TITLE
Fix marble wall trapping; add V-shaped funnel start area

### DIFF
--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -96,8 +96,10 @@ const hasJoined = computed(() =>
 const threeCanvas = ref(null)
 
 // ─── Marble race constants (must match server) ──────────────────────────────
-const MBL_RADIUS  = 0.8
-const FINISH_Z    = -118
+const MBL_RADIUS         = 0.8
+const FINISH_Z           = -118
+const FUNNEL_Z_OPEN      = 109
+const FUNNEL_OPEN_HALF_W = 14
 
 // Curved course — Catmull-Rom spine [x, z]
 const COURSE_SPINE = [
@@ -244,6 +246,7 @@ function initThree() {
   scene.add(fill)
 
   buildTrackMeshes()
+  buildFunnelMeshes()
   buildFinishLine()
   buildLabelContainer()
 
@@ -335,6 +338,27 @@ function buildTrackMeshes() {
     scene.add(rw)
   }
 
+  // Junction cylinder posts — placed at every wall-edge junction to fill the wedge
+  // pocket formed where two rotated box segments meet, so marbles deflect smoothly.
+  {
+    const POST_R = WALL_T + 0.05
+    const postGeoJ = new THREE.CylinderGeometry(POST_R, POST_R, WALL_H * 2, 8)
+    for (let i = 0; i <= nSegs; i++) {
+      const [px, pz] = samples[i]
+      const si = Math.min(i, nSegs - 1)
+      const { dx, dz, len } = { dx: sDx[si], dz: sDz[si], len: sLen[si] }
+      const nx = -dz / len, nz = dx / len
+
+      const lp = new THREE.Mesh(postGeoJ, wallMat)
+      lp.position.set(px + nx * COURSE_HALF_W, WALL_H, pz + nz * COURSE_HALF_W)
+      scene.add(lp)
+
+      const rp = new THREE.Mesh(postGeoJ, wallMat)
+      rp.position.set(px - nx * COURSE_HALF_W, WALL_H, pz - nz * COURSE_HALF_W)
+      scene.add(rp)
+    }
+  }
+
   // Pegs — same logic as server (denser, every 5 samples, cycling left/center/right/center)
   const PEG_PATTERN = [-1, 0, 1, 0]
   for (let i = 5; i < samples.length - 7; i += 5) {
@@ -350,6 +374,45 @@ function buildTrackMeshes() {
     mesh.castShadow = true
     scene.add(mesh)
   }
+}
+
+function buildFunnelMeshes() {
+  const WALL_H = 3, WALL_T = 0.3
+  const floorMat = new THREE.MeshStandardMaterial({ color: 0x2d6a4f, roughness: 0.8, metalness: 0.1 })
+  const wallMat  = new THREE.MeshStandardMaterial({ color: 0x3a86ff, roughness: 0.6, metalness: 0.2, transparent: true, opacity: 0.85 })
+
+  const F_Z0 = 90, F_Z1 = FUNNEL_Z_OPEN
+  const F_HW0 = COURSE_HALF_W, F_HW1 = FUNNEL_OPEN_HALF_W
+
+  // Floor
+  const fFloor = new THREE.Mesh(new THREE.BoxGeometry(F_HW1 * 2, 1, F_Z1 - F_Z0), floorMat)
+  fFloor.position.set(0, -0.5, (F_Z0 + F_Z1) / 2)
+  fFloor.receiveShadow = true
+  scene.add(fFloor)
+
+  // Left angled wall
+  const ldx = -(F_HW1 - F_HW0), ldz = F_Z1 - F_Z0
+  const llen = Math.sqrt(ldx * ldx + ldz * ldz)
+  const lw = new THREE.Mesh(new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, llen), wallMat)
+  lw.position.set(-(F_HW0 + F_HW1) / 2, WALL_H, (F_Z0 + F_Z1) / 2)
+  lw.rotation.y = Math.atan2(ldx, ldz)
+  lw.castShadow = true
+  scene.add(lw)
+
+  // Right angled wall
+  const rdx = F_HW1 - F_HW0, rdz = F_Z1 - F_Z0
+  const rlen = Math.sqrt(rdx * rdx + rdz * rdz)
+  const rw = new THREE.Mesh(new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, rlen), wallMat)
+  rw.position.set((F_HW0 + F_HW1) / 2, WALL_H, (F_Z0 + F_Z1) / 2)
+  rw.rotation.y = Math.atan2(rdx, rdz)
+  rw.castShadow = true
+  scene.add(rw)
+
+  // Back wall across the open end
+  const bw = new THREE.Mesh(new THREE.BoxGeometry((F_HW1 + WALL_T) * 2, WALL_H * 2, WALL_T * 2), wallMat)
+  bw.position.set(0, WALL_H, F_Z1)
+  bw.castShadow = true
+  scene.add(bw)
 }
 
 function buildFinishLine() {
@@ -426,9 +489,11 @@ function syncMarbleMeshes(marbles) {
     }
   }
 
-  const maxSpread = (COURSE_HALF_W - MBL_RADIUS - 0.3) * 2
-  const spreadMax = Math.min((marbles.length - 1) * 1.5, maxSpread)
-  const step = marbles.length > 1 ? spreadMax / (marbles.length - 1) : 0
+  const count = marbles.length
+  const cols  = Math.min(count, 4)
+  const rows  = Math.ceil(count / cols)
+  const zTop  = FUNNEL_Z_OPEN - 2
+  const zBot  = 93
 
   marbles.forEach((m, i) => {
     if (marbleMeshMap.has(m.id)) return
@@ -440,8 +505,14 @@ function syncMarbleMeshes(marbles) {
       envMapIntensity: 1,
     })
     const mesh = new THREE.Mesh(geo, mat)
-    const startX = -spreadMax / 2 + i * step
-    mesh.position.set(startX, MBL_RADIUS, 87)
+    const row  = Math.floor(i / cols)
+    const col  = i % cols
+    const z    = rows > 1 ? zTop - row * (zTop - zBot) / (rows - 1) : (zTop + zBot) / 2
+    const t    = (z - 90) / (FUNNEL_Z_OPEN - 90)
+    const hw   = COURSE_HALF_W + (FUNNEL_OPEN_HALF_W - COURSE_HALF_W) * t
+    const usHW = (hw - MBL_RADIUS - 0.2) * 0.9
+    const startX = cols > 1 ? -usHW + col * (usHW * 2) / (cols - 1) : 0
+    mesh.position.set(startX, MBL_RADIUS, z)
     mesh.castShadow = true
     scene.add(mesh)
 
@@ -481,10 +552,10 @@ function resetScene() {
 
 // ─── Camera helpers ────────────────────────────────────────────────────────
 function snapCameraToStart() {
-  camTarget.set(0, 0, 75)
+  camTarget.set(0, 0, 90)
   camTheta = Math.PI
   camPhi   = Math.PI / 4.5
-  camDist  = 65
+  camDist  = 75
   applyCameraOrbit()
 }
 

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -145,6 +145,8 @@ const COURSE_SPINE = [
 ]
 const COURSE_HALF_W = 5   // half-width of channel
 const COURSE_N_SEGS = 120 // number of approximation segments
+const FUNNEL_Z_OPEN     = 109  // z-position of the open (top) end of the staging funnel
+const FUNNEL_OPEN_HALF_W = 14  // half-width of the funnel at its open end
 
 function crSample(pts, t) {
   const n   = pts.length - 1
@@ -249,6 +251,66 @@ function buildMarblesWorld() {
     world.addBody(rw)
   }
 
+  // Junction cylinder posts — one at each sample point along both wall edges.
+  // A convex cylinder at the joint fills the wedge pocket that forms when two rotated
+  // box segments meet at an angle, so marbles deflect smoothly instead of getting stuck.
+  {
+    const POST_R = WALL_T + 0.05
+    for (let i = 0; i <= nSegs; i++) {
+      const [px, pz] = samples[i]
+      const si = Math.min(i, nSegs - 1)
+      const { dx, dz, len } = segData[si]
+      const nx = -dz / len, nz = dx / len  // left-side unit normal
+
+      const lp = new CANNON.Body({ mass: 0, material: trackMat })
+      lp.addShape(new CANNON.Cylinder(POST_R, POST_R, WALL_H * 2, 8))
+      lp.position.set(px + nx * COURSE_HALF_W, WALL_H, pz + nz * COURSE_HALF_W)
+      world.addBody(lp)
+
+      const rp = new CANNON.Body({ mass: 0, material: trackMat })
+      rp.addShape(new CANNON.Cylinder(POST_R, POST_R, WALL_H * 2, 8))
+      rp.position.set(px - nx * COURSE_HALF_W, WALL_H, pz - nz * COURSE_HALF_W)
+      world.addBody(rp)
+    }
+  }
+
+  // Funnel — V-shaped staging area attached to the start of the course.
+  // Marbles wait here before the race; the open end is at FUNNEL_Z_OPEN.
+  {
+    const F_Z0 = 90, F_Z1 = FUNNEL_Z_OPEN
+    const F_HW0 = COURSE_HALF_W, F_HW1 = FUNNEL_OPEN_HALF_W
+
+    // Floor covering the entire funnel area
+    const fFloor = new CANNON.Body({ mass: 0, material: trackMat })
+    fFloor.addShape(new CANNON.Box(new CANNON.Vec3(F_HW1, FLOOR_H, (F_Z1 - F_Z0) / 2)))
+    fFloor.position.set(0, -FLOOR_H, (F_Z0 + F_Z1) / 2)
+    world.addBody(fFloor)
+
+    // Left angled wall: from (-F_HW0, F_Z0) to (-F_HW1, F_Z1)
+    const ldx = -(F_HW1 - F_HW0), ldz = F_Z1 - F_Z0
+    const llen = Math.sqrt(ldx * ldx + ldz * ldz)
+    const lw = new CANNON.Body({ mass: 0, material: trackMat })
+    lw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, llen / 2)))
+    lw.position.set(-(F_HW0 + F_HW1) / 2, WALL_H, (F_Z0 + F_Z1) / 2)
+    lw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), Math.atan2(ldx, ldz))
+    world.addBody(lw)
+
+    // Right angled wall: from (F_HW0, F_Z0) to (F_HW1, F_Z1)
+    const rdx = F_HW1 - F_HW0, rdz = F_Z1 - F_Z0
+    const rlen = Math.sqrt(rdx * rdx + rdz * rdz)
+    const rw = new CANNON.Body({ mass: 0, material: trackMat })
+    rw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, rlen / 2)))
+    rw.position.set((F_HW0 + F_HW1) / 2, WALL_H, (F_Z0 + F_Z1) / 2)
+    rw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), Math.atan2(rdx, rdz))
+    world.addBody(rw)
+
+    // Back wall across the open end of the funnel
+    const bw = new CANNON.Body({ mass: 0, material: trackMat })
+    bw.addShape(new CANNON.Box(new CANNON.Vec3(F_HW1 + WALL_T, WALL_H, WALL_T)))
+    bw.position.set(0, WALL_H, F_Z1)
+    world.addBody(bw)
+  }
+
   // End-cap wall at the finish line — solid physics body matching the visual cap
   {
     const lastIdx = samples.length - 1
@@ -283,14 +345,20 @@ function buildMarblesWorld() {
 }
 
 function getMarbleStartPositions(count) {
-  const maxSpread = (COURSE_HALF_W - MBL_RADIUS - 0.3) * 2
-  const spread    = Math.min((count - 1) * 1.5, maxSpread)
-  const step      = count > 1 ? spread / (count - 1) : 0
-  return Array.from({ length: count }, (_, i) => ({
-    x: -spread / 2 + i * step + (Math.random() - 0.5) * 0.2,
-    y: 2,
-    z: 87 + (Math.random() - 0.5) * 1.5,
-  }))
+  const cols  = Math.min(count, 4)
+  const rows  = Math.ceil(count / cols)
+  const zTop  = FUNNEL_Z_OPEN - 2
+  const zBot  = 93
+  return Array.from({ length: count }, (_, i) => {
+    const row  = Math.floor(i / cols)
+    const col  = i % cols
+    const z    = rows > 1 ? zTop - row * (zTop - zBot) / (rows - 1) : (zTop + zBot) / 2
+    const t    = (z - 90) / (FUNNEL_Z_OPEN - 90)
+    const hw   = COURSE_HALF_W + (FUNNEL_OPEN_HALF_W - COURSE_HALF_W) * t
+    const usHW = (hw - MBL_RADIUS - 0.2) * 0.9
+    const x    = cols > 1 ? -usHW + col * (usHW * 2) / (cols - 1) : 0
+    return { x: x + (Math.random() - 0.5) * 0.2, y: 2, z: z + (Math.random() - 0.5) * 0.3 }
+  })
 }
 
 function stopMarblesPhysics() {


### PR DESCRIPTION
## Summary

- **Fix marbles getting stuck in walls**: At every sample-point junction along both course walls, a cylinder post (radius ≈ WALL_T) is now placed in both the Cannon.js physics world and the Three.js scene. A convex cylinder at each joint fills the wedge pocket formed when two rotated box segments meet at an angle — marbles deflect smoothly off the cylinder instead of catching on the step between adjacent boxes.

- **V-shaped funnel start area**: A staging funnel (z=90–109) is attached to the top of the course on both server (physics bodies) and client (visual meshes). It opens from the course width (±5) to ±14 units wide at the back wall. As players join, their marbles are placed in a grid within the funnel (up to 4 per row, filling from the top down). When the race starts, the physics naturally channels them into the course. The initial camera position is updated to frame the funnel area.

- **Updated start positions**: `getMarbleStartPositions` now distributes marbles across the funnel grid instead of cramming them into a single line at the course start.

## Test plan

- [ ] Start a race and confirm marbles no longer get stuck at wall corners/curves
- [ ] Join as multiple players and verify each marble appears at a distinct spot in the funnel before the race starts
- [ ] Start the race and confirm marbles flow out of the funnel into the course naturally
- [ ] Verify the finish line, winner modal, and late-joiner camera follow still work correctly

https://claude.ai/code/session_018EPynM6UbYY5y6mGwQihBk

---
_Generated by [Claude Code](https://claude.ai/code/session_018EPynM6UbYY5y6mGwQihBk)_