### PR TITLE
Fix auction page route in homepage management

### DIFF
--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -411,7 +411,7 @@ const PAGE_LINKS = {
   'win-wheel':   '/newsite/winwheel',
   'winball':     '/newsite/winball',
   'lottery':     '/newsite/lottery',
-  'auctions':    '/newsite/auctions',
+  'auctions':    '/newsite/AuctionHouse',
   'gtoons-clash':'/newsite/gtoons-clash',
   'news':        '/newsite/news',
   'earn-points': '/newsite/earnpoints'


### PR DESCRIPTION
## Summary
Updated the auction page route configuration to use the correct endpoint path.

## Changes
- Changed the `auctions` page link from `/newsite/auctions` to `/newsite/AuctionHouse` in the PAGE_LINKS configuration on the manage-homepage admin page

## Details
This fix ensures that the auction page navigation link points to the correct route handler. The route path has been updated to match the actual endpoint name `AuctionHouse` (with proper casing) instead of the previous `auctions` path.

https://claude.ai/code/session_01P97ryZL5bP9aUtXeQ1UBAh