### PR TITLE
Fix race conditions in points and lottery transactions

### DIFF
--- a/server/api/lottery.post.js
+++ b/server/api/lottery.post.js
@@ -51,11 +51,22 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // Daily limit is enforced atomically later when purchasesToday is incremented.
-  // An early non-atomic check is intentionally omitted to avoid TOCTOU races.
-
-  // Atomically deduct ticket cost — the WHERE clause makes this race-safe
+  // Atomically enforce the daily limit, increment purchasesToday, and deduct the
+  // ticket cost in a single transaction. Prizes are only awarded after this
+  // succeeds, so a limit violation or insufficient-points error always rolls back
+  // before any reward is committed.
+  let purchasesTodayAfter
   const pointsAfterPurchase = await db.$transaction(async (tx) => {
+    const current = await tx.lottoUser.findUnique({ where: { userId: me.id } })
+    if (settings.countPerDay !== -1 && (current?.purchasesToday ?? 0) >= settings.countPerDay) {
+      throw createError({ statusCode: 400, statusMessage: 'Daily ticket limit reached' })
+    }
+    const next = await tx.lottoUser.update({
+      where: { userId: me.id },
+      data: { purchasesToday: { increment: 1 }, lastPurchaseAt: now }
+    })
+    purchasesTodayAfter = next.purchasesToday
+
     const deducted = await tx.userPoints.updateMany({
       where: { userId: me.id, points: { gte: settings.cost } },
       data: { points: { decrement: settings.cost }, updatedAt: new Date() }
@@ -161,35 +172,22 @@ export default defineEventHandler(async (event) => {
 
   const outcome = ctoonWin ? 'CTOON' : pointsWin ? 'POINTS' : 'NOTHING'
 
-  // Atomically increment purchasesToday and enforce the daily cap in the same
-  // transaction to prevent TOCTOU races from concurrent requests.
-  const updated = await db.$transaction(async (tx) => {
-    const current = await tx.lottoUser.findUnique({ where: { userId: me.id } })
-    if (settings.countPerDay !== -1 && (current?.purchasesToday ?? 0) >= settings.countPerDay) {
-      throw createError({ statusCode: 400, statusMessage: 'Daily ticket limit reached' })
+  await db.lottoLog.create({
+    data: {
+      userId: me.id,
+      outcome,
+      oddsBefore,
+      oddsAfter,
+      ...(wonUserCtoonId ? { userCtoonId: wonUserCtoonId } : {})
     }
-    const next = await tx.lottoUser.update({
-      where: { userId: me.id },
-      data: { purchasesToday: { increment: 1 }, lastPurchaseAt: now }
-    })
-    await tx.lottoLog.create({
-      data: {
-        userId: me.id,
-        outcome,
-        oddsBefore,
-        oddsAfter,
-        ...(wonUserCtoonId ? { userCtoonId: wonUserCtoonId } : {})
-      }
-    })
-    return next
   })
 
-  const remaining = (settings.countPerDay === -1) ? -1 : Math.max(0, settings.countPerDay - updated.purchasesToday)
+  const remaining = (settings.countPerDay === -1) ? -1 : Math.max(0, settings.countPerDay - purchasesTodayAfter)
 
   return {
     roll,
     win: ctoonWin || pointsWin,
-    newOdds: updated.odds,
+    newOdds: oddsAfter,
     remaining,
     awardedPoints,
     awardedCtoon,

--- a/server/api/monsters/scan.post.js
+++ b/server/api/monsters/scan.post.js
@@ -495,35 +495,40 @@ export default defineEventHandler(async (event) => {
   }
 
   if (scanPointsValue > 0) {
-    let toGive = scanPointsValue
-    const globalConfig = await db.globalGameConfig.findUnique({
-      where: { id: 'singleton' },
-      select: { dailyPointLimit: true }
-    })
-    if (globalConfig) {
-      const cutoffUTC = getGamePointBoundaryUtc()
-      const agg = await db.gamePointLog.aggregate({
-        where: { userId, createdAt: { gte: cutoffUTC } },
-        _sum: { points: true }
+    // Wrap the cap-check and the award in a single transaction so concurrent
+    // scan requests cannot both read the same "used" total and each award full
+    // points, blowing past the daily cap.
+    await db.$transaction(async (tx) => {
+      let toGive = scanPointsValue
+      const globalConfig = await tx.globalGameConfig.findUnique({
+        where: { id: 'singleton' },
+        select: { dailyPointLimit: true }
       })
-      const used = agg._sum.points || 0
-      const cap = Number(globalConfig.dailyPointLimit ?? 0)
-      const remaining = Math.max(0, cap - used)
-      toGive = Math.min(scanPointsValue, remaining)
-    }
+      if (globalConfig) {
+        const cutoffUTC = getGamePointBoundaryUtc()
+        const agg = await tx.gamePointLog.aggregate({
+          where: { userId, createdAt: { gte: cutoffUTC } },
+          _sum: { points: true }
+        })
+        const used = agg._sum.points || 0
+        const cap = Number(globalConfig.dailyPointLimit ?? 0)
+        const remaining = Math.max(0, cap - used)
+        toGive = Math.min(scanPointsValue, remaining)
+      }
 
-    if (toGive > 0) {
-      await db.gamePointLog.create({ data: { userId, points: toGive } })
-      const updatedPoints = await db.userPoints.upsert({
-        where: { userId },
-        update: { points: { increment: toGive } },
-        create: { userId, points: toGive },
-      })
-      await db.pointsLog.create({
-        data: { userId, points: toGive, total: updatedPoints.points, method: 'Barcode Scan', direction: 'increase' }
-      })
-      scanPointsAwarded = toGive
-    }
+      if (toGive > 0) {
+        await tx.gamePointLog.create({ data: { userId, points: toGive } })
+        const updatedPoints = await tx.userPoints.upsert({
+          where: { userId },
+          update: { points: { increment: toGive } },
+          create: { userId, points: toGive },
+        })
+        await tx.pointsLog.create({
+          data: { userId, points: toGive, total: updatedPoints.points, method: 'Barcode Scan', direction: 'increase' }
+        })
+        scanPointsAwarded = toGive
+      }
+    })
   }
 
   let battleInfo = null

--- a/server/api/trade/offers.post.js
+++ b/server/api/trade/offers.post.js
@@ -171,8 +171,26 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // 6) Create the TradeOffer + nested C-Toon joins AND lock the offered points
+  // 6) Create the TradeOffer + nested C-Toon joins AND lock the offered points.
+  // Re-verify available points inside the transaction to prevent concurrent offers
+  // from over-committing the same balance (TOCTOU race on the pre-flight check above).
   const offer = await prisma.$transaction(async (tx) => {
+    if (pointsOffered > 0) {
+      const ptsNow = await tx.userPoints.findUnique({ where: { userId: initiatorId }, select: { points: true } })
+      const locksNow = await tx.lockedPoints.findMany({
+        where: { userId: initiatorId, status: 'ACTIVE' },
+        select: { amount: true }
+      })
+      const lockedNow = locksNow.reduce((acc, r) => acc + (r.amount || 0), 0)
+      const availableNow = (ptsNow?.points ?? 0) - lockedNow
+      if (pointsOffered > availableNow) {
+        throw createError({
+          statusCode: 400,
+          statusMessage: `Insufficient points: you have ${fmt(ptsNow?.points ?? 0)} points, with ${fmt(lockedNow)} locked; tried to offer ${fmt(pointsOffered)}.`
+        })
+      }
+    }
+
     const created = await tx.tradeOffer.create({
       data: {
         initiatorId,


### PR DESCRIPTION
## Summary
This PR fixes several race condition vulnerabilities where concurrent requests could bypass daily limits or over-commit resources by reading stale data before making updates. The fixes wrap critical sections in database transactions to ensure atomicity.

## Key Changes

- **Monster scan points (scan.post.js)**: Wrapped the daily points cap check and award logic in a single transaction. Previously, concurrent scans could both read the same "used" total and each award full points, exceeding the daily limit.

- **Lottery ticket purchase (lottery.post.js)**: Moved the daily ticket limit check and `purchasesToday` increment into the same transaction as the points deduction. This prevents TOCTOU (time-of-check-time-of-use) races where concurrent requests could both pass the limit check before either increments the counter. Also simplified the response logic to use the value captured during the transaction rather than re-querying.

- **Trade offer creation (offers.post.js)**: Added a re-verification of available points inside the transaction before creating the trade offer. This prevents concurrent offers from over-committing the same points balance by checking stale data from the pre-flight validation.

## Implementation Details

All three changes follow the same pattern:
1. Move the critical check-and-update logic into a `db.$transaction()` or `prisma.$transaction()` block
2. Re-read current state inside the transaction to ensure fresh data
3. Perform validation and updates atomically so concurrent requests cannot slip between the check and the update
4. Use transaction-scoped client (`tx`) for all database operations within the critical section

This ensures that even with concurrent requests, the system maintains invariants around daily limits and resource availability.

https://claude.ai/code/session_01PkHnMhodUB1KAJZQX17zf6