### PR TITLE
Invalidate user cZone condition cache after capturing cToon

### DIFF
--- a/server/api/czone/searches/capture.post.js
+++ b/server/api/czone/searches/capture.post.js
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { mintQueue } from '@/server/utils/queues'
 import { QueueEvents } from 'bullmq'
 import { prisma as db } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
 
 const redisConnection = {
   host: process.env.REDIS_HOST,
@@ -118,6 +119,10 @@ export default defineEventHandler(async (event) => {
     db.cZoneSearchCapture.count({ where: { userId, ctoonId: appearance.ctoonId } }),
     db.userCtoon.count({ where: { userId, ctoonId: appearance.ctoonId } })
   ])
+
+  // Invalidate the user's cached condition data so the next cZone search
+  // reflects the newly captured cToon (set counts, owns counts, etc.)
+  try { await redis.del(`czone:ucond:${userId}`) } catch {}
 
   const job = await mintQueue.add('mintCtoon', { userId, ctoonId: appearance.ctoonId, isSpecial: true })
   const qe = new QueueEvents(mintQueue.name, { connection: redisConnection })


### PR DESCRIPTION
## Summary
This change ensures that when a user captures a new cToon in cZone, their cached condition data is invalidated so that subsequent searches reflect the updated state (set counts, owns counts, etc.).

## Key Changes
- Added Redis import to the capture endpoint
- Added cache invalidation logic that deletes the user's `czone:ucond:{userId}` cache key after a cToon is successfully captured
- Wrapped the cache deletion in a try-catch to gracefully handle any Redis errors

## Implementation Details
The cache invalidation occurs after the database operations complete but before the mint job is queued. This ensures the cache is cleared before the user makes their next cZone search request, guaranteeing they see the most current data reflecting their newly captured cToon.

https://claude.ai/code/session_01Jbp4srjrE4eTzZ8u9XjYQX