### PR TITLE
Refactor spinthewheel layout to use layout prop instead of NuxtLayout

### DIFF
--- a/pages/newsite/spinthewheel.vue
+++ b/pages/newsite/spinthewheel.vue
@@ -1,78 +1,71 @@
 <template>
-  <NuxtLayout name="newsite-template">
-    <template #sidebar-top>
-      <UserInfo />
-    </template>
-    <template #main-content>
-      <div class="stw-container">
-        <h1 class="stw-title">Spin the Wheel</h1>
+  <div class="stw-container">
+    <h1 class="stw-title">Spin the Wheel</h1>
 
-        <!-- Admin controls -->
-        <div v-if="isAdmin" class="stw-buttons">
-          <button
-            class="stw-btn stw-btn-allow"
-            :disabled="wheelState.isOpen || wheelState.spinning"
-            @click="allowJoin"
-          >
-            Allow
-          </button>
-          <button
-            class="stw-btn stw-btn-clear"
-            :disabled="wheelState.spinning || (!wheelState.isOpen && wheelState.participants.length === 0)"
-            @click="clearWheel"
-          >
-            Clear
-          </button>
-          <button
-            class="stw-btn stw-btn-spin"
-            :disabled="wheelState.participants.length === 0 || wheelState.spinning"
-            @click="spinWheel"
-          >
-            Spin
-          </button>
-        </div>
+    <!-- Admin controls -->
+    <div v-if="isAdmin" class="stw-buttons">
+      <button
+        class="stw-btn stw-btn-allow"
+        :disabled="wheelState.isOpen || wheelState.spinning"
+        @click="allowJoin"
+      >
+        Allow
+      </button>
+      <button
+        class="stw-btn stw-btn-clear"
+        :disabled="wheelState.spinning || (!wheelState.isOpen && wheelState.participants.length === 0)"
+        @click="clearWheel"
+      >
+        Clear
+      </button>
+      <button
+        class="stw-btn stw-btn-spin"
+        :disabled="wheelState.participants.length === 0 || wheelState.spinning"
+        @click="spinWheel"
+      >
+        Spin
+      </button>
+    </div>
 
-        <!-- Non-admin controls -->
-        <div v-else class="stw-buttons">
-          <button
-            class="stw-btn stw-btn-join"
-            :disabled="!wheelState.isOpen || wheelState.spinning || hasJoined"
-            @click="joinWheel"
-          >
-            Join
-          </button>
-          <span class="stw-status-msg">
-            <template v-if="wheelState.spinning">Wheel is spinning...</template>
-            <template v-else-if="hasJoined">You are on the wheel!</template>
-            <template v-else-if="!wheelState.isOpen">Waiting for the host to open joining...</template>
-            <template v-else>Click Join to add yourself to the wheel!</template>
-          </span>
-        </div>
+    <!-- Non-admin controls -->
+    <div v-else class="stw-buttons">
+      <button
+        class="stw-btn stw-btn-join"
+        :disabled="!wheelState.isOpen || wheelState.spinning || hasJoined"
+        @click="joinWheel"
+      >
+        Join
+      </button>
+      <span class="stw-status-msg">
+        <template v-if="wheelState.spinning">Wheel is spinning...</template>
+        <template v-else-if="hasJoined">You are on the wheel!</template>
+        <template v-else-if="!wheelState.isOpen">Waiting for the host to open joining...</template>
+        <template v-else>Click Join to add yourself to the wheel!</template>
+      </span>
+    </div>
 
-        <!-- Participant count -->
-        <p class="stw-count">
-          {{ wheelState.participants.length }}
-          participant{{ wheelState.participants.length !== 1 ? 's' : '' }}
-        </p>
+    <!-- Participant count -->
+    <p class="stw-count">
+      {{ wheelState.participants.length }}
+      participant{{ wheelState.participants.length !== 1 ? 's' : '' }}
+    </p>
 
-        <!-- Wheel -->
-        <div class="stw-wheel-wrapper">
-          <canvas ref="wheelCanvas" class="stw-canvas" :width="canvasSize" :height="canvasSize" />
-        </div>
+    <!-- Wheel -->
+    <div class="stw-wheel-wrapper">
+      <canvas ref="wheelCanvas" class="stw-canvas" :width="canvasSize" :height="canvasSize" />
+    </div>
+  </div>
+
+  <!-- Winner modal -->
+  <Teleport to="body">
+    <div v-if="winner" class="stw-modal-backdrop" @click.self="dismissWinner">
+      <div class="stw-modal">
+        <div class="stw-modal-header">Winner!</div>
+        <div class="stw-modal-winner">{{ winner }}</div>
+        <button class="stw-btn stw-btn-dismiss" @click="dismissWinner">Dismiss</button>
       </div>
-
-      <!-- Winner modal -->
-      <Teleport to="body">
-        <div v-if="winner" class="stw-modal-backdrop" @click.self="dismissWinner">
-          <div class="stw-modal">
-            <div class="stw-modal-header">Winner!</div>
-            <div class="stw-modal-winner">{{ winner }}</div>
-            <button class="stw-btn stw-btn-dismiss" @click="dismissWinner">Dismiss</button>
-          </div>
-        </div>
-      </Teleport>
-    </template>
-  </NuxtLayout>
+    </div>
+  </Teleport>
 </template>
 
 <script setup>
@@ -80,7 +73,7 @@ import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { io } from 'socket.io-client'
 import { useRuntimeConfig } from '#imports'
 
-definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
 
 const { user, fetchSelf, isAdmin } = useAuth()
 const runtime = useRuntimeConfig()


### PR DESCRIPTION
## Summary
Refactored the Spin the Wheel page to use Nuxt's `layout` page meta property instead of explicitly wrapping the template with the `NuxtLayout` component. This simplifies the component structure and follows Nuxt 3 best practices.

## Key Changes
- Removed `NuxtLayout` wrapper component and its named slots (`#sidebar-top` and `#main-content`)
- Removed `UserInfo` component from sidebar-top slot
- Updated `definePageMeta` to use `layout: 'newsite-template'` instead of `layout: false`
- Simplified template structure by removing one level of nesting
- Maintained all existing functionality and styling (winner modal via Teleport remains unchanged)

## Implementation Details
- The page now relies on the layout system to inject the sidebar and main content structure
- The `UserInfo` component that was previously in the sidebar-top slot is now handled by the layout template itself
- All button controls, wheel canvas, and modal functionality remain identical
- This change reduces template complexity while maintaining the same visual and functional output

https://claude.ai/code/session_015TUQbAr8vkznvefxMPvcw1