### PR TITLE
Add selection logging for cZone search prize pool results

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -615,6 +615,16 @@ async function loadCzoneSearchItems() {
       query: { tz, zoneIndex: 0 }
     })
     const items = Array.isArray(res?.items) ? res.items : []
+
+    for (const item of items) {
+      if (!item.selectionLog) continue
+      const { name, dbChancePercent, relativeChancePercent, poolDetails } = item.selectionLog
+      console.log(
+        `[cZone Search] Selected: "${name}" | DB chance: ${dbChancePercent}% | Relative chance: ${relativeChancePercent}%`
+      )
+      console.log('[cZone Search] Prize pool details:', poolDetails)
+    }
+
     czoneSearchItems.value = buildSearchItems(items)
   } catch (err) {
     console.error('MyCzone: failed to load cZone search items', err)

--- a/pages/newsite/czonesearch/[id].vue
+++ b/pages/newsite/czonesearch/[id].vue
@@ -53,23 +53,41 @@
           </section>
 
           <section class="czs-prize-section">
-            <div class="flex items-center justify-between">
+            <div class="flex flex-wrap items-center justify-between gap-y-2">
               <h2 class="text-lg font-semibold text-white">Prize Pool</h2>
-              <div class="flex items-center gap-2">
-                <span class="text-xs text-white/50 select-none">Only Show Available cToons</span>
-                <button
-                  type="button"
-                  role="switch"
-                  :aria-checked="showOnlyAvailable"
-                  @click="showOnlyAvailable = !showOnlyAvailable"
-                  :class="showOnlyAvailable ? 'bg-[var(--OrbitLightBlue)]' : 'bg-white/20'"
-                  class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer items-center rounded-full transition-colors"
-                >
-                  <span
-                    :class="showOnlyAvailable ? 'translate-x-4' : 'translate-x-0.5'"
-                    class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
-                  />
-                </button>
+              <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
+                <div v-if="showOnlyAvailable" class="flex items-center gap-2">
+                  <span class="text-xs text-white/50 select-none">Include Background-Gated cToons</span>
+                  <button
+                    type="button"
+                    role="switch"
+                    :aria-checked="showBackgroundGated"
+                    @click="showBackgroundGated = !showBackgroundGated"
+                    :class="showBackgroundGated ? 'bg-[var(--OrbitLightBlue)]' : 'bg-white/20'"
+                    class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer items-center rounded-full transition-colors"
+                  >
+                    <span
+                      :class="showBackgroundGated ? 'translate-x-4' : 'translate-x-0.5'"
+                      class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+                    />
+                  </button>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-xs text-white/50 select-none">Only Show Available cToons</span>
+                  <button
+                    type="button"
+                    role="switch"
+                    :aria-checked="showOnlyAvailable"
+                    @click="showOnlyAvailable = !showOnlyAvailable"
+                    :class="showOnlyAvailable ? 'bg-[var(--OrbitLightBlue)]' : 'bg-white/20'"
+                    class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer items-center rounded-full transition-colors"
+                  >
+                    <span
+                      :class="showOnlyAvailable ? 'translate-x-4' : 'translate-x-0.5'"
+                      class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+                    />
+                  </button>
+                </div>
               </div>
             </div>
 
@@ -256,6 +274,7 @@ const ownedTotal = computed(() => (search.value?.prizePool || []).reduce((sum, e
 const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Local Time'
 
 const showOnlyAvailable = ref(false)
+const showBackgroundGated = ref(false)
 
 function getCurrentTimeOfDay() {
   const hour = new Date().getHours()
@@ -265,9 +284,11 @@ function getCurrentTimeOfDay() {
   return 'NIGHT'
 }
 
-function isEntryAvailable(entry) {
+function isEntryAvailable(entry, ignoreBackground = false) {
   const stats = search.value?.userStats
   if (!stats) return true
+
+  if (!ignoreBackground && entry.conditionBackgroundEnabled) return false
 
   if (entry.conditionDateEnabled) {
     const today = new Date().toISOString().split('T')[0]
@@ -328,7 +349,7 @@ function isEntryAvailable(entry) {
 const filteredPrizePool = computed(() => {
   const pool = search.value?.prizePool || []
   if (!showOnlyAvailable.value) return pool
-  return pool.filter(isEntryAvailable)
+  return pool.filter(e => isEntryAvailable(e, showBackgroundGated.value))
 })
 
 const formatNumber = (value) => {

--- a/pages/newsite/czonesearch/[id].vue
+++ b/pages/newsite/czonesearch/[id].vue
@@ -53,41 +53,23 @@
           </section>
 
           <section class="czs-prize-section">
-            <div class="flex flex-wrap items-center justify-between gap-y-2">
+            <div class="flex items-center justify-between">
               <h2 class="text-lg font-semibold text-white">Prize Pool</h2>
-              <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
-                <div v-if="showOnlyAvailable" class="flex items-center gap-2">
-                  <span class="text-xs text-white/50 select-none">Include Background-Gated cToons</span>
-                  <button
-                    type="button"
-                    role="switch"
-                    :aria-checked="showBackgroundGated"
-                    @click="showBackgroundGated = !showBackgroundGated"
-                    :class="showBackgroundGated ? 'bg-[var(--OrbitLightBlue)]' : 'bg-white/20'"
-                    class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer items-center rounded-full transition-colors"
-                  >
-                    <span
-                      :class="showBackgroundGated ? 'translate-x-4' : 'translate-x-0.5'"
-                      class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
-                    />
-                  </button>
-                </div>
-                <div class="flex items-center gap-2">
-                  <span class="text-xs text-white/50 select-none">Only Show Available cToons</span>
-                  <button
-                    type="button"
-                    role="switch"
-                    :aria-checked="showOnlyAvailable"
-                    @click="showOnlyAvailable = !showOnlyAvailable"
-                    :class="showOnlyAvailable ? 'bg-[var(--OrbitLightBlue)]' : 'bg-white/20'"
-                    class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer items-center rounded-full transition-colors"
-                  >
-                    <span
-                      :class="showOnlyAvailable ? 'translate-x-4' : 'translate-x-0.5'"
-                      class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
-                    />
-                  </button>
-                </div>
+              <div class="flex items-center gap-2">
+                <span class="text-xs text-white/50 select-none">Only Show Available cToons</span>
+                <button
+                  type="button"
+                  role="switch"
+                  :aria-checked="showOnlyAvailable"
+                  @click="showOnlyAvailable = !showOnlyAvailable"
+                  :class="showOnlyAvailable ? 'bg-[var(--OrbitLightBlue)]' : 'bg-white/20'"
+                  class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer items-center rounded-full transition-colors"
+                >
+                  <span
+                    :class="showOnlyAvailable ? 'translate-x-4' : 'translate-x-0.5'"
+                    class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+                  />
+                </button>
               </div>
             </div>
 
@@ -274,7 +256,6 @@ const ownedTotal = computed(() => (search.value?.prizePool || []).reduce((sum, e
 const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Local Time'
 
 const showOnlyAvailable = ref(false)
-const showBackgroundGated = ref(false)
 
 function getCurrentTimeOfDay() {
   const hour = new Date().getHours()
@@ -284,11 +265,9 @@ function getCurrentTimeOfDay() {
   return 'NIGHT'
 }
 
-function isEntryAvailable(entry, ignoreBackground = false) {
+function isEntryAvailable(entry) {
   const stats = search.value?.userStats
   if (!stats) return true
-
-  if (!ignoreBackground && entry.conditionBackgroundEnabled) return false
 
   if (entry.conditionDateEnabled) {
     const today = new Date().toISOString().split('T')[0]
@@ -349,7 +328,7 @@ function isEntryAvailable(entry, ignoreBackground = false) {
 const filteredPrizePool = computed(() => {
   const pool = search.value?.prizePool || []
   if (!showOnlyAvailable.value) return pool
-  return pool.filter(e => isEntryAvailable(e, showBackgroundGated.value))
+  return pool.filter(isEntryAvailable)
 })
 
 const formatNumber = (value) => {

--- a/server/api/czone/[username]/searches.get.js
+++ b/server/api/czone/[username]/searches.get.js
@@ -511,6 +511,10 @@ export default defineEventHandler(async (event) => {
     const chosen = pickWeighted(eligiblePool)
     if (!chosen) continue
 
+    const eligibleTotal = eligiblePool.reduce((sum, p) => sum + clampPercent(p.chancePercent), 0)
+    const chosenDbChance = clampPercent(chosen.chancePercent)
+    const chosenRelativeChance = eligibleTotal > 0 ? (chosenDbChance / eligibleTotal) * 100 : 0
+
     const appearanceId = randomUUID()
     toCreate.push({
       id:            appearanceId,
@@ -528,6 +532,25 @@ export default defineEventHandler(async (event) => {
         name:      chosen.ctoon.name,
         rarity:    chosen.ctoon.rarity,
         assetPath: chosen.ctoon.assetPath
+      },
+      selectionLog: {
+        name: chosen.ctoon.name,
+        dbChancePercent: parseFloat(chosenDbChance.toFixed(4)),
+        relativeChancePercent: parseFloat(chosenRelativeChance.toFixed(4)),
+        poolDetails: {
+          eligibleCount: eligiblePool.length,
+          totalCount: search.prizePool.length,
+          eligiblePool: eligiblePool.map(p => {
+            const dbChance = clampPercent(p.chancePercent)
+            return {
+              name: p.ctoon.name,
+              dbChancePercent: parseFloat(dbChance.toFixed(4)),
+              relativeChancePercent: eligibleTotal > 0
+                ? parseFloat(((dbChance / eligibleTotal) * 100).toFixed(4))
+                : 0
+            }
+          })
+        }
       }
     })
   }


### PR DESCRIPTION
## Summary
This PR adds detailed logging for cZone search prize pool selections, tracking both the absolute and relative chances of selected items within their eligible pool.

## Key Changes
- **Backend (searches.get.js)**: 
  - Calculate and store selection metadata including database chance percentage and relative chance within the eligible pool
  - Add `selectionLog` object to each created appearance containing:
    - Selected item name and chance percentages
    - Pool details with eligible count, total count, and full eligible pool breakdown with individual chance calculations
  
- **Frontend (MyCzone.vue)**:
  - Log selection results to console when items are loaded, displaying the selected item name and its chance percentages
  - Display full prize pool details for debugging and transparency

## Implementation Details
- Chance percentages are clamped and rounded to 4 decimal places for consistency
- Relative chance is calculated as a percentage of the total eligible pool chance (not the full pool)
- The `selectionLog` is included in the API response for each search result, enabling client-side inspection and logging
- Console logging provides visibility into the selection process without affecting UI

https://claude.ai/code/session_014bmJmXiSdctJvy8yFJvwN5