### PR TITLE
Add time-based purchase limits for cToon releases

### DIFF
--- a/pages/admin/addCtoon.vue
+++ b/pages/admin/addCtoon.vue
@@ -146,6 +146,42 @@
           </p>
         </div>
 
+        <!-- Time-Based Purchase Limit Override (only for Time Based Limit) -->
+        <div v-if="mintLimitType === 'timeBased'" class="border rounded bg-indigo-50 p-4 space-y-3">
+          <div>
+            <h3 class="font-medium text-sm text-gray-800">Purchase Limit Override
+              <span class="text-xs font-normal text-gray-500 ml-1">— optional, overrides the rarity default from Global Settings</span>
+            </h3>
+            <p class="text-xs text-gray-500 mt-1">Leave either field blank to use the rarity default. Window blank = full release window.</p>
+          </div>
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block mb-1 text-sm font-medium">Limit Count</label>
+              <input
+                type="number"
+                min="1"
+                :value="timeBasedLimitCountStr"
+                @input="timeBasedLimitCountStr = $event.target.value"
+                placeholder="Use rarity default"
+                class="w-full border rounded p-2"
+              />
+              <p class="text-xs text-gray-500 mt-1">Max purchases per user.</p>
+            </div>
+            <div>
+              <label class="block mb-1 text-sm font-medium">Window (days)</label>
+              <input
+                type="number"
+                min="1"
+                :value="timeBasedLimitWindowDaysStr"
+                @input="timeBasedLimitWindowDaysStr = $event.target.value"
+                placeholder="Full duration"
+                class="w-full border rounded p-2"
+              />
+              <p class="text-xs text-gray-500 mt-1">Rolling window. Blank = full release window.</p>
+            </div>
+          </div>
+        </div>
+
         <!-- Release schedule (computed, read-only) -->
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4" v-if="schedule.initialQty != null && schedule.finalAtDisplay">
           <div>
@@ -299,6 +335,8 @@ const characters = ref('')
 const releaseDate = ref('')
 const mintLimitType = ref('defined')
 const mintEndDate = ref('')
+const timeBasedLimitCountStr = ref('')      // '' = use rarity default
+const timeBasedLimitWindowDaysStr = ref('') // '' = use rarity default / full duration
 const totalQuantity = ref(null)
 const initialQuantity = ref(null)
 const perUserLimit = ref(null)
@@ -525,6 +563,8 @@ async function submitForm() {
       formData.append('mintEndDate', new Date(mintEndDate.value).toISOString())
     }
   }
+  formData.append('timeBasedLimitCount',      timeBasedLimitCountStr.value)
+  formData.append('timeBasedLimitWindowDays', timeBasedLimitWindowDaysStr.value)
   formData.append('totalQuantity', mintLimitType.value === 'defined' ? (totalQuantity.value ?? '') : '')
   formData.append('initialQuantity', mintLimitType.value === 'defined' ? (initialQuantity.value ?? '') : '')
   // advisory schedule fields

--- a/pages/admin/bulk-upload-ctoons.vue
+++ b/pages/admin/bulk-upload-ctoons.vue
@@ -121,6 +121,42 @@
           </div>
         </div>
 
+        <!-- Time-Based Purchase Limit Override (bulk, only for timeBased) -->
+        <div v-if="bulkMintLimitType === 'timeBased'" class="border rounded bg-indigo-50 p-4 space-y-3">
+          <div>
+            <h3 class="font-medium text-sm text-gray-800">Purchase Limit Override
+              <span class="text-xs font-normal text-gray-500 ml-1">— applied to all cToons in this batch; leave blank to use each rarity's default</span>
+            </h3>
+            <p class="text-xs text-gray-500 mt-1">Window blank = full release window (release date → mint end date).</p>
+          </div>
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block mb-1 text-sm font-medium">Limit Count</label>
+              <input
+                type="number"
+                min="1"
+                :value="bulkTimeBasedLimitCountStr"
+                @input="bulkTimeBasedLimitCountStr = $event.target.value"
+                placeholder="Use rarity default"
+                class="w-full border rounded p-2"
+              />
+              <p class="text-xs text-gray-500 mt-1">Max purchases per user for each cToon.</p>
+            </div>
+            <div>
+              <label class="block mb-1 text-sm font-medium">Window (days)</label>
+              <input
+                type="number"
+                min="1"
+                :value="bulkTimeBasedLimitWindowDaysStr"
+                @input="bulkTimeBasedLimitWindowDaysStr = $event.target.value"
+                placeholder="Full duration"
+                class="w-full border rounded p-2"
+              />
+              <p class="text-xs text-gray-500 mt-1">Rolling window. Blank = full release window.</p>
+            </div>
+          </div>
+        </div>
+
         <!-- Release schedule preview (applies to each row based on its Total Qty) -->
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4" v-if="bulkReleaseDate">
           <div>
@@ -467,6 +503,8 @@ const bulkSeries = ref('')
 const bulkReleaseDate = ref('')
 const bulkMintLimitType = ref('defined')
 const bulkMintEndDate = ref('')
+const bulkTimeBasedLimitCountStr = ref('')      // '' = use rarity default
+const bulkTimeBasedLimitWindowDaysStr = ref('') // '' = use rarity default / full duration
 const uploading = ref(false)
 const releasePercent = ref(75)
 const delayHours = ref(12)
@@ -787,6 +825,8 @@ async function uploadAll() {
         formData.append('mintEndDate', new Date(bulkMintEndDate.value).toISOString())
       }
     }
+    formData.append('timeBasedLimitCount',      bulkTimeBasedLimitCountStr.value)
+    formData.append('timeBasedLimitWindowDays', bulkTimeBasedLimitWindowDaysStr.value)
     formData.append('totalQuantity', bulkMintLimitType.value === 'defined' ? (f.totalQuantity ?? '') : '')
     formData.append('initialQuantity', bulkMintLimitType.value === 'defined' ? (f.initialQuantity ?? '') : '')
     // advisory schedule fields per row

--- a/pages/admin/editCtoon/[id].vue
+++ b/pages/admin/editCtoon/[id].vue
@@ -103,6 +103,42 @@
           </p>
         </div>
 
+        <!-- Time-Based Purchase Limit Override (only for Time Based Limit) -->
+        <div v-if="mintLimitType === 'timeBased'" class="border rounded bg-indigo-50 p-4 space-y-3">
+          <div>
+            <h3 class="font-medium text-sm text-gray-800">Purchase Limit Override
+              <span class="text-xs font-normal text-gray-500 ml-1">— optional, overrides the rarity default from Global Settings</span>
+            </h3>
+            <p class="text-xs text-gray-500 mt-1">Leave either field blank to use the rarity default. Window blank = full release window.</p>
+          </div>
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block mb-1 text-sm font-medium">Limit Count</label>
+              <input
+                type="number"
+                min="1"
+                :value="timeBasedLimitCountStr"
+                @input="timeBasedLimitCountStr = $event.target.value"
+                placeholder="Use rarity default"
+                class="w-full border rounded p-2"
+              />
+              <p class="text-xs text-gray-500 mt-1">Max purchases per user.</p>
+            </div>
+            <div>
+              <label class="block mb-1 text-sm font-medium">Window (days)</label>
+              <input
+                type="number"
+                min="1"
+                :value="timeBasedLimitWindowDaysStr"
+                @input="timeBasedLimitWindowDaysStr = $event.target.value"
+                placeholder="Full duration"
+                class="w-full border rounded p-2"
+              />
+              <p class="text-xs text-gray-500 mt-1">Rolling window. Blank = full release window.</p>
+            </div>
+          </div>
+        </div>
+
         <!-- Per-User Limit / Quantities -->
         <div class="grid grid-cols-2 gap-4">
           <div>
@@ -270,6 +306,8 @@ const description = ref('')
 /* mint limit refs */
 const mintLimitType = ref('defined')
 const mintEndDate = ref('')
+const timeBasedLimitCountStr = ref('')      // '' = no override (use rarity default)
+const timeBasedLimitWindowDaysStr = ref('') // '' = no override (use rarity default / full duration)
 
 /* new image refs */
 const newImageFile = ref(null)
@@ -401,6 +439,8 @@ onMounted(async ()=>{
     description.value = ctoon.description || ''
     mintLimitType.value = ctoon.mintLimitType || 'defined'
     if (ctoon.mintEndDate) mintEndDate.value = toDateTimeLocal(ctoon.mintEndDate)
+    timeBasedLimitCountStr.value      = ctoon.timeBasedLimitCount      != null ? String(ctoon.timeBasedLimitCount)      : ''
+    timeBasedLimitWindowDaysStr.value = ctoon.timeBasedLimitWindowDays != null ? String(ctoon.timeBasedLimitWindowDays) : ''
     currentSoundPath.value = ctoon.soundPath || ''
     if (ctoon.quantity != null && ctoon.initialReleaseQty != null) {
       const qty = Number(ctoon.quantity)
@@ -511,6 +551,8 @@ async function submitForm(){
     if (mintLimitType.value === 'timeBased' && mintEndDate.value) {
       fd.append('mintEndDate', localToUtcIso(mintEndDate.value))
     }
+    fd.append('timeBasedLimitCount',      timeBasedLimitCountStr.value)
+    fd.append('timeBasedLimitWindowDays', timeBasedLimitWindowDaysStr.value)
     fd.append('perUserLimit', perUserLimit.value ?? '')
     fd.append('quantity', mintLimitType.value === 'defined' ? (quantity.value ?? '') : '')
     fd.append('initialQuantity', mintLimitType.value === 'defined' ? (initialQuantity.value ?? '') : '')
@@ -558,6 +600,8 @@ async function submitForm(){
     mintLimitType:   mintLimitType.value,
     mintEndDate:     mintLimitType.value === 'timeBased' && mintEndDate.value
                        ? localToUtcIso(mintEndDate.value) : null,
+    timeBasedLimitCount:      timeBasedLimitCountStr.value      !== '' && !isNaN(Number(timeBasedLimitCountStr.value))      ? Number(timeBasedLimitCountStr.value)      : null,
+    timeBasedLimitWindowDays: timeBasedLimitWindowDaysStr.value !== '' && !isNaN(Number(timeBasedLimitWindowDaysStr.value)) ? Number(timeBasedLimitWindowDaysStr.value) : null,
     perUserLimit:    perUserLimit.value,
     quantity:        mintLimitType.value === 'defined' ? quantity.value : null,
     initialQuantity: mintLimitType.value === 'defined' ? initialQuantity.value : null,

--- a/pages/admin/global-settings.vue
+++ b/pages/admin/global-settings.vue
@@ -269,6 +269,89 @@
           </p>
         </div>
 
+        <!-- Time-Based Release Purchase Limits -->
+        <div class="border-t pt-5">
+          <h2 class="text-base font-semibold text-gray-800 mb-1">Time-Based Release Purchase Limits</h2>
+          <p class="text-sm text-gray-500 mb-4">
+            Default per-user purchase limits for time-based releases, applied by rarity tier.
+            These are overridden per-cToon when a cToon has its own limit set.
+            Leave <strong>Window (days)</strong> blank to use the full release window (release date → mint end date).
+          </p>
+
+          <!-- Desktop table -->
+          <div class="overflow-x-auto hidden sm:block mb-4">
+            <table class="min-w-full border-separate border-spacing-y-1">
+              <thead>
+                <tr class="text-left text-sm text-gray-600">
+                  <th class="px-3 py-2">Rarity</th>
+                  <th class="px-3 py-2">Purchase Limit</th>
+                  <th class="px-3 py-2">Window (days)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="r in timeBasedRarities" :key="r" class="bg-gray-50">
+                  <td class="px-3 py-2 font-medium">{{ r }}</td>
+                  <td class="px-3 py-2">
+                    <input
+                      type="number"
+                      min="1"
+                      class="input"
+                      :value="timeBasedLimits[r].countStr"
+                      @input="timeBasedLimits[r].countStr = $event.target.value"
+                      placeholder="No limit"
+                    />
+                  </td>
+                  <td class="px-3 py-2">
+                    <input
+                      type="number"
+                      min="1"
+                      class="input"
+                      :value="timeBasedLimits[r].windowDaysStr"
+                      @input="timeBasedLimits[r].windowDaysStr = $event.target.value"
+                      placeholder="Full duration"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Mobile cards -->
+          <div class="space-y-3 sm:hidden mb-4">
+            <div
+              v-for="r in timeBasedRarities"
+              :key="r"
+              class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3"
+            >
+              <div class="font-semibold text-gray-800 mb-2">{{ r }}</div>
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-xs text-gray-600 mb-1">Purchase Limit</label>
+                  <input
+                    type="number"
+                    min="1"
+                    class="input"
+                    :value="timeBasedLimits[r].countStr"
+                    @input="timeBasedLimits[r].countStr = $event.target.value"
+                    placeholder="No limit"
+                  />
+                </div>
+                <div>
+                  <label class="block text-xs text-gray-600 mb-1">Window (days)</label>
+                  <input
+                    type="number"
+                    min="1"
+                    class="input"
+                    :value="timeBasedLimits[r].windowDaysStr"
+                    @input="timeBasedLimits[r].windowDaysStr = $event.target.value"
+                    placeholder="Full duration"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div>
           <button class="btn-primary" :disabled="savingCmart" @click="saveCmart">
             <span v-if="!savingCmart">Save</span><span v-else>Saving…</span>
@@ -303,6 +386,16 @@ const firstAdditionalCzoneCost      = ref(25000)
 const subsequentAdditionalCzoneCost = ref(50000)
 const cmartHalfPriceEnabled         = ref(false)
 
+// Time-based purchase limits (per rarity)
+const timeBasedRarities = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare']
+const defaultTimeBasedCounts = { 'Common': 5, 'Uncommon': 4, 'Rare': 3, 'Very Rare': 2, 'Crazy Rare': 1 }
+const timeBasedLimits = ref(
+  Object.fromEntries(timeBasedRarities.map(r => [
+    r,
+    { countStr: String(defaultTimeBasedCounts[r]), windowDaysStr: '' }
+  ]))
+)
+
 // Global Points state
 const dailyLoginPoints     = ref(500)
 const dailyNewUserPoints   = ref(1000)
@@ -332,6 +425,17 @@ async function loadGlobal() {
     featuredAuctionIntervalDays.value = Number(g?.featuredAuctionIntervalDays ?? 1)
     featuredAuctionsPerSlot.value     = Number(g?.featuredAuctionsPerSlot ?? 1)
     cmartHalfPriceEnabled.value = Boolean(g?.cmartHalfPriceEnabled ?? false)
+    if (g?.timeBasedPurchaseLimits) {
+      for (const r of timeBasedRarities) {
+        const def = g.timeBasedPurchaseLimits[r]
+        if (def) {
+          timeBasedLimits.value[r] = {
+            countStr:      def.count      != null ? String(def.count)      : String(defaultTimeBasedCounts[r]),
+            windowDaysStr: def.windowDays != null ? String(def.windowDays) : ''
+          }
+        }
+      }
+    }
   } catch (e) {
     console.error('Failed to load global config', e)
   }
@@ -442,12 +546,22 @@ async function saveCmart() {
     savingCmart.value = false
     return
   }
+  // Build the time-based limits payload (convert strings → numbers/null)
+  const timeBasedPurchaseLimits = {}
+  for (const r of timeBasedRarities) {
+    const { countStr, windowDaysStr } = timeBasedLimits.value[r]
+    timeBasedPurchaseLimits[r] = {
+      count:      countStr      !== '' && !isNaN(Number(countStr))      ? Number(countStr)      : null,
+      windowDays: windowDaysStr !== '' && !isNaN(Number(windowDaysStr)) ? Number(windowDaysStr) : null
+    }
+  }
   try {
     await $fetch('/api/admin/global-config', {
       method: 'POST',
       body: {
         dailyPointLimit: Number(dailyPointLimit.value),
-        cmartHalfPriceEnabled: cmartHalfPriceEnabled.value
+        cmartHalfPriceEnabled: cmartHalfPriceEnabled.value,
+        timeBasedPurchaseLimits
       }
     })
     toast.value = { type: 'ok', msg: 'cMart settings saved.' }

--- a/prisma/migrations/20260521000000_time_based_purchase_limits/migration.sql
+++ b/prisma/migrations/20260521000000_time_based_purchase_limits/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: Add time-based purchase limit override fields to Ctoon
+ALTER TABLE "Ctoon" ADD COLUMN "timeBasedLimitCount" INTEGER;
+ALTER TABLE "Ctoon" ADD COLUMN "timeBasedLimitWindowDays" INTEGER;
+
+-- AlterTable: Add per-rarity time-based purchase limits defaults to GlobalGameConfig
+ALTER TABLE "GlobalGameConfig" ADD COLUMN "timeBasedPurchaseLimits" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -239,6 +239,10 @@ model Ctoon {
   initialReleaseQty Int?
   finalReleaseQty   Int?
 
+  // Time-based release purchase limit overrides (null = use rarity defaults from GlobalGameConfig)
+  timeBasedLimitCount      Int?      // max purchases per user; null = use rarity default
+  timeBasedLimitWindowDays Int?      // rolling window in days; null = use rarity default (falls back to full release duration)
+
   // gToon fields
   isGtoon     Boolean @default(false)
   gtoonType   String?
@@ -929,6 +933,9 @@ model GlobalGameConfig {
   featuredAuctionsPerSlot      Int      @default(1)      // auctions created per slot
   featuredAuctionLastFiredSlot String?                   // idempotency key e.g. "2026-03-30-08"
   cmartHalfPriceEnabled        Boolean  @default(false)   // halves cToon and pack prices in cMart
+  // Per-rarity time-based purchase limits: { "Common": { "count": 5, "windowDays": null }, ... }
+  // windowDays null = full release window (releaseDate → mintEndDate)
+  timeBasedPurchaseLimits      Json?
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 }

--- a/server/api/admin/ctoon.post.js
+++ b/server/api/admin/ctoon.post.js
@@ -54,7 +54,11 @@ export default defineEventHandler(async (event) => {
     initialReleaseAt, finalReleaseAt, initialReleaseQty, finalReleaseQty,
 
     /* Mint limit fields */
-    mintLimitType: mintLimitTypeRaw, mintEndDate: mintEndDateRaw
+    mintLimitType: mintLimitTypeRaw, mintEndDate: mintEndDateRaw,
+
+    /* Time-based purchase limit overrides */
+    timeBasedLimitCount: timeBasedLimitCountRaw,
+    timeBasedLimitWindowDays: timeBasedLimitWindowDaysRaw
   } = fields
 
   if (!name?.trim())   throw createError({ statusCode: 400, statusMessage: 'Name is required.' })
@@ -100,6 +104,8 @@ export default defineEventHandler(async (event) => {
 
   const priceInt = price ? parseInt(price, 10) : 0
   const limitInt = perUserLimit ? parseInt(perUserLimit, 10) : null
+  const timeBasedLimitCountInt      = timeBasedLimitCountRaw      != null && timeBasedLimitCountRaw      !== '' ? parseInt(timeBasedLimitCountRaw,      10) : null
+  const timeBasedLimitWindowDaysInt = timeBasedLimitWindowDaysRaw != null && timeBasedLimitWindowDaysRaw !== '' ? parseInt(timeBasedLimitWindowDaysRaw, 10) : null
   const initialReleaseAtDate = initialReleaseAt ? new Date(initialReleaseAt) : null
   const finalReleaseAtDate   = finalReleaseAt   ? new Date(finalReleaseAt)   : null
   const initialReleaseQtyInt = initialReleaseQty == null || initialReleaseQty === '' ? null : parseInt(initialReleaseQty, 10)
@@ -173,6 +179,8 @@ export default defineEventHandler(async (event) => {
       perUserLimit: limitInt,
       mintLimitType,
       mintEndDate,
+      timeBasedLimitCount:      mintLimitType === 'timeBased' ? timeBasedLimitCountInt      : null,
+      timeBasedLimitWindowDays: mintLimitType === 'timeBased' ? timeBasedLimitWindowDaysInt : null,
       set: setField,
       characters: charactersArr,
       type: type.trim(),

--- a/server/api/admin/ctoon/[id].put.js
+++ b/server/api/admin/ctoon/[id].put.js
@@ -52,7 +52,9 @@ export default defineEventHandler(async (event) => {
     isGtoon, cost, power, abilityKey, abilityData, gtoonType,
     initialReleaseAt, finalReleaseAt, initialReleaseQty, finalReleaseQty,
     clearSound,
-    mintLimitType: mintLimitTypeRaw, mintEndDate: mintEndDateRaw
+    mintLimitType: mintLimitTypeRaw, mintEndDate: mintEndDateRaw,
+    timeBasedLimitCount: timeBasedLimitCountRaw,
+    timeBasedLimitWindowDays: timeBasedLimitWindowDaysRaw
   } = payload
 
   // 4) Validate basics
@@ -148,7 +150,11 @@ export default defineEventHandler(async (event) => {
     initialReleaseAt: initialReleaseAt ? new Date(initialReleaseAt) : null,
     finalReleaseAt:   finalReleaseAt   ? new Date(finalReleaseAt)   : null,
     initialReleaseQty: initialReleaseQty == null || initialReleaseQty === '' ? null : Number(initialReleaseQty),
-    finalReleaseQty:   finalReleaseQty   == null || finalReleaseQty   === '' ? null : Number(finalReleaseQty)
+    finalReleaseQty:   finalReleaseQty   == null || finalReleaseQty   === '' ? null : Number(finalReleaseQty),
+
+    // Time-based purchase limit overrides (only meaningful for timeBased; cleared for defined)
+    timeBasedLimitCount:      mintLimitType === 'timeBased' && timeBasedLimitCountRaw      != null && timeBasedLimitCountRaw      !== '' ? Number(timeBasedLimitCountRaw)      : null,
+    timeBasedLimitWindowDays: mintLimitType === 'timeBased' && timeBasedLimitWindowDaysRaw != null && timeBasedLimitWindowDaysRaw !== '' ? Number(timeBasedLimitWindowDaysRaw) : null
   }
 
   let imageHashData = null
@@ -229,7 +235,8 @@ export default defineEventHandler(async (event) => {
       'name','series','description','rarity','price','releaseDate','perUserLimit','quantity','initialQuantity','inCmart','set','characters',
       'isGtoon','gtoonType','cost','power','abilityKey','abilityData','assetPath','type','soundPath',
       'initialReleaseAt','finalReleaseAt','initialReleaseQty','finalReleaseQty',
-      'mintLimitType','mintEndDate'
+      'mintLimitType','mintEndDate',
+      'timeBasedLimitCount','timeBasedLimitWindowDays'
     ]
     for (const k of keys) {
       const prev = before ? (before[k] instanceof Date ? before[k].toISOString() : (Array.isArray(before[k]) || typeof before[k] === 'object' ? JSON.stringify(before[k]) : before[k])) : undefined

--- a/server/api/admin/global-config.post.js
+++ b/server/api/admin/global-config.post.js
@@ -36,7 +36,8 @@ export default defineEventHandler(async (event) => {
     featuredAuctionHours,
     featuredAuctionIntervalDays,
     featuredAuctionsPerSlot,
-    cmartHalfPriceEnabled
+    cmartHalfPriceEnabled,
+    timeBasedPurchaseLimits
   } = body
 
   // minimally require the existing cap; other fields optional with defaults
@@ -62,7 +63,10 @@ export default defineEventHandler(async (event) => {
       : undefined,
     featuredAuctionIntervalDays: (typeof featuredAuctionIntervalDays === 'number') ? Math.max(1, featuredAuctionIntervalDays) : undefined,
     featuredAuctionsPerSlot: (typeof featuredAuctionsPerSlot === 'number') ? Number(featuredAuctionsPerSlot) : undefined,
-    cmartHalfPriceEnabled: (typeof cmartHalfPriceEnabled === 'boolean') ? cmartHalfPriceEnabled : undefined
+    cmartHalfPriceEnabled: (typeof cmartHalfPriceEnabled === 'boolean') ? cmartHalfPriceEnabled : undefined,
+    timeBasedPurchaseLimits: (timeBasedPurchaseLimits !== undefined && timeBasedPurchaseLimits !== null)
+      ? timeBasedPurchaseLimits
+      : undefined
   }
 
   // 3) Upsert the singleton global config row
@@ -83,7 +87,14 @@ export default defineEventHandler(async (event) => {
         featuredAuctionHours: payload.featuredAuctionHours ?? [],
         featuredAuctionIntervalDays: payload.featuredAuctionIntervalDays ?? 1,
         featuredAuctionsPerSlot: payload.featuredAuctionsPerSlot ?? 1,
-        cmartHalfPriceEnabled: payload.cmartHalfPriceEnabled ?? false
+        cmartHalfPriceEnabled: payload.cmartHalfPriceEnabled ?? false,
+        timeBasedPurchaseLimits: payload.timeBasedPurchaseLimits ?? {
+          'Common':     { count: 5, windowDays: null },
+          'Uncommon':   { count: 4, windowDays: null },
+          'Rare':       { count: 3, windowDays: null },
+          'Very Rare':  { count: 2, windowDays: null },
+          'Crazy Rare': { count: 1, windowDays: null }
+        }
       },
       update: {
         dailyPointLimit: payload.dailyPointLimit,
@@ -98,7 +109,8 @@ export default defineEventHandler(async (event) => {
         ...(payload.featuredAuctionHours !== undefined ? { featuredAuctionHours: payload.featuredAuctionHours } : {}),
         ...(payload.featuredAuctionIntervalDays !== undefined ? { featuredAuctionIntervalDays: payload.featuredAuctionIntervalDays } : {}),
         ...(payload.featuredAuctionsPerSlot !== undefined ? { featuredAuctionsPerSlot: payload.featuredAuctionsPerSlot } : {}),
-        ...(payload.cmartHalfPriceEnabled !== undefined ? { cmartHalfPriceEnabled: payload.cmartHalfPriceEnabled } : {})
+        ...(payload.cmartHalfPriceEnabled !== undefined ? { cmartHalfPriceEnabled: payload.cmartHalfPriceEnabled } : {}),
+        ...(payload.timeBasedPurchaseLimits !== undefined ? { timeBasedPurchaseLimits: payload.timeBasedPurchaseLimits } : {})
       }
     })
     clearUpgradesConfigCache()
@@ -129,6 +141,16 @@ export default defineEventHandler(async (event) => {
           newValue: nextVal
         })
       }
+    }
+    // JSON field: compare by serialized value
+    if (JSON.stringify(before?.timeBasedPurchaseLimits ?? null) !== JSON.stringify(result?.timeBasedPurchaseLimits ?? null)) {
+      await logAdminChange(db, {
+        userId: me.id,
+        area: 'GlobalGameConfig',
+        key: 'timeBasedPurchaseLimits',
+        prevValue: before?.timeBasedPurchaseLimits ?? null,
+        newValue: result?.timeBasedPurchaseLimits ?? null
+      })
     }
     return result
   } catch (err) {

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -81,23 +81,66 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
       throw new Error('Insufficient points')
     }
 
-    // Per-user limit enforcement (first 48h window)
-    if (!isSpecial && ctoon.releaseDate) {
-      const hoursSinceRelease =
-        (Date.now() - new Date(ctoon.releaseDate).getTime()) / (1000 * 60 * 60)
-      const enforceLimit = hoursSinceRelease < 48
-      if (
-        enforceLimit &&
-        ctoon.perUserLimit !== null &&
-        existing >= ctoon.perUserLimit
-      ) {
-        throw new Error(
-          `Purchase limit of ${ctoon.perUserLimit} within first 48h reached`
-        )
+    // Per-user limit enforcement
+    if (!isSpecial) {
+      if (ctoon.mintLimitType === 'timeBased') {
+        // ── Time-based release purchase limits (replaces 48h perUserLimit for this type) ──
+        // Resolve limit: per-cToon override first, then rarity defaults from global config.
+        let limitCount    = ctoon.timeBasedLimitCount    ?? null
+        let windowDays    = ctoon.timeBasedLimitWindowDays ?? null
+
+        if (limitCount === null || windowDays === null) {
+          try {
+            const cfg = await prisma.globalGameConfig.findUnique({ where: { id: 'singleton' } })
+            const rarityLimits = cfg?.timeBasedPurchaseLimits
+            if (rarityLimits && rarityLimits[ctoon.rarity]) {
+              const def = rarityLimits[ctoon.rarity]
+              if (limitCount === null && def.count != null) limitCount = Number(def.count)
+              if (windowDays === null && def.windowDays != null) windowDays = Number(def.windowDays)
+            }
+          } catch {}
+        }
+
+        if (limitCount !== null && limitCount > 0) {
+          // Determine window start:
+          // windowDays > 0 → rolling N-day window; otherwise use full release window (releaseDate → mintEndDate)
+          let windowStart
+          if (windowDays != null && windowDays > 0) {
+            windowStart = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000)
+          } else {
+            // Full release window — count all purchases since releaseDate
+            windowStart = ctoon.releaseDate ? new Date(ctoon.releaseDate) : new Date(0)
+          }
+
+          const purchasesInWindow = await prisma.cmartPurchaseLog.count({
+            where: { userId, ctoonId, createdAt: { gte: windowStart } }
+          })
+
+          if (purchasesInWindow >= limitCount) {
+            const windowDesc = (windowDays != null && windowDays > 0)
+              ? `${windowDays}-day window`
+              : 'this release'
+            throw new Error(`Purchase limit of ${limitCount} for ${windowDesc} reached`)
+          }
+        }
+      } else if (ctoon.releaseDate) {
+        // ── Defined-quantity releases: existing 48-hour perUserLimit ──
+        const hoursSinceRelease =
+          (Date.now() - new Date(ctoon.releaseDate).getTime()) / (1000 * 60 * 60)
+        const enforceLimit = hoursSinceRelease < 48
+        if (
+          enforceLimit &&
+          ctoon.perUserLimit !== null &&
+          existing >= ctoon.perUserLimit
+        ) {
+          throw new Error(
+            `Purchase limit of ${ctoon.perUserLimit} within first 48h reached`
+          )
+        }
+      } else if (ctoon.perUserLimit !== null && existing >= ctoon.perUserLimit) {
+        // Fallback if no releaseDate
+        throw new Error(`Purchase limit of ${ctoon.perUserLimit} reached`)
       }
-    } else if (!isSpecial && ctoon.perUserLimit !== null && existing >= ctoon.perUserLimit) {
-      // Fallback if no releaseDate
-      throw new Error(`Purchase limit of ${ctoon.perUserLimit} reached`)
     }
 
     // Load global settings (for window-aware caps)


### PR DESCRIPTION
## Summary
Implements a new time-based purchase limit system for cToon releases, allowing per-user purchase caps within configurable time windows. This replaces the existing 48-hour `perUserLimit` enforcement for time-based releases with a more flexible rarity-tier-based system.

## Key Changes

### Global Configuration
- Added `timeBasedPurchaseLimits` JSON field to `GlobalGameConfig` storing per-rarity purchase limits and rolling window durations
- Created admin UI in global settings page to configure default limits for each rarity tier (Common, Uncommon, Rare, Very Rare, Crazy Rare)
- Defaults: Common=5, Uncommon=4, Rare=3, Very Rare=2, Crazy Rare=1 purchases per user

### Per-cToon Overrides
- Added `timeBasedLimitCount` and `timeBasedLimitWindowDays` fields to `Ctoon` model for per-release limit overrides
- Updated cToon creation/edit forms (add, edit, bulk-upload) to allow optional override of rarity defaults
- Overrides are only applied when `mintLimitType === 'timeBased'`

### Purchase Enforcement Logic
- Refactored mint worker to distinguish between `timeBased` and `defined` release types
- For time-based releases:
  - Resolves limit from per-cToon override first, then falls back to rarity default from global config
  - Supports rolling N-day windows (when `windowDays > 0`) or full release window (when blank/null)
  - Counts purchases within the window using `cmartPurchaseLog` timestamps
  - Provides user-friendly error messages indicating window type
- Preserves existing 48-hour `perUserLimit` behavior for defined-quantity releases

### UI Enhancements
- Global settings: Desktop table + mobile card layouts for rarity limit configuration
- Per-cToon forms: Indigo-highlighted override section (only visible for time-based releases)
- Clear placeholder text and help text explaining window behavior

### Database
- Added migration creating new columns on `Ctoon` and `GlobalGameConfig` tables
- `timeBasedPurchaseLimits` stored as JSONB for flexible per-rarity configuration

## Implementation Details
- Empty/null window values default to full release window (from `releaseDate` to `mintEndDate`)
- String-to-number conversion with validation (`isNaN` checks) throughout forms
- Admin change logging tracks `timeBasedPurchaseLimits` updates as JSON serialized values
- Backward compatible: existing `perUserLimit` field remains for defined-quantity releases

https://claude.ai/code/session_01K3K3FriuCDm9rt3sZwbAE2