### PR TITLE
Fix badge visibility on AuctionHouse and Trade card views

### DIFF
--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -895,23 +895,23 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
   position: absolute;
   top: 3px;
   left: 3px;
-  font-size: 0.48rem;
+  font-size: 0.55rem;
   font-weight: bold;
-  padding: 1px 4px;
+  padding: 1px 5px;
   border-radius: 3px;
   pointer-events: none;
   white-space: nowrap;
   line-height: 1.4;
 }
 .ah-own-badge--owned {
-  background: rgba(74, 222, 128, 0.25);
-  color: #4ade80;
-  border: 1px solid rgba(74, 222, 128, 0.4);
+  background: #16a34a;
+  color: #fff;
+  border: 1px solid #15803d;
 }
 .ah-own-badge--unowned {
-  background: rgba(156, 163, 175, 0.2);
-  color: #d1d5db;
-  border: 1px solid rgba(156, 163, 175, 0.3);
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.3);
 }
 .ah-card-own-badge {
   position: absolute;

--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -1405,8 +1405,8 @@ onBeforeUnmount(() => {
   position: absolute; top: 4px; right: 4px;
   font-size: 0.52rem; font-weight: bold; padding: 1px 4px; border-radius: 9999px;
 }
-.tm-own-badge.owned { background: rgba(74,222,128,0.2); color: #4ade80; border: 1px solid rgba(74,222,128,0.3); }
-.tm-own-badge.unowned { background: rgba(156,163,175,0.15); color: #9ca3af; border: 1px solid rgba(156,163,175,0.2); }
+.tm-own-badge.owned { background: #16a34a; color: #fff; border: 1px solid #15803d; }
+.tm-own-badge.unowned { background: rgba(0,0,0,0.55); color: rgba(255,255,255,0.9); border: 1px solid rgba(0,0,0,0.3); }
 .tm-card-img { width: 80px; height: 80px; object-fit: contain; margin-top: 14px; }
 .tm-card-name { font-size: 0.65rem; color: white; font-weight: bold; text-align: center; line-height: 1.2; }
 .tm-dim { font-size: 0.6rem; color: rgba(255,255,255,0.45); text-align: center; }


### PR DESCRIPTION
Replace low-opacity semi-transparent badge backgrounds with solid
colors so Owned/Unowned labels are readable against light blue cards:
- Owned: solid green (#16a34a) with white text
- Unowned: dark semi-transparent bg with near-white text

Also bump AH badge font-size from 0.48rem → 0.55rem for legibility.

Matches the pattern already used in Cmart and AllCtoons.