### PR TITLE
Remove lazy loading attribute from czone search item images

### DIFF
--- a/pages/czone/[username].vue
+++ b/pages/czone/[username].vue
@@ -142,7 +142,7 @@
                   :class="{ 'opacity-70 cursor-wait': item.isCapturing }"
                   @click="captureCzoneSearchItem(item)"
                 >
-                  <img :src="item.assetPath" :alt="item.name" class="czone-search-image" loading="lazy" />
+                  <img :src="item.assetPath" :alt="item.name" class="czone-search-image" />
                 </button>
                 <CtoonAsset
                   v-else
@@ -418,7 +418,7 @@
                   :class="{ 'opacity-70 cursor-wait': item.isCapturing }"
                   @click="captureCzoneSearchItem(item)"
                 >
-                  <img :src="item.assetPath" :alt="item.name" class="czone-search-image" loading="lazy" />
+                  <img :src="item.assetPath" :alt="item.name" class="czone-search-image" />
                 </button>
                 <CtoonAsset
                   v-else


### PR DESCRIPTION
## Summary
Removed the `loading="lazy"` attribute from image elements in the czone search results to ensure images load immediately rather than on-demand.

## Changes
- Removed `loading="lazy"` attribute from two `<img>` elements displaying czone search items (lines 145 and 421)
- Images will now load eagerly when the page/section renders instead of waiting for them to enter the viewport

## Details
This change affects the image loading behavior in the czone search results. By removing the lazy loading attribute, images will be fetched and rendered immediately, which may be preferable for this UI component to ensure visual content is available without delay when users interact with the search results.

https://claude.ai/code/session_01GuqouwLbhovLTLNh2bsykg