### PR TITLE
Add cMart bot-clicker detection to suspicious activity monitor

### DIFF
--- a/pages/admin/suspicious-activity.vue
+++ b/pages/admin/suspicious-activity.vue
@@ -183,6 +183,15 @@
                   <span v-if="user.metrics.sharedIPUserCount != null">
                     {{ user.metrics.sharedIPUserCount }} shared-IP account{{ user.metrics.sharedIPUserCount !== 1 ? 's' : '' }}
                   </span>
+                  <span v-if="user.metrics.cmartPurchaseCount != null" class="text-orange-600 font-medium">
+                    {{ user.metrics.cmartPurchaseCount }} cMart purchase{{ user.metrics.cmartPurchaseCount !== 1 ? 's' : '' }}
+                  </span>
+                  <span v-if="user.metrics.cmartRapidBurstCount != null && user.metrics.cmartRapidBurstCount > 0" class="text-red-600 font-medium">
+                    {{ user.metrics.cmartRapidBurstCount }} rapid burst{{ user.metrics.cmartRapidBurstCount !== 1 ? 's' : '' }}
+                  </span>
+                  <span v-if="user.metrics.cmartSingleCtoonConcentrationPct != null">
+                    {{ user.metrics.cmartSingleCtoonConcentrationPct }}% cMart concentration
+                  </span>
                 </div>
               </div>
 
@@ -293,8 +302,23 @@
                 </div>
               </div>
 
+              <!-- cMart top cToons -->
+              <div v-if="user.context.cmartTopCtoons && user.context.cmartTopCtoons.length > 0">
+                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">cMart purchases by cToon</h4>
+                <div class="flex flex-wrap gap-2">
+                  <span
+                    v-for="c in user.context.cmartTopCtoons"
+                    :key="c.ctoonName"
+                    class="inline-flex items-center gap-1 text-xs bg-orange-50 border border-orange-200 rounded px-2 py-1 text-orange-800"
+                  >
+                    {{ c.ctoonName }}
+                    <span class="text-gray-400 font-normal">× {{ c.purchaseCount }}</span>
+                  </span>
+                </div>
+              </div>
+
               <div
-                v-if="user.context.topTradePartners.length === 0 && user.context.topAuctionSellers.length === 0 && user.context.sharedIPUsers.length === 0"
+                v-if="user.context.topTradePartners.length === 0 && user.context.topAuctionSellers.length === 0 && user.context.sharedIPUsers.length === 0 && (!user.context.cmartTopCtoons || user.context.cmartTopCtoons.length === 0)"
                 class="text-xs text-gray-400"
               >No contextual data available for this user.</div>
             </div>

--- a/pages/admin/suspicious-activity.vue
+++ b/pages/admin/suspicious-activity.vue
@@ -189,6 +189,9 @@
                   <span v-if="user.metrics.cmartRapidBurstCount != null && user.metrics.cmartRapidBurstCount > 0" class="text-red-600 font-medium">
                     {{ user.metrics.cmartRapidBurstCount }} rapid burst{{ user.metrics.cmartRapidBurstCount !== 1 ? 's' : '' }}
                   </span>
+                  <span v-if="user.metrics.cmartCrossCToonBurstCount != null && user.metrics.cmartCrossCToonBurstCount > 0" class="text-red-700 font-semibold">
+                    {{ user.metrics.cmartCrossCToonBurstCount }} cross-cToon burst{{ user.metrics.cmartCrossCToonBurstCount !== 1 ? 's' : '' }}
+                  </span>
                   <span v-if="user.metrics.cmartSingleCtoonConcentrationPct != null">
                     {{ user.metrics.cmartSingleCtoonConcentrationPct }}% cMart concentration
                   </span>

--- a/prisma/migrations/20260520000000_add_cmart_purchase_log/migration.sql
+++ b/prisma/migrations/20260520000000_add_cmart_purchase_log/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "CmartPurchaseLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "ctoonId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CmartPurchaseLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CmartPurchaseLog_userId_createdAt_idx" ON "CmartPurchaseLog"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CmartPurchaseLog_ctoonId_createdAt_idx" ON "CmartPurchaseLog"("ctoonId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CmartPurchaseLog_createdAt_idx" ON "CmartPurchaseLog"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "CmartPurchaseLog" ADD CONSTRAINT "CmartPurchaseLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CmartPurchaseLog" ADD CONSTRAINT "CmartPurchaseLog_ctoonId_fkey" FOREIGN KEY ("ctoonId") REFERENCES "Ctoon"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -278,6 +278,7 @@ model Ctoon {
   cZoneSearchPrizeRows  CZoneSearchPrize[]
   cZoneSearchAppearances CZoneSearchAppearance[]
   cZoneSearchCaptures   CZoneSearchCapture[]
+  cmartPurchaseLogs     CmartPurchaseLog[]
 }
 
 model CtoonImageHash {
@@ -446,6 +447,7 @@ model User {
 
   czoneContestSubmissions CZoneContestSubmission[]
   czoneContestVotes       CZoneContestVote[]
+  cmartPurchaseLogs       CmartPurchaseLog[]
 
   userMonsters     UserMonster[]
   userBarcodeScans UserBarcodeScan[]
@@ -2355,5 +2357,21 @@ model SuspiciousActivityMute {
   user    User @relation("SuspiciousMutedUser", fields: [userId], references: [id], onDelete: Cascade)
   mutedBy User @relation("SuspiciousMutedBy", fields: [mutedById], references: [id])
 
+  @@index([createdAt])
+}
+
+// ── cMart Bot Detection ───────────────────────────────────────────────────────
+
+model CmartPurchaseLog {
+  id        String   @id @default(uuid())
+  userId    String
+  ctoonId   String
+  createdAt DateTime @default(now())
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  ctoon Ctoon @relation(fields: [ctoonId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
+  @@index([ctoonId, createdAt])
   @@index([createdAt])
 }

--- a/server/utils/suspiciousActivityMetrics.js
+++ b/server/utils/suspiciousActivityMetrics.js
@@ -85,8 +85,14 @@ export const METRIC_DEFINITIONS = {
     unit: 'purchases',
   },
   cmartRapidBurstCount: {
-    label: 'Rapid-fire purchase bursts',
-    description: 'Number of cMart purchases made within 30 seconds of the prior purchase. Consistently high values indicate automated (bot) clicking.',
+    label: 'Rapid-fire purchase bursts (≤1s, any cToon)',
+    description: 'Number of cMart purchases made within 1 second of the prior purchase (any cToon). Near-impossible for a human consistently — strong bot indicator.',
+    category: 'cMart',
+    unit: 'bursts',
+  },
+  cmartCrossCToonBurstCount: {
+    label: 'Cross-cToon rapid bursts (≤1s, different cToon)',
+    description: 'Number of cMart purchases made within 1 second of the prior purchase where the cToon purchased is different. Buying distinct items this fast is virtually impossible without a script.',
     category: 'cMart',
     unit: 'bursts',
   },
@@ -309,6 +315,7 @@ async function computeAllUserMetrics(prisma, metricKeys, sinceDate) {
   // ── cMart bot detection metrics ────────────────────────────────────────────
   const needsCmart = metricKeys.has('cmartPurchaseCount') ||
                      metricKeys.has('cmartRapidBurstCount') ||
+                     metricKeys.has('cmartCrossCToonBurstCount') ||
                      metricKeys.has('cmartUniqueCtoonCount') ||
                      metricKeys.has('cmartSingleCtoonConcentrationPct')
 
@@ -349,13 +356,18 @@ async function computeAllUserMetrics(prisma, metricKeys, sinceDate) {
         rec.cmartSingleCtoonConcentrationPct = total > 0 ? Math.round((maxCount / total) * 100 * 10) / 10 : 0
       }
 
-      if (metricKeys.has('cmartRapidBurstCount')) {
+      if (metricKeys.has('cmartRapidBurstCount') || metricKeys.has('cmartCrossCToonBurstCount')) {
         let burstCount = 0
+        let crossBurstCount = 0
         for (let i = 1; i < ps.length; i++) {
           const gapMs = new Date(ps[i].createdAt).getTime() - new Date(ps[i - 1].createdAt).getTime()
-          if (gapMs <= 30000) burstCount++
+          if (gapMs <= 1000) {
+            burstCount++
+            if (ps[i].ctoonId !== ps[i - 1].ctoonId) crossBurstCount++
+          }
         }
-        rec.cmartRapidBurstCount = burstCount
+        if (metricKeys.has('cmartRapidBurstCount')) rec.cmartRapidBurstCount = burstCount
+        if (metricKeys.has('cmartCrossCToonBurstCount')) rec.cmartCrossCToonBurstCount = crossBurstCount
       }
     }
   }

--- a/server/utils/suspiciousActivityMetrics.js
+++ b/server/utils/suspiciousActivityMetrics.js
@@ -76,6 +76,32 @@ export const METRIC_DEFINITIONS = {
     category: 'IP / Account',
     unit: 'users',
   },
+
+  // ── cMart Bot Detection ────────────────────────────────────────────────────
+  cmartPurchaseCount: {
+    label: 'cMart purchases',
+    description: 'Total number of cToons purchased from cMart',
+    category: 'cMart',
+    unit: 'purchases',
+  },
+  cmartRapidBurstCount: {
+    label: 'Rapid-fire purchase bursts',
+    description: 'Number of cMart purchases made within 30 seconds of the prior purchase. Consistently high values indicate automated (bot) clicking.',
+    category: 'cMart',
+    unit: 'bursts',
+  },
+  cmartUniqueCtoonCount: {
+    label: 'Unique cToons bought from cMart',
+    description: 'Number of distinct cToons this user has purchased from cMart',
+    category: 'cMart',
+    unit: 'cToons',
+  },
+  cmartSingleCtoonConcentrationPct: {
+    label: 'cMart purchase concentration % (top cToon)',
+    description: 'Percentage of all cMart purchases that were for the single most-bought cToon. High values with a high purchase count suggest a bot targeting a specific release.',
+    category: 'cMart',
+    unit: '%',
+  },
 }
 
 /** Operator evaluation helper */
@@ -280,6 +306,60 @@ async function computeAllUserMetrics(prisma, metricKeys, sinceDate) {
     }
   }
 
+  // ── cMart bot detection metrics ────────────────────────────────────────────
+  const needsCmart = metricKeys.has('cmartPurchaseCount') ||
+                     metricKeys.has('cmartRapidBurstCount') ||
+                     metricKeys.has('cmartUniqueCtoonCount') ||
+                     metricKeys.has('cmartSingleCtoonConcentrationPct')
+
+  if (needsCmart) {
+    const purchases = await prisma.cmartPurchaseLog.findMany({
+      where: {
+        ...(dateFilter ? { createdAt: dateFilter } : {}),
+      },
+      select: {
+        userId: true,
+        ctoonId: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    // Group sorted purchases by user
+    const userPurchases = new Map()
+    for (const p of purchases) {
+      if (!userPurchases.has(p.userId)) userPurchases.set(p.userId, [])
+      userPurchases.get(p.userId).push(p)
+    }
+
+    for (const [userId, ps] of userPurchases) {
+      const rec = ensure(userId)
+      const total = ps.length
+
+      if (metricKeys.has('cmartPurchaseCount')) rec.cmartPurchaseCount = total
+
+      if (metricKeys.has('cmartUniqueCtoonCount')) {
+        rec.cmartUniqueCtoonCount = new Set(ps.map(p => p.ctoonId)).size
+      }
+
+      if (metricKeys.has('cmartSingleCtoonConcentrationPct')) {
+        const ctoonCounts = new Map()
+        for (const p of ps) ctoonCounts.set(p.ctoonId, (ctoonCounts.get(p.ctoonId) ?? 0) + 1)
+        const maxCount = Math.max(...ctoonCounts.values(), 0)
+        rec.cmartSingleCtoonConcentrationPct = total > 0 ? Math.round((maxCount / total) * 100 * 10) / 10 : 0
+      }
+
+      if (metricKeys.has('cmartRapidBurstCount')) {
+        let burstCount = 0
+        for (let i = 1; i < ps.length; i++) {
+          const gapMs = new Date(ps[i].createdAt).getTime() - new Date(ps[i - 1].createdAt).getTime()
+          if (gapMs <= 30000) burstCount++
+        }
+        rec.cmartRapidBurstCount = burstCount
+      }
+    }
+  }
+
   // ── Shared IP user count ───────────────────────────────────────────────────
   if (metricKeys.has('sharedIPUserCount')) {
     // Get all userIP records
@@ -328,7 +408,7 @@ async function buildContextForUsers(prisma, userIds, sinceDate) {
 
   const dateFilter = sinceDate ? { gte: sinceDate } : undefined
   const context = {}
-  for (const id of userIds) context[id] = { topTradePartners: [], topAuctionSellers: [], sharedIPUsers: [] }
+  for (const id of userIds) context[id] = { topTradePartners: [], topAuctionSellers: [], sharedIPUsers: [], cmartTopCtoons: [] }
 
   // ── Trade partners ─────────────────────────────────────────────────────────
   const offers = await prisma.tradeOffer.findMany({
@@ -447,6 +527,38 @@ async function buildContextForUsers(prisma, userIds, sinceDate) {
         }
       }
     }
+  }
+
+  // ── cMart top purchased cToons ─────────────────────────────────────────────
+  const cmartLogs = await prisma.cmartPurchaseLog.findMany({
+    where: {
+      userId: { in: userIds },
+      ...(dateFilter ? { createdAt: dateFilter } : {}),
+    },
+    select: {
+      userId: true,
+      ctoonId: true,
+      ctoon: { select: { name: true } },
+    },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  // userId → Map<ctoonId, { name, count }>
+  const cmartByUser = new Map()
+  for (const id of userIds) cmartByUser.set(id, new Map())
+
+  for (const log of cmartLogs) {
+    if (!cmartByUser.has(log.userId)) continue
+    const m = cmartByUser.get(log.userId)
+    if (!m.has(log.ctoonId)) m.set(log.ctoonId, { name: log.ctoon.name, count: 0 })
+    m.get(log.ctoonId).count++
+  }
+
+  for (const [userId, ctoonMap] of cmartByUser) {
+    context[userId].cmartTopCtoons = [...ctoonMap.values()]
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10)
+      .map(({ name, count }) => ({ ctoonName: name, purchaseCount: count }))
   }
 
   return context
@@ -589,7 +701,7 @@ export async function runAllRules(prisma, rules) {
         : null,
       triggeredRules: entry.rules,
       metrics: entry.metrics,
-      context: contextMap[userId] ?? { topTradePartners: [], topAuctionSellers: [], sharedIPUsers: [] },
+      context: contextMap[userId] ?? { topTradePartners: [], topAuctionSellers: [], sharedIPUsers: [], cmartTopCtoons: [] },
     }
   })
 

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -188,6 +188,13 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
           mintNumber: uc.mintNumber
         }
       })
+
+      // 5) Log cMart purchase for bot-clicker detection metrics
+      if (!isSpecial) {
+        await tx.cmartPurchaseLog.create({
+          data: { userId, ctoonId }
+        })
+      }
     })
 }, { connection })
 


### PR DESCRIPTION
Introduces a CmartPurchaseLog table that records every successful
non-special cMart mint, enabling behavioral analysis for bot detection.

New metrics available in the rule builder:
- cmartPurchaseCount: total cMart purchases
- cmartRapidBurstCount: purchases within 30s of the prior purchase (key bot signal)
- cmartUniqueCtoonCount: distinct cToons bought from cMart
- cmartSingleCtoonConcentrationPct: % of purchases targeting the top cToon

The suspicious activity page now surfaces cMart metrics in the quick
summary row and shows a breakdown of cToons purchased (by count) in the
expanded detail panel, so admins can see exactly which releases were targeted.

https://claude.ai/code/session_01A1tSSSPZgDefLkyHRbeXtC