### PR TITLE
Add All cToons page with set/series sidebar tabs

### DIFF
--- a/components/newsite/AllCtoons.vue
+++ b/components/newsite/AllCtoons.vue
@@ -1,0 +1,287 @@
+<template>
+  <div class="all-ctoons">
+
+    <div class="ac-header">All cToons</div>
+
+    <div class="ac-scroll">
+      <div v-if="loading" class="ac-status">Loading…</div>
+      <div v-else-if="!filteredCtoons.length" class="ac-status">No cToons found.</div>
+
+      <template v-else>
+        <div v-for="groupName in groupNames" :key="groupName" class="ac-group">
+          <div class="ac-group-header">
+            <span class="ac-group-name">{{ groupName }}</span>
+            <span class="ac-group-count">
+              {{ ownedInGroup(groupName) }}/{{ totalInGroup(groupName) }} owned
+            </span>
+          </div>
+          <div class="ac-grid">
+            <ShortCard
+              v-for="c in itemsInGroup(groupName)"
+              :key="c.id"
+              :style="{ '--footer-left-width': '100%', '--footer-right-width': '0%' }"
+            >
+              <template #header>
+                <img
+                  v-if="c.assetPath"
+                  :src="c.assetPath"
+                  :alt="c.name"
+                  class="card-img card-img--clickable"
+                  @click="openInfo(c)"
+                />
+              </template>
+              <template #middle>
+                <span class="card-name">{{ c.name }}</span>
+                <span class="rarity-dot" :style="{ background: rarityColor(c.rarity) }" :title="c.rarity" />
+              </template>
+              <template #footer-left>
+                <span class="owned-badge" :class="c.isOwned ? 'badge-owned' : 'badge-unowned'">
+                  {{ c.isOwned ? 'Owned' : 'Unowned' }}
+                </span>
+              </template>
+            </ShortCard>
+          </div>
+        </div>
+      </template>
+    </div>
+
+  </div>
+</template>
+
+<script setup>
+const { open: openCtoonModal } = useCtoonModal()
+const activeTab = useAllCtoonsTab()
+const filter    = useAllCtoonsFilter()
+
+function openInfo(c) {
+  openCtoonModal({ ctoonId: c.id, assetPath: c.assetPath, name: c.name })
+}
+
+const RARITY_COLORS = {
+  'common':       '#aaaaaa',
+  'uncommon':     '#33cc33',
+  'rare':         '#3399ff',
+  'very rare':    '#aa44ff',
+  'crazy rare':   '#ffaa00',
+  'prize only':   '#ff3366',
+  'code only':    '#00cccc',
+  'auction only': '#ff6600',
+}
+
+function rarityColor(rarity) {
+  return RARITY_COLORS[(rarity || '').toLowerCase()] || '#aaaaaa'
+}
+
+const RARITY_ORDER = {
+  'common': 0, 'uncommon': 1, 'rare': 2, 'very rare': 3,
+  'crazy rare': 4, 'prize only': 5, 'code only': 6, 'auction only': 7,
+}
+
+const allCtoons = ref([])
+const loading   = ref(true)
+
+const filteredCtoons = computed(() => {
+  const f = filter.value
+  return allCtoons.value.filter(c => {
+    const nm = !f.name || c.name.toLowerCase().includes(f.name.toLowerCase())
+    const r  = !f.rarities.length || f.rarities.includes((c.rarity || '').toLowerCase())
+    const o  = f.owned === 'all'
+      ? true
+      : f.owned === 'owned' ? c.isOwned : !c.isOwned
+    return nm && r && o
+  })
+})
+
+function sortedItems(list) {
+  const f = filter.value
+  return list.slice().sort((a, b) => {
+    let cmp = 0
+    if (f.sortField === 'rarity') {
+      const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99
+      const br = RARITY_ORDER[(b.rarity || '').toLowerCase()] ?? 99
+      cmp = ar - br
+    } else if (f.sortField === 'releaseDate') {
+      const at = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
+      const bt = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
+      cmp = at - bt
+    } else {
+      cmp = (a.name || '').localeCompare(b.name || '')
+    }
+    return f.sortAsc ? cmp : -cmp
+  })
+}
+
+const groupNames = computed(() => {
+  const key = activeTab.value === 'AllSeries' ? 'series' : 'set'
+  return [...new Set(filteredCtoons.value.map(c => c[key]).filter(Boolean))].sort()
+})
+
+function itemsInGroup(groupName) {
+  const key = activeTab.value === 'AllSeries' ? 'series' : 'set'
+  return sortedItems(filteredCtoons.value.filter(c => c[key] === groupName))
+}
+
+function ownedInGroup(groupName) {
+  return itemsInGroup(groupName).filter(c => c.isOwned).length
+}
+
+function totalInGroup(groupName) {
+  return itemsInGroup(groupName).length
+}
+
+onMounted(async () => {
+  try {
+    allCtoons.value = await $fetch('/api/collections/all')
+  } catch (err) {
+    console.error('AllCtoons: failed to load', err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+.all-ctoons {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: white;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.ac-header {
+  flex-shrink: 0;
+  width: 100%;
+  height: 23px;
+  line-height: 21px;
+  padding-bottom: 2px;
+  overflow: hidden;
+  text-align: center;
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: #fff;
+  background: var(--OrbitLightBlue);
+  box-sizing: border-box;
+}
+
+.ac-scroll {
+  flex: 1;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--OrbitLightBlue) transparent;
+  padding: 6px;
+  box-sizing: border-box;
+}
+
+.ac-status {
+  text-align: center;
+  color: #336699;
+  font-size: 2rem;
+  padding: 20px;
+}
+
+/* ── Group ── */
+.ac-group {
+  margin-bottom: 12px;
+}
+
+.ac-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 6px;
+  background: var(--OrbitDarkBlue);
+  border-radius: 4px;
+  margin-bottom: 4px;
+}
+
+.ac-group-name {
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: #fff;
+  text-transform: capitalize;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ac-group-count {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.7);
+  flex-shrink: 0;
+  margin-left: 6px;
+}
+
+/* ── Grid ── */
+.ac-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  grid-auto-rows: var(--shortcard-height);
+  gap: 4px;
+  --shortcard-width: 100%;
+}
+
+@media (max-width: 768px) {
+  .ac-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ── Card contents ── */
+.card-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transform: scale(0.7);
+}
+
+.card-img--clickable {
+  cursor: pointer;
+}
+
+.card-img--clickable:hover {
+  filter: brightness(1.12);
+}
+
+.card-name {
+  font-size: 0.6rem;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  text-align: center;
+}
+
+.rarity-dot {
+  width: 8px;
+  height: 8px;
+  min-width: 8px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  flex-shrink: 0;
+}
+
+.owned-badge {
+  display: block;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.58rem;
+  font-weight: bold;
+}
+
+.badge-owned {
+  background: #22c55e;
+  color: #fff;
+}
+
+.badge-unowned {
+  background: #6b7280;
+  color: #fff;
+}
+</style>

--- a/components/newsite/AllCtoonsSidebar.vue
+++ b/components/newsite/AllCtoonsSidebar.vue
@@ -1,0 +1,299 @@
+<template>
+  <div class="acs">
+
+    <!-- Tabs -->
+    <div class="acs-tabs">
+      <button
+        class="acs-tab"
+        :class="{ active: activeTab === 'AllSets' }"
+        @click="activeTab = 'AllSets'"
+      >All Sets</button>
+      <button
+        class="acs-tab"
+        :class="{ active: activeTab === 'AllSeries' }"
+        @click="activeTab = 'AllSeries'"
+      >All Series</button>
+    </div>
+
+    <hr class="acs-divider" />
+
+    <!-- Search -->
+    <div class="acs-search">
+      <span class="acs-search-icon">&#9906;</span>
+      <input type="text" v-model="filter.name" placeholder="Search name..." />
+    </div>
+
+    <hr class="acs-divider" />
+
+    <!-- Rarity -->
+    <div>
+      <div class="acs-label">Rarity</div>
+      <div class="acs-rarity-grid">
+        <button
+          v-for="r in RARITIES"
+          :key="r.value"
+          class="acs-rarity-btn"
+          :class="[r.cls, { active: filter.rarities.includes(r.value) }]"
+          @click="toggleRarity(r.value)"
+        >{{ r.label }}</button>
+      </div>
+    </div>
+
+    <hr class="acs-divider" />
+
+    <!-- Owned filter -->
+    <div>
+      <div class="acs-label">Ownership</div>
+      <div class="acs-owned-row">
+        <button class="acs-owned-btn" :class="{ active: filter.owned === 'all' }"     @click="filter.owned = 'all'"    >All</button>
+        <button class="acs-owned-btn" :class="{ active: filter.owned === 'owned' }"   @click="filter.owned = 'owned'"  >Owned</button>
+        <button class="acs-owned-btn" :class="{ active: filter.owned === 'unowned' }" @click="filter.owned = 'unowned'">Unowned</button>
+      </div>
+    </div>
+
+    <hr class="acs-divider" />
+
+    <!-- Sort -->
+    <div>
+      <div class="acs-label">Sort By</div>
+      <div class="acs-sort-row">
+        <select class="acs-select" v-model="filter.sortField">
+          <option value="name">Name (A→Z)</option>
+          <option value="rarity">Rarity</option>
+          <option value="releaseDate">Release Date</option>
+        </select>
+        <button class="acs-sort-dir" @click="filter.sortAsc = !filter.sortAsc">
+          {{ filter.sortAsc ? '▲' : '▼' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Clear -->
+    <button class="acs-clear" @click="clearFilters">Clear Filters</button>
+
+  </div>
+</template>
+
+<script setup>
+const activeTab = useAllCtoonsTab()
+const filter    = useAllCtoonsFilter()
+
+const RARITIES = [
+  { value: 'common',       label: 'C',  cls: 'acs-rb-common'        },
+  { value: 'uncommon',     label: 'U',  cls: 'acs-rb-uncommon'      },
+  { value: 'rare',         label: 'R',  cls: 'acs-rb-rare'          },
+  { value: 'very rare',    label: 'VR', cls: 'acs-rb-very-rare'     },
+  { value: 'crazy rare',   label: 'CR', cls: 'acs-rb-crazy-rare'    },
+  { value: 'prize only',   label: 'PO', cls: 'acs-rb-prize-only'    },
+  { value: 'code only',    label: 'CO', cls: 'acs-rb-code-only'     },
+  { value: 'auction only', label: 'AO', cls: 'acs-rb-auction-only'  },
+]
+
+function toggleRarity(val) {
+  const idx = filter.value.rarities.indexOf(val)
+  if (idx === -1) filter.value.rarities = [...filter.value.rarities, val]
+  else            filter.value.rarities = filter.value.rarities.filter(r => r !== val)
+}
+
+function clearFilters() {
+  Object.assign(filter.value, {
+    name:      '',
+    rarities:  [],
+    owned:     'all',
+    sortField: 'name',
+    sortAsc:   true,
+  })
+}
+</script>
+
+<style scoped>
+.acs {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  overflow-y: auto;
+  padding: 6px 4px;
+  box-sizing: border-box;
+  scrollbar-width: thin;
+  scrollbar-color: var(--OrbitDarkBlue) transparent;
+}
+
+/* ── Tabs ── */
+.acs-tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.acs-tab {
+  flex: 1;
+  padding: 5px 4px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.7rem;
+  font-weight: bold;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.acs-tab.active {
+  background: var(--OrbitLightBlue);
+  border-color: var(--OrbitLightBlue);
+  color: #fff;
+}
+
+.acs-tab:not(.active):hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* ── Label ── */
+.acs-label {
+  font-size: 0.6rem;
+  font-weight: bold;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 2px;
+}
+
+/* ── Search ── */
+.acs-search {
+  display: flex;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 20px;
+  padding: 3px 8px;
+  gap: 4px;
+}
+
+.acs-search-icon { font-size: 0.7rem; color: rgba(255, 255, 255, 0.4); }
+
+.acs-search input {
+  background: none;
+  border: none;
+  outline: none;
+  color: #fff;
+  font-size: 0.75rem;
+  width: 100%;
+  padding: 0;
+}
+
+.acs-search input::placeholder { color: rgba(255, 255, 255, 0.35); }
+
+/* ── Rarity ── */
+.acs-rarity-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.acs-rarity-btn {
+  border: none;
+  border-radius: 4px;
+  padding: 2px 5px;
+  font-size: 0.6rem;
+  font-weight: bold;
+  cursor: pointer;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+
+.acs-rarity-btn.active { opacity: 1; }
+.acs-rarity-btn:hover  { opacity: 0.85; }
+
+.acs-rb-common       { background: #6b7280; color: #fff; }
+.acs-rb-uncommon     { background: #e5e7eb; color: #111; }
+.acs-rb-rare         { background: #16a34a; color: #fff; }
+.acs-rb-very-rare    { background: #2563eb; color: #fff; }
+.acs-rb-crazy-rare   { background: #7c3aed; color: #fff; }
+.acs-rb-prize-only   { background: #111;    color: #e5e7eb; }
+.acs-rb-code-only    { background: #ea580c; color: #fff; }
+.acs-rb-auction-only { background: #eab308; color: #111; }
+
+/* ── Owned filter ── */
+.acs-owned-row {
+  display: flex;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.acs-owned-btn {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.58rem;
+  font-weight: bold;
+  padding: 3px 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  text-align: center;
+  transition: background 0.15s, color 0.15s;
+  font-family: inherit;
+}
+
+.acs-owned-btn.active { background: var(--OrbitLightBlue); color: #fff; }
+
+/* ── Sort ── */
+.acs-sort-row {
+  display: flex;
+  gap: 4px;
+}
+
+.acs-select {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.72rem;
+  padding: 3px 6px;
+  outline: none;
+  cursor: pointer;
+}
+
+.acs-select option { background: #1a3a58; }
+
+.acs-sort-dir {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.8rem;
+  padding: 2px 7px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+/* ── Clear ── */
+.acs-clear {
+  width: 100%;
+  padding: 4px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.2);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  margin-top: auto;
+  font-family: inherit;
+}
+
+.acs-clear:hover { background: rgba(255, 255, 255, 0.1); color: #fff; }
+
+/* ── Divider ── */
+.acs-divider {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 0;
+}
+</style>

--- a/components/newsite/MyCworld.vue
+++ b/components/newsite/MyCworld.vue
@@ -3,6 +3,7 @@
     <div class="mcw-nav">
       <GreenButton @click="goToCzone">My cZone</GreenButton>
       <GreenButton @click="$router.push('/newsite/MyCollection')">My Collection</GreenButton>
+      <GreenButton @click="$router.push('/newsite/allCtoons')">All cToons</GreenButton>
       <GreenButton @click="$router.push('/newsite/myachievements')">Achievements</GreenButton>
     </div>
     <div class="mcw-content">

--- a/composables/useAllCtoonsFilter.js
+++ b/composables/useAllCtoonsFilter.js
@@ -1,0 +1,7 @@
+export const useAllCtoonsFilter = () => useState('allCtoonsFilter', () => ({
+  name:      '',
+  rarities:  [],
+  owned:     'all',
+  sortField: 'name',
+  sortAsc:   true,
+}))

--- a/composables/useAllCtoonsTab.js
+++ b/composables/useAllCtoonsTab.js
@@ -1,0 +1,1 @@
+export const useAllCtoonsTab = () => useState('allCtoonsActiveTab', () => 'AllSets')

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -254,6 +254,7 @@ html.newsite-active body {
           <NewcmartSidebar     v-show="sidebarMiddleComponent === 'NewcmartSidebar'" />
           <AuctionHouseSidebar v-show="sidebarMiddleComponent === 'AuctionHouseSidebar'" />
           <MyCollectionSidebar v-show="sidebarMiddleComponent === 'MyCollectionSidebar'" />
+          <AllCtoonsSidebar    v-show="sidebarMiddleComponent === 'AllCtoonsSidebar'" />
           <TradeSidebarWrapper v-show="sidebarMiddleComponent === 'TradeSidebarWrapper'" />
           <CzoneSidebarMiddle  v-show="sidebarMiddleComponent === 'CzoneSidebarMiddle'" />
         </div>

--- a/pages/newsite/allCtoons.vue
+++ b/pages/newsite/allCtoons.vue
@@ -1,0 +1,26 @@
+<template>
+  <AllCtoons />
+</template>
+
+<script setup>
+definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+
+const { setSidebarMiddle } = useNewsiteLayout()
+setSidebarMiddle('AllCtoonsSidebar')
+
+const filter = useAllCtoonsFilter()
+Object.assign(filter.value, {
+  name:      '',
+  rarities:  [],
+  owned:     'all',
+  sortField: 'name',
+  sortAsc:   true,
+})
+
+const activeTab = useAllCtoonsTab()
+activeTab.value = 'AllSets'
+</script>
+
+<style>
+body.page-newsite-allctoons .main-content { overflow-y: auto !important; scrollbar-width: thin; }
+</style>


### PR DESCRIPTION
Creates pages/newsite/allCtoons.vue that shows all cToons (not just
the user's) in the newsite ShortCard grid layout, grouped by Set or
Series based on sidebar tab selection. Includes search, rarity,
ownership, and sort filters in the sidebar.

Adds an All cToons button to MyCworld.vue to the right of My Collection.

https://claude.ai/code/session_01WN5tGxb6R1ruuMCM8oTphE