### PR TITLE
Admin page start

### DIFF
--- a/components/newsite/AdminAnalytics.vue
+++ b/components/newsite/AdminAnalytics.vue
@@ -1,0 +1,1290 @@
+<template>
+  <div class="admin-analytics bg-gray-50">
+
+    <!-- Active Discord % Card -->
+    <div class="px-6 py-4">
+      <div class="inline-block bg-white shadow rounded p-4 mb-6">
+        <h2 class="text-lg font-semibold">Active in Discord</h2>
+        <p class="text-2xl font-bold">
+          {{ activeDiscord.percentage }}%
+          ({{ activeDiscord.count }} of {{ activeDiscord.total }})
+        </p>
+      </div>
+    </div>
+
+    <!-- Timeframe + GroupBy selector -->
+    <div class="px-6 py-4 flex flex-wrap items-center gap-4">
+      <div class="flex items-center space-x-2">
+        <label for="timeframe" class="font-medium">Timeframe:</label>
+        <select
+          id="timeframe"
+          v-model="selectedTimeframe"
+          class="border rounded px-2 py-1"
+        >
+          <option v-for="opt in timeframeOptions" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+      </div>
+
+      <div class="flex items-center space-x-2">
+        <label for="groupBy" class="font-medium">Group by:</label>
+        <select
+          id="groupBy"
+          v-model="groupBy"
+          class="border rounded px-2 py-1"
+        >
+          <option v-for="opt in groupOptions" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Charts grid -->
+    <div class="px-6 pb-6 grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <!-- 1) Cumulative Users -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">Cumulative Users</h2>
+        <div class="chart-container"><canvas ref="cumCanvas"></canvas></div>
+      </div>
+
+      <!-- 2) % First Purchase -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">
+          % of Users Buying First cToon within 1 {{ groupUnitLabel }}
+        </h2>
+        <div class="chart-container"><canvas ref="pctCanvas"></canvas></div>
+      </div>
+
+      <!-- 3) Unique Logons -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">Unique {{ groupLabel }} Logons</h2>
+        <div class="chart-container"><canvas ref="uniqueCanvas"></canvas></div>
+      </div>
+
+      <!-- 4) Codes Redeemed (bar) -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">Codes Redeemed</h2>
+        <div class="chart-container"><canvas ref="codesCanvas"></canvas></div>
+      </div>
+
+      <!-- 5) Trades Requested (bar) -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">Trades Requested</h2>
+        <div class="chart-container"><canvas ref="tradesCanvas"></canvas></div>
+      </div>
+
+      <!-- 5) cToons Purchased (bar) -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">cToons Purchased</h2>
+        <div class="chart-container"><canvas ref="ctoonCanvas"></canvas></div>
+      </div>
+
+      <!-- 6) Packs Purchased (bar) -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">Packs Purchased</h2>
+        <div class="chart-container"><canvas ref="packsCanvas"></canvas></div>
+      </div>
+
+      <!-- 4) gToons Clash Games -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">gToons Clash Games</h2>
+        <h3 class="text-sm text-gray-600 mb-1">
+          Total (window): {{ clashTotal }} — Finished: {{ clashPctFinished }}%
+        </h3>
+        <div class="chart-container mb-6">
+          <canvas ref="clashCanvas"></canvas>
+        </div>
+      </div>
+
+      <!-- Monster Scans -->
+      <div>
+        <h2 class="text-xl font-semibold mb-2">Monster Scans</h2>
+        <div class="chart-container">
+          <canvas ref="monsterScansCanvas"></canvas>
+        </div>
+      </div>
+
+      <!-- Socket State / Leak Signals -->
+      <div class="lg:col-span-2">
+        <h2 class="text-xl font-semibold mb-2 flex items-center">
+          Socket State Signals
+          <span
+            class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium"
+            :class="leakRiskBadgeClass"
+          >
+            {{ leakRiskBadgeText }}
+          </span>
+        </h2>
+        <p class="text-sm text-gray-600 mb-2">
+          {{ leakRiskSummary }}
+        </p>
+        <p class="text-xs text-gray-500 mb-2">
+          RSS MB is resident set size: the total memory the socket server process holds in RAM (heap + native).
+        </p>
+        <p v-if="socketMetricsUpdatedAt" class="text-xs text-gray-500 mb-3">
+          Last sample: {{ formatSocketTime(socketMetricsUpdatedAt) }} · Samples: {{ socketMetricsSeries.length }}
+        </p>
+        <div class="chart-container">
+          <canvas ref="socketMetricsCanvas"></canvas>
+        </div>
+      </div>
+
+      <!-- 7) Points Distribution (histogram) spans full width -->
+      <div class="lg:col-span-2">
+        <div class="flex flex-wrap items-center justify-between gap-4 mb-2">
+          <h2 class="text-xl font-semibold">Points Distribution</h2>
+          <div class="flex flex-wrap items-center gap-3">
+            <label class="flex items-center space-x-2 text-sm">
+              <span class="font-medium">Bucket size:</span>
+              <select v-model.number="pointsBucketSize" class="border rounded px-2 py-1">
+                <option v-for="opt in pointsBucketOptions" :key="opt.value" :value="opt.value">
+                  {{ opt.label }}
+                </option>
+              </select>
+            </label>
+            <div class="flex items-center gap-2 text-sm">
+              <button type="button" class="border rounded px-2 py-1" @click="zoomPointsIn">
+                Zoom In
+              </button>
+              <button type="button" class="border rounded px-2 py-1" @click="zoomPointsOut">
+                Zoom Out
+              </button>
+              <button type="button" class="border rounded px-2 py-1" @click="resetPointsZoom">
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="chart-container"><canvas ref="ptsDistCanvas"></canvas></div>
+      </div>
+
+      <!-- 0) Net Points Issued w/ health badge -->
+      <div class="lg:col-span-2">
+        <h2 class="text-xl font-semibold mb-2 flex items-center">
+          Net Points Issued
+          <span class="ml-2 text-sm text-gray-500">
+            (last {{ netWindowCount }} {{ windowUnitPlural }})
+          </span>
+          <span
+            class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium"
+            :class="badgeClass"
+          >
+            {{ badgeText }}
+          </span>
+        </h2>
+
+        <!-- suggestions block -->
+        <div v-if="netStatus !== 'good'" class="mt-2 p-3 bg-yellow-50 rounded">
+          <p class="font-medium mb-1">How to improve:</p>
+          <ul class="list-disc list-inside space-y-1 text-sm">
+            <li v-for="(s,i) in netSuggestions" :key="i">{{ s }}</li>
+          </ul>
+        </div>
+
+        <div class="chart-container">
+          <canvas ref="netCanvas"></canvas>
+        </div>
+      </div>
+
+      <!-- Spend / Earn Ratio -->
+      <div class="lg:col-span-2">
+        <h2 class="text-xl font-semibold mb-2 flex items-center">
+          Spend / Earn Ratio
+          <span class="ml-2 text-sm text-gray-500">
+            (last {{ ratioWindowCount }} {{ windowUnitPlural }})
+          </span>
+          <span
+            class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium"
+            :class="ratioBadgeClass"
+          >
+            {{ ratioBadgeText }}
+          </span>
+        </h2>
+
+        <div v-if="ratioStatus !== 'good'" class="mt-2 p-3 bg-yellow-50 rounded">
+          <p class="font-medium mb-1">How to improve:</p>
+          <ul class="list-disc list-inside space-y-1 text-sm">
+            <li v-for="(s,i) in ratioSuggestions" :key="i">{{ s }}</li>
+          </ul>
+        </div>
+
+        <div class="chart-container">
+          <canvas ref="ratioCanvas"></canvas>
+        </div>
+      </div>
+
+      <!-- 8) Rarity Turnover Rate -->
+      <div class="lg:col-span-2">
+        <h2 class="text-xl font-semibold mb-2 flex items-center">
+          Rarity Turnover Rate
+          <span class="ml-2 text-sm text-gray-500">
+            (last {{ turnoverWindowCount }} {{ windowUnitPlural }})
+          </span>
+          <span
+            class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium"
+            :class="turnoverBadgeClass"
+          >
+            {{ turnoverBadgeText }}
+          </span>
+        </h2>
+
+        <!-- healthy ranges subtitle -->
+        <div class="text-sm text-gray-500 mb-4">
+          <span v-for="(range, rarity) in healthyRanges" :key="rarity" class="mr-6">
+            {{ rarity }}: {{ range }}
+          </span>
+        </div>
+
+        <!-- suggestions if not healthy -->
+        <div v-if="turnoverStatus !== 'good'" class="mt-2 p-3 bg-yellow-50 rounded">
+          <p class="font-medium mb-1">How to improve:</p>
+          <ul class="list-disc list-inside space-y-1 text-sm">
+            <li v-for="(s,i) in turnoverSuggestions" :key="i">{{ s }}</li>
+          </ul>
+        </div>
+
+        <div class="chart-container">
+          <canvas ref="turnoverCanvas"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import {
+  Chart,
+  LineController, LineElement, PointElement,
+  BarController, BarElement,
+  CategoryScale, LinearScale, TimeScale,
+  Title, Tooltip, Legend
+} from 'chart.js'
+import ChartDataLabels from 'chartjs-plugin-datalabels'
+import 'chartjs-adapter-date-fns'
+import annotationPlugin from 'chartjs-plugin-annotation'
+
+// register controllers, scales & plugins
+Chart.register(
+  LineController, LineElement, PointElement,
+  BarController, BarElement,
+  CategoryScale, LinearScale, TimeScale,
+  Title, Tooltip, Legend, annotationPlugin,
+  ChartDataLabels, {
+    id: 'resetLabelPosition',
+    beforeDatasetsDraw(chart) {
+      chart._lastShownLabelX = -Infinity
+    }
+  }
+)
+
+// --- timeframe & groupBy ---
+const timeframeOptions = [
+  { value: '1m', label: '1 Month' },
+  { value: '3m', label: '3 Months' },
+  { value: '6m', label: '6 Months' },
+  { value: '1y', label: '1 Year' }
+]
+const selectedTimeframe = ref('3m')
+
+const TF_DAYS  = { '1m': 30, '3m': 90, '6m': 180, '1y': 365 }
+const TF_WEEKS = { '1m':  4, '3m': 13, '6m':  26, '1y':  52 }
+const TF_MONTHS = { '1m': 1, '3m': 3, '6m': 6, '1y': 12 }
+
+const groupOptions = [
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' }
+]
+const groupBy = ref('weekly')
+
+const pointsBucketOptions = [
+  { value: 500, label: '500' },
+  { value: 1000, label: '1,000' },
+  { value: 5000, label: '5,000' },
+  { value: 10000, label: '10,000' }
+]
+const pointsBucketSize = ref(1000)
+const pointsZoomSpan = ref(null)
+const pointsZoomCenter = ref(null)
+const pointsFullData = ref({ labels: [], counts: [] })
+
+const groupUnits = {
+  daily: 'day',
+  weekly: 'week',
+  monthly: 'month'
+}
+const groupUnitLabels = {
+  daily: 'Day',
+  weekly: 'Week',
+  monthly: 'Month'
+}
+const groupLabels = {
+  daily: 'Daily',
+  weekly: 'Weekly',
+  monthly: 'Monthly'
+}
+const windowUnitPlurals = {
+  daily: 'days',
+  weekly: 'weeks',
+  monthly: 'months'
+}
+
+// derived labels/units
+const groupUnit = computed(() => groupUnits[groupBy.value] || 'day')
+const groupUnitLabel = computed(() => groupUnitLabels[groupBy.value] || 'Day')
+const groupLabel = computed(() => groupLabels[groupBy.value] || 'Daily')
+const windowUnitPlural = computed(() => windowUnitPlurals[groupBy.value] || 'days')
+
+// Active Discord meta
+const activeDiscord = ref({ percentage: 0, count: 0, total: 0 })
+
+// canvas refs
+const cumCanvas     = ref(null)
+const pctCanvas     = ref(null)
+const uniqueCanvas  = ref(null)
+const clashCanvas   = ref(null)
+const tradesCanvas  = ref(null)
+const netCanvas     = ref(null)
+const codesCanvas   = ref(null)
+const ctoonCanvas   = ref(null)
+const packsCanvas   = ref(null)
+const ptsDistCanvas = ref(null)
+const ratioCanvas   = ref(null)
+const turnoverCanvas= ref(null)
+const monsterScansCanvas = ref(null)
+const socketMetricsCanvas = ref(null)
+
+// window counts
+const netWindowCount      = ref(0)
+const ratioWindowCount    = ref(0)
+const turnoverWindowCount = ref(0)
+
+const clashTotal       = ref(0)
+const clashFinished    = ref(0)
+const clashPctFinished = ref(0)
+
+const socketMetricsSeries = ref([])
+const socketMetricsIntervalMs = ref(60_000)
+const socketMetricsUpdatedAt = ref(null)
+const leakRiskLevel = ref('low')
+const leakRiskSummary = ref('Waiting for socket metrics...')
+
+// rarity turnover state/badges
+const turnoverStatus      = ref('good')
+const turnoverSuggestions = ref([])
+
+const turnoverBadgeClass = computed(() => ({
+  good:    'bg-green-100 text-green-800',
+  caution: 'bg-yellow-100 text-yellow-800',
+  danger:  'bg-red-100 text-red-800'
+})[turnoverStatus.value])
+
+const turnoverBadgeText = computed(() => ({
+  good:    'Healthy',
+  caution: 'Caution',
+  danger:  'Danger'
+})[turnoverStatus.value])
+
+const healthyRanges = {
+  Common:    '≥10%',
+  Uncommon:  '≥8%',
+  Rare:      '≥5%',
+  'Very Rare':'≥3%',
+  'Crazy Rare':'≥2%'
+}
+
+// net points badges
+const netStatus      = ref('good')
+const netSuggestions = ref([])
+
+const badgeClass = computed(() => ({
+  good:    'bg-green-100 text-green-800',
+  caution: 'bg-yellow-100 text-yellow-800',
+  danger:  'bg-red-100 text-red-800'
+}[netStatus.value]))
+
+const badgeText = computed(() => ({
+  good:    'Healthy',
+  caution: 'Caution',
+  danger:  'Danger'
+}[netStatus.value]))
+
+// ratio badges
+const ratioStatus      = ref('good')
+const ratioSuggestions = ref([])
+
+const ratioBadgeClass = computed(() => ({
+  good:    'bg-green-100 text-green-800',
+  caution: 'bg-yellow-100 text-yellow-800',
+  danger:  'bg-red-100 text-red-800'
+})[ratioStatus.value])
+
+const ratioBadgeText = computed(() => ({
+  good:    'Healthy',
+  caution: 'Caution',
+  danger:  'Danger'
+})[ratioStatus.value])
+
+const leakRiskBadgeClass = computed(() => ({
+  low:    'bg-green-100 text-green-800',
+  medium: 'bg-yellow-100 text-yellow-800',
+  high:   'bg-red-100 text-red-800'
+}[leakRiskLevel.value]))
+
+const leakRiskBadgeText = computed(() => ({
+  low:    'Low impact',
+  medium: 'Medium impact',
+  high:   'High impact'
+}[leakRiskLevel.value]))
+
+// Chart instances
+let cumChart, pctChart, uniqueChart,
+    codesChart, ctoonChart, packChart, ptsHistChart, clashChart, tradesChart,
+    netChart, ratioChart, turnoverChart, monsterScansChart, socketMetricsChart
+let socketMetricsTimer
+
+// --- color palette ---
+const colors = {
+  line:      '#4F46E5',
+  codesBar:  '#EF4444',
+  ctoonBar:  '#10B981',
+  tradesBar: '#D946EF',
+  clashBar:  '#8B5CF6',
+  packBar:   '#3B82F6',
+  histBar:   '#F59E0B',
+  earnedBar: '#22C55E',
+  spentBar:  '#EF4444',
+  netLine:   '#111827',
+  maLine:    '#FACC15',
+  scanBar:   '#F97316',
+  scanLine:  '#0EA5E9',
+  socketActive: '#111827',
+  socketZoneRefs: '#2563EB',
+  socketTradeSockets: '#10B981',
+  socketTradeSpectators: '#F97316',
+  socketAuction: '#14B8A6',
+  socketMonster: '#8B5CF6',
+  socketClash: '#0EA5E9',
+  socketRss: '#9CA3AF'
+}
+colors.turnover = {
+  Common:    '#9CA3AF',
+  Uncommon:  '#3B82F6',
+  Rare:      '#8B5CF6',
+  'Very Rare':'#F59E0B',
+  'Crazy Rare':'#EF4444'
+}
+
+const getTickValue = (tick) => (tick && typeof tick === 'object' && 'value' in tick ? tick.value : tick)
+const makeUniqueTickFormatter = (formatter, suffix = '') => (value, index, ticks = []) => {
+  const current = formatter(value)
+  if (!Number.isFinite(current)) return ''
+  if (index > 0) {
+    const prevRaw = getTickValue(ticks[index - 1])
+    const prev = formatter(prevRaw)
+    if (prev === current) return ''
+  }
+  return `${current}${suffix}`
+}
+const wholeTick = makeUniqueTickFormatter(v => Math.round(v))
+const percentTick = makeUniqueTickFormatter(v => Math.round(v), '%')
+const percentFromDecimalTick = makeUniqueTickFormatter(v => Math.round(v * 100), '%')
+
+// --- chart options (base) ---
+const commonLineOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } }
+}
+
+const pctOptions = {
+  ...commonLineOptions,
+  scales: {
+    x: { type: 'time', offset: true, time: { unit: 'day', tooltipFormat: 'PP' }, title: { color: '#000', display: true, text: 'Day' }, ticks: {color: '#000'} },
+    y: {
+      title: { color: '#000', display: true, text: '% First cToon Purchase' },
+      ticks: { callback: percentTick, color: '#000' },
+      min: 0,
+      suggestedMax: 100,
+      grace: '20%'
+    }
+  }
+}
+
+const ratioOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  spanGaps: false,
+  scales: {
+    x: { type: 'time', time: { unit: 'day', tooltipFormat: 'PP' }, title: { color: '#000', display: true, text: 'Day' }, ticks: {color: '#000'} },
+    y: { title: { color: '#000', display: true, text: 'Spend / Earn Ratio' }, min: 0, ticks: { color: '#000' }, grace: '20%' }
+  },
+  plugins: {
+    legend: { display: false },
+    annotation: {
+      annotations: {
+        bandLow:  { type: 'line', yMin: 0.9, yMax: 0.9, scaleID: 'y', borderColor: 'rgba(0,0,0,0.25)', borderWidth: 1, label:{enabled:true, content:'0.9'} },
+        bandHigh: { type: 'line', yMin: 1.1, yMax: 1.1, scaleID: 'y', borderColor: 'rgba(0,0,0,0.25)', borderWidth: 1, label:{enabled:true, content:'1.1'} },
+        oneLine:  { type: 'line', yMin: 1.0, yMax: 1.0, scaleID: 'y', borderColor: 'green', borderWidth: 2, label:{enabled:true, content:'1.0'} }
+      }
+    }
+  }
+}
+
+const uniqueOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    datalabels: {
+      anchor: 'center',
+      align:  'top',
+      offset: 4,
+      display: ctx => {
+        const chart  = ctx.chart
+        const xScale = chart.scales.x
+        const labels = chart.data.labels
+        if (ctx.dataIndex === 0) return true
+        const currX = xScale.getPixelForValue(labels[ctx.dataIndex])
+        const prevX = xScale.getPixelForValue(labels[ctx.dataIndex - 1])
+        return Math.abs(currX - prevX) > 30
+      }
+    }
+  },
+  scales: {
+    x: {
+      type: 'time',
+      offset: true,
+      time: { unit: 'day', tooltipFormat: 'PP' },
+      title: { color: '#000', display: true, text: 'Day' },
+      ticks: { color: '#000' }
+    },
+    y: {
+      title: { color: '#000', display: true, text: 'Unique Logons' },
+      min: 0,
+      ticks: { color: '#000', callback: wholeTick },
+      grace: '20%'
+    }
+  }
+}
+
+const netOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  scales: {
+    x: { type: 'time', offset: true, time: { unit: 'day', tooltipFormat: 'PP' }, title: { color: '#000', display: true, text: 'Day' }, ticks: { color: '#000' } },
+    yLeft: { title: { color: '#000', display: true, text: 'Net Points' }, beginAtZero: true, stacked: false, ticks: { color: '#000', callback: wholeTick }, grace: '20%' },
+    yRight:{ color: '#000', position: 'right', title: { color: '#000', display: true, text: 'Earned / Spent' }, beginAtZero: true, stacked: true, grid: { drawOnChartArea: false }, ticks: { color: '#000', callback: wholeTick }, grace: '20%' }
+  },
+  plugins: {
+    legend: {
+      display: true,
+      position: 'top',
+      onClick: (e, legendItem, legend) => {
+        const ci  = legend.chart
+        const idx = legendItem.datasetIndex
+        const meta= ci.getDatasetMeta(idx)
+        meta.hidden = !meta.hidden
+        ci.update()
+      }
+    },
+    annotation: {
+      annotations: {
+        zero: { type: 'line', yMin: 0, yMax: 0, scaleID: 'yLeft', borderColor: 'green', borderWidth: 2, label: { enabled: true, content: 'Zero' } }
+      }
+    }
+  }
+}
+
+const clashOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  scales: {
+    x: { type: 'time', offset: true, time: { unit: 'day', tooltipFormat: 'PP', displayFormats: { day: 'MMM d', week: 'MMM d' } }, title: { color: '#000', display: true, text: 'Day' },
+      ticks: { color: '#000', source: 'labels', autoSkip: true, maxRotation: 45, minRotation: 45 } },
+    y:  { title: { color: '#000', display: true, text: 'Games Played' }, beginAtZero: true, ticks: { color: '#000', callback: wholeTick }, grace: '20%' },
+    y1: { position: 'right', title: { color: '#000', display: true, text: '% Finished' }, grid: { drawOnChartArea: false }, ticks: { callback: percentTick, color: '#000' }, min: 0, suggestedMax: 100, grace: '20%' }
+  },
+  plugins: { legend: { position: 'top' } }
+}
+
+const monsterScansOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  scales: {
+    x: { type: 'time', offset: true, time: { unit: 'day', tooltipFormat: 'PP', displayFormats: { day: 'MMM d', week: 'MMM d' } }, title: { color: '#000', display: true, text: 'Day' },
+      ticks: { color: '#000', source: 'labels', autoSkip: true, maxRotation: 45, minRotation: 45 } },
+    y:  { title: { color: '#000', display: true, text: 'Scans' }, beginAtZero: true, ticks: { color: '#000', callback: wholeTick }, grace: '20%' },
+    y1: { position: 'right', title: { color: '#000', display: true, text: 'Unique Users' }, grid: { drawOnChartArea: false }, beginAtZero: true, ticks: { color: '#000', callback: wholeTick }, grace: '20%' }
+  },
+  plugins: { legend: { position: 'top' } }
+}
+
+const socketMetricsOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  spanGaps: true,
+  scales: {
+    x: { type: 'time', time: { unit: 'hour', tooltipFormat: 'PP p' }, title: { color: '#000', display: true, text: 'Time' }, ticks: { color: '#000' } },
+    y: { title: { color: '#000', display: true, text: 'Count' }, beginAtZero: true, ticks: { color: '#000', callback: wholeTick }, grace: '20%' },
+    y2: { position: 'right', title: { color: '#000', display: true, text: 'MB' }, grid: { drawOnChartArea: false }, beginAtZero: true, ticks: { color: '#000', callback: wholeTick }, grace: '20%' }
+  },
+  plugins: { legend: { position: 'top' }, datalabels: { display: false } }
+}
+
+const cumOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    datalabels: {
+      anchor:  'center',
+      align:   'bottom',
+      offset:  4,
+      display: ctx => {
+        const chart  = ctx.chart
+        const xScale = chart.scales.x
+        const labels = chart.data.labels
+        if (ctx.dataIndex === 0) return true
+        const currX = xScale.getPixelForValue(labels[ctx.dataIndex])
+        const prevX = xScale.getPixelForValue(labels[ctx.dataIndex - 1])
+        return Math.abs(currX - prevX) > 30
+      }
+    }
+  },
+  scales: {
+    x: { type: 'time', time: { unit: 'week', tooltipFormat: 'PP' }, title: { color: '#000', display: true, text: 'Week' }, ticks: {color: '#000'} },
+    y: { title: { color: '#000', display: true, text: 'Cumulative Users' }, ticks: { color: '#000', callback: wholeTick }, grace: '20%' }
+  }
+}
+
+const barOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    datalabels: { anchor: 'center', align: 'center', color: '#ffffff', font: { color: '#000', weight: 'bold' } },
+  },
+  scales: {
+    x: { type: 'time', offset: true, time: { unit: 'day', tooltipFormat: 'PP', displayFormats: { day: 'MMM d', week: 'MMM d' } }, title: { color: '#000', display: true, text: 'Day' },
+      ticks: { color: '#000', source: 'labels', autoSkip: true, maxRotation: 45, minRotation: 45 } },
+    y: { title: { color: '#000', display: true, text: 'Count' }, beginAtZero: true, ticks: {color: '#000', callback: wholeTick}, grace: '20%' }
+  }
+}
+
+const histOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false }, datalabels: { anchor: 'center', align: 'center', color: '#ffffff', font: { weight: 'bold' } } },
+  scales: { x: { title: { color: '#000', display: true, text: 'Points Range' }, ticks: { color: '#000' } }, y: { title: { color: '#000', display: true, text: 'Users' }, beginAtZero: true, ticks: { color: '#000', callback: wholeTick }, grace: '20%' } },
+  onClick: (_evt, elements) => {
+    if (!elements?.length) return
+    pointsZoomCenter.value = elements[0].index
+    applyPointsZoom()
+  }
+}
+
+const dateOf = (d) => new Date(d.period || d.day || d.week || d.month || d.date)
+const formatSocketTime = (value) => {
+  const date = value instanceof Date ? value : new Date(value)
+  return date.toLocaleString()
+}
+
+function applyTimeUnit () {
+  const unit  = groupUnit.value
+  const label = groupUnitLabel.value
+  const set = (chart) => {
+    if (!chart?.options?.scales?.x) return
+    chart.options.scales.x.time.unit = unit
+    if (chart.options.scales.x.title) chart.options.scales.x.title.text = label
+    const df = chart.options.scales.x.time.displayFormats || {}
+    const defaultFormat = unit === 'month' ? 'MMM yyyy' : 'MMM d'
+    df[unit] = df[unit] || defaultFormat
+    chart.options.scales.x.time.displayFormats = df
+    chart.update('none')
+  }
+  ;[cumChart, pctChart, uniqueChart, codesChart, ctoonChart, tradesChart, packChart, clashChart, monsterScansChart, netChart, ratioChart].forEach(set)
+}
+
+function applyPointsZoom () {
+  if (!ptsHistChart) return
+  const total = pointsFullData.value.labels.length
+  if (!total) return
+
+  const span = pointsZoomSpan.value
+  if (!span || span >= total) {
+    ptsHistChart.options.scales.x.min = undefined
+    ptsHistChart.options.scales.x.max = undefined
+  } else {
+    const center = pointsZoomCenter.value ?? 0
+    let min = Math.max(0, Math.floor(center - span / 2))
+    let max = Math.min(total - 1, min + span - 1)
+    min = Math.max(0, max - span + 1)
+    ptsHistChart.options.scales.x.min = min
+    ptsHistChart.options.scales.x.max = max
+  }
+  ptsHistChart.update('none')
+}
+
+function zoomPointsIn () {
+  const total = pointsFullData.value.labels.length
+  if (!total) return
+  if (pointsZoomCenter.value == null) pointsZoomCenter.value = 0
+  const current = pointsZoomSpan.value ?? total
+  const next = Math.max(5, Math.floor(current * 0.6))
+  pointsZoomSpan.value = next >= total ? null : next
+  applyPointsZoom()
+}
+
+function zoomPointsOut () {
+  const total = pointsFullData.value.labels.length
+  if (!total) return
+  if (pointsZoomCenter.value == null) pointsZoomCenter.value = 0
+  const current = pointsZoomSpan.value ?? total
+  const next = Math.min(total, Math.ceil(current * 1.4))
+  pointsZoomSpan.value = next >= total ? null : next
+  applyPointsZoom()
+}
+
+function resetPointsZoom () {
+  pointsZoomSpan.value = null
+  pointsZoomCenter.value = null
+  applyPointsZoom()
+}
+
+async function fetchPointsDistribution () {
+  const res = await fetch(`/api/admin/points-distribution?bucketSize=${pointsBucketSize.value}`, { credentials: 'include' })
+  const hd = await res.json()
+  const labels = hd.map(b => b.label)
+  const counts = hd.map(b => b.count)
+  pointsFullData.value = { labels, counts }
+  ptsHistChart.data.labels   = labels
+  ptsHistChart.data.datasets = [{
+    data: counts,
+    backgroundColor: colors.histBar,
+    borderColor: colors.histBar,
+    borderWidth: 1
+  }]
+  ptsHistChart.update()
+  resetPointsZoom()
+}
+
+function computeLeakRisk(samples, intervalMs) {
+  if (!samples.length) {
+    leakRiskLevel.value = 'low'
+    leakRiskSummary.value = 'No socket metrics yet.'
+    return
+  }
+  const latest = samples[samples.length - 1]
+  const interval = Math.max(1, Number(intervalMs || 60_000))
+  const windowSize = Math.max(1, Math.floor((60 * 60 * 1000) / interval))
+  const base = samples[Math.max(0, samples.length - windowSize - 1)] || latest
+
+  const zoneOrphans = Math.max(0, (latest.zoneSocketRefs || 0) - (latest.activeSockets || 0))
+  const tradeOrphans = Math.max(0, (latest.tradeSpectators || 0) - (latest.tradeSocketsCount || 0))
+  const zoneDelta = (latest.zoneSocketRefs || 0) - (base.zoneSocketRefs || 0)
+  const tradeDelta = (latest.tradeSpectators || 0) - (base.tradeSpectators || 0)
+
+  let level = 'low'
+  if (zoneOrphans > 50 || tradeOrphans > 50 || zoneDelta > 50 || tradeDelta > 50) {
+    level = 'high'
+  } else if (zoneOrphans > 10 || tradeOrphans > 10 || zoneDelta > 10 || tradeDelta > 10) {
+    level = 'medium'
+  }
+  leakRiskLevel.value = level
+
+  const label = level === 'high' ? 'High impact' : level === 'medium' ? 'Medium impact' : 'Low impact'
+  const zoneGap = zoneOrphans
+    ? `zone orphan refs ${zoneOrphans}`
+    : 'zone refs track active sockets'
+  const tradeGap = tradeOrphans
+    ? `trade orphan refs ${tradeOrphans}`
+    : 'trade refs track active sockets'
+  const trend = (zoneDelta > 0 || tradeDelta > 0)
+    ? `1h delta zone ${zoneDelta >= 0 ? '+' : ''}${zoneDelta}, trade ${tradeDelta >= 0 ? '+' : ''}${tradeDelta}.`
+    : 'No upward drift in the last hour.'
+
+  leakRiskSummary.value = `${label}: ${zoneGap}; ${tradeGap}. ${trend}`
+}
+
+async function fetchSocketMetrics() {
+  if (!socketMetricsChart) return
+  const res = await fetch('/api/admin/socket-metrics?limit=1440', { credentials: 'include' })
+  if (!res.ok) return
+  const payload = await res.json()
+  const samples = Array.isArray(payload.samples) ? payload.samples : []
+  socketMetricsIntervalMs.value = Number(payload.intervalMs || 60_000)
+  socketMetricsSeries.value = samples
+  const latest = samples[samples.length - 1]
+  socketMetricsUpdatedAt.value = latest ? new Date(latest.ts) : null
+
+  const series = (key) => samples.map(s => ({ x: s.ts, y: s[key] ?? 0 }))
+  socketMetricsChart.data.datasets[0].data = series('activeSockets')
+  socketMetricsChart.data.datasets[1].data = series('zoneSocketRefs')
+  socketMetricsChart.data.datasets[2].data = series('tradeSocketsCount')
+  socketMetricsChart.data.datasets[3].data = series('tradeSpectators')
+  socketMetricsChart.data.datasets[4].data = series('auctionSocketMembers')
+  socketMetricsChart.data.datasets[5].data = series('monsterSocketMembers')
+  socketMetricsChart.data.datasets[6].data = series('clashSocketMembers')
+  socketMetricsChart.data.datasets[7].data = series('rssMb')
+  socketMetricsChart.update()
+
+  computeLeakRisk(samples, socketMetricsIntervalMs.value)
+}
+
+async function fetchData() {
+  const groupParam = `&groupBy=${groupBy.value}`
+
+  let res = await fetch(`/api/admin/cumulative-users?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  let data = await res.json()
+  cumChart.data.labels   = data.map(d => dateOf(d))
+  cumChart.data.datasets = [{
+    data: data.map(d => d.cumulative),
+    borderColor: colors.line,
+    backgroundColor: colors.line,
+    borderWidth: 2,
+    fill: false
+  }]
+  cumChart.update()
+
+  res = await fetch(`/api/admin/trades-requested?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  const tr = await res.json()
+  tradesChart.data.labels   = tr.map(d => dateOf(d))
+  tradesChart.data.datasets = [{
+    data: tr.map(d => d.count),
+    backgroundColor: colors.tradesBar,
+    borderColor:     colors.tradesBar,
+    borderWidth: 1
+  }]
+  tradesChart.update()
+
+  res = await fetch(`/api/admin/net-points-issues?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  const np = await res.json()
+  const tfByGroup = {
+    daily: TF_DAYS,
+    weekly: TF_WEEKS,
+    monthly: TF_MONTHS
+  }
+  netWindowCount.value = (tfByGroup[groupBy.value] || TF_DAYS)[selectedTimeframe.value]
+
+  const netSeries = (np.daily || np.series || [])
+  netChart.data.labels               = netSeries.map(d => dateOf(d))
+  netChart.data.datasets[0].data     = netSeries.map(d => d.earned ?? 0)
+  netChart.data.datasets[1].data     = netSeries.map(d => (d.spent ?? 0))
+  netChart.data.datasets[2].data     = netSeries.map(d => d.net ?? d.netPoints ?? 0)
+  netChart.data.datasets[3].data     = netSeries.map(d => d.net_ma7 ?? d.movingAvg7Day ?? 0)
+  netChart.update()
+
+  const last = netSeries[netSeries.length - 1] || null
+  const avg7 = last ? (last.net_ma7 ?? last.movingAvg7Day ?? 0) : 0
+  const healthyThreshold = 500
+  const cautionThreshold = 1000
+  if (Math.abs(avg7) <= healthyThreshold) {
+    netStatus.value = 'good'
+    netSuggestions.value = []
+  } else if (Math.abs(avg7) <= cautionThreshold) {
+    netStatus.value = 'caution'
+    netSuggestions.value = avg7 > 0
+      ? [
+          `7-period net avg ${avg7}. Reduce supply:`,
+          'Increase point sinks',
+          'Offer high-cost cosmetics',
+          'Run point-burn events'
+        ]
+      : [
+          `7-period net avg ${avg7}. Boost supply:`,
+          'Earn-focused events',
+          'Lower pack prices or fees',
+          'Time-limited bonuses'
+        ]
+  } else {
+    netStatus.value = 'danger'
+    netSuggestions.value = avg7 > 0
+      ? [
+          `7-period net avg ${avg7}. Immediate burn:`,
+          'Premium limited items',
+          'Raise auction fees',
+          'Large point-burn events'
+        ]
+      : [
+          `7-period net avg ${avg7}. Immediate injection:`,
+          'Double/triple points',
+          'Pause major sinks',
+          'Generous referral rewards'
+        ]
+  }
+
+  res = await fetch(`/api/admin/percentage-first-purchase?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  data = await res.json()
+  pctChart.data.labels   = data.map(d => dateOf(d))
+  pctChart.data.datasets = [{
+    data: data.map(d => d.percentage),
+    borderColor: colors.line,
+    backgroundColor: colors.line,
+    borderWidth: 2,
+    fill: false
+  }]
+  pctChart.update()
+
+  res = await fetch(`/api/admin/unique-logins?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  data = await res.json()
+  uniqueChart.data.labels   = data.map(d => dateOf(d))
+  uniqueChart.data.datasets = [{
+    data: data.map(d => d.count),
+    borderColor: colors.line,
+    backgroundColor: colors.line,
+    borderWidth: 2,
+    fill: false
+  }]
+  uniqueChart.update()
+
+  res = await fetch('/api/admin/active-discord', { credentials: 'include' })
+  const ad = await res.json()
+  activeDiscord.value = {
+    percentage: Math.round((ad.active / ad.total) * 100),
+    count: ad.active,
+    total: ad.total
+  }
+
+  res = await fetch(`/api/admin/clash-stats?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  const cs = await res.json()
+  const total    = cs.reduce((s, d) => s + (d.count || 0), 0)
+  const finished = cs.reduce((s, d) => s + (d.finishedCount || 0), 0)
+  clashTotal.value       = total
+  clashFinished.value    = finished
+  clashPctFinished.value = total ? Math.round((finished / total) * 100) : 0
+  clashChart.data.labels = cs.map(s => dateOf(s))
+  clashChart.data.datasets = [
+    {
+      type: 'bar',
+      label: 'Games Played',
+      data: cs.map(s => s.count),
+      yAxisID: 'y',
+      backgroundColor: colors.clashBar,
+      borderColor: colors.clashBar,
+      borderWidth: 1,
+      order: 1,
+      datalabels: { anchor: 'center', align: 'center', color: '#ffffff', font: { weight: 'bold' } }
+    },
+    {
+      type: 'line',
+      label: '% Finished',
+      data: cs.map(s => s.percentFinished),
+      yAxisID: 'y1',
+      borderColor: '#FACC15',
+      backgroundColor: '#FACC15',
+      fill: false,
+      tension: 0.3,
+      order: 0,
+      pointBackgroundColor: '#FACC15',
+      datalabels: { anchor: 'end', align: 'top', color: '#222222', font: { weight: 'bold' } }
+    }
+  ]
+  clashChart.update()
+
+  res = await fetch(`/api/admin/monster-scans?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  const ms = await res.json()
+  monsterScansChart.data.labels = ms.map(d => dateOf(d))
+  monsterScansChart.data.datasets = [
+    {
+      type: 'bar',
+      label: 'Scans',
+      data: ms.map(d => d.scans ?? 0),
+      yAxisID: 'y',
+      backgroundColor: colors.scanBar,
+      borderColor: colors.scanBar,
+      borderWidth: 1,
+      order: 1,
+      datalabels: { anchor: 'center', align: 'center', color: '#ffffff', font: { weight: 'bold' } }
+    },
+    {
+      type: 'line',
+      label: 'Unique Users',
+      data: ms.map(d => d.uniqueUsers ?? 0),
+      yAxisID: 'y1',
+      borderColor: colors.scanLine,
+      backgroundColor: colors.scanLine,
+      fill: false,
+      tension: 0.3,
+      order: 0,
+      pointBackgroundColor: colors.scanLine,
+      datalabels: { anchor: 'end', align: 'top', color: '#222222', font: { weight: 'bold' } }
+    }
+  ]
+  monsterScansChart.update()
+
+  res = await fetch(`/api/admin/spend-earn-ratio?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  const sr = await res.json()
+  ratioWindowCount.value = (tfByGroup[groupBy.value] || TF_DAYS)[selectedTimeframe.value]
+
+  const ratioSeries = (sr.daily || sr.series || [])
+  ratioChart.data.labels           = ratioSeries.map(d => dateOf(d))
+  ratioChart.data.datasets[0].data = ratioSeries.map(d => d.spendEarnRatio)
+  ratioChart.data.datasets[1].data = ratioSeries.map(d => d.movingAvg7Day ?? null)
+  ratioChart.update()
+
+  const lastEntry = ratioSeries[ratioSeries.length - 1] || {}
+  const avg7forRatio = lastEntry.movingAvg7Day ?? null
+
+  if (avg7forRatio != null && avg7forRatio >= 0.9 && avg7forRatio <= 1.1) {
+    ratioStatus.value      = 'good'
+    ratioSuggestions.value = []
+  } else if (avg7forRatio != null && avg7forRatio >= 0.75 && avg7forRatio <= 1.25) {
+    ratioStatus.value = 'caution'
+    if (avg7forRatio < 1.0) {
+      ratioSuggestions.value = [
+        `7-period ratio ${avg7forRatio.toFixed(3)} below 1.0. Increase spending or reduce sinks:`,
+        'Bonus quests and referrals',
+        'Temporary fee reductions',
+        'Short double-points windows'
+      ]
+    } else {
+      ratioSuggestions.value = [
+        `7-period ratio ${avg7forRatio.toFixed(3)} above 1.0. Add sinks:`,
+        'Time-boxed cosmetics',
+        'Burn-and-earn events',
+        'Low-cost burn challenges'
+      ]
+    }
+  } else {
+    ratioStatus.value = 'danger'
+    if (avg7forRatio == null || avg7forRatio < 0.75) {
+      ratioSuggestions.value = [
+        `Ratio very low${avg7forRatio==null ? '' : ` (${avg7forRatio.toFixed(3)})`}. Boost earning now:`,
+        'Large event bonuses',
+        'Pause major sinks',
+        'Generous referrals'
+      ]
+    } else {
+      ratioSuggestions.value = [
+        `Ratio very high (${avg7forRatio.toFixed(3)}). Remove points quickly:`,
+        'Premium limited items',
+        'Raise auction fees',
+        'Large burn events'
+      ]
+    }
+  }
+
+  res = await fetch(`/api/admin/codes-redeemed?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  let cr = await res.json()
+  codesChart.data.labels   = cr.map(d => dateOf(d))
+  codesChart.data.datasets = [{
+    data: cr.map(d => d.count),
+    backgroundColor: colors.codesBar,
+    borderColor: colors.codesBar,
+    borderWidth: 1
+  }]
+  codesChart.update()
+
+  res = await fetch(`/api/admin/purchases?method=ctoon&timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  let pd = await res.json()
+  if (pd.ctoonPurchases) pd = pd.ctoonPurchases
+  ctoonChart.data.labels   = pd.map(d => dateOf(d))
+  ctoonChart.data.datasets = [{
+    data: pd.map(d => d.count),
+    backgroundColor: colors.ctoonBar,
+    borderColor: colors.ctoonBar,
+    borderWidth: 1
+  }]
+  ctoonChart.update()
+
+  res = await fetch(`/api/admin/purchases?method=pack&timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  let pp = await res.json()
+  if (pp.packPurchases) pp = pp.packPurchases
+  packChart.data.labels   = pp.map(d => dateOf(d))
+  packChart.data.datasets = [{
+    data: pp.map(d => d.count),
+    backgroundColor: colors.packBar,
+    borderColor: colors.packBar,
+    borderWidth: 1
+  }]
+  packChart.update()
+
+  await fetchPointsDistribution()
+
+  res = await fetch(`/api/admin/rarity-turnover-rate?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  const turnrate = await res.json()
+  const turnoverCounts = {
+    daily: turnrate.days,
+    weekly: turnrate.weeks,
+    monthly: turnrate.months
+  }
+  turnoverWindowCount.value = turnoverCounts[groupBy.value] ?? turnrate.days ?? turnrate.weeks ?? turnrate.months ?? 0
+
+  turnoverChart.data.labels = turnrate.data.map(d => d.rarity)
+  turnoverChart.data.datasets[0].data = turnrate.data.map(d => d.turnoverRate)
+  turnoverChart.data.datasets[0].backgroundColor = turnrate.data.map(d => colors.turnover[d.rarity])
+  turnoverChart.data.datasets[0].borderColor     = turnrate.data.map(d => colors.turnover[d.rarity])
+  turnoverChart.update()
+
+  const avg = turnrate.data.reduce((s,d) => s + d.turnoverRate, 0) / Math.max(1, turnrate.data.length)
+  const healthyT = 0.05
+  const cautionT = 0.02
+  if (avg >= healthyT) {
+    turnoverStatus.value = 'good'
+    turnoverSuggestions.value = []
+  } else if (avg >= cautionT) {
+    turnoverStatus.value = 'caution'
+    turnoverSuggestions.value = [
+      `Avg turnover ${(avg*100).toFixed(1)}% < 5%. Boost trading:`,
+      'Quests that reward Rare/V.Rare trading',
+      'Winball drops to spur swaps',
+      'Fee coupons for Crazy Rare trades'
+    ]
+  } else {
+    turnoverStatus.value = 'danger'
+    turnoverSuggestions.value = [
+      `Turnover ${(avg*100).toFixed(1)}% < 2%. Immediate actions:`,
+      'Limited-edition auctions with bid fees',
+      '24h triple-points on any trade',
+      'Temporarily waive trade sinks'
+    ]
+  }
+}
+
+onMounted(async () => {
+  cumChart    = new Chart(cumCanvas.value.getContext('2d'),    { type: 'line', data: { labels: [], datasets: [] }, options: cumOptions })
+  pctChart    = new Chart(pctCanvas.value.getContext('2d'),    { type: 'line', data: { labels: [], datasets: [] }, options: pctOptions })
+  uniqueChart = new Chart(uniqueCanvas.value.getContext('2d'), { type: 'line', data: { labels: [], datasets: [] }, options: uniqueOptions })
+
+  codesChart  = new Chart(codesCanvas.value.getContext('2d'),  { type: 'bar',  data: { labels: [], datasets: [] }, options: barOptions })
+  ctoonChart  = new Chart(ctoonCanvas.value.getContext('2d'),  { type: 'bar',  data: { labels: [], datasets: [] }, options: barOptions })
+  tradesChart = new Chart(tradesCanvas.value.getContext('2d'), { type: 'bar',  data: { labels: [], datasets: [] }, options: barOptions })
+  packChart   = new Chart(packsCanvas.value.getContext('2d'),  { type: 'bar',  data: { labels: [], datasets: [] }, options: barOptions })
+  ptsHistChart= new Chart(ptsDistCanvas.value.getContext('2d'),{ type: 'bar',  data: { labels: [], datasets: [] }, options: histOptions })
+  clashChart  = new Chart(clashCanvas.value.getContext('2d'),  { data: { labels: [], datasets: [] }, options: clashOptions })
+  monsterScansChart = new Chart(monsterScansCanvas.value.getContext('2d'), { data: { labels: [], datasets: [] }, options: monsterScansOptions })
+  socketMetricsChart = new Chart(socketMetricsCanvas.value.getContext('2d'), {
+    type: 'line',
+    data: {
+      datasets: [
+        { label: 'Active sockets', data: [], borderColor: colors.socketActive, backgroundColor: colors.socketActive, borderWidth: 2, fill: false, tension: 0.2 },
+        { label: 'Zone socket refs', data: [], borderColor: colors.socketZoneRefs, backgroundColor: colors.socketZoneRefs, borderWidth: 2, fill: false, tension: 0.2 },
+        { label: 'Trade sockets', data: [], borderColor: colors.socketTradeSockets, backgroundColor: colors.socketTradeSockets, borderWidth: 2, fill: false, tension: 0.2, borderDash: [4, 3] },
+        { label: 'Trade spectators', data: [], borderColor: colors.socketTradeSpectators, backgroundColor: colors.socketTradeSpectators, borderWidth: 2, fill: false, tension: 0.2 },
+        { label: 'Auction sockets', data: [], borderColor: colors.socketAuction, backgroundColor: colors.socketAuction, borderWidth: 2, fill: false, tension: 0.2 },
+        { label: 'Monster sockets', data: [], borderColor: colors.socketMonster, backgroundColor: colors.socketMonster, borderWidth: 2, fill: false, tension: 0.2 },
+        { label: 'Clash sockets', data: [], borderColor: colors.socketClash, backgroundColor: colors.socketClash, borderWidth: 2, fill: false, tension: 0.2 },
+        { label: 'RSS MB', data: [], borderColor: colors.socketRss, backgroundColor: colors.socketRss, borderWidth: 2, fill: false, tension: 0.2, yAxisID: 'y2' }
+      ]
+    },
+    options: socketMetricsOptions
+  })
+
+  ratioChart = new Chart(ratioCanvas.value.getContext('2d'), {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [
+        { label: 'Per-period ratio', data: [], borderColor: '#6366F1', borderWidth: 2, fill: false, datalabels: { anchor: 'end', align: 'top' } },
+        { label: '7-period MA ratio', data: [], borderColor: colors.maLine, borderWidth: 2, borderDash: [5, 5], fill: false, datalabels: { anchor: 'start', align: 'bottom' } }
+      ]
+    },
+    options: {
+      ...ratioOptions,
+      plugins: {
+        ...ratioOptions.plugins,
+        legend: {
+          display: true,
+          position: 'top',
+          onClick: (e, legendItem, legend) => {
+            const chart = legend.chart
+            const idx   = legendItem.datasetIndex
+            const meta  = chart.getDatasetMeta(idx)
+            meta.hidden = !meta.hidden
+            chart.update()
+          }
+        }
+      }
+    }
+  })
+
+  turnoverChart = new Chart(turnoverCanvas.value.getContext('2d'), {
+    type: 'bar',
+    data: { labels: [], datasets: [{
+      data: [],
+      backgroundColor: [],
+      borderColor:  [],
+      borderWidth: 1,
+      datalabels: { anchor: 'end', align: 'top', formatter: v => (v * 100).toFixed(1) + '%' }
+    }]},
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false }, datalabels: {} },
+      scales: {
+        x: { title: { color: '#000', display: true, text: 'Rarity' } },
+        y: {
+          title: { color: '#000', display: true, text: 'Turnover Rate' },
+          ticks: { callback: percentFromDecimalTick, color: '#000' },
+          beginAtZero: true,
+          grace: '20%'
+        }
+      }
+    },
+    plugins: [ ChartDataLabels ]
+  })
+
+  netChart = new Chart(netCanvas.value.getContext('2d'), {
+    data: {
+      labels: [],
+      datasets: [
+        { type: 'bar',  label: 'Earned', data: [], backgroundColor: colors.earnedBar, borderColor: colors.earnedBar, yAxisID: 'yRight', stack: 'points', hidden: true,
+          datalabels: { anchor: 'center', align: 'center', color: '#ffffff', font: { weight: 'bold' } } },
+        { type: 'bar',  label: 'Spent',  data: [], backgroundColor: colors.spentBar,  borderColor: colors.spentBar,  yAxisID: 'yRight', stack: 'points', hidden: true,
+          datalabels: { anchor: 'center', align: 'center', color: '#ffffff', font: { weight: 'bold' } } },
+        { type: 'line', label: 'Net',    data: [], borderColor: colors.netLine, backgroundColor: colors.netLine, borderWidth: 2, fill: false, yAxisID: 'yLeft',
+          datalabels: { anchor: 'end', align: 'top' } },
+        { type: 'line', label: '7-period MA (Net)', data: [], borderColor: colors.maLine, backgroundColor: colors.maLine, borderWidth: 2, fill: false, borderDash: [5,5], yAxisID: 'yLeft',
+          datalabels: { anchor: 'start', align: 'bottom' } }
+      ]
+    },
+    options: netOptions
+  })
+
+  applyTimeUnit()
+
+  await nextTick()
+  await fetchData()
+  await fetchSocketMetrics()
+  socketMetricsTimer = setInterval(fetchSocketMetrics, socketMetricsIntervalMs.value)
+})
+
+onBeforeUnmount(() => {
+  if (socketMetricsTimer) clearInterval(socketMetricsTimer)
+})
+
+watch([selectedTimeframe, groupBy], async () => {
+  if (!netChart) return
+  applyTimeUnit()
+  ;[cumChart, pctChart, uniqueChart, codesChart, ctoonChart, tradesChart, packChart, clashChart, monsterScansChart, netChart, ratioChart].forEach(ch => {
+    if (!ch) return
+    ch.data.labels = []
+    ch.data.datasets.forEach(ds => (ds.data = []))
+    ch.update('none')
+  })
+  await fetchData()
+})
+
+watch(pointsBucketSize, async () => {
+  if (!ptsHistChart) return
+  await fetchPointsDistribution()
+})
+</script>
+
+<style scoped>
+.admin-analytics {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+
+.chart-container {
+  height: 300px;
+  position: relative;
+  padding: 10px;
+}
+</style>

--- a/components/newsite/AdminNav.vue
+++ b/components/newsite/AdminNav.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="admin-nav">
+    <div class="admin-nav-dropdown" ref="dropdownRef">
+      <BlueButton :style="{ height: buttonHeight }" @click.stop="toggleOpen">Admin Core ▾</BlueButton>
+      <div v-if="open" class="admin-nav-menu">
+        <button
+          v-for="item in items"
+          :key="item.id"
+          class="admin-nav-menu-item"
+          @click="onItemClick(item)"
+        >{{ item.label }}</button>
+      </div>
+    </div>
+
+    <NuxtLink to="/admin" class="admin-nav-old-admin">
+      <BlueButton :style="{ height: buttonHeight }">Old Admin</BlueButton>
+    </NuxtLink>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  buttonHeight: {
+    type: String,
+    default: '22px'
+  },
+  isMobile: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['select'])
+
+const items = [
+  { id: 'analytics', label: 'Analytics' },
+  { id: 'placeholder-1', label: 'Placeholder' },
+  { id: 'placeholder-2', label: 'Placeholder' },
+  { id: 'placeholder-3', label: 'Placeholder' },
+  { id: 'placeholder-4', label: 'Placeholder' },
+  { id: 'placeholder-5', label: 'Placeholder' },
+  { id: 'placeholder-6', label: 'Placeholder' },
+  { id: 'placeholder-7', label: 'Placeholder' },
+  { id: 'placeholder-8', label: 'Placeholder' },
+  { id: 'placeholder-9', label: 'Placeholder' }
+]
+
+const open = ref(false)
+const dropdownRef = ref(null)
+
+function toggleOpen() {
+  open.value = !open.value
+}
+
+function onItemClick(item) {
+  open.value = false
+  emit('select', item.id)
+}
+
+function onGlobalClick(e) {
+  if (!open.value) return
+  const root = dropdownRef.value
+  if (root && !root.contains(e.target)) open.value = false
+}
+
+onMounted(() => {
+  if (process.client) window.addEventListener('click', onGlobalClick)
+})
+onBeforeUnmount(() => {
+  if (process.client) window.removeEventListener('click', onGlobalClick)
+})
+</script>
+
+<style scoped>
+.admin-nav {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  height: 100%;
+  padding: 0 6px;
+  box-sizing: border-box;
+  overflow: visible;
+}
+
+.admin-nav-dropdown {
+  position: relative;
+}
+
+.admin-nav-old-admin {
+  margin-left: auto;
+  text-decoration: none;
+}
+
+.admin-nav-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  background: var(--OrbitDarkBlue);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 4px;
+  min-width: 180px;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.admin-nav-menu-item {
+  background: transparent;
+  border: none;
+  color: #fff;
+  text-align: left;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.admin-nav-menu-item:hover {
+  background: var(--OrbitLightBlue);
+}
+
+@media (max-width: 768px) {
+  .admin-nav {
+    flex-wrap: wrap;
+    height: auto;
+    padding: 4px 6px;
+  }
+}
+</style>

--- a/components/newsite/NavLeft.vue
+++ b/components/newsite/NavLeft.vue
@@ -3,7 +3,7 @@
     <NuxtLink to="/newsite/home">
       <BlueButton :style="{ height: buttonHeight }">ReOrbit Home</BlueButton>
     </NuxtLink>
-    <NuxtLink v-if="isAdmin" to="/admin">
+    <NuxtLink v-if="isAdmin" to="/newsite/admin">
       <BlueButton :style="{ height: buttonHeight }">Admin</BlueButton>
     </NuxtLink>
     <NuxtLink v-if="isMobile" to="/newsite/settings" class="nav-link">

--- a/pages/newsite/admin.vue
+++ b/pages/newsite/admin.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="newsite-admin">
+    <div class="newsite-admin-nav">
+      <AdminNav @select="onSelect" />
+    </div>
+    <div class="newsite-admin-body">
+      <AdminAnalytics v-if="currentSection === 'analytics'" />
+      <div v-else class="newsite-admin-placeholder">
+        <h1 class="newsite-admin-title">Admin</h1>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: ['newsite', 'admin'],
+  showAdbar: true,
+  showNav: true,
+  showSidebar: false,
+})
+useHead({ htmlAttrs: { class: 'newsite-admin-page' } })
+
+const { clearSidebarMiddle } = useNewsiteLayout()
+clearSidebarMiddle()
+
+const currentSection = ref('analytics')
+function onSelect(id) {
+  if (id === 'analytics') currentSection.value = 'analytics'
+  // placeholders intentionally do nothing
+}
+</script>
+
+<style>
+html.newsite-admin-page {
+  min-height: 100vh;
+  background: linear-gradient(
+    to bottom,
+    #000000 0px,
+    #000000 65px,
+    #003466 115px,
+    #003466 100%
+  ) no-repeat fixed !important;
+}
+
+html.newsite-admin-page body {
+  background: transparent !important;
+  min-height: 100vh;
+}
+</style>
+
+<style scoped>
+.newsite-admin {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.newsite-admin-nav {
+  flex-shrink: 0;
+  width: 100%;
+  min-height: var(--topbar-nav-height);
+  background: var(--OrbitLightBlue);
+  border-radius: var(--topbar-nav-left-radius);
+  overflow: visible;
+  position: relative;
+  z-index: 20;
+}
+
+.newsite-admin-body {
+  flex: 1;
+  width: 100%;
+  box-sizing: border-box;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.newsite-admin-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.newsite-admin-title {
+  font-size: 2rem;
+  font-weight: bold;
+  color: #fff;
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
Introduces /newsite/admin under the newsite-template layout, gated by both the newsite and admin middleware. The page hides the left sidebar so the main content area spans full width, and renders an in-page nav bar at the top of the content area.

AdminNav contains an "Admin Core" dropdown trigger (10 items: Analytics plus 9 Placeholder entries that route nowhere) and a right-aligned "Old Admin" link to /admin. Selecting Analytics swaps the body to render AdminAnalytics.

AdminAnalytics ports the full content of the old /admin index page (all chart-js dashboards, fetch logic, and health badges) into a reusable component with the page-level shell (<Nav />, definePageMeta, min-h-screen wrapper, top spacing) stripped out.

NavLeft's Admin button now links to /newsite/admin instead of /admin. Analytics is the default view when landing on the new admin page; the dropdown still lets you re-select it or visit Old Admin.