### PR TITLE
Feat/seed official and one sided trades

### DIFF
--- a/pages/admin/initiate-trade.vue
+++ b/pages/admin/initiate-trade.vue
@@ -84,8 +84,7 @@
             <span class="text-xs text-gray-500">Select one or more</span>
           </div>
           <button
-            class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white disabled:opacity-50"
-            :disabled="!selectedTargetCtoons.length"
+            class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white"
             @click="currentStep = 2"
           >
             Next
@@ -132,8 +131,7 @@
 
         <div class="mt-4 flex justify-end">
           <button
-            class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white disabled:opacity-50"
-            :disabled="!selectedTargetCtoons.length"
+            class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white"
             @click="currentStep = 2"
           >
             Next
@@ -150,7 +148,7 @@
           <div class="flex items-center gap-3">
             <button
               class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white disabled:opacity-50"
-              :disabled="selectedOfficialCtoons.length === 0"
+              :disabled="!hasAnySelection"
               @click="currentStep = 3"
             >
               Confirm Offer
@@ -221,7 +219,7 @@
           <button class="px-3 py-2 rounded border hover:bg-gray-50" @click="currentStep = 1">Back</button>
           <button
             class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white disabled:opacity-50"
-            :disabled="selectedOfficialCtoons.length === 0"
+            :disabled="!hasAnySelection"
             @click="currentStep = 3"
           >
             Confirm Offer
@@ -276,7 +274,7 @@
           <button class="px-3 py-2 rounded border hover:bg-gray-50" @click="currentStep = 2">Back</button>
           <button
             class="px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-700 text-white disabled:opacity-50"
-            :disabled="selectedOfficialCtoons.length === 0 || makingOffer"
+            :disabled="!hasAnySelection || makingOffer"
             @click="sendOffer"
           >
             <span v-if="makingOffer">Making Offer...</span>
@@ -521,6 +519,7 @@ const selectedTargetCtoons = ref([])
 const selectedOfficialCtoons = ref([])
 const selectedTargetCtoonsMap = computed(() => new Set(selectedTargetCtoons.value.map(c => c.id)))
 const selectedOfficialCtoonsMap = computed(() => new Set(selectedOfficialCtoons.value.map(c => c.id)))
+const hasAnySelection = computed(() => selectedTargetCtoons.value.length + selectedOfficialCtoons.value.length > 0)
 
 function toggleTargetCtoon(c) {
   const i = selectedTargetCtoons.value.findIndex(x => x.id === c.id)
@@ -651,7 +650,7 @@ const toast = reactive({ show:false, message:'' })
 
 async function sendOffer() {
   if (!targetUser.value || !officialUser.value) return
-  if (selectedTargetCtoons.value.length === 0 || selectedOfficialCtoons.value.length === 0) return
+  if (!hasAnySelection.value) return
 
   const recipient = targetUser.value.username // capture before any reset
   const payload = {

--- a/prisma/SeedOfficialAccount.js
+++ b/prisma/SeedOfficialAccount.js
@@ -1,0 +1,301 @@
+// prisma/SeedOfficialAccount.js
+// Bootstrap the configured "official" account. Idempotent per-step:
+// re-running the script will skip whatever was already done and resume the rest.
+//
+// Usage: node prisma/SeedOfficialAccount.js
+//
+// Steps:
+//   1. Create a User with the username from OFFICIAL_USERNAME
+//      (defaults to CartoonReOrbitOfficial), flagged as admin + verified.
+//   2. Grant one random active StarterSet (all items minted for free).
+//   3. Set UserPoints to 1,000,000.
+//   4. "Purchase" 10 random cMart cToons (mint + points deduction + purchase log).
+//   5. Pick a random background from public/backgrounds/ and place 5 random
+//      owned cToons onto a single zone of the user's cZone.
+
+import 'dotenv/config'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { randomInt } from 'node:crypto'
+import { prisma } from '../server/prisma.js'
+
+const OFFICIAL_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
+const STARTING_POINTS = 1_000_000
+const CMART_PURCHASE_COUNT = 10
+const CZONE_TOON_COUNT = 5
+const CZONE_PLACEMENT_WIDTH = 700
+const CZONE_PLACEMENT_HEIGHT = 400
+
+function pickRandom(arr) {
+  return arr[randomInt(arr.length)]
+}
+
+function pickUnique(arr, n) {
+  const pool = [...arr]
+  const out = []
+  while (out.length < n && pool.length) {
+    out.push(pool.splice(randomInt(pool.length), 1)[0])
+  }
+  return out
+}
+
+async function ensureOfficialUser() {
+  const existing = await prisma.user.findUnique({
+    where: { username: OFFICIAL_USERNAME },
+    select: { id: true, username: true }
+  })
+  if (existing) {
+    console.log(`[1/5] User "${existing.username}" already exists (${existing.id}) — reusing`)
+    return existing
+  }
+  const user = await prisma.user.create({
+    data: {
+      username: OFFICIAL_USERNAME,
+      discordId: `seed-official-${OFFICIAL_USERNAME}`,
+      isAdmin: true,
+      isVerified: true,
+      inGuild: true,
+      active: true,
+      lastLogin: new Date()
+    },
+    select: { id: true, username: true }
+  })
+  console.log(`[1/5] Created user "${user.username}" (${user.id})`)
+  return user
+}
+
+// Atomic mint mirroring server/workers/mint.worker.js — without the queue,
+// rate-limit, holiday-window, and time-based release machinery (this script
+// runs against pre-filtered, currently-purchasable cToons).
+async function mintCtoonForUser(userId, ctoon, { paid }) {
+  return prisma.$transaction(async (tx) => {
+    const updated = await tx.ctoon.update({
+      where: { id: ctoon.id },
+      data: { totalMinted: { increment: 1 } },
+      select: { totalMinted: true, initialQuantity: true, quantity: true }
+    })
+    const mintNumber = updated.totalMinted
+    if (updated.quantity !== null && mintNumber > updated.quantity) {
+      throw new Error(`cToon "${ctoon.name}" sold out`)
+    }
+    const isFirstEdition =
+      updated.initialQuantity === null || mintNumber <= updated.initialQuantity
+
+    const uc = await tx.userCtoon.create({
+      data: { userId, ctoonId: ctoon.id, mintNumber, isFirstEdition },
+      select: { id: true, mintNumber: true }
+    })
+
+    await tx.ctoonOwnerLog.create({
+      data: { userId, ctoonId: ctoon.id, userCtoonId: uc.id, mintNumber: uc.mintNumber }
+    })
+
+    if (paid) {
+      const updatedPoints = await tx.userPoints.update({
+        where: { userId },
+        data: { points: { decrement: ctoon.price } }
+      })
+      await tx.pointsLog.create({
+        data: {
+          userId,
+          points: ctoon.price,
+          total: updatedPoints.points,
+          method: 'Bought cToon',
+          direction: 'decrease'
+        }
+      })
+      await tx.cmartPurchaseLog.create({
+        data: { userId, ctoonId: ctoon.id }
+      })
+    }
+    return uc
+  })
+}
+
+async function grantRandomStarterSet(userId) {
+  // Idempotency: if the user already owns any UserCtoon at all, assume step 2
+  // ran on a prior invocation (it's the first step that mints, and runs before
+  // any cMart purchases).
+  const existing = await prisma.userCtoon.count({ where: { userId } })
+  if (existing > 0) {
+    console.log(`[2/5] User already owns ${existing} cToon(s) — skipping starter set`)
+    return
+  }
+  const sets = await prisma.starterSet.findMany({
+    where: { isActive: true },
+    include: { items: { include: { ctoon: true } } }
+  })
+  const eligible = sets.filter(s => s.items.length > 0)
+  if (!eligible.length) {
+    console.warn('[2/5] No active starter sets with items found; skipping')
+    return
+  }
+  const set = pickRandom(eligible)
+  console.log(`[2/5] Granting starter set "${set.name}" (${set.items.length} cToons)`)
+  for (const item of set.items) {
+    await mintCtoonForUser(userId, item.ctoon, { paid: false })
+  }
+}
+
+async function setUserPoints(userId, points) {
+  // Idempotency: if a UserPoints row already exists, leave the current balance
+  // alone (don't overwrite the user's actual remaining points).
+  const existing = await prisma.userPoints.findUnique({ where: { userId } })
+  if (existing) {
+    console.log(`[3/5] UserPoints already exists (${existing.points.toLocaleString()}pt) — skipping`)
+    return
+  }
+  await prisma.userPoints.create({ data: { userId, points } })
+  console.log(`[3/5] Set points to ${points.toLocaleString()}`)
+}
+
+async function purchaseCmartCtoons(userId) {
+  // Idempotency: only buy as many as needed to reach CMART_PURCHASE_COUNT total.
+  const alreadyPurchased = await prisma.cmartPurchaseLog.count({ where: { userId } })
+  const remaining = CMART_PURCHASE_COUNT - alreadyPurchased
+  if (remaining <= 0) {
+    console.log(`[4/5] Already purchased ${alreadyPurchased} cMart cToon(s) — skipping`)
+    return
+  }
+  if (alreadyPurchased > 0) {
+    console.log(`[4/5] Already purchased ${alreadyPurchased}, will buy ${remaining} more`)
+  }
+
+  // Exclude ctoons the user already owns to avoid hitting per-user limits.
+  const ownedCtoonIds = (await prisma.userCtoon.findMany({
+    where: { userId },
+    select: { ctoonId: true },
+    distinct: ['ctoonId']
+  })).map(r => r.ctoonId)
+
+  const now = new Date()
+  const candidates = await prisma.ctoon.findMany({
+    where: {
+      inCmart: true,
+      codeOnly: false,
+      releaseDate: { lte: now },
+      holidayItems: { none: {} },
+      id: { notIn: ownedCtoonIds }
+    },
+    select: {
+      id: true, name: true, price: true,
+      quantity: true, initialQuantity: true, totalMinted: true,
+      perUserLimit: true
+    }
+  })
+  const available = candidates.filter(c =>
+    c.quantity === null || c.totalMinted < c.quantity
+  )
+  if (!available.length) {
+    console.warn('[4/5] No eligible cMart cToons available; skipping')
+    return
+  }
+  if (available.length < remaining) {
+    console.warn(
+      `[4/5] Only ${available.length} eligible cMart cToons available; ` +
+      `will purchase as many as possible.`
+    )
+  }
+  const picked = pickUnique(available, Math.min(remaining, available.length))
+  console.log(`[4/5] Purchasing ${picked.length} cToons from cMart…`)
+  for (const c of picked) {
+    await mintCtoonForUser(userId, c, { paid: true })
+    console.log(`        • ${c.name} (-${c.price}pt)`)
+  }
+}
+
+function zoneHasToons(layoutData) {
+  return (
+    layoutData &&
+    typeof layoutData === 'object' &&
+    Array.isArray(layoutData.zones) &&
+    layoutData.zones.some(z => Array.isArray(z.toons) && z.toons.length > 0)
+  )
+}
+
+async function buildCzone(userId) {
+  // Idempotency: if a CZone row already exists with any placed toons, skip.
+  const existing = await prisma.cZone.findUnique({ where: { userId } })
+  if (existing && zoneHasToons(existing.layoutData)) {
+    console.log('[5/5] cZone already has placed toons — skipping')
+    return
+  }
+
+  const backgroundsDir = path.join(process.cwd(), 'public', 'backgrounds')
+  let backgrounds
+  try {
+    const files = await fs.readdir(backgroundsDir)
+    backgrounds = files.filter(f => /\.(png|jpe?g|gif|webp)$/i.test(f))
+  } catch (e) {
+    console.warn(`[5/5] Could not read ${backgroundsDir}: ${e.message}; skipping cZone`)
+    return
+  }
+  if (!backgrounds.length) {
+    console.warn('[5/5] No background files found; skipping cZone')
+    return
+  }
+  const chosenBackground = pickRandom(backgrounds)
+
+  const owned = await prisma.userCtoon.findMany({
+    where: { userId, burnedAt: null },
+    include: { ctoon: true }
+  })
+  if (!owned.length) {
+    console.warn('[5/5] User owns no cToons; skipping cZone placement')
+    return
+  }
+  const placed = pickUnique(owned, Math.min(CZONE_TOON_COUNT, owned.length))
+
+  const toons = placed.map(uc => ({
+    id: uc.id,
+    x: randomInt(CZONE_PLACEMENT_WIDTH),
+    y: randomInt(CZONE_PLACEMENT_HEIGHT),
+    mintNumber: uc.mintNumber,
+    name: uc.ctoon.name,
+    assetPath: uc.ctoon.assetPath,
+    series: uc.ctoon.series,
+    set: uc.ctoon.set,
+    rarity: uc.ctoon.rarity,
+    releaseDate: uc.ctoon.releaseDate,
+    isGtoon: uc.ctoon.isGtoon,
+    cost: uc.ctoon.cost,
+    power: uc.ctoon.power,
+    quantity: uc.ctoon.quantity,
+    isFirstEdition: uc.isFirstEdition,
+    characters: Array.isArray(uc.ctoon.characters) ? uc.ctoon.characters : []
+  }))
+
+  const config = await prisma.globalGameConfig.findUnique({
+    where: { id: 'singleton' },
+    select: { czoneCount: true }
+  })
+  const totalZones = Math.max(1, Number(config?.czoneCount ?? 3))
+  const zones = [{ background: chosenBackground, toons }]
+  while (zones.length < totalZones) zones.push({ background: '', toons: [] })
+
+  await prisma.cZone.upsert({
+    where: { userId },
+    update: { layoutData: { zones }, background: chosenBackground },
+    create: { userId, layoutData: { zones }, background: chosenBackground }
+  })
+  console.log(
+    `[5/5] Placed ${toons.length} cToons on cZone with background "${chosenBackground}"`
+  )
+}
+
+async function main() {
+  console.log(`Seeding official account "${OFFICIAL_USERNAME}"…`)
+  const user = await ensureOfficialUser()
+  await grantRandomStarterSet(user.id)
+  await setUserPoints(user.id, STARTING_POINTS)
+  await purchaseCmartCtoons(user.id)
+  await buildCzone(user.id)
+  console.log(`✅ Done seeding "${user.username}"`)
+}
+
+main()
+  .catch((e) => {
+    console.error('❌ Error:', e)
+    process.exit(1)
+  })
+  .finally(() => {})

--- a/prisma/migrations/20260330000000_featured_auction_schedule/migration.sql
+++ b/prisma/migrations/20260330000000_featured_auction_schedule/migration.sql
@@ -6,4 +6,4 @@ ALTER TABLE "GlobalGameConfig"
   ADD COLUMN "featuredAuctionLastFiredSlot" TEXT;
 
 ALTER TABLE "GlobalGameConfig"
-  DROP COLUMN "featuredAuctionsPerDay";
+  DROP COLUMN IF EXISTS "featuredAuctionsPerDay";

--- a/server/api/admin/trade-offers.post.js
+++ b/server/api/admin/trade-offers.post.js
@@ -6,6 +6,11 @@ import {
   createError
 } from 'h3'
 import { prisma } from '@/server/prisma'
+import { isSyntheticUserCtoonId, resolveUserCtoonId } from '@/server/utils/userCtoonId'
+
+async function resolveIds(ids) {
+  return Promise.all(ids.map(id => isSyntheticUserCtoonId(id) ? resolveUserCtoonId(id) : id))
+}
 
 export default defineEventHandler(async (event) => {
   // 1) Admin check
@@ -49,6 +54,9 @@ export default defineEventHandler(async (event) => {
   if (Number(pointsOffered) > 0) {
     throw createError({ statusCode: 400, statusMessage: 'Points are not supported for admin-initiated trades.' })
   }
+  if (ctoonIdsOffered.length + ctoonIdsRequested.length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Trade must include at least one cToon.' })
+  }
 
   // 4) Lookup recipient & ensure not the official account
   const recipient = await prisma.user.findUnique({
@@ -65,13 +73,25 @@ export default defineEventHandler(async (event) => {
     console.warn(`Cannot DM ${recipientUsername}: no discordId on record`)
   }
 
+  // 4a) Resolve synthetic UserCtoon IDs (uc|userId|ctoonId|mint) returned by
+  // /api/collection/[username] into real DB UUIDs. /api/admin/official-collection
+  // already returns real UUIDs, so non-synthetic inputs pass through.
+  const resolvedOffered = await resolveIds(ctoonIdsOffered)
+  const resolvedRequested = await resolveIds(ctoonIdsRequested)
+  if (resolvedOffered.some(id => !id) || resolvedRequested.some(id => !id)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'One or more cToons could not be resolved (may have been traded, burned, or moved).'
+    })
+  }
+
   // 5) Verify ownership of offered cToons (official account)
-  if (ctoonIdsOffered.length) {
+  if (resolvedOffered.length) {
     const ownedByOfficial = await prisma.userCtoon.findMany({
-      where: { id: { in: ctoonIdsOffered }, userId: official.id },
+      where: { id: { in: resolvedOffered }, userId: official.id },
       select: { id: true }
     })
-    if (ownedByOfficial.length !== ctoonIdsOffered.length) {
+    if (ownedByOfficial.length !== resolvedOffered.length) {
       throw createError({
         statusCode: 400,
         statusMessage: 'One or more offered cToons are not owned by the official account or no longer available'
@@ -80,12 +100,12 @@ export default defineEventHandler(async (event) => {
   }
 
   // 6) Verify ownership of requested cToons (recipient)
-  if (ctoonIdsRequested.length) {
+  if (resolvedRequested.length) {
     const ownedByRecipient = await prisma.userCtoon.findMany({
-      where: { id: { in: ctoonIdsRequested }, userId: recipient.id },
+      where: { id: { in: resolvedRequested }, userId: recipient.id },
       select: { id: true }
     })
-    if (ownedByRecipient.length !== ctoonIdsRequested.length) {
+    if (ownedByRecipient.length !== resolvedRequested.length) {
       throw createError({
         statusCode: 400,
         statusMessage: 'One or more requested cToons are not owned by the recipient or no longer available'
@@ -94,9 +114,9 @@ export default defineEventHandler(async (event) => {
   }
 
   // 7) Prevent trades involving cToons in active auctions
-  if (ctoonIdsOffered.length) {
+  if (resolvedOffered.length) {
     const offeredActiveAuction = await prisma.auction.findFirst({
-      where: { userCtoonId: { in: ctoonIdsOffered }, status: 'ACTIVE' },
+      where: { userCtoonId: { in: resolvedOffered }, status: 'ACTIVE' },
       select: { id: true }
     })
     if (offeredActiveAuction) {
@@ -106,9 +126,9 @@ export default defineEventHandler(async (event) => {
       })
     }
   }
-  if (ctoonIdsRequested.length) {
+  if (resolvedRequested.length) {
     const requestedActiveAuction = await prisma.auction.findFirst({
-      where: { userCtoonId: { in: ctoonIdsRequested }, status: 'ACTIVE' },
+      where: { userCtoonId: { in: resolvedRequested }, status: 'ACTIVE' },
       select: { id: true }
     })
     if (requestedActiveAuction) {
@@ -128,8 +148,8 @@ export default defineEventHandler(async (event) => {
         pointsOffered: 0,
         ctoons: {
           create: [
-            ...ctoonIdsOffered.map(id => ({ userCtoonId: id, role: 'OFFERED' })),
-            ...ctoonIdsRequested.map(id => ({ userCtoonId: id, role: 'REQUESTED' }))
+            ...resolvedOffered.map(id => ({ userCtoonId: id, role: 'OFFERED' })),
+            ...resolvedRequested.map(id => ({ userCtoonId: id, role: 'REQUESTED' }))
           ]
         }
       },


### PR DESCRIPTION
Added an admin tool to seed and emulate an "CartoonReorbitOffical" account in dev.

Fixed a bug that currently does not allow the admin initiate trade function to work. Trades can now go through with ReorbitOfficial.

Additially allowed the admin initiate trade function to operate one sided, where one account does not have to offer a ctoon. Previously required both sides to offer at least one toon 