### PR TITLE
Allow clearance purchases after time-based mint window closes

### DIFF
--- a/server/api/cmart/buy.post.js
+++ b/server/api/cmart/buy.post.js
@@ -69,7 +69,14 @@ export default defineEventHandler(async (event) => {
     // Time-based mint window guard
     if (ctoon.mintLimitType === 'timeBased' && ctoon.mintEndDate) {
       if (new Date(ctoon.mintEndDate) <= now) {
-        throw createError({ statusCode: 410, statusMessage: 'Minting period has ended.' })
+        // After the minting window closes, allow clearance purchases as long as the
+        // mint-end job has finalized the quantity (i.e., it's no longer the
+        // TIME_BASED_CAP sentinel).  If the quantity is still TIME_BASED_CAP the
+        // mint-end job hasn't run yet — block immediately.
+        if (ctoon.quantity === TIME_BASED_CAP) {
+          throw createError({ statusCode: 410, statusMessage: 'Minting period has ended.' })
+        }
+        // quantity is finalized — fall through to the normal sold-out check below
       }
     }
 

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -20,7 +20,14 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
     // ───────────────────── Time-based mint window guard ─────────────────────
     if (ctoon.mintLimitType === 'timeBased' && ctoon.mintEndDate) {
       if (new Date(ctoon.mintEndDate) <= new Date()) {
-        throw new Error('Minting period has ended')
+        // After the minting window closes the mint-end job finalizes the quantity
+        // (changes it away from TIME_BASED_CAP).  Only hard-block while the sentinel
+        // is still in place; once finalized, fall through and let normal sold-out
+        // checks handle clearance purchases.
+        if (ctoon.quantity === TIME_BASED_CAP) {
+          throw new Error('Minting period has ended')
+        }
+        // quantity is finalized — fall through to normal sold-out checks
       }
     }
 


### PR DESCRIPTION
## Summary
Modified the time-based mint window guard logic in both the buy endpoint and mint worker to allow clearance purchases after the minting period ends, rather than blocking all purchases immediately.

## Key Changes
- **Buy endpoint (`buy.post.js`)**: Changed the mint-end check to only throw an error if the quantity is still set to the `TIME_BASED_CAP` sentinel value. Once the mint-end job has finalized the quantity, purchases are allowed to proceed through normal sold-out checks.
- **Mint worker (`mint.worker.js`)**: Applied the same logic to the worker's time-based mint guard, allowing the job to continue processing once the quantity has been finalized by the mint-end job.

## Implementation Details
The changes introduce a two-phase approach to handling time-based mint windows:
1. **Before finalization**: While `quantity === TIME_BASED_CAP`, the mint-end job hasn't run yet, so purchases are blocked with a 410 error.
2. **After finalization**: Once the mint-end job has updated the quantity away from the sentinel value, clearance purchases are permitted and handled by the normal sold-out inventory checks.

This allows for a grace period where customers can still purchase items at clearance prices after the official minting window closes, as long as inventory remains available.

https://claude.ai/code/session_01TbcQ4Z4vGo2vqV3VLdb4P2