### PR TITLE
Fix marble winner detection: use finish plane instead of world-Z threshold

### DIFF
--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -125,7 +125,6 @@ let marblesPhysInterval = null
 let marblesBroadcastInterval = null
 
 const MBL_RADIUS   = 0.8
-const MBL_FINISH_Z = -118  // world-Z at finish line
 
 // Curved course definition — Catmull-Rom spine control points [x, z]
 const COURSE_SPINE = [
@@ -147,6 +146,23 @@ const COURSE_HALF_W      = 5   // half-width of channel
 const COURSE_N_SEGS      = 120 // number of approximation segments
 const FUNNEL_OPEN_HALF_W = 14  // half-width at the funnel's open end
 const FUNNEL_LENGTH      = 19  // distance from course start to funnel open end
+
+// Finish-line detection plane — derived from the last COURSE_SPINE segment so detection
+// matches the angled end-cap wall at every lane.  The wall is rotated to follow the
+// course direction, so its world-Z spans from ≈-114 on one side to ≈-121 on the other.
+// A raw z <= -118 threshold misses every marble that stops against the "high" side of the
+// wall; the dot-product test fires correctly regardless of which lane the marble crosses.
+{
+  const _fs  = COURSE_SPINE[COURSE_SPINE.length - 1]   // [x, z] of finish centre
+  const _fsp = COURSE_SPINE[COURSE_SPINE.length - 2]   // [x, z] one step before
+  const _fdx = _fs[0] - _fsp[0], _fdz = _fs[1] - _fsp[1]
+  const _fl  = Math.sqrt(_fdx * _fdx + _fdz * _fdz)
+  var FINISH_NORM_X     = _fdx / _fl   // finish approach normal  X (unit)
+  var FINISH_NORM_Z     = _fdz / _fl   // finish approach normal  Z (unit)
+  // Threshold = projection of finish wall centre onto approach normal, minus (wall
+  // half-thickness 0.3 + marble radius).  Fires when marble surface reaches wall face.
+  var FINISH_DETECT_DOT = (_fs[0] * FINISH_NORM_X + _fs[1] * FINISH_NORM_Z) - (0.3 + MBL_RADIUS)
+}
 
 // Funnel approach direction — unit vector pointing from course start backward into the funnel,
 // derived from the first spine segment so the funnel aligns with the track.
@@ -458,17 +474,18 @@ function startMarblesPhysics() {
 
     if (marblesState.phase !== 'racing') return
 
-    // Collect all marbles that crossed the finish line this step, then sort by
-    // Z ascending (most negative = furthest past the line = physically first).
-    // Without this, index order (join order) would break ties instead of position.
+    // Collect all marbles that reached the finish this step using the approach-plane
+    // dot-product test (see FINISH_NORM_X/Z constants).  Sort by dot descending so
+    // the marble furthest past the finish wall is processed first and wins ties.
     const crossedThisStep = []
     for (let i = 0; i < marbleBodies.length; i++) {
       if (marblesFinished.has(i)) continue
-      if (marbleBodies[i].position.z <= MBL_FINISH_Z) {
-        crossedThisStep.push({ i, z: marbleBodies[i].position.z })
+      const dot = marbleBodies[i].position.x * FINISH_NORM_X + marbleBodies[i].position.z * FINISH_NORM_Z
+      if (dot >= FINISH_DETECT_DOT) {
+        crossedThisStep.push({ i, dot })
       }
     }
-    crossedThisStep.sort((a, b) => a.z - b.z)
+    crossedThisStep.sort((a, b) => b.dot - a.dot)
 
     for (const { i } of crossedThisStep) {
       marblesFinished.add(i)


### PR DESCRIPTION
## Root cause

The end-cap wall at the finish line is **rotated** to align with the course approach direction (~35° from world Z). Because of that rotation, the wall's world-Z spans from approximately **-114 on one side to -121 on the other** (with the finish centre at -118).

The previous detection condition was:

```js
if (marbleBodies[i].position.z <= MBL_FINISH_Z)  // MBL_FINISH_Z = -118
```

A marble stopping against the "shallow" side of the wall has its centre at roughly z ≈ -117, which never crosses -118. Only marbles that happened to stop at the extreme corner (world x ≈ -5, z ≈ -121) were ever detected. This is exactly what the user reported: *"it doesn't count unless the marble touches the very bottom corner of the finish line."*

## Fix

Replace the world-Z threshold with a **dot-product test against the actual finish plane normal**:

```js
// approach unit-vector of the last spine segment
FINISH_NORM_X, FINISH_NORM_Z

// fires when marble surface reaches the wall face from any lane
const dot = body.position.x * FINISH_NORM_X + body.position.z * FINISH_NORM_Z
if (dot >= FINISH_DETECT_DOT) { … }
```

`FINISH_DETECT_DOT` is the projection of the wall centre onto the approach normal, minus `(wall_half_thickness + marble_radius)`, so the detector fires the instant any marble's surface touches the wall face — regardless of which lane it crosses.

The tie-break sort (from PR #486) is also updated to sort by dot-product descending (higher = further past the finish) instead of z ascending.

## Changes

- Remove `MBL_FINISH_Z` (no longer used)
- Add `FINISH_NORM_X`, `FINISH_NORM_Z`, `FINISH_DETECT_DOT` derived from the last `COURSE_SPINE` segment
- Replace `z <= MBL_FINISH_Z` check with dot-product threshold
- Update `crossedThisStep` sort from `a.z - b.z` to `b.dot - a.dot`

https://claude.ai/code/session_01UZGQFCHkE4Uj2Za8EsJntB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZGQFCHkE4Uj2Za8EsJntB)_