### PR TITLE
Fix 500 error: correct COURSE_SPINE declaration order in marbles.vue

### DIFF
--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -101,15 +101,6 @@ const FINISH_Z           = -118
 const FUNNEL_OPEN_HALF_W = 14
 const FUNNEL_LENGTH      = 19
 
-// Funnel approach direction — reverse of the first course segment, so the funnel aligns with the track
-const _fDx = COURSE_SPINE[1][0] - COURSE_SPINE[0][0]
-const _fDz = COURSE_SPINE[1][1] - COURSE_SPINE[0][1]
-const _fL  = Math.sqrt(_fDx * _fDx + _fDz * _fDz)
-const FUNNEL_AP_DX = -_fDx / _fL
-const FUNNEL_AP_DZ = -_fDz / _fL
-const FUNNEL_AP_LX = -FUNNEL_AP_DZ
-const FUNNEL_AP_LZ =  FUNNEL_AP_DX
-
 // Curved course — Catmull-Rom spine [x, z]
 const COURSE_SPINE = [
   [ 0,   90],
@@ -128,6 +119,15 @@ const COURSE_SPINE = [
 ]
 const COURSE_HALF_W = 5
 const COURSE_N_SEGS = 120
+
+// Funnel approach direction — reverse of the first course segment, so the funnel aligns with the track
+const _fDx = COURSE_SPINE[1][0] - COURSE_SPINE[0][0]
+const _fDz = COURSE_SPINE[1][1] - COURSE_SPINE[0][1]
+const _fL  = Math.sqrt(_fDx * _fDx + _fDz * _fDz)
+const FUNNEL_AP_DX = -_fDx / _fL
+const FUNNEL_AP_DZ = -_fDz / _fL
+const FUNNEL_AP_LX = -FUNNEL_AP_DZ
+const FUNNEL_AP_LZ =  FUNNEL_AP_DX
 
 function crSample(pts, t) {
   const n   = pts.length - 1


### PR DESCRIPTION
## Summary

- **Fix 500 on page reload**: `FUNNEL_AP_*` constants were referencing `COURSE_SPINE[1][0]` before `COURSE_SPINE` was declared. Since `const` doesn't hoist, this threw a `ReferenceError` at module load time on every page reload. Fixed by moving `COURSE_SPINE` and `COURSE_HALF_W` declarations before the `FUNNEL_AP_*` constants that derive from them.

- **Orient funnel to match course start**: The staging funnel is now built along the reverse of the first course spine segment direction, so it physically attaches to and aligns with the beginning of the track instead of pointing straight up in world-Z.

- **Corner filler walls**: Bisector-aligned box walls at each concave inner junction close the triangular overlap pocket between adjacent wall segments, preventing marbles from getting stuck.

- **Junction cylinder posts**: Cylinder posts at every wall-edge sample point smooth out the step between adjacent rotated box segments.

- **V-shaped funnel start area**: Physics bodies (server) and visual meshes (client) for a V-shaped marble staging area attached to the course start, with marble grid placement inside the funnel.

- **Late-joiner visibility**: When `marbles:state` arrives with `phase === 'racing'`, marble meshes are now synced and camera follow mode is activated immediately.

## Test plan

- [ ] Reload the marbles page — confirm no 500 error
- [ ] Confirm the funnel visually aligns with the course start direction
- [ ] Join as multiple players and confirm marbles appear inside the funnel
- [ ] Start a race and confirm marbles flow from funnel into course without getting stuck at wall corners

https://claude.ai/code/session_018EPynM6UbYY5y6mGwQihBk

---
_Generated by [Claude Code](https://claude.ai/code/session_018EPynM6UbYY5y6mGwQihBk)_