### PR TITLE
Clear upgrades config cache when global config is updated

### DIFF
--- a/server/api/admin/global-config.post.js
+++ b/server/api/admin/global-config.post.js
@@ -7,6 +7,7 @@ import {
 } from 'h3'
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { clearUpgradesConfigCache } from '@/server/api/cmart/upgrades-config.get'
 
 export default defineEventHandler(async (event) => {
   // 1) Authenticate & authorize
@@ -100,6 +101,7 @@ export default defineEventHandler(async (event) => {
         ...(payload.cmartHalfPriceEnabled !== undefined ? { cmartHalfPriceEnabled: payload.cmartHalfPriceEnabled } : {})
       }
     })
+    clearUpgradesConfigCache()
     // Log field-level changes
     const fields = [
       'dailyPointLimit',

--- a/server/api/cmart/upgrades-config.get.js
+++ b/server/api/cmart/upgrades-config.get.js
@@ -7,6 +7,11 @@ const CACHE_TTL_MS = 10 * 60 * 1000 // 10 minutes
 let _cache = null
 let _cacheAt = 0
 
+export function clearUpgradesConfigCache() {
+  _cache = null
+  _cacheAt = 0
+}
+
 export default defineEventHandler(async () => {
   const now = Date.now()
   if (_cache && now - _cacheAt < CACHE_TTL_MS) {


### PR DESCRIPTION
## Summary
Added cache invalidation for the upgrades configuration when global configuration settings are updated through the admin API.

## Key Changes
- **upgrades-config.get.js**: Exported a new `clearUpgradesConfigCache()` function that resets the internal cache and cache timestamp
- **global-config.post.js**: Imported the cache clearing function and call it after successfully updating global configuration to ensure stale upgrades config data is not served

## Implementation Details
The upgrades configuration endpoint maintains a 10-minute TTL cache to improve performance. When administrators update global configuration (including cmart-related settings like `cmartHalfPriceEnabled`), the cache is now explicitly cleared to ensure the next request fetches fresh data. This prevents serving outdated configuration to clients after administrative changes.

https://claude.ai/code/session_01DH48rgeVep3mHrQYQKCzNC