### PR TITLE
Fix owner link, prize pool stats, and admin trade limit

### DIFF
--- a/components/CtoonInfoModal.vue
+++ b/components/CtoonInfoModal.vue
@@ -241,7 +241,7 @@
                 <span v-else>&nbsp;</span>
               </span>
               <NuxtLink
-                :to="`/czone/${owner.username}`"
+                :to="`/newsite/czone/${owner.username}`"
                 class="text-indigo-300 hover:text-indigo-200 hover:underline truncate text-left"
               >
                 {{ owner.username }}

--- a/pages/admin/initiate-trade.vue
+++ b/pages/admin/initiate-trade.vue
@@ -212,11 +212,7 @@
               :badge="targetOwnedIds.has(c.ctoonId) ? 'Owned by User' : 'Unowned by User'"
               badge-class-owned="bg-blue-100 text-blue-800"
               badge-class-unowned="bg-gray-200 text-gray-600"
-              @toggle="() => {
-                const already = selectedOfficialCtoonsMap.has(c.id)
-                if (!already && officialOfferLimitReached) return
-                toggleOfficialCtoon(c)
-              }"
+              @toggle="toggleOfficialCtoon(c)"
             />
           </div>
         </div>
@@ -319,7 +315,6 @@ const currentStep = ref(1) // 1-3
 // ------------------------------------------------------------------------------
 const MIN_CHARS = 3
 const DEBOUNCE_MS = 250
-const MAX_OFFICIAL_OFFER = 5
 
 const userQuery = ref('')
 const userResults = ref([])
@@ -534,27 +529,9 @@ function toggleTargetCtoon(c) {
 }
 function toggleOfficialCtoon(c) {
   const i = selectedOfficialCtoons.value.findIndex(x => x.id === c.id)
-
-  // unselect always allowed
-  if (i >= 0) {
-    selectedOfficialCtoons.value.splice(i, 1)
-    return
-  }
-
-  // enforce max
-  if (selectedOfficialCtoons.value.length >= MAX_OFFICIAL_OFFER) {
-    toast.message = `You can only offer up to ${MAX_OFFICIAL_OFFER} cToons.`
-    toast.show = true
-    setTimeout(() => (toast.show = false), 2500)
-    return
-  }
-
-  selectedOfficialCtoons.value.push(c)
+  if (i >= 0) selectedOfficialCtoons.value.splice(i, 1)
+  else selectedOfficialCtoons.value.push(c)
 }
-
-const officialOfferLimitReached = computed(
-  () => selectedOfficialCtoons.value.length >= MAX_OFFICIAL_OFFER
-)
 
 function sortAlpha(arr) {
   return [...arr].sort((a, b) => String(a).localeCompare(String(b), undefined, { sensitivity: 'base' }))

--- a/pages/newsite/czonesearch/[id].vue
+++ b/pages/newsite/czonesearch/[id].vue
@@ -45,7 +45,9 @@
               </div>
               <div class="czs-info-box">
                 <p class="text-xs uppercase tracking-widest text-white/40">Prize Pool</p>
-                <p class="mt-1 text-sm text-white/80">{{ prizeCount }} cToon{{ prizeCount === 1 ? '' : 's' }}</p>
+                <p class="mt-1 text-sm text-white/80"># of unique cToons available: {{ prizeCount }}</p>
+                <p class="text-sm text-white/80"># of unique cToons from the set owned: {{ ownedUnique }}</p>
+                <p class="text-sm text-white/80"># of total cToons from the set owned: {{ ownedTotal }}</p>
               </div>
             </div>
           </section>
@@ -249,6 +251,8 @@ const { data, pending, error } = await useFetch(
 const search = computed(() => data.value || null)
 const searchName = computed(() => (search.value?.name || '').trim() || 'cZone Search')
 const prizeCount = computed(() => Number(search.value?.prizePool?.length || 0))
+const ownedUnique = computed(() => (search.value?.prizePool || []).filter(e => (e.userOwnedCount || 0) > 0).length)
+const ownedTotal = computed(() => (search.value?.prizePool || []).reduce((sum, e) => sum + (e.userOwnedCount || 0), 0))
 const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Local Time'
 
 const showOnlyAvailable = ref(false)


### PR DESCRIPTION
## Summary

- **Fix owner link in CtoonInfoModal**: The owners tab link now routes to `/newsite/czone/[username]` instead of `/czone/[username]`
- **Prize Pool stats on cZone search page**: Relabeled existing count to "# of unique cToons available", and added two new lines showing the user's unique and total cToon ownership from the prize pool set
- **Remove 5-cToon limit on admin initiate trade**: Admins can now select an unlimited number of cToons when initiating a trade (the backend had no such restriction)

## Test plan

- [ ] Open CtoonInfoModal, go to Owners tab, click a username — confirm it navigates to `/newsite/czone/[username]`
- [ ] Visit a cZone search page and confirm the Prize Pool info box shows "# of unique cToons available", "# of unique cToons from the set owned", and "# of total cToons from the set owned"
- [ ] On the admin initiate trade page, select more than 5 cToons from the official collection — confirm no toast/block appears

https://claude.ai/code/session_01C5Ykf9993Z2RPmppP1uVEi