### PR TITLE
Fix canvas scaling and simplify auth fetch logic

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -202,8 +202,13 @@ const scale = ref(1)
 function recalcScale() {
   if (typeof window === 'undefined') return
   const gutter = 32 // account for page padding / scrollbar
-  scale.value = Math.min(1, (window.innerWidth - gutter) / CANVAS_W)
+  const w = window.innerWidth || document.documentElement?.clientWidth || CANVAS_W
+  scale.value = Math.min(1, Math.max(0.1, (w - gutter) / CANVAS_W))
 }
+
+// Set the correct scale immediately on the client to avoid a post-hydration
+// layout flash where the canvas briefly renders at full 800px width.
+if (process.client) recalcScale()
 
 // Outer box reserves the scaled visual footprint in layout flow
 const outerScaleStyle = computed(() => ({

--- a/composables/useAuth.js
+++ b/composables/useAuth.js
@@ -53,13 +53,13 @@ export const useAuth = () => {
           fetchSelfLastFetchedAt.value = Date.now()
           return me
         }
-        const { data } = await useFetch('/api/auth/me', {
+        const me = await $fetch('/api/auth/me', {
           credentials: 'include',
           headers: process.server ? useRequestHeaders(['cookie']) : undefined
         })
-        user.value = data.value
+        user.value = me
         fetchSelfLastFetchedAt.value = Date.now()
-        return data.value
+        return me
       } catch (err) {
         user.value = null
         // If banned, kick to /join-discord with notice


### PR DESCRIPTION
## Summary
This PR addresses two issues: a layout flash on hydration in the canvas component and unnecessary complexity in the auth fetch logic.

## Key Changes

- **MyCzone.vue**: 
  - Improved `recalcScale()` to handle edge cases with fallback width calculation using `document.documentElement.clientWidth`
  - Added minimum scale constraint of 0.1 to prevent canvas from becoming too small
  - Call `recalcScale()` immediately on client to prevent post-hydration layout flash where canvas briefly renders at full 800px width before being scaled down

- **useAuth.js**:
  - Replaced `useFetch()` with `$fetch()` for simpler, more direct API calls
  - Removed unnecessary `data.value` unwrapping since `$fetch()` returns the response directly
  - Simplified variable naming and reduced indirection in the auth check flow

## Implementation Details
The canvas scaling fix ensures the correct scale is applied before the component renders on the client, eliminating the visual glitch where the canvas would briefly display at its unscaled width during hydration. The auth refactor reduces boilerplate by using the simpler `$fetch()` API which is more appropriate for this use case than `useFetch()`.

https://claude.ai/code/session_01Umt1CoP1Mb1aXw3Bbf3irB