### PR TITLE
Track zone visits by posting to points API

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -320,6 +320,10 @@ async function loadZone(username) {
     viewedUsername.value = target
     viewedOwner.value    = { username: data.ownerName, avatar: data.avatar }
     loadCzoneSearchItems()
+
+    if (user.value && data.ownerId && data.ownerId !== user.value.id) {
+      $fetch('/api/points/visit', { method: 'POST', body: { zoneOwnerId: data.ownerId } }).catch(() => {})
+    }
   } catch (e) {
     console.error('MyCzone: failed to load zone', e)
   }


### PR DESCRIPTION
## Summary
Added functionality to track when users visit other users' zones by posting to the points API endpoint.

## Key Changes
- Added a visit tracking call to `/api/points/visit` when a zone is loaded
- The visit is only recorded when:
  - The current user is authenticated (`user.value` exists)
  - The zone has an owner ID (`data.ownerId` exists)
  - The zone being visited belongs to a different user (not the current user's own zone)
- Errors from the API call are silently caught to prevent disrupting the zone loading experience

## Implementation Details
- The visit tracking is performed asynchronously after the zone data is loaded
- The `zoneOwnerId` is sent in the request body to identify which zone was visited
- Error handling uses `.catch(() => {})` to ensure failed tracking requests don't impact user experience

https://claude.ai/code/session_01DthLFeoSRr1L5o6CvtBjpA