### PR TITLE
Improve auction and trade UI with bid status badges and interactions

### DIFF
--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -89,7 +89,6 @@
             <div v-if="activeTab === 'mybids'" class="ah-bid-val">My: {{ item.myBid != null ? item.myBid + ' pts' : '—' }}</div>
             <div class="ah-bid-label">{{ Number(item.bidCount ?? 0) > 0 ? 'Current:' : 'Start:' }}</div>
             <div class="ah-bid-val">{{ Number(item.bidCount ?? 0) > 0 ? formatHighestBid(item) : (item.initialBid != null ? item.initialBid + ' pts' : '—') }}</div>
-            <div class="ah-bid-ct">{{ item.bidCount ?? 0 }} bid{{ item.bidCount !== 1 ? 's' : '' }}</div>
           </div>
 
           <!-- Time -->
@@ -553,8 +552,11 @@ function formatRemaining(endAt) {
 }
 
 function formatHighestBid(item) {
-  if (Number(item?.bidCount ?? 0) < 1) return 'No bids'
-  return item?.highestBid != null ? `${item.highestBid} pts` : 'No bids'
+  const count = Number(item?.bidCount ?? 0)
+  if (count < 1) return 'No bids'
+  const bid = item?.highestBid ?? item?.winningBid
+  if (bid == null) return 'No bids'
+  return `${bid} pts (${count} bid${count !== 1 ? 's' : ''})`
 }
 
 const RARITY_MAP = {

--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -136,6 +136,16 @@
                 class="ah-own-badge ah-card-own-badge"
                 :class="item.isOwned ? 'ah-own-badge--owned' : 'ah-own-badge--unowned'"
               >{{ item.isOwned ? 'Owned' : 'Unowned' }}</span>
+              <span
+                v-else-if="activeTab === 'mybids' && isEnded(item.endAt)"
+                class="ah-own-badge ah-card-own-badge"
+                :class="item.didWin ? 'ah-own-badge--won' : 'ah-own-badge--lost'"
+              >{{ item.didWin ? 'Won' : 'Lost' }}</span>
+              <span
+                v-else-if="activeTab === 'mybids'"
+                class="ah-own-badge ah-card-own-badge"
+                :class="item.myBid != null && item.myBid === item.highestBid ? 'ah-own-badge--won' : 'ah-own-badge--lost'"
+              >{{ item.myBid != null && item.myBid === item.highestBid ? 'Winning' : 'Losing' }}</span>
             </div>
           </template>
           <template #middle>
@@ -914,6 +924,16 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
   background: rgba(0, 0, 0, 0.55);
   color: rgba(255, 255, 255, 0.9);
   border: 1px solid rgba(0, 0, 0, 0.3);
+}
+.ah-own-badge--won {
+  background: #16a34a;
+  color: #fff;
+  border: 1px solid #15803d;
+}
+.ah-own-badge--lost {
+  background: #dc2626;
+  color: #fff;
+  border: 1px solid #b91c1c;
 }
 .ah-card-own-badge {
   position: absolute;

--- a/components/newsite/MyCollection.vue
+++ b/components/newsite/MyCollection.vue
@@ -249,7 +249,7 @@ onMounted(async () => {
   scrollbar-width: thin;
   scrollbar-color: var(--OrbitLightBlue) transparent;
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   grid-auto-rows: var(--shortcard-height);
   grid-auto-flow: row;
   gap: 4px;

--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -402,7 +402,7 @@
                     <span class="tm-own-badge" :class="selfOwnedIdsModal.has(tc.userCtoon.ctoonId) ? 'owned' : 'unowned'">
                       {{ selfOwnedIdsModal.has(tc.userCtoon.ctoonId) ? 'Owned' : 'Unowned' }}
                     </span>
-                    <img :src="tc.userCtoon.ctoon.assetPath" class="tm-card-img" />
+                    <img :src="tc.userCtoon.ctoon.assetPath" class="tm-card-img" @click="openTradeCToon(tc)" />
                     <span class="tm-card-name">{{ tc.userCtoon.ctoon.name }}</span>
                     <span class="tm-dim">{{ tc.userCtoon.ctoon.rarity }}</span>
                     <span class="tm-dim">Mint #{{ tc.userCtoon.mintNumber }} of {{ formatQuantity(tc.userCtoon.ctoon.quantity) }}</span>
@@ -423,7 +423,7 @@
                     <span class="tm-own-badge" :class="selfOwnedIdsModal.has(tc.userCtoon.ctoonId) ? 'owned' : 'unowned'">
                       {{ selfOwnedIdsModal.has(tc.userCtoon.ctoonId) ? 'Owned' : 'Unowned' }}
                     </span>
-                    <img :src="tc.userCtoon.ctoon.assetPath" class="tm-card-img" />
+                    <img :src="tc.userCtoon.ctoon.assetPath" class="tm-card-img" @click="openTradeCToon(tc)" />
                     <span class="tm-card-name">{{ tc.userCtoon.ctoon.name }}</span>
                     <span class="tm-dim">{{ tc.userCtoon.ctoon.rarity }}</span>
                     <span class="tm-dim">Mint #{{ tc.userCtoon.mintNumber }} of {{ formatQuantity(tc.userCtoon.ctoon.quantity) }}</span>
@@ -489,6 +489,15 @@ import CtoonCard from '@/components/trade/CtoonCard.vue'
 
 const route = useRoute()
 const { user, fetchSelf } = useAuth()
+const { open: openCtoonModal } = useCtoonModal()
+
+function openTradeCToon(tc) {
+  openCtoonModal({
+    userCtoonId: tc.userCtoon.id,
+    assetPath:   tc.userCtoon.ctoon.assetPath,
+    name:        tc.userCtoon.ctoon.name,
+  })
+}
 
 const {
   tradeActiveTab,
@@ -1407,7 +1416,8 @@ onBeforeUnmount(() => {
 }
 .tm-own-badge.owned { background: #16a34a; color: #fff; border: 1px solid #15803d; }
 .tm-own-badge.unowned { background: rgba(0,0,0,0.55); color: rgba(255,255,255,0.9); border: 1px solid rgba(0,0,0,0.3); }
-.tm-card-img { width: 80px; height: 80px; object-fit: contain; margin-top: 14px; }
+.tm-card-img { width: 80px; height: 80px; object-fit: contain; margin-top: 14px; cursor: pointer; transition: opacity 0.15s; }
+.tm-card-img:hover { opacity: 0.8; }
 .tm-card-name { font-size: 0.65rem; color: white; font-weight: bold; text-align: center; line-height: 1.2; }
 .tm-dim { font-size: 0.6rem; color: rgba(255,255,255,0.45); text-align: center; }
 .tm-own-stats {

--- a/server/api/my-auctions.get.js
+++ b/server/api/my-auctions.get.js
@@ -194,6 +194,7 @@ export default defineEventHandler(async (event) => {
     createdAt:        a.createdAt.toISOString(),
     endAt:            a.endAt.toISOString(),      // <— new
     initialBid:       a.initialBet,
+    highestBid:       a.bids[0]?.amount ?? null,
     winningBid:       a.bids[0]?.amount ?? null,
     winningBidder:    a.bids[0]?.user.username ?? null,
     bidCount:         a._count?.bids ?? 0,


### PR DESCRIPTION
## Summary
This PR enhances the auction house and trade components with better visual feedback for bid status, improved bid information display, and interactive card viewing in trades.

## Key Changes

**Auction House (AuctionHouse.vue)**
- Removed redundant bid count display from the bid section
- Enhanced `formatHighestBid()` to include bid count in the formatted output (e.g., "100 pts (5 bids)")
- Added status badges for "My Bids" tab showing:
  - "Won" / "Lost" for completed auctions (when `isEnded()` is true)
  - "Winning" / "Losing" for active auctions based on whether user's bid matches highest bid
- Added new CSS classes for won/lost badge styling (green for won, red for lost)

**Trade Component (Trade.vue)**
- Made trade card images clickable to open a detailed card modal
- Added `openTradeCToon()` function to handle card image clicks and open the ctoon modal with relevant details
- Enhanced card image styling with cursor pointer and hover opacity effect for better UX

**My Collection (MyCollection.vue)**
- Adjusted grid layout from 6 columns to 5 columns for better card display

**API Endpoint (my-auctions.get.js)**
- Added `highestBid` field to auction response (mirrors `winningBid` from first bid amount)
- Maintains backward compatibility with existing `winningBid` field

## Implementation Details
- The bid status badges intelligently show different information based on auction state and active tab
- The trade card modal integration reuses existing `useCtoonModal()` composable
- Styling uses consistent color scheme (green #16a34a for won, red #dc2626 for lost)

https://claude.ai/code/session_01Xp8HRBZLgTz6o7expj8s8p