### PR TITLE
Add OFFICIAL_USERNAME environment variable to PM2 configs

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -26,8 +26,9 @@
 // Load .env so NUXT_PORT / SOCKET_PORT are available at config-parse time
 require('dotenv').config()
 
-const NUXT_PORT   = process.env.NUXT_PORT   || '3000'
-const SOCKET_PORT = process.env.SOCKET_PORT || '3001'
+const NUXT_PORT        = process.env.NUXT_PORT   || '3000'
+const SOCKET_PORT      = process.env.SOCKET_PORT || '3001'
+const OFFICIAL_USERNAME = 'UmbraRobotTycoon'
 
 const DIAG_ENV = {
   DIAG_ENABLED:           '0',
@@ -63,10 +64,11 @@ module.exports = {
         ...DIAG_ENV,
       },
       env_development: {
-        NODE_ENV:      'production',
-        NITRO_PORT:    NUXT_PORT,
-        NUXT_PORT:     NUXT_PORT,
-        TKO_PASSCODE:  process.env.TKO_PASSCODE,
+        NODE_ENV:        'production',
+        NITRO_PORT:      NUXT_PORT,
+        NUXT_PORT:       NUXT_PORT,
+        TKO_PASSCODE:    process.env.TKO_PASSCODE,
+        OFFICIAL_USERNAME,
         ...DIAG_ENV,
       },
     },
@@ -90,8 +92,9 @@ module.exports = {
         ...DIAG_ENV,
       },
       env_development: {
-        NODE_ENV:    'production',
-        SOCKET_PORT: SOCKET_PORT,
+        NODE_ENV:        'production',
+        SOCKET_PORT:     SOCKET_PORT,
+        OFFICIAL_USERNAME,
         ...DIAG_ENV,
       },
     },
@@ -103,7 +106,7 @@ module.exports = {
       exec_mode: 'fork',
       instances: 1,
       env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development' },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── BullMQ worker: time-based mint window closure ───────────────────────
@@ -113,7 +116,7 @@ module.exports = {
       exec_mode: 'fork',
       instances: 1,
       env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development' },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── BullMQ worker: account dissolution ────────────────────────────────
@@ -123,7 +126,7 @@ module.exports = {
       exec_mode: 'fork',
       instances: 1,
       env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development' },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── BullMQ worker: dissolve auction launch ────────────────────────────
@@ -133,7 +136,7 @@ module.exports = {
       exec_mode: 'fork',
       instances: 1,
       env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development' },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── BullMQ worker: daily achievements ─────────────────────────────────
@@ -143,7 +146,7 @@ module.exports = {
       exec_mode: 'fork',
       instances: 1,
       env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development' },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── Cron: Discord guild member sync ───────────────────────────────────
@@ -153,7 +156,7 @@ module.exports = {
       exec_mode: 'fork',
       instances: 1,
       env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development' },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
   ],
 }

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -28,8 +28,8 @@ require('dotenv').config()
 
 const NUXT_PORT             = process.env.NUXT_PORT   || '3000'
 const SOCKET_PORT           = process.env.SOCKET_PORT || '3001'
-const OFFICIAL_USERNAME_PROD = 'CartoonReOrbitOfficial'
-const OFFICIAL_USERNAME_DEV  = 'UmbraRobotTycoon'
+const OFFICIAL_USERNAME_PROD = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
+const OFFICIAL_USERNAME_DEV  = process.env.OFFICIAL_USERNAME || 'UmbraRobotTycoon'
 
 const DIAG_ENV = {
   DIAG_ENABLED:           '0',

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -26,9 +26,10 @@
 // Load .env so NUXT_PORT / SOCKET_PORT are available at config-parse time
 require('dotenv').config()
 
-const NUXT_PORT        = process.env.NUXT_PORT   || '3000'
-const SOCKET_PORT      = process.env.SOCKET_PORT || '3001'
-const OFFICIAL_USERNAME = 'UmbraRobotTycoon'
+const NUXT_PORT             = process.env.NUXT_PORT   || '3000'
+const SOCKET_PORT           = process.env.SOCKET_PORT || '3001'
+const OFFICIAL_USERNAME_PROD = 'CartoonReOrbitOfficial'
+const OFFICIAL_USERNAME_DEV  = 'UmbraRobotTycoon'
 
 const DIAG_ENV = {
   DIAG_ENABLED:           '0',
@@ -57,18 +58,19 @@ module.exports = {
       node_args:          '--max-old-space-size=2048',
       max_memory_restart: '2G',
       env: {
-        NODE_ENV:      'production',
-        NITRO_PORT:    NUXT_PORT,
-        NUXT_PORT:     NUXT_PORT,
-        TKO_PASSCODE:  process.env.TKO_PASSCODE,
+        NODE_ENV:         'production',
+        NITRO_PORT:       NUXT_PORT,
+        NUXT_PORT:        NUXT_PORT,
+        TKO_PASSCODE:     process.env.TKO_PASSCODE,
+        OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD,
         ...DIAG_ENV,
       },
       env_development: {
-        NODE_ENV:        'production',
-        NITRO_PORT:      NUXT_PORT,
-        NUXT_PORT:       NUXT_PORT,
-        TKO_PASSCODE:    process.env.TKO_PASSCODE,
-        OFFICIAL_USERNAME,
+        NODE_ENV:         'production',
+        NITRO_PORT:       NUXT_PORT,
+        NUXT_PORT:        NUXT_PORT,
+        TKO_PASSCODE:     process.env.TKO_PASSCODE,
+        OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV,
         ...DIAG_ENV,
       },
     },
@@ -87,14 +89,15 @@ module.exports = {
       node_args:          '--max-old-space-size=2048',
       max_memory_restart: '2G',
       env: {
-        NODE_ENV:    'production',
-        SOCKET_PORT: SOCKET_PORT,
+        NODE_ENV:         'production',
+        SOCKET_PORT:      SOCKET_PORT,
+        OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD,
         ...DIAG_ENV,
       },
       env_development: {
-        NODE_ENV:        'production',
-        SOCKET_PORT:     SOCKET_PORT,
-        OFFICIAL_USERNAME,
+        NODE_ENV:         'production',
+        SOCKET_PORT:      SOCKET_PORT,
+        OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV,
         ...DIAG_ENV,
       },
     },
@@ -105,8 +108,8 @@ module.exports = {
       script:    'server/workers/mint.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
+      env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
     },
 
     // ── BullMQ worker: time-based mint window closure ───────────────────────
@@ -115,8 +118,8 @@ module.exports = {
       script:    'server/workers/mint-end.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
+      env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
     },
 
     // ── BullMQ worker: account dissolution ────────────────────────────────
@@ -125,8 +128,8 @@ module.exports = {
       script:    'server/workers/dissolve.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
+      env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
     },
 
     // ── BullMQ worker: dissolve auction launch ────────────────────────────
@@ -135,8 +138,8 @@ module.exports = {
       script:    'server/workers/dissolve-auction-launch.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
+      env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
     },
 
     // ── BullMQ worker: daily achievements ─────────────────────────────────
@@ -145,8 +148,8 @@ module.exports = {
       script:    'server/workers/achievements.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
+      env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
     },
 
     // ── Cron: Discord guild member sync ───────────────────────────────────
@@ -155,8 +158,8 @@ module.exports = {
       script:    'server/cron/sync-guild-members.js',
       exec_mode: 'fork',
       instances: 1,
-      env:             { NODE_ENV: 'production' },
-      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME },
+      env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
     },
   ],
 }

--- a/ecosystem.dev.config.cjs
+++ b/ecosystem.dev.config.cjs
@@ -2,8 +2,9 @@
 
 require('dotenv').config()
 
-const NUXT_PORT   = process.env.NUXT_PORT   || '3000'
-const SOCKET_PORT = process.env.SOCKET_PORT || '3001'
+const NUXT_PORT        = process.env.NUXT_PORT   || '3000'
+const SOCKET_PORT      = process.env.SOCKET_PORT || '3001'
+const OFFICIAL_USERNAME = 'UmbraRobotTycoon'
 
 /**
  * PM2 ecosystem file — cartoon-reorbit (DEVELOPMENT)
@@ -26,9 +27,10 @@ module.exports = {
       exec_mode: 'fork',
       instances: 1,
       env: {
-        NODE_ENV:   'development',
-        NITRO_PORT: NUXT_PORT,
-        NUXT_PORT:  NUXT_PORT,
+        NODE_ENV:        'development',
+        NITRO_PORT:      NUXT_PORT,
+        NUXT_PORT:       NUXT_PORT,
+        OFFICIAL_USERNAME,
       },
     },
 
@@ -39,8 +41,9 @@ module.exports = {
       exec_mode: 'fork',
       instances: 1,
       env: {
-        NODE_ENV:    'development',
-        SOCKET_PORT: SOCKET_PORT,
+        NODE_ENV:        'development',
+        SOCKET_PORT:     SOCKET_PORT,
+        OFFICIAL_USERNAME,
       },
     },
 
@@ -50,7 +53,7 @@ module.exports = {
       script:    'server/workers/mint.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env: { NODE_ENV: 'development' },
+      env: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── BullMQ worker: account dissolution ────────────────────────────────
@@ -59,7 +62,7 @@ module.exports = {
       script:    'server/workers/dissolve.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env: { NODE_ENV: 'development' },
+      env: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── BullMQ worker: dissolve auction launch ────────────────────────────
@@ -68,7 +71,7 @@ module.exports = {
       script:    'server/workers/dissolve-auction-launch.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env: { NODE_ENV: 'development' },
+      env: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── BullMQ worker: daily achievements ─────────────────────────────────
@@ -77,7 +80,7 @@ module.exports = {
       script:    'server/workers/achievements.worker.js',
       exec_mode: 'fork',
       instances: 1,
-      env: { NODE_ENV: 'development' },
+      env: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
 
     // ── Cron: Discord guild member sync ───────────────────────────────────
@@ -86,7 +89,7 @@ module.exports = {
       script:    'server/cron/sync-guild-members.js',
       exec_mode: 'fork',
       instances: 1,
-      env: { NODE_ENV: 'development' },
+      env: { NODE_ENV: 'development', OFFICIAL_USERNAME },
     },
   ],
 }

--- a/ecosystem.dev.config.cjs
+++ b/ecosystem.dev.config.cjs
@@ -4,7 +4,7 @@ require('dotenv').config()
 
 const NUXT_PORT        = process.env.NUXT_PORT   || '3000'
 const SOCKET_PORT      = process.env.SOCKET_PORT || '3001'
-const OFFICIAL_USERNAME = 'UmbraRobotTycoon'
+const OFFICIAL_USERNAME = process.env.OFFICIAL_USERNAME || 'UmbraRobotTycoon'
 
 /**
  * PM2 ecosystem file — cartoon-reorbit (DEVELOPMENT)


### PR DESCRIPTION
## Summary
This PR adds support for an `OFFICIAL_USERNAME` environment variable across all PM2-managed processes, with different values for production and development environments.

## Key Changes
- Added two new constants to `ecosystem.config.cjs`:
  - `OFFICIAL_USERNAME_PROD = 'CartoonReOrbitOfficial'` (production)
  - `OFFICIAL_USERNAME_DEV = 'UmbraRobotTycoon'` (development)
- Added `OFFICIAL_USERNAME` constant to `ecosystem.dev.config.cjs` set to `'UmbraRobotTycoon'`
- Injected `OFFICIAL_USERNAME` environment variable into all PM2 app configurations:
  - Nuxt server (main app)
  - Socket server
  - All BullMQ workers (mint, mint-end, dissolve, dissolve-auction-launch, achievements)
  - All cron jobs (sync-guild-members)
- Aligned environment variable declarations for improved readability and consistency across both config files

## Implementation Details
- Production and development environments use different official usernames to distinguish between the official accounts in each environment
- The variable is consistently passed to all server processes, workers, and cron jobs
- Code formatting was improved to align variable assignments for better maintainability

https://claude.ai/code/session_01KGvtH8ix3aRx9G6vq57iyJ