### PR TITLE
Add gToons/Wishlist/Owned filters to cmart sidebar

### DIFF
--- a/components/newsite/AuctionHouseSidebar.vue
+++ b/components/newsite/AuctionHouseSidebar.vue
@@ -3,6 +3,7 @@
     :sort-options="auctionSortOptions"
     :show-sort-dir="false"
     :show-auction-filters="true"
+    :show-common-filters="true"
   />
 </template>
 

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -248,6 +248,21 @@ const loading    = ref(true)
 const buyingIds  = ref([])
 const cmartEl    = ref(null)
 const filter     = useNewSiteCtoonFilter()
+const aFilters   = useAuctionHouseFilters()
+
+// Lazily loaded list of ctoonIds the user has wishlisted (for the Wishlist pill)
+const wishlistCtoonIds = ref([])
+let wishlistLoaded = false
+async function loadWishlist() {
+  if (wishlistLoaded) return
+  try {
+    const items = await $fetch('/api/wishlist')
+    wishlistCtoonIds.value = Array.isArray(items) ? items.map(i => i?.id).filter(Boolean) : []
+  } finally {
+    wishlistLoaded = true
+  }
+}
+watch(() => aFilters.value.wishlistOnly, val => { if (val) loadWishlist() })
 
 // ── Half-price setting ─────────────────────────────────────────
 const cmartHalfPriceEnabled = ref(false)
@@ -391,6 +406,19 @@ const ctoons = computed(() => {
 
   if (f.hideUnavailable)
     list = list.filter(c => !c.nextReleaseAt && !(c.quantity != null && c.totalMinted >= c.quantity))
+
+  if (aFilters.value.gtoonsOnly)
+    list = list.filter(c => c.isGtoon)
+
+  if (aFilters.value.wishlistOnly) {
+    const wishSet = new Set(wishlistCtoonIds.value)
+    list = list.filter(c => wishSet.has(c.id))
+  }
+
+  if (aFilters.value.selectedOwned === 'owned')
+    list = list.filter(c => originalOwnedSet.value.has(c.id))
+  else if (aFilters.value.selectedOwned === 'unowned')
+    list = list.filter(c => !originalOwnedSet.value.has(c.id))
 
   const byReleaseDateDesc = (a, b) => {
     const at = a.releaseDate ? new Date(a.releaseDate).getTime() : 0

--- a/components/newsite/CmartSidebar.vue
+++ b/components/newsite/CmartSidebar.vue
@@ -15,6 +15,7 @@
     <CtoonFilter
       v-if="cmartTab === 'ctoons'"
       :show-hide-unavailable="true"
+      :show-common-filters="true"
       :sort-options="cmartSortOptions"
     />
   </div>

--- a/components/newsite/CtoonFilter.vue
+++ b/components/newsite/CtoonFilter.vue
@@ -68,18 +68,18 @@
       </div>
     </div>
 
-    <!-- Auction-specific filters -->
-    <template v-if="showAuctionFilters">
+    <!-- Auction-specific + common filters -->
+    <template v-if="showAuctionFilters || showCommonFilters">
       <hr class="cf-divider" />
       <div>
         <div class="cf-section-label">Filters</div>
         <div class="cf-pill-row">
-          <button class="cf-pill" :class="{ active: aFilters.featuredOnly }" @click="aFilters.featuredOnly = !aFilters.featuredOnly">★ Feat.</button>
-          <button class="cf-pill" :class="{ active: aFilters.hasBidsOnly  }" @click="aFilters.hasBidsOnly  = !aFilters.hasBidsOnly" >Has Bids</button>
-          <button class="cf-pill" :class="{ active: aFilters.gtoonsOnly   }" @click="aFilters.gtoonsOnly   = !aFilters.gtoonsOnly"  >gToons</button>
-          <button class="cf-pill" :class="{ active: aFilters.wishlistOnly }" @click="aFilters.wishlistOnly = !aFilters.wishlistOnly">Wishlist</button>
+          <button v-if="showAuctionFilters" class="cf-pill" :class="{ active: aFilters.featuredOnly }" @click="aFilters.featuredOnly = !aFilters.featuredOnly">★ Feat.</button>
+          <button v-if="showAuctionFilters" class="cf-pill" :class="{ active: aFilters.hasBidsOnly  }" @click="aFilters.hasBidsOnly  = !aFilters.hasBidsOnly" >Has Bids</button>
+          <button v-if="showCommonFilters"  class="cf-pill" :class="{ active: aFilters.gtoonsOnly   }" @click="aFilters.gtoonsOnly   = !aFilters.gtoonsOnly"  >gToons</button>
+          <button v-if="showCommonFilters"  class="cf-pill" :class="{ active: aFilters.wishlistOnly }" @click="aFilters.wishlistOnly = !aFilters.wishlistOnly">Wishlist</button>
         </div>
-        <div class="cf-owned-row">
+        <div v-if="showCommonFilters" class="cf-owned-row">
           <button class="cf-owned-btn" :class="{ active: aFilters.selectedOwned === 'all'     }" @click="aFilters.selectedOwned = 'all'"    >All</button>
           <button class="cf-owned-btn" :class="{ active: aFilters.selectedOwned === 'owned'   }" @click="aFilters.selectedOwned = 'owned'"  >Owned</button>
           <button class="cf-owned-btn" :class="{ active: aFilters.selectedOwned === 'unowned' }" @click="aFilters.selectedOwned = 'unowned'">Unowned</button>
@@ -108,6 +108,7 @@ const props = defineProps({
   showHideUnavailable: { type: Boolean, default: false },
   showSortDir:         { type: Boolean, default: true  },
   showAuctionFilters:  { type: Boolean, default: false },
+  showCommonFilters:   { type: Boolean, default: false },
   sortOptions: {
     type: Array,
     default: () => [
@@ -159,7 +160,7 @@ function clearFilters() {
     sortAsc:         true,
     hideUnavailable: false,
   })
-  if (props.showAuctionFilters) {
+  if (props.showAuctionFilters || props.showCommonFilters) {
     Object.assign(aFilters.value, {
       featuredOnly:  false,
       hasBidsOnly:   false,

--- a/pages/newsite/cmart.vue
+++ b/pages/newsite/cmart.vue
@@ -10,6 +10,7 @@ setSidebarMiddle('CmartSidebar')
 
 const cmartTab = useState('newSiteCmartTab', () => 'ctoons')
 const filter   = useNewSiteCtoonFilter()
+const aFilters = useAuctionHouseFilters()
 const route    = useRoute()
 const router   = useRouter()
 
@@ -24,6 +25,13 @@ Object.assign(filter.value, {
   sortField:       'releaseDate',
   sortAsc:         false,
   hideUnavailable: false,
+})
+Object.assign(aFilters.value, {
+  featuredOnly:  false,
+  hasBidsOnly:   false,
+  gtoonsOnly:    false,
+  wishlistOnly:  false,
+  selectedOwned: 'all',
 })
 
 const q = route.query


### PR DESCRIPTION
The "Filters" section in CtoonFilter previously rendered only on the Auction House and bundled all five toggles (Featured, Has Bids, gToons, Wishlist, Owned/Unowned/All) behind a single showAuctionFilters flag.

Split that into two flags so cmart can opt into the three filters that make sense there without inheriting the auction-only Featured/Has Bids:

- showAuctionFilters gates Featured + Has Bids (Auction House only).
- showCommonFilters gates gToons, Wishlist, and Owned/Unowned/All.
- Section header renders when either flag is true; Clear Filters resets the auxiliary state under either flag.

Wired the three filters into Cmart.vue (gtoonsOnly, wishlistOnly, selectedOwned), lazily fetching /api/wishlist when the Wishlist pill is toggled on. Cmart page now resets useAuctionHouseFilters defaults on mount so cmart starts clean, matching the existing pattern for the main filter.