### PR TITLE
Fix marble finish line detection to use position instead of join order

### DIFF
--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -457,31 +457,41 @@ function startMarblesPhysics() {
     world.step(FIXED_STEP, FIXED_STEP, 6)
 
     if (marblesState.phase !== 'racing') return
+
+    // Collect all marbles that crossed the finish line this step, then sort by
+    // Z ascending (most negative = furthest past the line = physically first).
+    // Without this, index order (join order) would break ties instead of position.
+    const crossedThisStep = []
     for (let i = 0; i < marbleBodies.length; i++) {
       if (marblesFinished.has(i)) continue
       if (marbleBodies[i].position.z <= MBL_FINISH_Z) {
-        marblesFinished.add(i)
+        crossedThisStep.push({ i, z: marbleBodies[i].position.z })
+      }
+    }
+    crossedThisStep.sort((a, b) => a.z - b.z)
 
-        // Freeze the finished marble in place
-        const body = marbleBodies[i]
-        body.velocity.set(0, 0, 0)
-        body.angularVelocity.set(0, 0, 0)
-        body.type = CANNON.Body.STATIC
-        body.updateMassProperties()
+    for (const { i } of crossedThisStep) {
+      marblesFinished.add(i)
 
-        if (marblesFinished.size === 1) {
-          // First marble across = winner
-          marblesState.winner = marblesState.marbles[i].username
-          io.to(MARBLES_ROOM).emit('marbles:state', marblesSnapshot())
-          io.to(MARBLES_ROOM).emit('marbles:winner', { username: marblesState.winner })
-        }
+      // Freeze the finished marble in place
+      const body = marbleBodies[i]
+      body.velocity.set(0, 0, 0)
+      body.angularVelocity.set(0, 0, 0)
+      body.type = CANNON.Body.STATIC
+      body.updateMassProperties()
 
-        if (marblesFinished.size >= marbleBodies.length) {
-          marblesState.phase = 'finished'
-          io.to(MARBLES_ROOM).emit('marbles:state', marblesSnapshot())
-          stopMarblesPhysics()
-          return
-        }
+      if (marblesFinished.size === 1) {
+        // First marble across = winner
+        marblesState.winner = marblesState.marbles[i].username
+        io.to(MARBLES_ROOM).emit('marbles:state', marblesSnapshot())
+        io.to(MARBLES_ROOM).emit('marbles:winner', { username: marblesState.winner })
+      }
+
+      if (marblesFinished.size >= marbleBodies.length) {
+        marblesState.phase = 'finished'
+        io.to(MARBLES_ROOM).emit('marbles:state', marblesSnapshot())
+        stopMarblesPhysics()
+        return
       }
     }
   }, 1000 / 60)


### PR DESCRIPTION
## Summary
Fixed a race condition in marble finish line detection where multiple marbles crossing the finish line in the same physics step would be ranked by their join order rather than their actual position. Now marbles are correctly ranked by how far past the finish line they've traveled.

## Key Changes
- Collect all marbles that cross the finish line in a single physics step into a temporary array before processing
- Sort marbles by their Z position (ascending) to determine true finish order, where more negative Z values indicate marbles further past the finish line
- Process marbles in sorted order to ensure the first marble in the array is correctly identified as the winner

## Implementation Details
The fix introduces a two-phase approach:
1. **Collection phase**: Scan all marbles and collect those that crossed the finish line this step with their Z positions
2. **Processing phase**: Sort by Z position and process in order, ensuring physics state updates and winner determination reflect actual position rather than array index

This prevents ties from being broken by marble join order and ensures fair race results when marbles finish simultaneously or within the same frame.

https://claude.ai/code/session_01UZGQFCHkE4Uj2Za8EsJntB