### PR TITLE
Fix unescaped apostrophe in auctions.post.js

### DIFF
--- a/server/api/auctions.post.js
+++ b/server/api/auctions.post.js
@@ -97,7 +97,7 @@ export default defineEventHandler(async (event) => {
     where: { userCtoonId, status: 'ACTIVE' }
   })
   if (existing) {
-    throw createError({ statusCode: 400, statusMessage: 'There’s already an active auction for this cToon' })
+    throw createError({ statusCode: 400, statusMessage: "There’s already an active auction for this cToon" })
   }
 
   // 4.5 Active pending trade check — block auctions if this UserCtoon is in any pending trade


### PR DESCRIPTION
## Summary

Fixes an esbuild parse error caused by an unescaped apostrophe inside a single-quoted string literal in `server/api/auctions.post.js`.

- Changed `'There's already an active auction for this cToon'` → `"There's already an active auction for this cToon"`

Scanned all server JS files for similar patterns — no other instances found (one other file uses a properly escaped `\'` which is valid).

https://claude.ai/code/session_01NhA51WvV6M1qCEDfCTAwkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhA51WvV6M1qCEDfCTAwkQ)_