### PR TITLE
Fix TOCTOU races in visit points and lottery endpoints

### DIFF
--- a/server/api/lottery.post.js
+++ b/server/api/lottery.post.js
@@ -51,11 +51,8 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // buy one ticket per request
-  // check daily limit
-  if (settings.countPerDay !== -1 && u.purchasesToday >= settings.countPerDay) {
-    throw createError({ statusCode: 400, statusMessage: 'Daily ticket limit reached' })
-  }
+  // Daily limit is enforced atomically later when purchasesToday is incremented.
+  // An early non-atomic check is intentionally omitted to avoid TOCTOU races.
 
   // Atomically deduct ticket cost — the WHERE clause makes this race-safe
   const pointsAfterPurchase = await db.$transaction(async (tx) => {
@@ -149,20 +146,28 @@ export default defineEventHandler(async (event) => {
     await db.lottoUser.update({ where: { userId: me.id }, data: { odds: newOdds } })
 
     if (pointsWin) {
-      // Secondary Prize: Win points
+      // Secondary Prize: Win points — use increment (not SET) to avoid overwriting
+      // concurrent point changes with a stale computed total.
       awardedPoints = settings.lottoPointsWinnings
       await db.$transaction(async (tx) => {
-        const newTotal = pointsAfterPurchase + awardedPoints
-        await tx.userPoints.update({ where: { userId: me.id }, data: { points: newTotal, updatedAt: new Date() } })
-        await tx.pointsLog.create({ data: { userId: me.id, direction: 'increase', points: awardedPoints, total: newTotal, method: 'lottery-win' } })
+        const updated = await tx.userPoints.update({
+          where: { userId: me.id },
+          data: { points: { increment: awardedPoints }, updatedAt: new Date() }
+        })
+        await tx.pointsLog.create({ data: { userId: me.id, direction: 'increase', points: awardedPoints, total: updated.points, method: 'lottery-win' } })
       })
     }
   }
 
   const outcome = ctoonWin ? 'CTOON' : pointsWin ? 'POINTS' : 'NOTHING'
 
-  // increment purchasesToday and lastPurchaseAt + log outcome
+  // Atomically increment purchasesToday and enforce the daily cap in the same
+  // transaction to prevent TOCTOU races from concurrent requests.
   const updated = await db.$transaction(async (tx) => {
+    const current = await tx.lottoUser.findUnique({ where: { userId: me.id } })
+    if (settings.countPerDay !== -1 && (current?.purchasesToday ?? 0) >= settings.countPerDay) {
+      throw createError({ statusCode: 400, statusMessage: 'Daily ticket limit reached' })
+    }
     const next = await tx.lottoUser.update({
       where: { userId: me.id },
       data: { purchasesToday: { increment: 1 }, lastPurchaseAt: now }

--- a/server/api/points/visit.post.js
+++ b/server/api/points/visit.post.js
@@ -55,14 +55,7 @@ export default defineEventHandler(async (event) => {
     return { success: false, message: 'Already awarded points for this zone owner in this period' }
   }
 
-  // ── 3) log the visit ────────────────────────────────────────────────────
-  await prisma.visit.create({
-    data: { userId: viewerId, zoneOwnerId: ownerId },
-  })
-
-  // ── 4) award points ─────────────────────────────────────────────────────
-  // Load public-safe config values for cZone visits with fallback
-  // Fetch visit points (may be cached above; fetch again selecting points)
+  // ── 3) fetch visit points config ────────────────────────────────────────
   let cfg2
   try {
     cfg2 = await prisma.globalGameConfig.findUnique({ where: { id: 'singleton' }, select: { czoneVisitPoints: true } })
@@ -71,15 +64,48 @@ export default defineEventHandler(async (event) => {
   }
   const visitPoints = Number(cfg2?.czoneVisitPoints ?? 20)
 
-  const updated = await prisma.userPoints.upsert({
-    where:  { userId: viewerId },
-    update: { points: { increment: visitPoints } },
-    create: { userId: viewerId, points: visitPoints },
-  })
+  // ── 4) atomically log the visit and award points ─────────────────────────
+  // All three operations run in one transaction to prevent TOCTOU races where
+  // concurrent requests pass the duplicate-visit check before any write lands.
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Re-check total visits inside transaction
+      const totalVisitsInTx = await tx.visit.count({
+        where: { userId: viewerId, createdAt: { gte: boundaryUtc } },
+      })
+      if (totalVisitsInTx >= maxVisits) {
+        throw new Error('LIMIT_REACHED')
+      }
 
-  await prisma.pointsLog.create({
-    data: { userId: viewerId, points: visitPoints, total: updated.points, method: "cZone Visit", direction: 'increase' }
-  });
+      // Re-check duplicate visit inside transaction
+      const dupInTx = await tx.visit.findFirst({
+        where: { userId: viewerId, zoneOwnerId: ownerId, createdAt: { gte: boundaryUtc } },
+      })
+      if (dupInTx) {
+        throw new Error('ALREADY_VISITED')
+      }
+
+      await tx.visit.create({ data: { userId: viewerId, zoneOwnerId: ownerId } })
+
+      const updated = await tx.userPoints.upsert({
+        where:  { userId: viewerId },
+        update: { points: { increment: visitPoints } },
+        create: { userId: viewerId, points: visitPoints },
+      })
+
+      await tx.pointsLog.create({
+        data: { userId: viewerId, points: visitPoints, total: updated.points, method: 'cZone Visit', direction: 'increase' },
+      })
+    })
+  } catch (err) {
+    if (err.message === 'LIMIT_REACHED') {
+      return { success: false, message: `Daily limit of ${maxVisits} visits reached` }
+    }
+    if (err.message === 'ALREADY_VISITED') {
+      return { success: false, message: 'Already awarded points for this zone owner in this period' }
+    }
+    throw err
+  }
 
   return { success: true, message: 'Points awarded' }
 })


### PR DESCRIPTION
## Summary
This PR eliminates time-of-check-time-of-use (TOCTOU) race conditions in the visit points and lottery endpoints by moving validation checks inside database transactions. This prevents concurrent requests from bypassing limits and duplicate checks.

## Key Changes

**Visit Points Endpoint (`server/api/points/visit.post.js`)**
- Wrapped visit logging, points awarding, and points log creation in a single `prisma.$transaction()` block
- Moved duplicate visit and daily limit checks inside the transaction and re-execute them to catch races
- Ensures all three operations (visit creation, points increment, log creation) are atomic
- Returns appropriate error messages if limits are hit during the transaction

**Lottery Endpoint (`server/api/lottery.post.js`)**
- Removed non-atomic early daily limit check that could be bypassed by concurrent requests
- Moved daily limit enforcement inside the transaction where `purchasesToday` is incremented
- Changed points award logic to use `increment` instead of computing and setting an absolute value, preventing stale data overwrites from concurrent operations
- Added comment explaining why the early check was removed

## Implementation Details
- Both endpoints now use database transactions to ensure race-safe operations
- Checks are performed twice in visit endpoint: once before transaction (for fast-path rejection) and again inside transaction (for correctness)
- Lottery endpoint defers all validation to inside the transaction to avoid TOCTOU entirely
- Error handling distinguishes between different failure modes (limit reached vs. duplicate visit)

https://claude.ai/code/session_0165Ex4GLASg2BpqNR2zv1hZ