### PR TITLE
Clear czone searches cache on admin mutations

### DIFF
--- a/server/api/admin/czone-searches.post.js
+++ b/server/api/admin/czone-searches.post.js
@@ -1,6 +1,7 @@
 import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
 import { DateTime } from 'luxon'
 import { prisma as db } from '@/server/prisma'
+import { clearSearchesCache } from '@/server/api/czone/[username]/searches.get'
 
 function parsePercent(value, label) {
   const num = Number(value)
@@ -295,6 +296,8 @@ export default defineEventHandler(async (event) => {
       }
     }
   })
+
+  clearSearchesCache()
 
   return created
 })

--- a/server/api/admin/czone-searches/[id].delete.js
+++ b/server/api/admin/czone-searches/[id].delete.js
@@ -1,5 +1,7 @@
 import { defineEventHandler, getRequestHeader, createError } from 'h3'
 import { prisma as db } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { clearSearchesCache } from '@/server/api/czone/[username]/searches.get'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -17,6 +19,9 @@ export default defineEventHandler(async (event) => {
   if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing search id' })
 
   await db.cZoneSearch.delete({ where: { id } })
+
+  try { await redis.del(`czone:search-meta:${id}`) } catch {}
+  clearSearchesCache()
 
   return { ok: true }
 })

--- a/server/api/admin/czone-searches/[id].put.js
+++ b/server/api/admin/czone-searches/[id].put.js
@@ -1,6 +1,8 @@
 import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
 import { DateTime } from 'luxon'
 import { prisma as db } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { clearSearchesCache } from '@/server/api/czone/[username]/searches.get'
 
 function parsePercent(value, label) {
   const num = Number(value)
@@ -307,6 +309,9 @@ export default defineEventHandler(async (event) => {
       }
     }
   })
+
+  try { await redis.del(`czone:search-meta:${id}`) } catch {}
+  clearSearchesCache()
 
   return updated
 })

--- a/server/api/czone/[username]/searches.get.js
+++ b/server/api/czone/[username]/searches.get.js
@@ -12,6 +12,12 @@ let _searchesCache = null
 let _searchesCacheExpiry = 0
 let _searchesFetch = null
 
+export function clearSearchesCache() {
+  _searchesCache = null
+  _searchesCacheExpiry = 0
+  _searchesFetch = null
+}
+
 async function getActiveSearches() {
   const now = Date.now()
   if (_searchesCache && now < _searchesCacheExpiry) return _searchesCache


### PR DESCRIPTION
## Summary
This PR ensures that the czone searches cache is properly invalidated whenever search data is modified through admin endpoints. This prevents stale data from being served to users after administrative changes.

## Key Changes
- **Added cache clearing function**: Exported `clearSearchesCache()` from the searches endpoint to allow other modules to invalidate the in-memory cache
- **Updated DELETE endpoint** (`[id].delete.js`): Clears both Redis cache and in-memory searches cache when a search is deleted
- **Updated PUT endpoint** (`[id].put.js`): Clears both Redis cache and in-memory searches cache when a search is updated
- **Updated POST endpoint** (`czone-searches.post.js`): Clears in-memory searches cache when a new search is created

## Implementation Details
- The cache clearing is implemented by resetting the internal cache variables (`_searchesCache`, `_searchesCacheExpiry`, `_searchesFetch`) to their initial states
- Redis cache entries are also cleared using the `czone:search-meta:{id}` key pattern (with error handling to prevent failures if the key doesn't exist)
- This ensures consistency across both the in-memory cache layer and the Redis cache layer

https://claude.ai/code/session_01HRb9hAzfwZaWdstUtpWcqG