### PR TITLE
Add global 50% off sale toggle for cMart items

### DIFF
--- a/pages/admin/global-settings.vue
+++ b/pages/admin/global-settings.vue
@@ -246,6 +246,29 @@
             <p class="text-xs text-gray-500 mt-1">Cost when a user already has 1 or more additional cZones.</p>
           </div>
         </div>
+
+        <!-- Global Price Changes -->
+        <div class="border-t pt-5">
+          <h2 class="text-base font-semibold text-gray-800 mb-1">Global Price Changes</h2>
+          <p class="text-sm text-gray-500 mb-4">
+            When enabled, all cToon and pack prices in cMart will be cut in half at purchase time.
+            Prices shown to users will reflect the discount.
+          </p>
+          <label class="flex items-center gap-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              v-model="cmartHalfPriceEnabled"
+              class="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+            />
+            <span class="text-sm font-medium text-gray-700">
+              Enable 50% off all cToons &amp; packs
+            </span>
+          </label>
+          <p v-if="cmartHalfPriceEnabled" class="mt-2 text-xs text-indigo-600 font-medium">
+            Half-price mode is currently ON. Users will be charged half the listed price.
+          </p>
+        </div>
+
         <div>
           <button class="btn-primary" :disabled="savingCmart" @click="saveCmart">
             <span v-if="!savingCmart">Save</span><span v-else>Saving…</span>
@@ -275,6 +298,11 @@ const savingDuplicates = ref(false)
 const savingAuctions = ref(false)
 const savingCmart = ref(false)
 
+// cMart state
+const firstAdditionalCzoneCost      = ref(25000)
+const subsequentAdditionalCzoneCost = ref(50000)
+const cmartHalfPriceEnabled         = ref(false)
+
 // Global Points state
 const dailyLoginPoints     = ref(500)
 const dailyNewUserPoints   = ref(1000)
@@ -303,6 +331,7 @@ async function loadGlobal() {
     featuredAuctionHours.value        = Array.isArray(g?.featuredAuctionHours) ? g.featuredAuctionHours : []
     featuredAuctionIntervalDays.value = Number(g?.featuredAuctionIntervalDays ?? 1)
     featuredAuctionsPerSlot.value     = Number(g?.featuredAuctionsPerSlot ?? 1)
+    cmartHalfPriceEnabled.value = Boolean(g?.cmartHalfPriceEnabled ?? false)
   } catch (e) {
     console.error('Failed to load global config', e)
   }
@@ -404,6 +433,29 @@ function formatHour(h) {
   if (h < 12) return `${h}am`
   if (h === 12) return '12pm'
   return `${h - 12}pm`
+}
+
+async function saveCmart() {
+  savingCmart.value = true; toast.value = null
+  if (typeof cmartHalfPriceEnabled.value !== 'boolean') {
+    toast.value = { type: 'error', msg: 'Invalid value for half-price toggle.' }
+    savingCmart.value = false
+    return
+  }
+  try {
+    await $fetch('/api/admin/global-config', {
+      method: 'POST',
+      body: {
+        dailyPointLimit: Number(dailyPointLimit.value),
+        cmartHalfPriceEnabled: cmartHalfPriceEnabled.value
+      }
+    })
+    toast.value = { type: 'ok', msg: 'cMart settings saved.' }
+  } catch (e) {
+    console.error(e); toast.value = { type: 'error', msg: e?.statusMessage || 'Save failed' }
+  } finally {
+    savingCmart.value = false; setTimeout(() => { toast.value = null }, 2500)
+  }
 }
 
 async function saveDuplicateSettings() {

--- a/pages/cmart.vue
+++ b/pages/cmart.vue
@@ -174,6 +174,14 @@
         </div>
       </div>
 
+      <!-- Half-price banner -->
+      <div
+        v-if="cmartHalfPriceEnabled"
+        class="mb-4 rounded-lg bg-indigo-50 border border-indigo-200 px-4 py-3 text-sm text-indigo-800 font-medium"
+      >
+        🏷️ <strong>50% Off Sale!</strong> All cToon and pack prices are currently half price.
+      </div>
+
       <!-- ──────── LAYOUT: SIDEBAR + CONTENT ──────── -->
       <button
         class="lg:hidden mb-4 px-4 py-2 bg-indigo-600 text-white rounded"
@@ -424,7 +432,10 @@
                 >
                   <span v-if="ctoon.quantity !== null && ctoon.quantity !== TIME_BASED_CAP && ctoon.minted >= currentAllowedCap(ctoon)">Sold Out</span>
                   <span v-else-if="buyingCtoons.has(ctoon.id)">Purchasing…</span>
-                  <span v-else>Buy for {{ ctoon.price }} Pts</span>
+                  <span v-else>
+                    Buy for {{ displayPrice(ctoon.price) }} Pts
+                    <span v-if="cmartHalfPriceEnabled" class="ml-1 line-through text-indigo-200 text-xs">{{ ctoon.price }}</span>
+                  </span>
                 </button>
               </div>
             </div>
@@ -499,7 +510,10 @@
               >
                 <span v-if="ctoon.quantity && ctoon.quantity !== TIME_BASED_CAP && ctoon.minted >= ctoon.quantity">Sold Out</span>
                 <span v-else-if="buyingCtoons.has(ctoon.id)">Purchasing…</span>
-                <span v-else>Buy for {{ ctoon.price }} Pts</span>
+                <span v-else>
+                  Buy for {{ displayPrice(ctoon.price) }} Pts
+                  <span v-if="cmartHalfPriceEnabled" class="ml-1 line-through text-indigo-200 text-xs">{{ ctoon.price }}</span>
+                </span>
               </button>
             </div>
           </div>
@@ -543,7 +557,8 @@
               Purchasing…
             </span>
             <span v-else>
-              Buy Pack for {{ pack.price }} Pts
+              Buy Pack for {{ displayPrice(pack.price) }} Pts
+              <span v-if="cmartHalfPriceEnabled" class="ml-1 line-through text-indigo-200 text-xs">{{ pack.price }}</span>
             </span>
             </button>
           </div>
@@ -670,7 +685,8 @@
               class="mt-2 w-full bg-indigo-600 hover:bg-indigo-700 text-white py-2 rounded"
               @click.stop="buyPack(packDetails)"
             >
-              Buy Pack for {{ packDetails?.price }} Pts
+              Buy Pack for {{ displayPrice(packDetails?.price) }} Pts
+              <span v-if="cmartHalfPriceEnabled && packDetails?.price" class="ml-1 line-through text-indigo-200 text-xs">{{ packDetails?.price }}</span>
             </button>
           </template>
 
@@ -766,7 +782,13 @@ const buyingPacks  = ref(new Set())
 const buyingCzone  = ref(false)
 
 // ────────── cZones Upgrades ────────────────────
-const upgradesConfig = ref({ firstAdditionalCzoneCost: 25000, subsequentAdditionalCzoneCost: 50000 })
+const upgradesConfig = ref({ firstAdditionalCzoneCost: 25000, subsequentAdditionalCzoneCost: 50000, cmartHalfPriceEnabled: false })
+
+const cmartHalfPriceEnabled = computed(() => upgradesConfig.value.cmartHalfPriceEnabled === true)
+
+function displayPrice(originalPrice) {
+  return cmartHalfPriceEnabled.value ? Math.floor(originalPrice / 2) : originalPrice
+}
 
 const loading = ref(true)
 
@@ -1258,7 +1280,7 @@ onUnmounted(() => {
 
 // ────────── BUY SINGLE cToon ────────────────────
 async function buyCtoon(ctoon) {
-  if (user.value.points < ctoon.price) {
+  if (user.value.points < displayPrice(ctoon.price)) {
     return showToast("You don't have enough points")
   }
   buyingCtoons.value.add(ctoon.id)
@@ -1300,7 +1322,7 @@ async function openPackModal(pack) {
 
 // ────────── Buy Pack & Start Animation ──────────
 async function buyPack(pack) {
-  if (user.value.points < pack.price) {
+  if (user.value.points < displayPrice(pack.price)) {
     return showToast("You don't have enough points")
   }
   buyingPacks.value.add(pack.id)

--- a/prisma/migrations/20260511120000_add_cmart_half_price/migration.sql
+++ b/prisma/migrations/20260511120000_add_cmart_half_price/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GlobalGameConfig" ADD COLUMN "cmartHalfPriceEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -926,6 +926,7 @@ model GlobalGameConfig {
   featuredAuctionIntervalDays  Int      @default(1)      // fire every N days
   featuredAuctionsPerSlot      Int      @default(1)      // auctions created per slot
   featuredAuctionLastFiredSlot String?                   // idempotency key e.g. "2026-03-30-08"
+  cmartHalfPriceEnabled        Boolean  @default(false)   // halves cToon and pack prices in cMart
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 }

--- a/server/api/admin/global-config.post.js
+++ b/server/api/admin/global-config.post.js
@@ -34,7 +34,8 @@ export default defineEventHandler(async (event) => {
     dhashDuplicateThreshold,
     featuredAuctionHours,
     featuredAuctionIntervalDays,
-    featuredAuctionsPerSlot
+    featuredAuctionsPerSlot,
+    cmartHalfPriceEnabled
   } = body
 
   // minimally require the existing cap; other fields optional with defaults
@@ -59,7 +60,8 @@ export default defineEventHandler(async (event) => {
       ? featuredAuctionHours.map(Number).filter(h => h >= 0 && h <= 23)
       : undefined,
     featuredAuctionIntervalDays: (typeof featuredAuctionIntervalDays === 'number') ? Math.max(1, featuredAuctionIntervalDays) : undefined,
-    featuredAuctionsPerSlot: (typeof featuredAuctionsPerSlot === 'number') ? Number(featuredAuctionsPerSlot) : undefined
+    featuredAuctionsPerSlot: (typeof featuredAuctionsPerSlot === 'number') ? Number(featuredAuctionsPerSlot) : undefined,
+    cmartHalfPriceEnabled: (typeof cmartHalfPriceEnabled === 'boolean') ? cmartHalfPriceEnabled : undefined
   }
 
   // 3) Upsert the singleton global config row
@@ -79,7 +81,8 @@ export default defineEventHandler(async (event) => {
         dhashDuplicateThreshold: payload.dhashDuplicateThreshold ?? 16,
         featuredAuctionHours: payload.featuredAuctionHours ?? [],
         featuredAuctionIntervalDays: payload.featuredAuctionIntervalDays ?? 1,
-        featuredAuctionsPerSlot: payload.featuredAuctionsPerSlot ?? 1
+        featuredAuctionsPerSlot: payload.featuredAuctionsPerSlot ?? 1,
+        cmartHalfPriceEnabled: payload.cmartHalfPriceEnabled ?? false
       },
       update: {
         dailyPointLimit: payload.dailyPointLimit,
@@ -93,7 +96,8 @@ export default defineEventHandler(async (event) => {
         ...(payload.dhashDuplicateThreshold !== undefined ? { dhashDuplicateThreshold: payload.dhashDuplicateThreshold } : {}),
         ...(payload.featuredAuctionHours !== undefined ? { featuredAuctionHours: payload.featuredAuctionHours } : {}),
         ...(payload.featuredAuctionIntervalDays !== undefined ? { featuredAuctionIntervalDays: payload.featuredAuctionIntervalDays } : {}),
-        ...(payload.featuredAuctionsPerSlot !== undefined ? { featuredAuctionsPerSlot: payload.featuredAuctionsPerSlot } : {})
+        ...(payload.featuredAuctionsPerSlot !== undefined ? { featuredAuctionsPerSlot: payload.featuredAuctionsPerSlot } : {}),
+        ...(payload.cmartHalfPriceEnabled !== undefined ? { cmartHalfPriceEnabled: payload.cmartHalfPriceEnabled } : {})
       }
     })
     // Log field-level changes
@@ -108,7 +112,8 @@ export default defineEventHandler(async (event) => {
       'dhashDuplicateThreshold',
       'featuredAuctionHours',
       'featuredAuctionIntervalDays',
-      'featuredAuctionsPerSlot'
+      'featuredAuctionsPerSlot',
+      'cmartHalfPriceEnabled'
     ]
     for (const k of fields) {
       const prevVal = before ? before[k] : undefined

--- a/server/api/cmart/buy.post.js
+++ b/server/api/cmart/buy.post.js
@@ -130,6 +130,15 @@ export default defineEventHandler(async (event) => {
       }
     }
 
+    // — Resolve effective price (apply global half-price discount if active)
+    let effectivePrice = ctoon.price
+    try {
+      const cfg = await prisma.globalGameConfig.findUnique({ where: { id: 'singleton' }, select: { cmartHalfPriceEnabled: true } })
+      if (cfg?.cmartHalfPriceEnabled === true) {
+        effectivePrice = Math.floor(ctoon.price / 2)
+      }
+    } catch {}
+
     // — Verify available points (total - active locks)
     const [wallet, activeLocks] = await Promise.all([
       prisma.userPoints.findUnique({
@@ -144,12 +153,12 @@ export default defineEventHandler(async (event) => {
     const totalPoints = wallet?.points ?? 0
     const lockedSum = activeLocks.reduce((acc, lock) => acc + (lock.amount || 0), 0)
     const availablePoints = totalPoints - lockedSum
-    if (ctoon.price > availablePoints) {
+    if (effectivePrice > availablePoints) {
       throw createError({ statusCode: 400, statusMessage: 'Not enough available points.' })
     }
 
     // — Enqueue the mint job
-    const job = await mintQueue.add('mintCtoon', { userId, ctoonId })
+    const job = await mintQueue.add('mintCtoon', { userId, ctoonId, effectivePrice })
 
     // — Set up a QueueEvents listener on the same queue
     queueEvents = new QueueEvents(mintQueue.name, { connection: redisConnection })

--- a/server/api/cmart/packs/buy.post.js
+++ b/server/api/cmart/packs/buy.post.js
@@ -91,7 +91,7 @@ export default defineEventHandler(async (event) => {
   }
 
   /* 3.  lookup pack & user points --------------------------------------- */
-  const [pack, userPts, activeLocks] = await Promise.all([
+  const [pack, userPts, activeLocks, globalCfg] = await Promise.all([
     db.pack.findUnique({
       where:  { id: packId },
       select: { id: true, price: true, inCmart: true, dailyPurchaseLimit: true }
@@ -100,15 +100,19 @@ export default defineEventHandler(async (event) => {
     db.lockedPoints.findMany({
       where:  { userId: me.id, status: 'ACTIVE' },
       select: { amount: true }
-    })
+    }),
+    db.globalGameConfig.findUnique({ where: { id: 'singleton' }, select: { cmartHalfPriceEnabled: true } })
   ])
   if (!pack || !pack.inCmart) {
     throw createError({ statusCode: 404, statusMessage: 'Pack not found' })
   }
+  const effectivePackPrice = globalCfg?.cmartHalfPriceEnabled === true
+    ? Math.floor(pack.price / 2)
+    : pack.price
   const totalPoints    = userPts?.points || 0
   const lockedSum      = activeLocks.reduce((acc, lock) => acc + (lock.amount || 0), 0)
   const availablePoints = totalPoints - lockedSum
-  if (availablePoints < pack.price) {
+  if (availablePoints < effectivePackPrice) {
     throw createError({ statusCode: 400, statusMessage: 'Not enough available points' })
   }
 
@@ -135,11 +139,11 @@ export default defineEventHandler(async (event) => {
     // 5-a  deduct points
     const updated = await tx.userPoints.update({
       where: { userId: me.id },
-      data:  { points: { decrement: pack.price } }
+      data:  { points: { decrement: effectivePackPrice } }
     })
 
     await tx.pointsLog.create({
-      data: { userId: me.id, points: pack.price, total: updated.points, method: "Bought Pack", direction: 'decrease' }
+      data: { userId: me.id, points: effectivePackPrice, total: updated.points, method: "Bought Pack", direction: 'decrease' }
     })
 
     // 5-b  create UserPack (sealed)

--- a/server/api/cmart/upgrades-config.get.js
+++ b/server/api/cmart/upgrades-config.get.js
@@ -17,7 +17,8 @@ export default defineEventHandler(async () => {
 
   _cache = {
     firstAdditionalCzoneCost:      cfg?.firstAdditionalCzoneCost      ?? 25000,
-    subsequentAdditionalCzoneCost: cfg?.subsequentAdditionalCzoneCost ?? 50000
+    subsequentAdditionalCzoneCost: cfg?.subsequentAdditionalCzoneCost ?? 50000,
+    cmartHalfPriceEnabled:         cfg?.cmartHalfPriceEnabled         ?? false
   }
   _cacheAt = now
   return _cache

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -9,7 +9,7 @@ const connection = {
 
 // Create a BullMQ worker to process mint jobs
 const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
-    const { userId, ctoonId, isSpecial = false } = job.data
+    const { userId, ctoonId, isSpecial = false, effectivePrice } = job.data
 
     const TIME_BASED_CAP = 999999999
 
@@ -79,7 +79,8 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
     const totalPoints = wallet?.points ?? 0
     const lockedSum = activeLocks.reduce((acc, lock) => acc + (lock.amount || 0), 0)
     const availablePoints = totalPoints - lockedSum
-    if (!isSpecial && availablePoints < ctoon.price) {
+    const chargePrice = (typeof effectivePrice === 'number' && effectivePrice >= 0) ? effectivePrice : ctoon.price
+    if (!isSpecial && availablePoints < chargePrice) {
       throw new Error('Insufficient points')
     }
 
@@ -162,12 +163,12 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
       if (!isSpecial) {
         const updated = await tx.userPoints.update({
           where: { userId },
-          data:  { points: { decrement: ctoon.price } }
+          data:  { points: { decrement: chargePrice } }
         })
         await tx.pointsLog.create({
           data: {
             userId,
-            points: ctoon.price,
+            points: chargePrice,
             total: updated.points,
             method: 'Bought cToon',
             direction: 'decrease'


### PR DESCRIPTION
## Summary
This PR adds a global "half-price mode" feature that allows admins to enable a 50% discount on all cToon and pack purchases in cMart. When enabled, users are charged half the listed price while the UI displays both the discounted and original prices.

## Key Changes

- **Admin Settings UI**: Added a new "Global Price Changes" section in the admin global settings page with a toggle to enable/disable the 50% off sale mode
- **Database Schema**: Added `cmartHalfPriceEnabled` boolean field to `GlobalGameConfig` model with migration
- **API Endpoints**: 
  - Updated `/api/admin/global-config` to accept and persist the `cmartHalfPriceEnabled` setting
  - Updated `/api/cmart/upgrades-config` to include the half-price flag in the response
  - Modified `/api/cmart/buy.post.js` to calculate effective prices and pass them to the mint worker
  - Modified `/api/cmart/packs/buy.post.js` to apply the discount when charging for pack purchases
- **Frontend Display**: 
  - Added promotional banner on cMart page when half-price mode is active
  - Updated all price displays (cToons and packs) to show discounted price with strikethrough original price
  - Added `displayPrice()` helper function to calculate effective prices
  - Updated purchase validation to check against discounted prices
- **Worker Process**: Updated mint worker to accept and use `effectivePrice` parameter when deducting points from user accounts

## Implementation Details

- The discount is applied server-side during purchase validation and point deduction to prevent price manipulation
- Effective price is calculated as `Math.floor(originalPrice / 2)` to ensure whole number point values
- The feature is backward compatible—when disabled, prices display normally without any discount
- All price checks (availability validation) use the effective price to ensure users have sufficient points for the discounted amount

https://claude.ai/code/session_01BUgPrNEimTPrCPZi73Gk6M