### PR TITLE
fix: ensure marble pegs always leave enough wall clearance

### DIFF
--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -409,9 +409,9 @@ function buildTrackMeshes() {
     const dlen = Math.sqrt(ddx * ddx + ddz * ddz)
     if (dlen < 0.001) continue
     const side = PEG_BASE[Math.floor(i / 3) % PEG_BASE.length]
-    // Clamp so the peg always leaves a full marble-diameter gap (plus 0.2 buffer) between
+    // Clamp so the peg always leaves a full marble-diameter gap (plus 0.5 buffer) between
     // its surface and the wall — preventing marbles from getting wedged against the wall.
-    const MAX_OFF = COURSE_HALF_W - 0.45 - MBL_RADIUS * 2 - 0.2  // 2.75
+    const MAX_OFF = COURSE_HALF_W - 0.45 - MBL_RADIUS * 2 - 0.5  // 2.45
     const off  = Math.max(-MAX_OFF, Math.min(MAX_OFF, side * (COURSE_HALF_W * 0.8)))
     const mesh = new THREE.Mesh(pegGeo, pegMat)
     mesh.position.set(px + (-ddz / dlen) * off, 1.5, pz + (ddx / dlen) * off)

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -382,9 +382,9 @@ function buildMarblesWorld() {
     const baseOff = PEG_BASE[Math.floor(i / 3) % PEG_BASE.length]
     const jitter  = (Math.random() - 0.5) * 0.5
     const rawSide = baseOff + jitter
-    // Clamp so the peg always leaves a full marble-diameter gap (plus 0.2 buffer) between
+    // Clamp so the peg always leaves a full marble-diameter gap (plus 0.5 buffer) between
     // its surface and the wall — preventing marbles from getting wedged against the wall.
-    const MAX_OFF = COURSE_HALF_W - 0.45 - MBL_RADIUS * 2 - 0.2  // 2.75
+    const MAX_OFF = COURSE_HALF_W - 0.45 - MBL_RADIUS * 2 - 0.5  // 2.45
     const off     = Math.max(-MAX_OFF, Math.min(MAX_OFF, rawSide * (COURSE_HALF_W * 0.8)))
     const b = new CANNON.Body({ mass: 0, material: trackMat })
     b.addShape(new CANNON.Cylinder(0.45, 0.45, 3, 8))


### PR DESCRIPTION
## Summary

- Pegs near the walls were placed with insufficient clearance, causing marbles to get wedged between the peg surface and the wall
- The peg lateral offset is now clamped so the gap between the peg surface and the wall is always at least a marble diameter (1.6) plus a 0.5-unit buffer (2.1 total gap)
- Fix applied to both the server physics (`socket-server.js`) and the client visuals (`marbles.vue`)

## Test plan

- [ ] Start a marble race and observe that no marbles get stuck against the walls near pegs
- [ ] Confirm pegs still visually appear close to walls (just not so close marbles get stuck)

---
_Generated by [Claude Code](https://claude.ai/code/session_019e76W2ySv8cu28dsRbD5b4)_