### PR TITLE
Prevent marbles from wedging against walls by clamping peg offsets

### DIFF
--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -409,7 +409,10 @@ function buildTrackMeshes() {
     const dlen = Math.sqrt(ddx * ddx + ddz * ddz)
     if (dlen < 0.001) continue
     const side = PEG_BASE[Math.floor(i / 3) % PEG_BASE.length]
-    const off  = side * (COURSE_HALF_W * 0.8)
+    // Clamp so the peg always leaves a full marble-diameter gap (plus 0.2 buffer) between
+    // its surface and the wall — preventing marbles from getting wedged against the wall.
+    const MAX_OFF = COURSE_HALF_W - 0.45 - MBL_RADIUS * 2 - 0.2  // 2.75
+    const off  = Math.max(-MAX_OFF, Math.min(MAX_OFF, side * (COURSE_HALF_W * 0.8)))
     const mesh = new THREE.Mesh(pegGeo, pegMat)
     mesh.position.set(px + (-ddz / dlen) * off, 1.5, pz + (ddx / dlen) * off)
     mesh.castShadow = true

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -381,8 +381,11 @@ function buildMarblesWorld() {
     if (dlen < 0.001) continue
     const baseOff = PEG_BASE[Math.floor(i / 3) % PEG_BASE.length]
     const jitter  = (Math.random() - 0.5) * 0.5
-    const side    = Math.max(-0.9, Math.min(0.9, baseOff + jitter))
-    const off     = side * (COURSE_HALF_W * 0.8)
+    const rawSide = baseOff + jitter
+    // Clamp so the peg always leaves a full marble-diameter gap (plus 0.2 buffer) between
+    // its surface and the wall — preventing marbles from getting wedged against the wall.
+    const MAX_OFF = COURSE_HALF_W - 0.45 - MBL_RADIUS * 2 - 0.2  // 2.75
+    const off     = Math.max(-MAX_OFF, Math.min(MAX_OFF, rawSide * (COURSE_HALF_W * 0.8)))
     const b = new CANNON.Body({ mass: 0, material: trackMat })
     b.addShape(new CANNON.Cylinder(0.45, 0.45, 3, 8))
     b.position.set(px + (-ddz / dlen) * off, 1.5, pz + (ddx / dlen) * off)


### PR DESCRIPTION
## Summary
Fixed a physics issue where marbles could get wedged against the course walls by improving the peg offset clamping logic in both the physics simulation and visual rendering.

## Key Changes
- **Physics simulation (socket-server.js)**: Updated peg offset calculation to clamp values based on a computed `MAX_OFF` that ensures a full marble-diameter gap (plus 0.2 buffer) between peg surfaces and walls
- **Visual rendering (marbles.vue)**: Applied the same clamping logic to keep peg mesh positions synchronized with physics bodies
- Replaced the previous hardcoded clamp range (-0.9 to 0.9) with a calculated `MAX_OFF` value (2.75) that accounts for:
  - Course half-width (COURSE_HALF_W)
  - Peg radius (0.45)
  - Marble diameter (MBL_RADIUS * 2)
  - Safety buffer (0.2)

## Implementation Details
- The clamping is now applied after jitter is added in the physics code, ensuring randomization doesn't push pegs into unsafe positions
- Both files use identical clamping logic to maintain consistency between visual and physical representations
- Added explanatory comments documenting the safety margin calculation

https://claude.ai/code/session_019e76W2ySv8cu28dsRbD5b4