### PR TITLE
Add wishlist modal, wishlist filter, and fix manage-homepage auction link

### DIFF
--- a/components/newsite/AllCtoons.vue
+++ b/components/newsite/AllCtoons.vue
@@ -125,7 +125,8 @@ const filteredCtoons = computed(() => {
     const o  = f.owned === 'all'
       ? true
       : f.owned === 'owned' ? c.isOwned : !c.isOwned
-    return nm && r && o
+    const w  = !f.wishlist || wishlist.value.includes(c.id)
+    return nm && r && o && w
   })
 })
 

--- a/components/newsite/AllCtoons.vue
+++ b/components/newsite/AllCtoons.vue
@@ -51,6 +51,13 @@
     </div>
 
   </div>
+
+  <WishlistModal
+    v-if="wishlistModalCtoon"
+    :ctoon="wishlistModalCtoon"
+    @close="wishlistModalCtoon = null"
+    @added="wishlistModalCtoon = null"
+  />
 </template>
 
 <script setup>
@@ -82,8 +89,10 @@ const RARITY_ORDER = {
   'crazy rare': 4, 'prize only': 5, 'code only': 6, 'auction only': 7,
 }
 
-const { wishlist, loading: wishlistLoading, add: wishlistAdd, remove: wishlistRemove } = useWishlist()
+const { wishlist, loading: wishlistLoading, remove: wishlistRemove } = useWishlist()
 const processing = ref(new Set())
+
+const wishlistModalCtoon = ref(null)
 
 function inWishlist(ctoonId) {
   return wishlist.value.includes(ctoonId)
@@ -91,17 +100,17 @@ function inWishlist(ctoonId) {
 
 async function toggleWishlist(c) {
   if (processing.value.has(c.id)) return
-  processing.value = new Set([...processing.value, c.id])
-  try {
-    if (inWishlist(c.id)) {
+  if (inWishlist(c.id)) {
+    processing.value = new Set([...processing.value, c.id])
+    try {
       await wishlistRemove(c.id)
-    } else {
-      await wishlistAdd(c.id, 0)
+    } finally {
+      const next = new Set(processing.value)
+      next.delete(c.id)
+      processing.value = next
     }
-  } finally {
-    const next = new Set(processing.value)
-    next.delete(c.id)
-    processing.value = next
+  } else {
+    wishlistModalCtoon.value = c
   }
 }
 

--- a/components/newsite/AllCtoonsSidebar.vue
+++ b/components/newsite/AllCtoonsSidebar.vue
@@ -53,6 +53,14 @@
 
     <hr class="acs-divider" />
 
+    <!-- Wishlist filter -->
+    <label class="acs-checkbox-row">
+      <input type="checkbox" v-model="filter.wishlist" class="acs-checkbox" />
+      <span class="acs-checkbox-label">My Wishlist</span>
+    </label>
+
+    <hr class="acs-divider" />
+
     <!-- Sort -->
     <div>
       <div class="acs-label">Sort By</div>
@@ -100,6 +108,7 @@ function clearFilters() {
     name:      '',
     rarities:  [],
     owned:     'all',
+    wishlist:  false,
     sortField: 'name',
     sortAsc:   true,
   })
@@ -272,6 +281,31 @@ function clearFilters() {
   cursor: pointer;
   flex-shrink: 0;
 }
+
+/* ── Wishlist checkbox ── */
+.acs-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.acs-checkbox {
+  accent-color: var(--OrbitLightBlue);
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.acs-checkbox-label {
+  font-size: 0.72rem;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.acs-checkbox-row:hover .acs-checkbox-label { color: #fff; }
 
 /* ── Clear ── */
 .acs-clear {

--- a/components/newsite/WishlistModal.vue
+++ b/components/newsite/WishlistModal.vue
@@ -1,0 +1,263 @@
+<template>
+  <Teleport to="body">
+    <div class="wm-overlay" @mousedown.self="$emit('close')">
+      <div class="wm-modal">
+
+        <!-- Header -->
+        <div class="wm-header">
+          <span class="wm-title">Add to Wishlist</span>
+          <button class="wm-close" @click="$emit('close')">✕</button>
+        </div>
+
+        <!-- Body -->
+        <div class="wm-body">
+          <div class="wm-preview">
+            <img v-if="ctoon.assetPath" class="wm-preview-img" :src="ctoon.assetPath" :alt="ctoon.name" draggable="false" />
+            <div class="wm-preview-info">
+              <div class="wm-preview-name">{{ ctoon.name }}</div>
+              <div v-if="ctoon.rarity" class="wm-preview-meta">
+                <span class="wm-rarity-badge" :class="`r-${rarityKey(ctoon.rarity)}`">{{ ctoon.rarity }}</span>
+              </div>
+            </div>
+          </div>
+
+          <hr class="wm-divider" />
+
+          <div class="wm-field">
+            <label class="wm-label">Points to offer</label>
+            <input
+              ref="inputRef"
+              class="wm-input"
+              type="number"
+              min="1"
+              step="1"
+              inputmode="numeric"
+              v-model.number="offerInput"
+              @keyup.enter="confirm"
+            />
+            <div v-if="error" class="wm-error">{{ error }}</div>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="wm-footer">
+          <button class="wm-cancel" @click="$emit('close')">Cancel</button>
+          <button
+            class="wm-submit"
+            :disabled="confirmDisabled || submitting"
+            @click="confirm"
+          >{{ submitting ? 'Adding…' : 'Add to Wishlist' }}</button>
+        </div>
+
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+const props = defineProps({
+  ctoon: { type: Object, required: true },
+})
+const emit = defineEmits(['close', 'added'])
+
+const offerInput = ref(1)
+const error      = ref('')
+const submitting = ref(false)
+const inputRef   = ref(null)
+
+const { add } = useWishlist()
+
+const confirmDisabled = computed(() =>
+  !Number.isInteger(offerInput.value) || offerInput.value <= 0
+)
+
+onMounted(() => {
+  nextTick(() => inputRef.value?.focus())
+})
+
+async function confirm() {
+  if (confirmDisabled.value) {
+    error.value = 'Enter a whole number greater than 0.'
+    return
+  }
+  error.value  = ''
+  submitting.value = true
+  try {
+    await add(props.ctoon.id, offerInput.value)
+    emit('added', props.ctoon.id)
+    emit('close')
+  } finally {
+    submitting.value = false
+  }
+}
+
+function rarityKey(r) { return (r || '').toLowerCase().replace(/\s+/g, '-') }
+</script>
+
+<style scoped>
+.wm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wm-modal {
+  position: relative;
+  width: 340px;
+  max-width: 95vw;
+  background: var(--OrbitDarkBlue);
+  border: 2px solid var(--OrbitLightBlue);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+.wm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--OrbitLightBlue);
+  flex-shrink: 0;
+}
+
+.wm-title {
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: #fff;
+  letter-spacing: 0.04em;
+}
+
+.wm-close {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+}
+.wm-close:hover { color: #fff; }
+
+.wm-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+}
+
+.wm-preview {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.wm-preview-img {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  flex-shrink: 0;
+  image-rendering: pixelated;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 6px;
+  padding: 3px;
+  box-sizing: border-box;
+}
+
+.wm-preview-info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+
+.wm-preview-name {
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: #fff;
+}
+
+.wm-preview-meta { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+
+.wm-rarity-badge {
+  font-size: 0.6rem;
+  font-weight: bold;
+  padding: 1px 6px;
+  border-radius: 3px;
+  text-transform: capitalize;
+}
+.r-common       { background: #6b7280; color: #fff; }
+.r-uncommon     { background: #e5e7eb; color: #111; }
+.r-rare         { background: #16a34a; color: #fff; }
+.r-very-rare    { background: #2563eb; color: #fff; }
+.r-crazy-rare   { background: #7c3aed; color: #fff; }
+.r-prize-only   { background: #111;    color: #e5e7eb; }
+.r-code-only    { background: #ea580c; color: #fff; }
+.r-auction-only { background: #eab308; color: #111; }
+
+.wm-divider { border: none; border-top: 1px solid rgba(255, 255, 255, 0.1); margin: 0; }
+
+.wm-field { display: flex; flex-direction: column; gap: 5px; }
+
+.wm-label {
+  font-size: 0.65rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.wm-input {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.8rem;
+  padding: 5px 8px;
+  outline: none;
+  box-sizing: border-box;
+}
+.wm-input:focus { border-color: var(--OrbitLightBlue); }
+
+.wm-error { font-size: 0.62rem; color: #fca5a5; }
+
+.wm-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 8px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  flex-shrink: 0;
+}
+
+.wm-cancel {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.65rem;
+  font-weight: bold;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.wm-cancel:hover { background: rgba(255, 255, 255, 0.14); color: #fff; }
+
+.wm-submit {
+  border: none;
+  border-radius: 6px;
+  background: var(--OrbitGreen);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: bold;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: filter 0.12s;
+  white-space: nowrap;
+}
+.wm-submit:not(:disabled):hover { filter: brightness(1.1); }
+.wm-submit:disabled { opacity: 0.4; cursor: default; }
+</style>

--- a/composables/useAllCtoonsFilter.js
+++ b/composables/useAllCtoonsFilter.js
@@ -2,6 +2,7 @@ export const useAllCtoonsFilter = () => useState('allCtoonsFilter', () => ({
   name:      '',
   rarities:  [],
   owned:     'all',
+  wishlist:  false,
   sortField: 'name',
   sortAsc:   true,
 }))

--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -466,6 +466,8 @@ const delayHours = ref(12)
 
 function detectPreset(link) {
   if (!link) return ''
+  // Treat old /newsite/auctions path as the auctions preset
+  if (link === '/newsite/auctions') return 'auctions'
   for (const [preset, path] of Object.entries(PAGE_LINKS)) {
     if (link === path) return preset
   }

--- a/pages/newsite/allCtoons.vue
+++ b/pages/newsite/allCtoons.vue
@@ -13,6 +13,7 @@ Object.assign(filter.value, {
   name:      '',
   rarities:  [],
   owned:     'all',
+  wishlist:  false,
   sortField: 'name',
   sortAsc:   true,
 })


### PR DESCRIPTION
## Summary

- **Wishlist points modal** (`components/newsite/WishlistModal.vue`): When clicking "Add to Wishlist" in the newsite AllCtoons view, a styled modal opens asking how many points to offer. Matches the newsite dark-blue design language (same as `AuctionModal.vue`). Removing from wishlist still works without a modal.
- **My Wishlist filter** (`AllCtoonsSidebar.vue`, `AllCtoons.vue`, `useAllCtoonsFilter.js`): New checkbox in the sidebar filters the cToon grid to show only items on the user's wishlist. Cleared by the "Clear Filters" button. Button text on each card correctly shows "Remove from Wishlist" / "Add to Wishlist" based on actual wishlist state.
- **Manage Homepage auction link** (`pages/admin/manage-homepage.vue`): `PAGE_LINKS` already maps the "Auctions" dropdown option to `/newsite/AuctionHouse`. Added backward-compat to `detectPreset` so any previously-saved `/newsite/auctions` links are still recognised as the auctions preset instead of falling back to "Custom URL".

## Test plan

- [ ] Navigate to `/newsite/allCtoons`
- [ ] Click **Add to Wishlist** on any cToon — confirm the points modal appears with cToon preview
- [ ] Submit with 0 or empty — confirm validation error shown
- [ ] Enter a valid positive integer and confirm — cToon moves to wishlist, button changes to **Remove from Wishlist**
- [ ] Click **Remove from Wishlist** — removes without a modal
- [ ] Enable the **My Wishlist** checkbox in the sidebar — grid filters to only wishlisted cToons
- [ ] Click **Clear Filters** — checkbox resets, all cToons shown again
- [ ] In `/admin/manage-homepage`, open any image "Link to" dropdown — confirm "Auctions" option is present and resolves to `/newsite/AuctionHouse` on save

https://claude.ai/code/session_013KaBsQKRsHNnVzidvojFkv