### PR TITLE
Add corner filler walls to close triangular overlap pockets in marble walls

### DIFF
--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -98,8 +98,17 @@ const threeCanvas = ref(null)
 // ─── Marble race constants (must match server) ──────────────────────────────
 const MBL_RADIUS         = 0.8
 const FINISH_Z           = -118
-const FUNNEL_Z_OPEN      = 109
 const FUNNEL_OPEN_HALF_W = 14
+const FUNNEL_LENGTH      = 19
+
+// Funnel approach direction — reverse of the first course segment, so the funnel aligns with the track
+const _fDx = COURSE_SPINE[1][0] - COURSE_SPINE[0][0]
+const _fDz = COURSE_SPINE[1][1] - COURSE_SPINE[0][1]
+const _fL  = Math.sqrt(_fDx * _fDx + _fDz * _fDz)
+const FUNNEL_AP_DX = -_fDx / _fL
+const FUNNEL_AP_DZ = -_fDz / _fL
+const FUNNEL_AP_LX = -FUNNEL_AP_DZ
+const FUNNEL_AP_LZ =  FUNNEL_AP_DX
 
 // Curved course — Catmull-Rom spine [x, z]
 const COURSE_SPINE = [
@@ -413,38 +422,44 @@ function buildFunnelMeshes() {
   const floorMat = new THREE.MeshStandardMaterial({ color: 0x2d6a4f, roughness: 0.8, metalness: 0.1 })
   const wallMat  = new THREE.MeshStandardMaterial({ color: 0x3a86ff, roughness: 0.6, metalness: 0.2, transparent: true, opacity: 0.85 })
 
-  const F_Z0 = 90, F_Z1 = FUNNEL_Z_OPEN
-  const F_HW0 = COURSE_HALF_W, F_HW1 = FUNNEL_OPEN_HALF_W
+  const [s0x, s0z] = COURSE_SPINE[0]  // [0, 90]
+  const fCx = s0x + FUNNEL_AP_DX * FUNNEL_LENGTH
+  const fCz = s0z + FUNNEL_AP_DZ * FUNNEL_LENGTH
 
-  // Floor
-  const fFloor = new THREE.Mesh(new THREE.BoxGeometry(F_HW1 * 2, 1, F_Z1 - F_Z0), floorMat)
-  fFloor.position.set(0, -0.5, (F_Z0 + F_Z1) / 2)
-  fFloor.receiveShadow = true
-  scene.add(fFloor)
+  // Four corners of the trapezoid
+  const nLx = s0x + FUNNEL_AP_LX * COURSE_HALF_W,      nLz = s0z + FUNNEL_AP_LZ * COURSE_HALF_W
+  const nRx = s0x - FUNNEL_AP_LX * COURSE_HALF_W,      nRz = s0z - FUNNEL_AP_LZ * COURSE_HALF_W
+  const fLx = fCx + FUNNEL_AP_LX * FUNNEL_OPEN_HALF_W, fLz = fCz + FUNNEL_AP_LZ * FUNNEL_OPEN_HALF_W
+  const fRx = fCx - FUNNEL_AP_LX * FUNNEL_OPEN_HALF_W, fRz = fCz - FUNNEL_AP_LZ * FUNNEL_OPEN_HALF_W
 
-  // Left angled wall
-  const ldx = -(F_HW1 - F_HW0), ldz = F_Z1 - F_Z0
-  const llen = Math.sqrt(ldx * ldx + ldz * ldz)
-  const lw = new THREE.Mesh(new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, llen), wallMat)
-  lw.position.set(-(F_HW0 + F_HW1) / 2, WALL_H, (F_Z0 + F_Z1) / 2)
-  lw.rotation.y = Math.atan2(ldx, ldz)
-  lw.castShadow = true
-  scene.add(lw)
+  // Helper — add a wall mesh between two endpoint positions
+  function addWallMesh(x1, z1, x2, z2) {
+    const dx = x2 - x1, dz = z2 - z1
+    const len = Math.sqrt(dx * dx + dz * dz)
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, len), wallMat)
+    mesh.position.set((x1 + x2) / 2, WALL_H, (z1 + z2) / 2)
+    mesh.rotation.y = Math.atan2(dx, dz)
+    mesh.castShadow = true
+    scene.add(mesh)
+  }
 
-  // Right angled wall
-  const rdx = F_HW1 - F_HW0, rdz = F_Z1 - F_Z0
-  const rlen = Math.sqrt(rdx * rdx + rdz * rdz)
-  const rw = new THREE.Mesh(new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, rlen), wallMat)
-  rw.position.set((F_HW0 + F_HW1) / 2, WALL_H, (F_Z0 + F_Z1) / 2)
-  rw.rotation.y = Math.atan2(rdx, rdz)
-  rw.castShadow = true
-  scene.add(rw)
+  addWallMesh(nLx, nLz, fLx, fLz)  // left angled wall
+  addWallMesh(nRx, nRz, fRx, fRz)  // right angled wall
+  addWallMesh(fLx, fLz, fRx, fRz)  // back wall across open end
 
-  // Back wall across the open end
-  const bw = new THREE.Mesh(new THREE.BoxGeometry((F_HW1 + WALL_T) * 2, WALL_H * 2, WALL_T * 2), wallMat)
-  bw.position.set(0, WALL_H, F_Z1)
-  bw.castShadow = true
-  scene.add(bw)
+  // Floor: wide box oriented along the approach axis
+  const floor = new THREE.Mesh(
+    new THREE.BoxGeometry(FUNNEL_OPEN_HALF_W * 2, 1, FUNNEL_LENGTH),
+    floorMat
+  )
+  floor.position.set(
+    s0x + FUNNEL_AP_DX * FUNNEL_LENGTH / 2,
+    -0.5,
+    s0z + FUNNEL_AP_DZ * FUNNEL_LENGTH / 2
+  )
+  floor.rotation.y = Math.atan2(FUNNEL_AP_DX, FUNNEL_AP_DZ)
+  floor.receiveShadow = true
+  scene.add(floor)
 }
 
 function buildFinishLine() {
@@ -521,11 +536,10 @@ function syncMarbleMeshes(marbles) {
     }
   }
 
+  const [s0x, s0z] = COURSE_SPINE[0]
   const count = marbles.length
   const cols  = Math.min(count, 4)
   const rows  = Math.ceil(count / cols)
-  const zTop  = FUNNEL_Z_OPEN - 2
-  const zBot  = 93
 
   marbles.forEach((m, i) => {
     if (marbleMeshMap.has(m.id)) return
@@ -539,12 +553,14 @@ function syncMarbleMeshes(marbles) {
     const mesh = new THREE.Mesh(geo, mat)
     const row  = Math.floor(i / cols)
     const col  = i % cols
-    const z    = rows > 1 ? zTop - row * (zTop - zBot) / (rows - 1) : (zTop + zBot) / 2
-    const t    = (z - 90) / (FUNNEL_Z_OPEN - 90)
+    const dist = rows > 1 ? (FUNNEL_LENGTH - 3) - row * (FUNNEL_LENGTH - 5) / (rows - 1) : FUNNEL_LENGTH / 2
+    const t    = dist / FUNNEL_LENGTH
     const hw   = COURSE_HALF_W + (FUNNEL_OPEN_HALF_W - COURSE_HALF_W) * t
     const usHW = (hw - MBL_RADIUS - 0.2) * 0.9
-    const startX = cols > 1 ? -usHW + col * (usHW * 2) / (cols - 1) : 0
-    mesh.position.set(startX, MBL_RADIUS, z)
+    const side = cols > 1 ? -usHW + col * (usHW * 2) / (cols - 1) : 0
+    const startX = s0x + FUNNEL_AP_DX * dist + FUNNEL_AP_LX * side
+    const startZ = s0z + FUNNEL_AP_DZ * dist + FUNNEL_AP_LZ * side
+    mesh.position.set(startX, MBL_RADIUS, startZ)
     mesh.castShadow = true
     scene.add(mesh)
 

--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -359,6 +359,38 @@ function buildTrackMeshes() {
     }
   }
 
+  // Corner filler walls — bisector-aligned boxes that close the triangular overlap
+  // pocket at each concave inner junction so marbles deflect cleanly off the wall.
+  for (let i = 1; i < nSegs; i++) {
+    let delta = sAngle[i] - sAngle[i - 1]
+    if (delta >  Math.PI) delta -= 2 * Math.PI
+    if (delta < -Math.PI) delta += 2 * Math.PI
+    if (Math.abs(delta) < 0.05) continue
+
+    const pocketLen = Math.min(COURSE_HALF_W * Math.abs(Math.tan(delta / 2)), COURSE_HALF_W)
+    if (pocketLen < 0.05) continue
+
+    const [px, pz] = samples[i]
+    const dx1 = sDx[i - 1] / sLen[i - 1], dz1 = sDz[i - 1] / sLen[i - 1]
+    const dx2 = sDx[i]     / sLen[i],     dz2 = sDz[i]     / sLen[i]
+    const bDx = dx1 + dx2, bDz = dz1 + dz2
+    const bLen = Math.sqrt(bDx * bDx + bDz * bDz) || 1
+    const bisAngle = Math.atan2(bDx / bLen, bDz / bLen)
+    const bnx = -(bDz / bLen), bnz = bDx / bLen
+
+    const side = delta > 0 ? 1 : -1
+    const cx = px + side * bnx * (COURSE_HALF_W + WALL_T)
+    const cz = pz + side * bnz * (COURSE_HALF_W + WALL_T)
+
+    const fw = new THREE.Mesh(
+      new THREE.BoxGeometry(WALL_T * 2, WALL_H * 2, pocketLen * 2 + WALL_T),
+      wallMat
+    )
+    fw.position.set(cx, WALL_H, cz)
+    fw.rotation.y = bisAngle
+    scene.add(fw)
+  }
+
   // Pegs — same logic as server (denser, every 5 samples, cycling left/center/right/center)
   const PEG_PATTERN = [-1, 0, 1, 0]
   for (let i = 5; i < samples.length - 7; i += 5) {

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -143,10 +143,22 @@ const COURSE_SPINE = [
   [-15, -108],
   [ 0,  -118],
 ]
-const COURSE_HALF_W = 5   // half-width of channel
-const COURSE_N_SEGS = 120 // number of approximation segments
-const FUNNEL_Z_OPEN     = 109  // z-position of the open (top) end of the staging funnel
-const FUNNEL_OPEN_HALF_W = 14  // half-width of the funnel at its open end
+const COURSE_HALF_W      = 5   // half-width of channel
+const COURSE_N_SEGS      = 120 // number of approximation segments
+const FUNNEL_OPEN_HALF_W = 14  // half-width at the funnel's open end
+const FUNNEL_LENGTH      = 19  // distance from course start to funnel open end
+
+// Funnel approach direction — unit vector pointing from course start backward into the funnel,
+// derived from the first spine segment so the funnel aligns with the track.
+{
+  const _dx = COURSE_SPINE[1][0] - COURSE_SPINE[0][0]  // 15
+  const _dz = COURSE_SPINE[1][1] - COURSE_SPINE[0][1]  // -18
+  const _l  = Math.sqrt(_dx * _dx + _dz * _dz)
+  var FUNNEL_AP_DX = -_dx / _l   // approach X  (unit)
+  var FUNNEL_AP_DZ = -_dz / _l   // approach Z  (unit)
+  var FUNNEL_AP_LX = -FUNNEL_AP_DZ  // left-normal X of approach
+  var FUNNEL_AP_LZ =  FUNNEL_AP_DX  // left-normal Z of approach
+}
 
 function crSample(pts, t) {
   const n   = pts.length - 1
@@ -305,41 +317,43 @@ function buildMarblesWorld() {
     world.addBody(fw)
   }
 
-  // Funnel — V-shaped staging area attached to the start of the course.
-  // Marbles wait here before the race; the open end is at FUNNEL_Z_OPEN.
+  // Funnel — V-shaped staging area oriented along the reverse of the course start direction.
   {
-    const F_Z0 = 90, F_Z1 = FUNNEL_Z_OPEN
-    const F_HW0 = COURSE_HALF_W, F_HW1 = FUNNEL_OPEN_HALF_W
+    const [s0x, s0z] = COURSE_SPINE[0]  // [0, 90]
+    // Open-end centre point
+    const fCx = s0x + FUNNEL_AP_DX * FUNNEL_LENGTH
+    const fCz = s0z + FUNNEL_AP_DZ * FUNNEL_LENGTH
+    // Four corners of the trapezoid
+    const nLx = s0x + FUNNEL_AP_LX * COURSE_HALF_W,      nLz = s0z + FUNNEL_AP_LZ * COURSE_HALF_W
+    const nRx = s0x - FUNNEL_AP_LX * COURSE_HALF_W,      nRz = s0z - FUNNEL_AP_LZ * COURSE_HALF_W
+    const fLx = fCx + FUNNEL_AP_LX * FUNNEL_OPEN_HALF_W, fLz = fCz + FUNNEL_AP_LZ * FUNNEL_OPEN_HALF_W
+    const fRx = fCx - FUNNEL_AP_LX * FUNNEL_OPEN_HALF_W, fRz = fCz - FUNNEL_AP_LZ * FUNNEL_OPEN_HALF_W
 
-    // Floor covering the entire funnel area
+    // Helper — add a static wall body between two endpoint positions
+    function addFunnelWall(x1, z1, x2, z2, hw) {
+      const dx = x2 - x1, dz = z2 - z1
+      const len = Math.sqrt(dx * dx + dz * dz)
+      const body = new CANNON.Body({ mass: 0, material: trackMat })
+      body.addShape(new CANNON.Box(new CANNON.Vec3(hw, WALL_H, len / 2)))
+      body.position.set((x1 + x2) / 2, WALL_H, (z1 + z2) / 2)
+      body.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), Math.atan2(dx, dz))
+      world.addBody(body)
+    }
+
+    addFunnelWall(nLx, nLz, fLx, fLz, WALL_T)  // left angled wall
+    addFunnelWall(nRx, nRz, fRx, fRz, WALL_T)  // right angled wall
+    addFunnelWall(fLx, fLz, fRx, fRz, WALL_T)  // back wall across open end
+
+    // Floor: wide box along the approach axis
     const fFloor = new CANNON.Body({ mass: 0, material: trackMat })
-    fFloor.addShape(new CANNON.Box(new CANNON.Vec3(F_HW1, FLOOR_H, (F_Z1 - F_Z0) / 2)))
-    fFloor.position.set(0, -FLOOR_H, (F_Z0 + F_Z1) / 2)
+    fFloor.addShape(new CANNON.Box(new CANNON.Vec3(FUNNEL_OPEN_HALF_W, FLOOR_H, FUNNEL_LENGTH / 2)))
+    fFloor.position.set(
+      s0x + FUNNEL_AP_DX * FUNNEL_LENGTH / 2,
+      -FLOOR_H,
+      s0z + FUNNEL_AP_DZ * FUNNEL_LENGTH / 2
+    )
+    fFloor.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), Math.atan2(FUNNEL_AP_DX, FUNNEL_AP_DZ))
     world.addBody(fFloor)
-
-    // Left angled wall: from (-F_HW0, F_Z0) to (-F_HW1, F_Z1)
-    const ldx = -(F_HW1 - F_HW0), ldz = F_Z1 - F_Z0
-    const llen = Math.sqrt(ldx * ldx + ldz * ldz)
-    const lw = new CANNON.Body({ mass: 0, material: trackMat })
-    lw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, llen / 2)))
-    lw.position.set(-(F_HW0 + F_HW1) / 2, WALL_H, (F_Z0 + F_Z1) / 2)
-    lw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), Math.atan2(ldx, ldz))
-    world.addBody(lw)
-
-    // Right angled wall: from (F_HW0, F_Z0) to (F_HW1, F_Z1)
-    const rdx = F_HW1 - F_HW0, rdz = F_Z1 - F_Z0
-    const rlen = Math.sqrt(rdx * rdx + rdz * rdz)
-    const rw = new CANNON.Body({ mass: 0, material: trackMat })
-    rw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, rlen / 2)))
-    rw.position.set((F_HW0 + F_HW1) / 2, WALL_H, (F_Z0 + F_Z1) / 2)
-    rw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), Math.atan2(rdx, rdz))
-    world.addBody(rw)
-
-    // Back wall across the open end of the funnel
-    const bw = new CANNON.Body({ mass: 0, material: trackMat })
-    bw.addShape(new CANNON.Box(new CANNON.Vec3(F_HW1 + WALL_T, WALL_H, WALL_T)))
-    bw.position.set(0, WALL_H, F_Z1)
-    world.addBody(bw)
   }
 
   // End-cap wall at the finish line — solid physics body matching the visual cap
@@ -376,19 +390,23 @@ function buildMarblesWorld() {
 }
 
 function getMarbleStartPositions(count) {
-  const cols  = Math.min(count, 4)
-  const rows  = Math.ceil(count / cols)
-  const zTop  = FUNNEL_Z_OPEN - 2
-  const zBot  = 93
+  const [s0x, s0z] = COURSE_SPINE[0]
+  const cols = Math.min(count, 4)
+  const rows = Math.ceil(count / cols)
   return Array.from({ length: count }, (_, i) => {
     const row  = Math.floor(i / cols)
     const col  = i % cols
-    const z    = rows > 1 ? zTop - row * (zTop - zBot) / (rows - 1) : (zTop + zBot) / 2
-    const t    = (z - 90) / (FUNNEL_Z_OPEN - 90)
+    // Distance along approach axis: row 0 near the open end, last row near course start
+    const dist = rows > 1 ? (FUNNEL_LENGTH - 3) - row * (FUNNEL_LENGTH - 5) / (rows - 1) : FUNNEL_LENGTH / 2
+    const t    = dist / FUNNEL_LENGTH
     const hw   = COURSE_HALF_W + (FUNNEL_OPEN_HALF_W - COURSE_HALF_W) * t
     const usHW = (hw - MBL_RADIUS - 0.2) * 0.9
-    const x    = cols > 1 ? -usHW + col * (usHW * 2) / (cols - 1) : 0
-    return { x: x + (Math.random() - 0.5) * 0.2, y: 2, z: z + (Math.random() - 0.5) * 0.3 }
+    const side = cols > 1 ? -usHW + col * (usHW * 2) / (cols - 1) : 0
+    return {
+      x: s0x + FUNNEL_AP_DX * dist + FUNNEL_AP_LX * side + (Math.random() - 0.5) * 0.2,
+      y: 2,
+      z: s0z + FUNNEL_AP_DZ * dist + FUNNEL_AP_LZ * side + (Math.random() - 0.5) * 0.3,
+    }
   })
 }
 

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -274,6 +274,37 @@ function buildMarblesWorld() {
     }
   }
 
+  // Corner filler walls — at each concave inner junction a box oriented along the
+  // angle bisector closes the triangular overlap pocket so marbles can't get trapped.
+  for (let i = 1; i < nSegs; i++) {
+    let delta = segData[i].angle - segData[i - 1].angle
+    if (delta >  Math.PI) delta -= 2 * Math.PI
+    if (delta < -Math.PI) delta += 2 * Math.PI
+    if (Math.abs(delta) < 0.05) continue
+
+    const pocketLen = Math.min(COURSE_HALF_W * Math.abs(Math.tan(delta / 2)), COURSE_HALF_W)
+    if (pocketLen < 0.05) continue
+
+    const [px, pz] = samples[i]
+    const dx1 = segData[i - 1].dx / segData[i - 1].len, dz1 = segData[i - 1].dz / segData[i - 1].len
+    const dx2 = segData[i].dx     / segData[i].len,     dz2 = segData[i].dz     / segData[i].len
+    const bDx = dx1 + dx2, bDz = dz1 + dz2
+    const bLen = Math.sqrt(bDx * bDx + bDz * bDz) || 1
+    const bisAngle = Math.atan2(bDx / bLen, bDz / bLen)
+    const bnx = -(bDz / bLen), bnz = bDx / bLen  // left normal of bisector
+
+    // delta > 0 → left wall is concave inner; delta < 0 → right wall is concave inner
+    const side = delta > 0 ? 1 : -1
+    const cx = px + side * bnx * (COURSE_HALF_W + WALL_T)
+    const cz = pz + side * bnz * (COURSE_HALF_W + WALL_T)
+
+    const fw = new CANNON.Body({ mass: 0, material: trackMat })
+    fw.addShape(new CANNON.Box(new CANNON.Vec3(WALL_T, WALL_H, pocketLen + WALL_T / 2)))
+    fw.position.set(cx, WALL_H, cz)
+    fw.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), bisAngle)
+    world.addBody(fw)
+  }
+
   // Funnel — V-shaped staging area attached to the start of the course.
   // Marbles wait here before the race; the open end is at FUNNEL_Z_OPEN.
   {


### PR DESCRIPTION
## Summary

At each concave inner wall junction, two adjacent box-wall segments overlap and create a triangular pocket on the track-facing side that catches marbles. This PR adds a bisector-aligned "filler wall" box at every such junction to close the pocket.

**How it works:** At junction `i` between wall segments `i-1` and `i`, the angle bisector direction is computed by averaging the two adjacent segment forward vectors. A thin box is placed at the wall inner edge (`COURSE_HALF_W + WALL_T` from the course center), oriented along the bisector. Its inner face is flush with the course boundary and its length spans the full triangular pocket, so marbles deflect off the angled filler face instead of catching in the stepped gap.

Applied to both:
- **Cannon.js physics world** (server) — prevents actual physics trapping
- **Three.js visual scene** (client) — keeps visuals in sync, the filler appears as a small angled wall segment at each corner

## Test plan

- [ ] Run a race with multiple marbles through the full S-curve course
- [ ] Confirm marbles no longer get stuck at inner wall corners/curves
- [ ] Verify the funnel, finish line, and race flow still work correctly
- [ ] Check visually that the corner fillers look like natural wall segments, not visual artifacts

https://claude.ai/code/session_018EPynM6UbYY5y6mGwQihBk

---
_Generated by [Claude Code](https://claude.ai/code/session_018EPynM6UbYY5y6mGwQihBk)_