### PR TITLE
Add All cToons page with wishlist points modal (newsite)

### DIFF
--- a/components/newsite/AllCtoons.vue
+++ b/components/newsite/AllCtoons.vue
@@ -1,0 +1,302 @@
+<template>
+  <div class="all-ctoons">
+
+    <!-- Header bar -->
+    <div class="ac-header">All cToons</div>
+
+    <!-- Wishlist modal -->
+    <WishlistModal
+      v-if="wishlistTarget"
+      :ctoon="wishlistTarget"
+      @close="wishlistTarget = null"
+      @added="onWishlistAdded"
+    />
+
+    <!-- Card grid -->
+    <div class="ac-grid">
+      <div v-if="loading" class="ac-status">Loading…</div>
+      <div v-else-if="!ctoons.length" class="ac-status">No cToons found.</div>
+      <template v-else>
+        <ShortCard
+          v-for="c in ctoons"
+          :key="c.id"
+          :style="{ '--footer-left-width': '65%', '--footer-right-width': '35%' }"
+        >
+          <template #header>
+            <img
+              v-if="c.assetPath"
+              :src="c.assetPath"
+              :alt="c.name"
+              class="card-img card-img--clickable"
+              @click="openInfo(c)"
+            />
+          </template>
+          <template #middle>
+            <span class="card-mint">{{ c.highestMint ? `/${c.highestMint}` : '' }}</span>
+            <span class="card-name">{{ c.name }}</span>
+            <span class="rarity-dot" :style="{ background: rarityColor(c.rarity) }" :title="c.rarity" />
+          </template>
+          <template #footer-left>
+            <button
+              class="card-btn"
+              :class="inWishlist(c.id) ? 'card-btn--remove' : 'card-btn--add'"
+              :disabled="wishlistLoading || processingId === c.id"
+              @click.stop="handleWishlist(c)"
+            >
+              {{ wishlistBtnText(c.id) }}
+            </button>
+          </template>
+          <template #footer-right>
+            <button class="card-btn card-btn--info" @click.stop="openInfo(c)">Info</button>
+          </template>
+        </ShortCard>
+      </template>
+    </div>
+
+  </div>
+</template>
+
+<script setup>
+const { open: openCtoonModal } = useCtoonModal()
+const { wishlist, loading: wishlistLoading, remove } = useWishlist()
+
+const RARITY_COLORS = {
+  'common':       '#aaaaaa',
+  'uncommon':     '#33cc33',
+  'rare':         '#3399ff',
+  'very rare':    '#aa44ff',
+  'crazy rare':   '#ffaa00',
+  'prize only':   '#ff3366',
+  'code only':    '#00cccc',
+  'auction only': '#ff6600',
+}
+
+function rarityColor(rarity) {
+  return RARITY_COLORS[(rarity || '').toLowerCase()] || '#aaaaaa'
+}
+
+const RARITY_ORDER = {
+  'common': 0, 'uncommon': 1, 'rare': 2, 'very rare': 3,
+  'crazy rare': 4, 'prize only': 5, 'code only': 6, 'auction only': 7,
+}
+
+const allCtoons = useState('allCtoonsCtoons', () => [])
+const loading = ref(true)
+const filter = useNewSiteCtoonFilter()
+const wishlistTarget = ref(null)
+const processingId = ref(null)
+
+function openInfo(c) {
+  openCtoonModal({ ctoonId: c.id, assetPath: c.assetPath, name: c.name })
+}
+
+function inWishlist(ctoonId) {
+  return !wishlistLoading.value && wishlist.value.includes(ctoonId)
+}
+
+function wishlistBtnText(ctoonId) {
+  if (processingId.value === ctoonId) return '…'
+  return inWishlist(ctoonId) ? 'Unwishlist' : '+ Wishlist'
+}
+
+async function handleWishlist(c) {
+  if (wishlistLoading.value || processingId.value === c.id) return
+  if (inWishlist(c.id)) {
+    processingId.value = c.id
+    try {
+      await remove(c.id)
+    } finally {
+      processingId.value = null
+    }
+  } else {
+    wishlistTarget.value = c
+  }
+}
+
+function onWishlistAdded() {
+  wishlistTarget.value = null
+}
+
+const ctoons = computed(() => {
+  const f = filter.value
+  let list = allCtoons.value
+
+  if (f.name)
+    list = list.filter(c => c.name.toLowerCase().includes(f.name.toLowerCase()))
+
+  if (f.rarities.length)
+    list = list.filter(c => f.rarities.includes((c.rarity || '').toLowerCase()))
+
+  if (f.series)
+    list = list.filter(c => c.series === f.series)
+
+  if (f.set)
+    list = list.filter(c => c.set === f.set)
+
+  if (f.priceMin !== '')
+    list = list.filter(c => c.price >= Number(f.priceMin))
+
+  if (f.priceMax !== '')
+    list = list.filter(c => c.price <= Number(f.priceMax))
+
+  list = [...list].sort((a, b) => {
+    let cmp = 0
+    if (f.sortField === 'price') {
+      cmp = a.price - b.price
+    } else if (f.sortField === 'rarity') {
+      const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99
+      const br = RARITY_ORDER[(b.rarity || '').toLowerCase()] ?? 99
+      cmp = ar - br
+    } else if (f.sortField === 'releaseDate') {
+      const at = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
+      const bt = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
+      cmp = at - bt
+    } else {
+      cmp = (a.name || '').localeCompare(b.name || '')
+    }
+    return f.sortAsc ? cmp : -cmp
+  })
+
+  return list
+})
+
+onMounted(async () => {
+  try {
+    allCtoons.value = await $fetch('/api/collections/all')
+  } catch (err) {
+    console.error('AllCtoons: failed to load', err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+.all-ctoons {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: white;
+  box-sizing: border-box;
+  overflow: hidden;
+
+  --img-scale: 0.7;
+}
+
+.ac-header {
+  flex-shrink: 0;
+  width: 100%;
+  height: 23px;
+  line-height: 21px;
+  padding-bottom: 2px;
+  overflow: hidden;
+  text-align: center;
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: #ffffff;
+  background: var(--OrbitLightBlue);
+  box-sizing: border-box;
+}
+
+.ac-grid {
+  flex: 1;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--OrbitLightBlue) transparent;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  grid-auto-rows: var(--shortcard-height);
+  grid-auto-flow: row;
+  gap: 4px;
+  padding: 4px;
+  box-sizing: border-box;
+  --shortcard-width: 100%;
+}
+
+@media (max-width: 768px) {
+  .ac-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.ac-status {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: #336699;
+  font-size: 2rem;
+  padding: 20px;
+}
+
+.rarity-dot {
+  width: 8px;
+  height: 8px;
+  min-width: 8px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  flex-shrink: 0;
+}
+
+.card-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transform: scale(var(--img-scale));
+}
+
+.card-img--clickable {
+  cursor: pointer;
+}
+.card-img--clickable:hover {
+  filter: brightness(1.12);
+}
+
+.card-btn {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  font-size: 0.7rem;
+  font-weight: bold;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: filter 0.12s;
+}
+.card-btn:disabled { opacity: 0.5; cursor: default; }
+.card-btn:not(:disabled):hover { filter: brightness(1.12); }
+
+.card-btn--add {
+  background: var(--OrbitGreen, #66CC00);
+  color: #fff;
+}
+
+.card-btn--remove {
+  background: #cc3300;
+  color: #fff;
+}
+
+.card-btn--info {
+  background: var(--OrbitDarkBlue, #336699);
+  color: #fff;
+}
+
+.card-mint {
+  font-size: 0.7rem;
+  color: #fff;
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding: 0 2px;
+}
+
+.card-name {
+  font-size: 0.6rem;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  text-align: center;
+}
+</style>

--- a/components/newsite/AllCtoonsSidebar.vue
+++ b/components/newsite/AllCtoonsSidebar.vue
@@ -1,0 +1,15 @@
+<template>
+  <CtoonFilter
+    :sort-options="allCtoonsSortOptions"
+    ctoons-state-key="allCtoonsCtoons"
+  />
+</template>
+
+<script setup>
+const allCtoonsSortOptions = [
+  { value: 'name',        label: 'Name'         },
+  { value: 'releaseDate', label: 'Release Date'  },
+  { value: 'price',       label: 'Price'         },
+  { value: 'rarity',      label: 'Rarity'        },
+]
+</script>

--- a/components/newsite/CtoonFilter.vue
+++ b/components/newsite/CtoonFilter.vue
@@ -108,6 +108,7 @@ const props = defineProps({
   showHideUnavailable: { type: Boolean, default: false },
   showSortDir:         { type: Boolean, default: true  },
   showAuctionFilters:  { type: Boolean, default: false },
+  ctoonsStateKey:      { type: String,  default: 'cmartCtoons' },
   sortOptions: {
     type: Array,
     default: () => [
@@ -120,7 +121,7 @@ const props = defineProps({
 
 const filter   = useNewSiteCtoonFilter()
 const aFilters = useAuctionHouseFilters()
-const ctoons   = useState('cmartCtoons', () => [])
+const ctoons   = useState(props.ctoonsStateKey, () => [])
 
 const RARITIES = [
   { value: 'common',       label: 'C',  cls: 'cf-rb-common'        },

--- a/components/newsite/NavRight.vue
+++ b/components/newsite/NavRight.vue
@@ -3,6 +3,9 @@
     <NuxtLink to="/newsite/MycWorld" class="nav-link">
       <BlueButton :style="{ height: buttonHeight }">My cWorld</BlueButton>
     </NuxtLink>
+    <NuxtLink to="/newsite/allCtoons" class="nav-link">
+      <BlueButton :style="{ height: buttonHeight }">All cToons</BlueButton>
+    </NuxtLink>
     <NuxtLink to="/newsite/cmart" class="nav-link">
       <BlueButton :style="{ height: buttonHeight }">cMart</BlueButton>
     </NuxtLink>

--- a/components/newsite/WishlistModal.vue
+++ b/components/newsite/WishlistModal.vue
@@ -1,0 +1,287 @@
+<template>
+  <Teleport to="body">
+    <div class="wm-overlay" @mousedown.self="$emit('close')">
+      <div class="wm-modal">
+
+        <!-- Header -->
+        <div class="wm-header">
+          <span class="wm-title">Add to Wishlist</span>
+          <button class="wm-close" @click="$emit('close')">✕</button>
+        </div>
+
+        <!-- Body -->
+        <div class="wm-body">
+          <div class="wm-preview">
+            <img class="wm-preview-img" :src="ctoon.assetPath" :alt="ctoon.name" draggable="false" />
+            <div class="wm-preview-info">
+              <div class="wm-preview-name">{{ ctoon.name }}</div>
+              <div class="wm-preview-meta">
+                <span class="wm-rarity-badge" :class="`r-${rarityKey(ctoon.rarity)}`">{{ ctoon.rarity }}</span>
+              </div>
+            </div>
+          </div>
+
+          <hr class="wm-divider" />
+
+          <div class="wm-field">
+            <label class="wm-label">
+              Points to offer <span class="wm-dim">(min 1)</span>
+            </label>
+            <input
+              class="wm-input"
+              type="number"
+              v-model.number="offerInput"
+              min="1"
+              step="1"
+              inputmode="numeric"
+              @keyup.enter="confirm"
+            />
+            <div v-if="error" class="wm-error">{{ error }}</div>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="wm-footer">
+          <button class="wm-cancel" @click="$emit('close')">Cancel</button>
+          <button
+            class="wm-submit"
+            :disabled="confirmDisabled || processing"
+            @click="confirm"
+          >{{ processing ? 'Adding…' : 'Add to Wishlist' }}</button>
+        </div>
+
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+const props = defineProps({
+  ctoon: { type: Object, required: true },
+})
+const emit = defineEmits(['close', 'added'])
+
+const { add } = useWishlist()
+
+const offerInput = ref(1)
+const error = ref('')
+const processing = ref(false)
+
+const confirmDisabled = computed(() =>
+  !Number.isInteger(offerInput.value) || offerInput.value <= 0
+)
+
+async function confirm() {
+  if (confirmDisabled.value) {
+    error.value = 'Enter an integer greater than 0.'
+    return
+  }
+  processing.value = true
+  error.value = ''
+  try {
+    await add(props.ctoon.id, offerInput.value)
+    emit('added', props.ctoon.id)
+    emit('close')
+  } catch (e) {
+    error.value = e.data?.message || 'Failed to add to wishlist.'
+  } finally {
+    processing.value = false
+  }
+}
+
+function rarityKey(r) { return (r || '').toLowerCase().replace(/\s+/g, '-') }
+</script>
+
+<style scoped>
+.wm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wm-modal {
+  position: relative;
+  width: 360px;
+  max-width: 95vw;
+  background: var(--OrbitDarkBlue);
+  border: 2px solid var(--OrbitLightBlue);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+.wm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--OrbitLightBlue);
+  flex-shrink: 0;
+}
+
+.wm-title {
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: #fff;
+  letter-spacing: 0.04em;
+}
+
+.wm-close {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+}
+.wm-close:hover { color: #fff; }
+
+.wm-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+}
+
+.wm-preview {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.wm-preview-img {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  flex-shrink: 0;
+  image-rendering: pixelated;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 6px;
+  padding: 3px;
+  box-sizing: border-box;
+}
+
+.wm-preview-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.wm-preview-name {
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: #fff;
+}
+
+.wm-preview-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.wm-rarity-badge {
+  font-size: 0.6rem;
+  font-weight: bold;
+  padding: 1px 6px;
+  border-radius: 3px;
+  text-transform: capitalize;
+}
+.r-common       { background: #6b7280; color: #fff; }
+.r-uncommon     { background: #e5e7eb; color: #111; }
+.r-rare         { background: #16a34a; color: #fff; }
+.r-very-rare    { background: #2563eb; color: #fff; }
+.r-crazy-rare   { background: #7c3aed; color: #fff; }
+.r-prize-only   { background: #111;    color: #e5e7eb; }
+.r-code-only    { background: #ea580c; color: #fff; }
+.r-auction-only { background: #eab308; color: #111; }
+
+.wm-dim {
+  font-size: 0.62rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.wm-divider {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 0;
+}
+
+.wm-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.wm-label {
+  font-size: 0.65rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.wm-input {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.8rem;
+  padding: 5px 8px;
+  outline: none;
+  box-sizing: border-box;
+}
+.wm-input:focus { border-color: var(--OrbitLightBlue); }
+
+.wm-error {
+  font-size: 0.62rem;
+  color: #fca5a5;
+}
+
+.wm-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 8px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  flex-shrink: 0;
+}
+
+.wm-cancel {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.65rem;
+  font-weight: bold;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.wm-cancel:hover { background: rgba(255, 255, 255, 0.14); color: #fff; }
+
+.wm-submit {
+  border: none;
+  border-radius: 6px;
+  background: var(--OrbitLightBlue);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: bold;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: filter 0.12s;
+  white-space: nowrap;
+}
+.wm-submit:not(:disabled):hover { filter: brightness(1.15); }
+.wm-submit:disabled { opacity: 0.4; cursor: default; }
+</style>

--- a/pages/newsite/allCtoons.vue
+++ b/pages/newsite/allCtoons.vue
@@ -1,0 +1,27 @@
+<template>
+  <AllCtoons />
+</template>
+
+<script setup>
+definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+
+const { setSidebarMiddle } = useNewsiteLayout()
+setSidebarMiddle('AllCtoonsSidebar')
+
+const filter = useNewSiteCtoonFilter()
+Object.assign(filter.value, {
+  name:            '',
+  rarities:        [],
+  series:          '',
+  set:             '',
+  priceMin:        '',
+  priceMax:        '',
+  sortField:       'name',
+  sortAsc:         true,
+  hideUnavailable: false,
+})
+</script>
+
+<style>
+body.page-allctoons .main-content { overflow-y: auto !important; scrollbar-width: thin; }
+</style>


### PR DESCRIPTION
## Summary

- Adds `pages/newsite/allCtoons.vue` — a new newsite-template page that lets users browse every cToon in the catalog with filter/sort controls in the sidebar
- Adds `components/newsite/AllCtoons.vue` — card grid (using `ShortCard`) where each card has an **Add to Wishlist** / **Unwishlist** footer button; clicking "Add to Wishlist" opens the new `WishlistModal` to enter a points offer before saving
- Adds `components/newsite/WishlistModal.vue` — dark-blue themed modal (consistent with `AuctionModal.vue`) that prompts for points to offer, validates input, and calls `useWishlist().add()` — mirrors the points flow in `pages/collection.vue` but styled for the new layout
- Adds `components/newsite/AllCtoonsSidebar.vue` — sidebar wrapping `CtoonFilter` with all-cToons sort options (Name, Release Date, Price, Rarity)
- Extends `components/newsite/CtoonFilter.vue` with a `ctoonsStateKey` prop (default `'cmartCtoons'`, backward-compatible) so each page can power the series/set dropdowns from its own data
- Adds an **All cToons** nav link to `NavRight.vue` between "My cWorld" and "cMart"

## Test plan

- [ ] Navigate to `/newsite/allCtoons` — page loads with card grid and sidebar filter
- [ ] Filter by name, rarity, series, set, price; verify grid updates correctly
- [ ] Click **+ Wishlist** on a cToon not already wishlisted — `WishlistModal` opens with cToon preview and points input
- [ ] Enter 0 or a non-integer and click Confirm — error message appears, request is not sent
- [ ] Enter a valid integer (≥ 1) and confirm — cToon is added to wishlist; button changes to **Unwishlist**
- [ ] Click **Unwishlist** — cToon is removed from wishlist; button reverts to **+ Wishlist**
- [ ] Click **Info** button — `CtoonInfoModal` opens for that cToon
- [ ] Verify existing pages (cMart, MyCollection) are unaffected by the `CtoonFilter` prop change
- [ ] "All cToons" nav link appears in the right nav bar and routes correctly

https://claude.ai/code/session_01E6N9SDUvyFVYbYDGWZvRo5

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6N9SDUvyFVYbYDGWZvRo5)_