### PR TITLE
Add Admin Logs migrations + Cheat Finder under /newsite/admin

### DIFF
--- a/components/newsite/AdminAchievementLogs.vue
+++ b/components/newsite/AdminAchievementLogs.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="admin-achievement-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <div class="flex items-center justify-between mb-2">
+        <h1 class="text-base font-bold">Achievement Logs</h1>
+        <div class="text-[11px] text-gray-500">Showing {{ showingRange }}</div>
+      </div>
+
+      <div class="bg-white rounded shadow p-2">
+        <div v-if="loading" class="text-gray-500">Loading…</div>
+        <div v-else-if="logs.length === 0" class="text-gray-500">No logs found.</div>
+        <div v-else>
+          <!-- Desktop table -->
+          <div class="hidden lg:block overflow-auto">
+            <table class="min-w-full w-full border rounded text-[11px]">
+              <thead class="bg-gray-50 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">Achieved At (CDT)</th>
+                  <th class="px-1.5 py-1 border-b">User</th>
+                  <th class="px-1.5 py-1 border-b">Achievement</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="log in logs" :key="log.id" class="border-b">
+                  <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(log.achievedAt) }}</td>
+                  <td class="px-1.5 py-1">
+                    <div class="font-medium">{{ displayUser(log.user) }}</div>
+                    <div class="text-[10px] text-gray-500">{{ log.user?.id || '—' }}</div>
+                  </td>
+                  <td class="px-1.5 py-1">
+                    <div class="font-medium">{{ log.achievement?.title || '—' }}</div>
+                    <div class="text-[10px] text-gray-500">{{ log.achievement?.slug || log.achievement?.id || '—' }}</div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Mobile cards -->
+          <div class="lg:hidden space-y-2">
+            <div v-for="log in logs" :key="log.id" class="border rounded bg-white p-2 text-[11px]">
+              <div class="flex items-center justify-between text-[10px] text-gray-500">
+                <span>{{ formatDate(log.achievedAt) }}</span>
+                <span>{{ log.achievement?.slug || '—' }}</span>
+              </div>
+              <div class="mt-1">
+                <div class="font-semibold">{{ log.achievement?.title || '—' }}</div>
+                <div class="text-[10px] text-gray-500">{{ log.achievement?.id || '—' }}</div>
+              </div>
+              <div class="mt-1.5">
+                <div class="font-medium">{{ displayUser(log.user) }}</div>
+                <div class="text-[10px] text-gray-500">{{ log.user?.id || '—' }}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-3 flex items-center justify-between">
+          <div class="text-[11px] text-gray-600">
+            Page {{ page }} of {{ totalPages }} • Showing {{ showingRange }}
+          </div>
+          <div class="space-x-1">
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+const logs = ref([])
+const total = ref(0)
+const loading = ref(false)
+const page = ref(1)
+const pageSize = 100
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const showingRange = computed(() => {
+  if (!total.value) return '0–0 of 0'
+  const start = (page.value - 1) * pageSize + 1
+  const end = Math.min(page.value * pageSize, total.value)
+  return `${start}–${end} of ${total.value}`
+})
+
+function formatDate(dt) {
+  if (!dt) return '—'
+  return new Date(dt).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Chicago',
+    timeZoneName: 'short'
+  })
+}
+
+function displayUser(user) {
+  return user?.username || user?.discordTag || user?.id || '—'
+}
+
+async function fetchLogs() {
+  loading.value = true
+  try {
+    const res = await $fetch('/api/admin/achievement-logs', {
+      query: { page: String(page.value) }
+    })
+    logs.value = res.items || []
+    total.value = res.total || 0
+  } catch (e) {
+    console.error('Failed to load achievement logs', e)
+    logs.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+async function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  await fetchLogs()
+}
+
+async function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  await fetchLogs()
+}
+
+onMounted(fetchLogs)
+</script>
+
+<style scoped>
+.admin-achievement-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+</style>

--- a/components/newsite/AdminAnalytics.vue
+++ b/components/newsite/AdminAnalytics.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="admin-analytics bg-gray-50">
+  <div class="admin-analytics bg-gray-50 text-xs">
 
     <!-- Active Discord % Card -->
-    <div class="px-6 py-4">
-      <div class="inline-block bg-white shadow rounded p-4 mb-6">
-        <h2 class="text-lg font-semibold">Active in Discord</h2>
-        <p class="text-2xl font-bold">
+    <div class="px-2 pt-2">
+      <div class="inline-block bg-white shadow rounded p-2 mb-2">
+        <h2 class="text-xs font-semibold">Active in Discord</h2>
+        <p class="text-sm font-bold">
           {{ activeDiscord.percentage }}%
           ({{ activeDiscord.count }} of {{ activeDiscord.total }})
         </p>
@@ -13,13 +13,13 @@
     </div>
 
     <!-- Timeframe + GroupBy selector -->
-    <div class="px-6 py-4 flex flex-wrap items-center gap-4">
-      <div class="flex items-center space-x-2">
+    <div class="px-2 py-1 flex flex-wrap items-center gap-2">
+      <div class="flex items-center space-x-1">
         <label for="timeframe" class="font-medium">Timeframe:</label>
         <select
           id="timeframe"
           v-model="selectedTimeframe"
-          class="border rounded px-2 py-1"
+          class="border rounded px-1.5 py-0.5 text-xs"
         >
           <option v-for="opt in timeframeOptions" :key="opt.value" :value="opt.value">
             {{ opt.label }}
@@ -27,12 +27,12 @@
         </select>
       </div>
 
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center space-x-1">
         <label for="groupBy" class="font-medium">Group by:</label>
         <select
           id="groupBy"
           v-model="groupBy"
-          class="border rounded px-2 py-1"
+          class="border rounded px-1.5 py-0.5 text-xs"
         >
           <option v-for="opt in groupOptions" :key="opt.value" :value="opt.value">
             {{ opt.label }}
@@ -42,16 +42,16 @@
     </div>
 
     <!-- Charts grid -->
-    <div class="px-6 pb-6 grid grid-cols-1 lg:grid-cols-2 gap-8">
+    <div class="px-2 pb-2 grid grid-cols-1 lg:grid-cols-2 gap-3">
       <!-- 1) Cumulative Users -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">Cumulative Users</h2>
+        <h2 class="text-sm font-semibold mb-1">Cumulative Users</h2>
         <div class="chart-container"><canvas ref="cumCanvas"></canvas></div>
       </div>
 
       <!-- 2) % First Purchase -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">
+        <h2 class="text-sm font-semibold mb-1">
           % of Users Buying First cToon within 1 {{ groupUnitLabel }}
         </h2>
         <div class="chart-container"><canvas ref="pctCanvas"></canvas></div>
@@ -59,48 +59,48 @@
 
       <!-- 3) Unique Logons -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">Unique {{ groupLabel }} Logons</h2>
+        <h2 class="text-sm font-semibold mb-1">Unique {{ groupLabel }} Logons</h2>
         <div class="chart-container"><canvas ref="uniqueCanvas"></canvas></div>
       </div>
 
       <!-- 4) Codes Redeemed (bar) -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">Codes Redeemed</h2>
+        <h2 class="text-sm font-semibold mb-1">Codes Redeemed</h2>
         <div class="chart-container"><canvas ref="codesCanvas"></canvas></div>
       </div>
 
       <!-- 5) Trades Requested (bar) -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">Trades Requested</h2>
+        <h2 class="text-sm font-semibold mb-1">Trades Requested</h2>
         <div class="chart-container"><canvas ref="tradesCanvas"></canvas></div>
       </div>
 
       <!-- 5) cToons Purchased (bar) -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">cToons Purchased</h2>
+        <h2 class="text-sm font-semibold mb-1">cToons Purchased</h2>
         <div class="chart-container"><canvas ref="ctoonCanvas"></canvas></div>
       </div>
 
       <!-- 6) Packs Purchased (bar) -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">Packs Purchased</h2>
+        <h2 class="text-sm font-semibold mb-1">Packs Purchased</h2>
         <div class="chart-container"><canvas ref="packsCanvas"></canvas></div>
       </div>
 
       <!-- 4) gToons Clash Games -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">gToons Clash Games</h2>
-        <h3 class="text-sm text-gray-600 mb-1">
+        <h2 class="text-sm font-semibold mb-1">gToons Clash Games</h2>
+        <h3 class="text-[11px] text-gray-600 mb-1">
           Total (window): {{ clashTotal }} — Finished: {{ clashPctFinished }}%
         </h3>
-        <div class="chart-container mb-6">
+        <div class="chart-container mb-2">
           <canvas ref="clashCanvas"></canvas>
         </div>
       </div>
 
       <!-- Monster Scans -->
       <div>
-        <h2 class="text-xl font-semibold mb-2">Monster Scans</h2>
+        <h2 class="text-sm font-semibold mb-1">Monster Scans</h2>
         <div class="chart-container">
           <canvas ref="monsterScansCanvas"></canvas>
         </div>
@@ -108,22 +108,22 @@
 
       <!-- Socket State / Leak Signals -->
       <div class="lg:col-span-2">
-        <h2 class="text-xl font-semibold mb-2 flex items-center">
+        <h2 class="text-sm font-semibold mb-1 flex items-center">
           Socket State Signals
           <span
-            class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium"
+            class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium"
             :class="leakRiskBadgeClass"
           >
             {{ leakRiskBadgeText }}
           </span>
         </h2>
-        <p class="text-sm text-gray-600 mb-2">
+        <p class="text-[11px] text-gray-600 mb-1">
           {{ leakRiskSummary }}
         </p>
-        <p class="text-xs text-gray-500 mb-2">
+        <p class="text-[10px] text-gray-500 mb-1">
           RSS MB is resident set size: the total memory the socket server process holds in RAM (heap + native).
         </p>
-        <p v-if="socketMetricsUpdatedAt" class="text-xs text-gray-500 mb-3">
+        <p v-if="socketMetricsUpdatedAt" class="text-[10px] text-gray-500 mb-1">
           Last sample: {{ formatSocketTime(socketMetricsUpdatedAt) }} · Samples: {{ socketMetricsSeries.length }}
         </p>
         <div class="chart-container">
@@ -133,25 +133,25 @@
 
       <!-- 7) Points Distribution (histogram) spans full width -->
       <div class="lg:col-span-2">
-        <div class="flex flex-wrap items-center justify-between gap-4 mb-2">
-          <h2 class="text-xl font-semibold">Points Distribution</h2>
-          <div class="flex flex-wrap items-center gap-3">
-            <label class="flex items-center space-x-2 text-sm">
+        <div class="flex flex-wrap items-center justify-between gap-2 mb-1">
+          <h2 class="text-sm font-semibold">Points Distribution</h2>
+          <div class="flex flex-wrap items-center gap-2">
+            <label class="flex items-center space-x-1 text-[11px]">
               <span class="font-medium">Bucket size:</span>
-              <select v-model.number="pointsBucketSize" class="border rounded px-2 py-1">
+              <select v-model.number="pointsBucketSize" class="border rounded px-1.5 py-0.5 text-xs">
                 <option v-for="opt in pointsBucketOptions" :key="opt.value" :value="opt.value">
                   {{ opt.label }}
                 </option>
               </select>
             </label>
-            <div class="flex items-center gap-2 text-sm">
-              <button type="button" class="border rounded px-2 py-1" @click="zoomPointsIn">
+            <div class="flex items-center gap-1 text-[11px]">
+              <button type="button" class="border rounded px-1.5 py-0.5" @click="zoomPointsIn">
                 Zoom In
               </button>
-              <button type="button" class="border rounded px-2 py-1" @click="zoomPointsOut">
+              <button type="button" class="border rounded px-1.5 py-0.5" @click="zoomPointsOut">
                 Zoom Out
               </button>
-              <button type="button" class="border rounded px-2 py-1" @click="resetPointsZoom">
+              <button type="button" class="border rounded px-1.5 py-0.5" @click="resetPointsZoom">
                 Reset
               </button>
             </div>
@@ -162,13 +162,13 @@
 
       <!-- 0) Net Points Issued w/ health badge -->
       <div class="lg:col-span-2">
-        <h2 class="text-xl font-semibold mb-2 flex items-center">
+        <h2 class="text-sm font-semibold mb-1 flex items-center flex-wrap gap-1">
           Net Points Issued
-          <span class="ml-2 text-sm text-gray-500">
+          <span class="text-[10px] text-gray-500">
             (last {{ netWindowCount }} {{ windowUnitPlural }})
           </span>
           <span
-            class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium"
+            class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium"
             :class="badgeClass"
           >
             {{ badgeText }}
@@ -176,9 +176,9 @@
         </h2>
 
         <!-- suggestions block -->
-        <div v-if="netStatus !== 'good'" class="mt-2 p-3 bg-yellow-50 rounded">
-          <p class="font-medium mb-1">How to improve:</p>
-          <ul class="list-disc list-inside space-y-1 text-sm">
+        <div v-if="netStatus !== 'good'" class="mt-1 p-2 bg-yellow-50 rounded">
+          <p class="font-medium mb-1 text-[11px]">How to improve:</p>
+          <ul class="list-disc list-inside space-y-0.5 text-[11px]">
             <li v-for="(s,i) in netSuggestions" :key="i">{{ s }}</li>
           </ul>
         </div>
@@ -190,22 +190,22 @@
 
       <!-- Spend / Earn Ratio -->
       <div class="lg:col-span-2">
-        <h2 class="text-xl font-semibold mb-2 flex items-center">
+        <h2 class="text-sm font-semibold mb-1 flex items-center flex-wrap gap-1">
           Spend / Earn Ratio
-          <span class="ml-2 text-sm text-gray-500">
+          <span class="text-[10px] text-gray-500">
             (last {{ ratioWindowCount }} {{ windowUnitPlural }})
           </span>
           <span
-            class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium"
+            class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium"
             :class="ratioBadgeClass"
           >
             {{ ratioBadgeText }}
           </span>
         </h2>
 
-        <div v-if="ratioStatus !== 'good'" class="mt-2 p-3 bg-yellow-50 rounded">
-          <p class="font-medium mb-1">How to improve:</p>
-          <ul class="list-disc list-inside space-y-1 text-sm">
+        <div v-if="ratioStatus !== 'good'" class="mt-1 p-2 bg-yellow-50 rounded">
+          <p class="font-medium mb-1 text-[11px]">How to improve:</p>
+          <ul class="list-disc list-inside space-y-0.5 text-[11px]">
             <li v-for="(s,i) in ratioSuggestions" :key="i">{{ s }}</li>
           </ul>
         </div>
@@ -217,13 +217,13 @@
 
       <!-- 8) Rarity Turnover Rate -->
       <div class="lg:col-span-2">
-        <h2 class="text-xl font-semibold mb-2 flex items-center">
+        <h2 class="text-sm font-semibold mb-1 flex items-center flex-wrap gap-1">
           Rarity Turnover Rate
-          <span class="ml-2 text-sm text-gray-500">
+          <span class="text-[10px] text-gray-500">
             (last {{ turnoverWindowCount }} {{ windowUnitPlural }})
           </span>
           <span
-            class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium"
+            class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium"
             :class="turnoverBadgeClass"
           >
             {{ turnoverBadgeText }}
@@ -231,16 +231,16 @@
         </h2>
 
         <!-- healthy ranges subtitle -->
-        <div class="text-sm text-gray-500 mb-4">
-          <span v-for="(range, rarity) in healthyRanges" :key="rarity" class="mr-6">
+        <div class="text-[10px] text-gray-500 mb-2">
+          <span v-for="(range, rarity) in healthyRanges" :key="rarity" class="mr-3">
             {{ rarity }}: {{ range }}
           </span>
         </div>
 
         <!-- suggestions if not healthy -->
-        <div v-if="turnoverStatus !== 'good'" class="mt-2 p-3 bg-yellow-50 rounded">
-          <p class="font-medium mb-1">How to improve:</p>
-          <ul class="list-disc list-inside space-y-1 text-sm">
+        <div v-if="turnoverStatus !== 'good'" class="mt-1 p-2 bg-yellow-50 rounded">
+          <p class="font-medium mb-1 text-[11px]">How to improve:</p>
+          <ul class="list-disc list-inside space-y-0.5 text-[11px]">
             <li v-for="(s,i) in turnoverSuggestions" :key="i">{{ s }}</li>
           </ul>
         </div>
@@ -1283,8 +1283,8 @@ watch(pointsBucketSize, async () => {
 }
 
 .chart-container {
-  height: 300px;
+  height: 220px;
   position: relative;
-  padding: 10px;
+  padding: 4px;
 }
 </style>

--- a/components/newsite/AdminAuctionLogs.vue
+++ b/components/newsite/AdminAuctionLogs.vue
@@ -1,0 +1,311 @@
+<template>
+  <div class="admin-auction-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <!-- Filters -->
+      <div class="mb-2 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2 items-end">
+        <div>
+          <label for="ctoonNameSearch" class="block text-[10px] font-medium text-gray-700 mb-0.5">cToon Name</label>
+          <input
+            id="ctoonNameSearch"
+            v-model="ctoonNameQuery"
+            type="text"
+            placeholder="Search by name…"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+
+        <div>
+          <label for="characterSearch" class="block text-[10px] font-medium text-gray-700 mb-0.5">Characters</label>
+          <input
+            id="characterSearch"
+            v-model="characterQuery"
+            type="text"
+            placeholder="e.g. Bugs, Daffy"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+
+        <div>
+          <label for="creatorSearch" class="block text-[10px] font-medium text-gray-700 mb-0.5">Creator</label>
+          <input
+            id="creatorSearch"
+            v-model="creatorQuery"
+            type="text"
+            placeholder="Type a username…"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+
+        <div class="relative">
+          <label for="winnerSearch" class="block text-[10px] font-medium text-gray-700 mb-0.5">Winner</label>
+          <input
+            id="winnerSearch"
+            v-model="winnerQuery"
+            type="text"
+            placeholder="Type a username…"
+            autocomplete="off"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            @blur="hideWinnerSuggestions"
+          />
+          <ul
+            v-if="winnerSuggestions.length > 0"
+            class="absolute z-10 mt-0.5 w-full bg-white border rounded shadow-lg max-h-40 overflow-y-auto"
+          >
+            <li
+              v-for="user in winnerSuggestions"
+              :key="user.id"
+              class="px-2 py-1 text-[11px] cursor-pointer hover:bg-indigo-50"
+              @mousedown.prevent="selectWinner(user.username)"
+            >
+              {{ user.username }}
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <label for="rarityFilter" class="block text-[10px] font-medium text-gray-700 mb-0.5">Rarity</label>
+          <select
+            id="rarityFilter"
+            v-model="selectedRarity"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          >
+            <option value="">All</option>
+            <option v-for="opt in rarityOptions" :key="opt" :value="opt">{{ opt }}</option>
+          </select>
+        </div>
+
+        <div>
+          <label for="statusFilter" class="block text-[10px] font-medium text-gray-700 mb-0.5">Status</label>
+          <select
+            id="statusFilter"
+            v-model="selectedStatus"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          >
+            <option value="">All</option>
+            <option v-for="status in statusOptions" :key="status" :value="status">{{ status }}</option>
+          </select>
+        </div>
+
+        <div>
+          <label for="bidderFilter" class="block text-[10px] font-medium text-gray-700 mb-0.5">Has Bidder</label>
+          <select
+            id="bidderFilter"
+            v-model="selectedHasBidder"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          >
+            <option v-for="opt in hasBidderOptions" :key="opt.value" :value="opt.value">
+              {{ opt.label }}
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <div class="mb-2 text-[11px] text-gray-600">
+        Total Results: {{ total }} auctions
+      </div>
+
+      <!-- Desktop Table -->
+      <div class="hidden md:block overflow-x-auto">
+        <table class="min-w-full bg-white rounded shadow text-[11px]">
+          <thead class="bg-gray-100">
+            <tr>
+              <th class="px-1.5 py-1 text-left">cToon</th>
+              <th class="px-1.5 py-1 text-left">Creator</th>
+              <th class="px-1.5 py-1 text-left">Status</th>
+              <th class="px-1.5 py-1 text-left">Created</th>
+              <th class="px-1.5 py-1 text-right">Days</th>
+              <th class="px-1.5 py-1 text-right">Hrs Left</th>
+              <th class="px-1.5 py-1 text-left">Top Bidder</th>
+              <th class="px-1.5 py-1 text-left">Winner</th>
+              <th class="px-1.5 py-1 text-right">High Bid</th>
+              <th class="px-1.5 py-1 text-right"># Bids</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="auc in auctions" :key="auc.id" class="border-t">
+              <td class="px-1.5 py-1">
+                <img :src="auc.userCtoon.ctoon?.assetPath" alt="" class="w-8 h-8 object-cover rounded" />
+              </td>
+              <td class="px-1.5 py-1">{{ auc.creator?.username || '—' }}</td>
+              <td class="px-1.5 py-1">{{ auc.status }}</td>
+              <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(auc.createdAt) }}</td>
+              <td class="px-1.5 py-1 text-right tabular-nums">{{ auc.duration }}</td>
+              <td class="px-1.5 py-1 text-right tabular-nums">{{ hoursLeft(auc.endAt) }}</td>
+              <td class="px-1.5 py-1">{{ auc.highestBidder?.username || '—' }}</td>
+              <td class="px-1.5 py-1">{{ auc.winner?.username || '—' }}</td>
+              <td class="px-1.5 py-1 text-right tabular-nums">{{ auc.highestBid }}</td>
+              <td class="px-1.5 py-1 text-right tabular-nums">{{ auc.bids.length }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Mobile Cards -->
+      <div class="md:hidden grid grid-cols-1 gap-2">
+        <div v-for="auc in auctions" :key="auc.id" class="border rounded p-2 shadow text-[11px]">
+          <div class="flex items-center mb-2">
+            <img :src="auc.userCtoon.ctoon?.assetPath" alt="" class="w-12 h-12 object-cover rounded mr-2" />
+            <div>
+              <div class="font-semibold text-xs">{{ auc.userCtoon.ctoon?.name || 'Unknown' }}</div>
+              <div class="text-[10px] text-gray-500">{{ hoursLeft(auc.endAt) }} hours left</div>
+            </div>
+          </div>
+          <div class="space-y-0.5 text-gray-700">
+            <div><span class="font-medium">Creator:</span> {{ auc.creator?.username || '—' }}</div>
+            <div><span class="font-medium">Status:</span> {{ auc.status }}</div>
+            <div><span class="font-medium">Created:</span> {{ formatDate(auc.createdAt) }}</div>
+            <div><span class="font-medium">Duration:</span> {{ auc.duration }} days</div>
+            <div><span class="font-medium">Top Bidder:</span> {{ auc.highestBidder?.username || '—' }}</div>
+            <div><span class="font-medium">Winner:</span> {{ auc.winner?.username || '—' }}</div>
+            <div><span class="font-medium">Highest Bid:</span> {{ auc.highestBid }}</div>
+            <div><span class="font-medium"># of Bids:</span> {{ auc.bids.length }}</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Pagination -->
+      <div class="mt-3 flex items-center justify-between">
+        <div class="text-[11px] text-gray-600">
+          Page {{ page }} of {{ totalPages }} • Showing
+          {{ Math.min(total, (page-1)*pageSize + 1) }}–{{ Math.min(page*pageSize, total) }}
+          of {{ total }}
+        </div>
+        <div class="space-x-1">
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page<=1" @click="prevPage">Prev</button>
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page>=totalPages" @click="nextPage">Next</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
+
+const pageSize = 100
+const page = ref(1)
+const total = ref(0)
+const auctions = ref([])
+
+// Filters
+const ctoonNameQuery = ref('')
+const characterQuery = ref('')
+const creatorQuery = ref('')
+const winnerQuery = ref('')
+const winnerSuggestions = ref([])
+const selectedRarity = ref('')
+const selectedStatus = ref('')
+const selectedHasBidder = ref('')
+
+const statusOptions = ['ACTIVE', 'CLOSED', 'CANCELLED']
+const rarityOptions = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare', 'Prize Only', 'Code Only', 'Auction Only']
+const hasBidderOptions = [
+  { value: '', label: 'All' },
+  { value: 'has', label: 'With Bidder' },
+  { value: 'none', label: 'No Bidder' }
+]
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+
+function scrollTop() {
+  if (process.client) window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+async function fetchAuctions() {
+  const res = await $fetch('/api/admin/auctions', {
+    query: {
+      page: page.value,
+      limit: pageSize,
+      creator: creatorQuery.value.trim() || undefined,
+      winner: winnerQuery.value.trim() || undefined,
+      ctoonName: ctoonNameQuery.value.trim() || undefined,
+      characters: characterQuery.value.trim() || undefined,
+      rarity: selectedRarity.value || undefined,
+      status: selectedStatus.value || undefined,
+      hasBidder: selectedHasBidder.value || undefined
+    }
+  })
+  auctions.value = res.items || []
+  total.value = res.total || 0
+}
+
+let filterDebounceId = null
+function scheduleFilterFetch() {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  filterDebounceId = setTimeout(async () => {
+    if (page.value !== 1) {
+      page.value = 1
+      return
+    }
+    await fetchAuctions()
+    await nextTick()
+    scrollTop()
+  }, 300)
+}
+
+// Winner autocomplete
+let winnerSuggestDebounceId = null
+watch(winnerQuery, (val) => {
+  if (winnerSuggestDebounceId) clearTimeout(winnerSuggestDebounceId)
+  const trimmed = val.trim()
+  if (trimmed.length < 3) {
+    winnerSuggestions.value = []
+    return
+  }
+  winnerSuggestDebounceId = setTimeout(async () => {
+    const results = await $fetch('/api/admin/auction-winners', { query: { q: trimmed } })
+    winnerSuggestions.value = results
+  }, 300)
+})
+
+function selectWinner(username) {
+  winnerQuery.value = username
+  winnerSuggestions.value = []
+}
+
+function hideWinnerSuggestions() {
+  setTimeout(() => { winnerSuggestions.value = [] }, 150)
+}
+
+// React to text filters with debounce
+watch([ctoonNameQuery, characterQuery, creatorQuery, winnerQuery], () => {
+  scheduleFilterFetch()
+})
+
+watch([selectedStatus, selectedHasBidder, selectedRarity], async () => {
+  if (page.value !== 1) {
+    page.value = 1
+    return
+  }
+  await fetchAuctions()
+  await nextTick()
+  scrollTop()
+})
+
+watch(page, async () => {
+  await fetchAuctions()
+  await nextTick()
+  scrollTop()
+})
+
+onMounted(async () => {
+  await fetchAuctions()
+})
+
+function prevPage() { if (page.value > 1) page.value-- }
+function nextPage() { if (page.value < totalPages.value) page.value++ }
+
+const hoursLeft = (endAt) => {
+  const diff = new Date(endAt) - new Date()
+  return diff > 0 ? Math.floor(diff / (1000 * 60 * 60)) : 0
+}
+const formatDate = (dt) => new Date(dt).toLocaleDateString()
+</script>
+
+<style scoped>
+.admin-auction-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+</style>

--- a/components/newsite/AdminAuthLogs.vue
+++ b/components/newsite/AdminAuthLogs.vue
@@ -1,0 +1,368 @@
+<template>
+  <div class="admin-auth-logs bg-gray-50">
+    <div class="p-2 space-y-2 text-xs">
+      <h1 class="text-base font-bold mb-2">Auth Logs</h1>
+
+      <div>
+        <!-- Search bar -->
+        <div class="mb-2">
+          <input
+            v-model="searchTerm"
+            type="text"
+            placeholder="Search by username…"
+            class="w-full border border-gray-300 rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+
+        <div v-if="logsLoading" class="text-gray-500">Loading...</div>
+        <div v-else-if="filteredLogs.length === 0" class="text-gray-500">No logs found.</div>
+        <div v-else>
+          <!-- Card view (small/medium) -->
+          <div class="lg:hidden space-y-2">
+            <div
+              v-for="log in filteredLogs"
+              :key="log.id"
+              :class="[
+                'p-2 border rounded shadow text-[11px] space-y-0.5',
+                isSuspicious(log.ip) ? 'bg-yellow-100' : 'bg-white'
+              ]"
+            >
+              <p><strong>Login Time:</strong> {{ formatDate(log.createdAt, true) }}</p>
+              <p><strong>Username:</strong> {{ log.user.username || '—' }}</p>
+              <p><strong>User Created:</strong> {{ formatDate(log.user.createdAt) }}</p>
+              <p><strong>Discord Username:</strong> {{ log.user.discordTag || '—' }}</p>
+              <p><strong>Discord Created:</strong> {{ formatDate(log.user.discordCreatedAt) }}</p>
+              <p><strong>IP:</strong> {{ log.ip }}</p>
+              <p v-if="isSuspicious(log.ip)" class="mt-1">
+                <strong>Other Usernames:</strong>
+                {{ otherKnownUsernames(log.ip, log.user.username).join(', ') }}
+              </p>
+
+              <div class="mt-1">
+                <button
+                  class="px-2 py-0.5 text-[11px] border rounded hover:bg-gray-100"
+                  @click="openCheatSummary(log.user.username, otherKnownUsernames(log.ip, log.user.username))"
+                  :disabled="!isKnown(log.user.username) || otherKnownUsernames(log.ip, log.user.username).length === 0"
+                >
+                  Cheat Check
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Table view (large+) -->
+          <div class="hidden lg:block overflow-x-auto">
+            <table class="min-w-full border border-gray-300 text-[11px]">
+              <thead class="bg-gray-100 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">Login Time</th>
+                  <th class="px-1.5 py-1 border-b">Username</th>
+                  <th class="px-1.5 py-1 border-b">User Created</th>
+                  <th class="px-1.5 py-1 border-b">Discord Username</th>
+                  <th class="px-1.5 py-1 border-b">Discord Created</th>
+                  <th class="px-1.5 py-1 border-b">IP</th>
+                  <th class="px-1.5 py-1 border-b">Other Usernames</th>
+                  <th class="px-1.5 py-1 border-b"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="log in filteredLogs"
+                  :key="log.id"
+                  :class="isSuspicious(log.ip) ? 'bg-yellow-100' : ''"
+                >
+                  <td class="px-1.5 py-1 border-b whitespace-nowrap">{{ formatDate(log.createdAt, true) }}</td>
+                  <td class="px-1.5 py-1 border-b">{{ log.user.username || '—' }}</td>
+                  <td class="px-1.5 py-1 border-b whitespace-nowrap">{{ formatDate(log.user.createdAt) }}</td>
+                  <td class="px-1.5 py-1 border-b">{{ log.user.discordTag || '—' }}</td>
+                  <td class="px-1.5 py-1 border-b whitespace-nowrap">{{ formatDate(log.user.discordCreatedAt) }}</td>
+                  <td class="px-1.5 py-1 border-b">{{ log.ip }}</td>
+                  <td class="px-1.5 py-1 border-b">
+                    <span v-if="isSuspicious(log.ip)">
+                      {{ otherKnownUsernames(log.ip, log.user.username).join(', ') }}
+                    </span>
+                    <span v-else>—</span>
+                  </td>
+                  <td class="px-1.5 py-1 border-b">
+                    <button
+                      class="px-2 py-0.5 text-[11px] border rounded hover:bg-gray-100"
+                      @click="openCheatSummary(log.user.username, otherKnownUsernames(log.ip, log.user.username))"
+                      :disabled="!isKnown(log.user.username) || otherKnownUsernames(log.ip, log.user.username).length === 0"
+                    >
+                      Cheat Check
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="mt-2 flex items-center justify-between">
+          <div class="text-[11px] text-gray-600">
+            Page {{ logsPage }} of {{ logsTotalPages }} - Showing {{ logsShowingRange }}
+          </div>
+          <div class="space-x-1">
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="logsPage <= 1" @click="prevLogsPage">Prev</button>
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="logsPage >= logsTotalPages" @click="nextLogsPage">Next</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Cheat summary modal -->
+      <teleport to="body">
+        <div
+          v-if="showCheatModal"
+          class="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-3"
+        >
+          <div class="bg-white rounded-lg shadow-xl w-full max-w-xl p-3 max-h-[85vh] overflow-auto text-xs">
+            <div class="flex items-start justify-between">
+              <h3 class="text-sm font-semibold">Cheating Summary</h3>
+              <button class="text-gray-500" @click="closeCheatModal">✕</button>
+            </div>
+
+            <div class="mt-1 text-gray-600">
+              <div><strong>Target:</strong> {{ previewTarget }}</div>
+              <div><strong>Sources:</strong> {{ previewSources.join(', ') || '—' }}</div>
+            </div>
+
+            <div v-if="previewLoading" class="mt-2 text-gray-500">Loading…</div>
+            <div v-else-if="previewError" class="mt-2 text-red-600">{{ previewError }}</div>
+
+            <div v-else-if="preview" class="mt-2 space-y-2">
+              <div class="grid grid-cols-2 gap-2">
+                <div class="p-2 border rounded bg-gray-50">
+                  <div class="font-medium">Seed items</div>
+                  <div class="text-sm">{{ preview.seedCount }}</div>
+                </div>
+                <div class="p-2 border rounded bg-gray-50">
+                  <div class="font-medium">Currently owned by target</div>
+                  <div class="text-sm">{{ preview.currentOwnedCount }}</div>
+                </div>
+                <div class="p-2 border rounded bg-gray-50">
+                  <div class="font-medium">Auction points received</div>
+                  <div class="text-sm">{{ preview.auctionPoints }}</div>
+                </div>
+                <div class="p-2 border rounded bg-gray-50">
+                  <div class="font-medium">Trade value received</div>
+                  <div class="text-sm">{{ preview.tradeValue }}</div>
+                </div>
+              </div>
+
+              <div>
+                <h4 class="font-medium mb-1">By source</h4>
+                <div
+                  v-if="preview.bySource && Object.keys(preview.bySource).length"
+                  class="space-y-1"
+                >
+                  <div
+                    v-for="(row, name) in preview.bySource"
+                    :key="name"
+                    class="flex justify-between bg-gray-50 p-1.5 rounded border"
+                  >
+                    <div class="font-medium">{{ name }}</div>
+                    <div class="text-right">
+                      <div>Seed: {{ row.seedCount }}</div>
+                      <div>Owned by target: {{ row.currentOwnedCount }}</div>
+                      <div>Auction pts: {{ row.auctionPoints }}</div>
+                      <div>Trade value: {{ row.tradeValue }}</div>
+                    </div>
+                  </div>
+                </div>
+                <div v-else class="text-gray-500">No breakdown.</div>
+              </div>
+            </div>
+
+            <div class="mt-3 text-right">
+              <button class="px-3 py-1 border rounded text-[11px]" @click="closeCheatModal">Close</button>
+            </div>
+          </div>
+        </div>
+      </teleport>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+
+const logs             = ref([])
+const logsTotal        = ref(0)
+const logsPage         = ref(1)
+const logsLoading      = ref(false)
+const logsPageSize     = 100
+const searchTerm       = ref('')
+
+const usersLoaded     = ref(false)
+const knownUsernames  = ref(new Set())
+
+async function ensureUsersLoaded () {
+  if (usersLoaded.value) return
+  const res = await fetch('/api/admin/users', { credentials: 'include' })
+  if (!res.ok) return
+  const users = await res.json()
+  const set = new Set()
+  for (const u of users || []) {
+    if (u?.username) set.add(u.username)
+  }
+  knownUsernames.value = set
+  usersLoaded.value    = true
+}
+
+const isKnown = (name) => knownUsernames.value.has(name)
+
+const showCheatModal  = ref(false)
+const previewLoading  = ref(false)
+const previewError    = ref('')
+const preview         = ref(null)
+const previewTarget   = ref('')
+const previewSources  = ref([])
+
+async function fetchAllLogs() {
+  logsLoading.value = true
+  try {
+    const params = new URLSearchParams({
+      page: String(logsPage.value),
+      limit: String(logsPageSize)
+    })
+    const term = searchTerm.value.trim()
+    if (term) params.set('username', term)
+
+    const res = await fetch(`/api/admin/auth-logs?${params.toString()}`, { credentials: 'include' })
+    if (!res.ok) {
+      logs.value = []
+      logsTotal.value = 0
+      return
+    }
+    const { items, total, page } = await res.json()
+    logs.value = items || []
+    logsTotal.value = total || 0
+    if (page) logsPage.value = page
+  } finally {
+    logsLoading.value = false
+  }
+}
+
+const filteredLogs = computed(() =>
+  logs.value.filter(l =>
+    (l.user?.username ?? '')
+      .toLowerCase()
+      .includes(searchTerm.value.toLowerCase())
+  )
+)
+
+const logsTotalPages = computed(() => Math.max(1, Math.ceil(logsTotal.value / logsPageSize)))
+
+const logsShowingRange = computed(() => {
+  if (!logsTotal.value) return '0-0 of 0'
+  const start = (logsPage.value - 1) * logsPageSize + 1
+  const end = Math.min(logsPage.value * logsPageSize, logsTotal.value)
+  return `${start}-${end} of ${logsTotal.value}`
+})
+
+function isSuspicious(ip) {
+  const users = logs.value
+    .filter(l => l.ip === ip && !l.user.isAdmin)
+    .map(l => l.user.username || '__null__')
+  return new Set(users).size > 1
+}
+
+function otherKnownUsernames(ip, current) {
+  const uniq = new Set(
+    logs.value
+      .filter(l => l.ip === ip && !l.user.isAdmin)
+      .map(l => l.user.username || '__null__')
+  )
+  uniq.delete(current || '__null__')
+  return Array.from(uniq).filter(u => isKnown(u))
+}
+
+async function nextLogsPage() {
+  if (logsPage.value >= logsTotalPages.value) return
+  logsPage.value += 1
+  await fetchAllLogs()
+}
+
+async function prevLogsPage() {
+  if (logsPage.value <= 1) return
+  logsPage.value -= 1
+  await fetchAllLogs()
+}
+
+function formatDate(input, withTime = false) {
+  const d = new Date(input)
+  return d.toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: withTime ? 'short' : undefined
+  })
+}
+
+async function openCheatSummary(target, sources) {
+  const t = target || ''
+  const s = Array.isArray(sources) ? sources.filter(isKnown) : []
+
+  previewTarget.value  = t
+  previewSources.value = s
+  previewLoading.value = true
+  previewError.value   = ''
+  preview.value        = null
+  showCheatModal.value = true
+
+  if (!t || !isKnown(t)) {
+    previewLoading.value = false
+    previewError.value = 'Target username is unknown.'
+    return
+  }
+  if (!s.length) {
+    previewLoading.value = false
+    previewError.value = 'Need at least one known source username from the same IP.'
+    return
+  }
+
+  try {
+    const res = await fetch('/api/admin/check-cheating', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ target: t, sources: s })
+    })
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}))
+      throw new Error(j?.statusMessage || `HTTP ${res.status}`)
+    }
+    preview.value = await res.json()
+  } catch (err) {
+    previewError.value = err.message || 'Failed to load summary.'
+  } finally {
+    previewLoading.value = false
+  }
+}
+
+function closeCheatModal() {
+  showCheatModal.value = false
+}
+
+onMounted(() => {
+  ensureUsersLoaded()
+  fetchAllLogs()
+})
+
+let searchDebounceId = null
+watch(searchTerm, () => {
+  if (searchDebounceId) clearTimeout(searchDebounceId)
+  searchDebounceId = setTimeout(() => {
+    logsPage.value = 1
+    fetchAllLogs()
+  }, 300)
+})
+</script>
+
+<style scoped>
+.admin-auth-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+
+th, td { vertical-align: middle; }
+</style>

--- a/components/newsite/AdminCheatFinder.vue
+++ b/components/newsite/AdminCheatFinder.vue
@@ -1,0 +1,201 @@
+<template>
+  <div class="admin-cheat-finder bg-gray-50">
+    <div class="p-2 text-xs">
+      <h1 class="text-base font-bold mb-2">Cheat Finder</h1>
+
+      <!-- Tabs -->
+      <div class="flex space-x-3 border-b border-gray-300 mb-2 overflow-x-auto">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          @click="activeTab = tab.id"
+          :class="activeTab === tab.id
+            ? 'border-b-2 border-indigo-600 text-indigo-600'
+            : 'text-gray-500 hover:text-gray-700'"
+          class="pb-1 px-1 text-xs font-medium whitespace-nowrap"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+
+      <!-- Duplicate IPs tab -->
+      <div v-if="activeTab === 'duplicateIps'">
+      <div class="mb-2">
+        <input
+          v-model="searchTerm"
+          type="text"
+          placeholder="Search usernames…"
+          class="w-full border border-gray-300 rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+        />
+      </div>
+
+      <div v-if="loading" class="text-gray-500">Loading…</div>
+      <div v-else-if="groups.length === 0" class="text-gray-500">No IPs with multiple users found.</div>
+
+      <div v-else class="space-y-2">
+        <div
+          v-for="group in groups"
+          :key="group.ip"
+          class="bg-white border rounded shadow p-2"
+        >
+          <div class="flex items-center justify-between mb-1">
+            <h2 class="font-mono font-semibold text-xs">{{ group.ip }}</h2>
+            <span class="text-[10px] text-gray-500">{{ group.aliases.length }} accounts</span>
+          </div>
+
+          <!-- Desktop table -->
+          <div class="hidden md:block overflow-x-auto">
+            <table class="min-w-full text-[11px]">
+              <thead class="bg-gray-50 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">Username</th>
+                  <th class="px-1.5 py-1 border-b">Joined</th>
+                  <th class="px-1.5 py-1 border-b">Discord Username</th>
+                  <th class="px-1.5 py-1 border-b">Discord Account Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="alias in group.aliases" :key="alias.username" class="border-b last:border-b-0">
+                  <td class="px-1.5 py-1 font-medium">{{ alias.username }}</td>
+                  <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(alias.joined) }}</td>
+                  <td class="px-1.5 py-1">{{ alias.discordTag || '—' }}</td>
+                  <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(alias.discordCreatedAt) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Mobile cards -->
+          <div class="md:hidden space-y-1.5">
+            <div
+              v-for="alias in group.aliases"
+              :key="alias.username"
+              class="border rounded p-1.5 bg-gray-50"
+            >
+              <div class="font-medium text-[11px]">{{ alias.username }}</div>
+              <div class="mt-0.5 grid grid-cols-1 gap-0.5 text-[10px] text-gray-700">
+                <div><span class="text-gray-500">Joined:</span> {{ formatDate(alias.joined) }}</div>
+                <div><span class="text-gray-500">Discord:</span> {{ alias.discordTag || '—' }}</div>
+                <div><span class="text-gray-500">Discord Created:</span> {{ formatDate(alias.discordCreatedAt) }}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="!loading && total > 0" class="mt-3 flex items-center justify-between">
+        <div class="text-[11px] text-gray-600">
+          Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
+        </div>
+        <div class="space-x-1">
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+        </div>
+      </div>
+      </div>
+
+      <!-- Placeholder tabs -->
+      <div v-else class="text-gray-500 py-8 text-center">
+        Placeholder
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+
+const tabs = [
+  { id: 'duplicateIps', label: 'Duplicate IPs' },
+  { id: 'placeholder-1', label: 'Placeholder' },
+  { id: 'placeholder-2', label: 'Placeholder' },
+  { id: 'placeholder-3', label: 'Placeholder' },
+  { id: 'placeholder-4', label: 'Placeholder' },
+  { id: 'placeholder-5', label: 'Placeholder' }
+]
+const activeTab = ref('duplicateIps')
+
+const groups = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = 100
+const loading = ref(false)
+const searchTerm = ref('')
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const showingRange = computed(() => {
+  if (!total.value) return '0-0 of 0'
+  const start = (page.value - 1) * pageSize + 1
+  const end = Math.min(page.value * pageSize, total.value)
+  return `${start}-${end} of ${total.value}`
+})
+
+function formatDate(dt) {
+  if (!dt) return '—'
+  return new Date(dt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
+}
+
+async function fetchGroups() {
+  loading.value = true
+  try {
+    const params = new URLSearchParams({
+      page: String(page.value),
+      limit: String(pageSize)
+    })
+    const term = searchTerm.value.trim()
+    if (term) params.set('username', term)
+
+    const res = await fetch(`/api/admin/duplicate-users?${params.toString()}`, { credentials: 'include' })
+    if (!res.ok) {
+      groups.value = []
+      total.value = 0
+      return
+    }
+    const data = await res.json()
+    groups.value = data.groups || []
+    total.value = data.total || 0
+    if (data.page) page.value = data.page
+  } catch (e) {
+    console.error('Failed to load duplicate users', e)
+    groups.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  fetchGroups()
+}
+
+function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  fetchGroups()
+}
+
+let searchDebounceId = null
+watch(searchTerm, () => {
+  if (searchDebounceId) clearTimeout(searchDebounceId)
+  searchDebounceId = setTimeout(() => {
+    page.value = 1
+    fetchGroups()
+  }, 300)
+})
+
+onMounted(fetchGroups)
+</script>
+
+<style scoped>
+.admin-cheat-finder {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+</style>

--- a/components/newsite/AdminCtoonOwnerLogs.vue
+++ b/components/newsite/AdminCtoonOwnerLogs.vue
@@ -1,0 +1,345 @@
+<template>
+  <div class="admin-ctoon-owner-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <!-- Filters -->
+      <div class="mb-2 flex flex-wrap items-center gap-2">
+        <div class="flex items-center">
+          <label for="userFilter" class="mr-1 font-medium">User:</label>
+          <input
+            id="userFilter"
+            v-model="userQuery"
+            list="userSuggestions"
+            type="text"
+            class="border rounded px-1.5 py-0.5 text-xs"
+            placeholder="Type a username..."
+          />
+          <datalist id="userSuggestions">
+            <option v-for="u in userSuggestions" :key="u" :value="u" />
+          </datalist>
+        </div>
+
+        <div class="flex items-center">
+          <label for="ctoonFilter" class="mr-1 font-medium">cToon:</label>
+          <input
+            id="ctoonFilter"
+            v-model="ctoonQuery"
+            list="ctoonSuggestions"
+            type="text"
+            class="border rounded px-1.5 py-0.5 text-xs"
+            placeholder="3+ chars"
+          />
+          <datalist id="ctoonSuggestions">
+            <option v-for="n in ctoonSuggestions" :key="n" :value="n" />
+          </datalist>
+        </div>
+
+        <div class="flex items-center">
+          <label for="mintFilter" class="mr-1 font-medium">Mint #:</label>
+          <input
+            id="mintFilter"
+            v-model.number="mintFilter"
+            type="number"
+            min="1"
+            class="border rounded px-1.5 py-0.5 text-xs w-20"
+            placeholder="Any"
+          />
+        </div>
+
+        <div class="flex items-center">
+          <label for="idSearch" class="mr-1 font-medium">UserCtoonId:</label>
+          <input
+            id="idSearch"
+            v-model="idSearch"
+            type="text"
+            class="border rounded px-1.5 py-0.5 text-xs w-40"
+            placeholder="Contains…"
+          />
+        </div>
+
+        <div class="flex items-center">
+          <label for="fromDate" class="mr-1 font-medium">From:</label>
+          <input id="fromDate" v-model="fromDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+        <div class="flex items-center">
+          <label for="toDate" class="mr-1 font-medium">To:</label>
+          <input id="toDate" v-model="toDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+      </div>
+
+      <div class="mb-2 text-[11px] text-gray-600">
+        Total Results: {{ total }} logs
+      </div>
+
+      <div v-if="isLoading" class="text-gray-500">Loading...</div>
+      <div v-else-if="!logs.length" class="text-center text-gray-500 mt-6">
+        No logs match the current filters.
+      </div>
+      <div v-else>
+        <!-- Desktop table -->
+        <div class="hidden md:block overflow-x-auto">
+          <table class="min-w-full bg-white rounded shadow text-[11px]">
+            <thead class="bg-gray-100">
+              <tr>
+                <th class="px-1.5 py-1 text-left">Time</th>
+                <th class="px-1.5 py-1 text-left">User</th>
+                <th class="px-1.5 py-1 text-left">cToon</th>
+                <th class="px-1.5 py-1 text-left">Rarity</th>
+                <th class="px-1.5 py-1 text-right">Mint #</th>
+                <th class="px-1.5 py-1 text-left">UserCtoonId</th>
+                <th class="px-1.5 py-1"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="log in logs"
+                :key="log.id"
+                class="border-t"
+              >
+                <td class="px-1.5 py-1 whitespace-nowrap">{{ formatTs(log.createdAt) }}</td>
+                <td class="px-1.5 py-1 break-words">{{ log.user?.username || 'Unknown' }}</td>
+                <td class="px-1.5 py-1">
+                  <div class="flex items-center gap-1.5">
+                    <img
+                      v-if="log.ctoon?.assetPath"
+                      :src="img(log.ctoon.assetPath)"
+                      alt
+                      class="w-6 h-6 object-contain rounded"
+                    />
+                    <span class="break-words">{{ log.ctoon?.name || 'Unknown' }}</span>
+                  </div>
+                </td>
+                <td class="px-1.5 py-1">{{ log.ctoon?.rarity || '-' }}</td>
+                <td class="px-1.5 py-1 text-right tabular-nums">{{ log.mintNumber ?? '—' }}</td>
+                <td class="px-1.5 py-1 font-mono">
+                  <span class="truncate inline-block max-w-[140px]" :title="log.userCtoonId">
+                    {{ shorten(log.userCtoonId) }}
+                  </span>
+                </td>
+                <td class="px-1.5 py-1">
+                  <button class="bg-blue-500 text-white px-2 py-0.5 rounded text-[11px]" @click="openModal(log)">
+                    View
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile cards -->
+        <div class="md:hidden grid grid-cols-1 gap-2">
+          <div v-for="log in logs" :key="log.id" class="border rounded p-2 shadow text-[11px]">
+            <div class="text-[10px] text-gray-500 mb-1">{{ formatTs(log.createdAt) }}</div>
+            <div class="mb-0.5"><span class="font-medium">User:</span> {{ log.user?.username || 'Unknown' }}</div>
+            <div class="mb-0.5 flex items-center gap-1.5">
+              <span class="font-medium">cToon:</span>
+              <img
+                v-if="log.ctoon?.assetPath"
+                :src="img(log.ctoon.assetPath)"
+                alt
+                class="w-6 h-6 object-contain rounded"
+              />
+              <span>{{ log.ctoon?.name || 'Unknown' }} <span class="text-gray-500">({{ log.ctoon?.rarity || '-' }})</span></span>
+            </div>
+            <div class="mb-0.5"><span class="font-medium">Mint #:</span> {{ log.mintNumber ?? '—' }}</div>
+            <div class="mb-1"><span class="font-medium">UserCtoonId:</span> <span class="font-mono">{{ shorten(log.userCtoonId) }}</span></div>
+            <button class="bg-blue-500 text-white px-2 py-0.5 rounded text-[11px]" @click="openModal(log)">View</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Pagination -->
+      <div v-if="!isLoading && logs.length" class="mt-3 flex items-center justify-between">
+        <div class="text-[11px] text-gray-600">
+          Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
+        </div>
+        <div class="space-x-1">
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+        </div>
+      </div>
+
+      <!-- Details modal -->
+      <div v-if="showModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-3 overflow-auto z-50">
+        <div class="bg-white rounded shadow-lg w-full max-w-xl relative max-h-[80vh] text-xs">
+          <div class="sticky top-0 z-20 bg-white flex justify-between items-center px-3 py-2 border-b">
+            <h2 class="text-sm font-semibold">Ownership Log</h2>
+            <button @click="closeModal" class="text-gray-500 hover:text-gray-800 text-base leading-none">×</button>
+          </div>
+          <div class="p-3 overflow-y-auto" style="max-height: calc(80vh - 50px);">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3 items-start">
+              <div class="md:col-span-1 flex justify-center">
+                <img
+                  v-if="selected?.ctoon?.assetPath"
+                  :src="img(selected.ctoon.assetPath)"
+                  alt
+                  class="max-w-[120px] h-auto object-contain rounded"
+                />
+              </div>
+              <div class="md:col-span-2 space-y-1">
+                <div><span class="font-medium">When:</span> {{ formatTs(selected?.createdAt) }}</div>
+                <div><span class="font-medium">User:</span> {{ selected?.user?.username || 'Unknown' }}</div>
+                <div><span class="font-medium">cToon:</span> {{ selected?.ctoon?.name || 'Unknown' }} <span class="text-gray-500">({{ selected?.ctoon?.rarity || '-' }})</span></div>
+                <div><span class="font-medium">Mint #:</span> {{ selected?.mintNumber ?? '—' }}</div>
+                <div><span class="font-medium">UserCtoonId:</span> <span class="font-mono break-all">{{ selected?.userCtoonId }}</span></div>
+                <div class="text-[10px] text-gray-500"><span class="font-medium">cToon ID:</span> <span class="font-mono break-all">{{ selected?.ctoonId }}</span></div>
+                <div class="text-[10px] text-gray-500"><span class="font-medium">User ID:</span> <span class="font-mono break-all">{{ selected?.userId }}</span></div>
+              </div>
+            </div>
+            <div class="mt-3 flex gap-1 flex-wrap">
+              <button class="border px-2 py-0.5 rounded text-[11px]" @click="copy(selected?.userCtoonId)">Copy UserCtoonId</button>
+              <button class="border px-2 py-0.5 rounded text-[11px]" @click="copy(selected?.ctoonId)">Copy cToonId</button>
+              <button class="border px-2 py-0.5 rounded text-[11px]" @click="copy(selected?.userId)">Copy UserId</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+
+const logs = ref([])
+const total = ref(0)
+const isLoading = ref(false)
+const page = ref(1)
+const PAGE_SIZE = 100
+
+const userQuery = ref('')
+const userSuggestions = ref([])
+const ctoonQuery = ref('')
+const ctoonSuggestions = ref([])
+const mintFilter = ref(null)
+const idSearch = ref('')
+const fromDate = ref('')
+const toDate = ref('')
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / PAGE_SIZE)))
+const showingRange = computed(() => {
+  if (!total.value) return '0-0 of 0'
+  const start = (page.value - 1) * PAGE_SIZE + 1
+  const end = Math.min(page.value * PAGE_SIZE, total.value)
+  return `${start}-${end} of ${total.value}`
+})
+
+const showModal = ref(false)
+const selected = ref(null)
+function openModal(log) { selected.value = log; showModal.value = true }
+function closeModal() { showModal.value = false }
+
+function shorten(id) { return !id ? '' : (id.length > 12 ? `${id.slice(0,6)}…${id.slice(-4)}` : id) }
+function formatTs(ts) { try { return new Date(ts).toLocaleString() } catch { return String(ts || '') } }
+function img(p) { return !p ? '' : (p.startsWith('http') ? p : p) }
+async function copy(text) { if (text) try { await navigator.clipboard.writeText(text) } catch {} }
+
+function normalizeDateRange() {
+  if (!fromDate.value || !toDate.value) return
+  if (new Date(fromDate.value) > new Date(toDate.value)) {
+    const tmp = fromDate.value
+    fromDate.value = toDate.value
+    toDate.value = tmp
+  }
+}
+
+async function fetchLogs() {
+  if (isLoading.value) return
+  normalizeDateRange()
+  isLoading.value = true
+  try {
+    const userTerm = userQuery.value.trim()
+    const ctoonTerm = ctoonQuery.value.trim()
+    const idTerm = idSearch.value.trim()
+    const params = {
+      limit: PAGE_SIZE,
+      page: page.value,
+      ...(userTerm && { username: userTerm }),
+      ...(ctoonTerm && { ctoonName: ctoonTerm }),
+      ...(mintFilter.value && { mintNumber: Number(mintFilter.value) }),
+      ...(idTerm && { userCtoonId: idTerm }),
+      ...(fromDate.value && { from: fromDate.value }),
+      ...(toDate.value && { to: toDate.value })
+    }
+    const res = await $fetch('/api/admin/ctoonOwnerLogs', { params })
+    logs.value = res.items || []
+    total.value = res.total || 0
+    if (res.page) page.value = res.page
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function fetchUserSuggestions() {
+  const term = userQuery.value.trim()
+  if (!term) {
+    userSuggestions.value = []
+    return
+  }
+  try {
+    const res = await $fetch('/api/admin/user-mentions', { query: { q: term, limit: 10 } })
+    userSuggestions.value = (res.items || []).map(item => item.username).filter(Boolean)
+  } catch {
+    userSuggestions.value = []
+  }
+}
+
+async function fetchCtoonSuggestions() {
+  const term = ctoonQuery.value.trim()
+  if (term.length < 3) {
+    ctoonSuggestions.value = []
+    return
+  }
+  try {
+    const res = await $fetch(`/api/admin/search-ctoons?q=${encodeURIComponent(term)}`)
+    const names = (Array.isArray(res) ? res : []).map(ct => ct.name).filter(Boolean)
+    ctoonSuggestions.value = Array.from(new Set(names))
+  } catch {
+    ctoonSuggestions.value = []
+  }
+}
+
+function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  fetchLogs()
+}
+
+function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  fetchLogs()
+}
+
+let filterDebounceId = null
+watch([userQuery, ctoonQuery, mintFilter, idSearch, fromDate, toDate], () => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  filterDebounceId = setTimeout(() => {
+    page.value = 1
+    fetchLogs()
+  }, 300)
+})
+
+let userSuggestDebounceId = null
+watch(userQuery, () => {
+  if (userSuggestDebounceId) clearTimeout(userSuggestDebounceId)
+  userSuggestDebounceId = setTimeout(fetchUserSuggestions, 200)
+})
+
+let ctoonSuggestDebounceId = null
+watch(ctoonQuery, () => {
+  if (ctoonSuggestDebounceId) clearTimeout(ctoonSuggestDebounceId)
+  ctoonSuggestDebounceId = setTimeout(fetchCtoonSuggestions, 250)
+})
+
+onMounted(() => {
+  fetchLogs()
+})
+</script>
+
+<style scoped>
+.admin-ctoon-owner-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+</style>

--- a/components/newsite/AdminCzoneSearchLogs.vue
+++ b/components/newsite/AdminCzoneSearchLogs.vue
@@ -1,0 +1,311 @@
+<template>
+  <div class="admin-czone-search-logs bg-gray-100">
+    <div class="p-2 text-xs">
+      <h1 class="text-base font-bold mb-2">cZone Search Logs</h1>
+
+      <div class="bg-white rounded-lg shadow-md p-2 space-y-3">
+        <div class="flex flex-wrap items-center gap-2">
+          <label class="text-[11px] font-medium">Window:</label>
+          <select v-model.number="days" class="border rounded px-1.5 py-0.5 text-xs">
+            <option :value="7">7 days</option>
+            <option :value="30">30 days</option>
+            <option :value="90">90 days</option>
+          </select>
+
+          <label class="text-[11px] font-medium">Search:</label>
+          <select v-model="selectedSearchId" class="border rounded px-1.5 py-0.5 text-xs min-w-[180px]">
+            <option value="">All Searches</option>
+            <option v-for="opt in searchOptions" :key="opt.id" :value="opt.id">{{ opt.label }}</option>
+          </select>
+
+          <button class="btn-primary" @click="loadAll" :disabled="loading">{{ loading ? 'Loading…' : 'Refresh' }}</button>
+          <button class="btn-secondary" @click="downloadCsv" :disabled="downloading">{{ downloading ? 'Downloading…' : 'Download' }}</button>
+        </div>
+
+        <!-- KPIs -->
+        <section class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
+          <div class="kpi">
+            <div class="kpi-label">Appearances</div>
+            <div class="kpi-value">{{ analytics.totals.appearances }}</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Captures</div>
+            <div class="kpi-value">{{ analytics.totals.captures }}</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Unique Viewers</div>
+            <div class="kpi-value">{{ analytics.totals.uniqueViewers }}</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Unique Captures</div>
+            <div class="kpi-value">{{ analytics.totals.uniqueCaptures }}</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Capture Rate</div>
+            <div class="kpi-value">{{ analytics.totals.captureRate }}%</div>
+          </div>
+        </section>
+
+        <!-- Search summary -->
+        <section>
+          <h2 class="text-sm font-semibold mb-1">Search Summary (Active During Window)</h2>
+          <div class="sm:hidden space-y-1.5">
+            <div v-for="row in analytics.searches" :key="row.id" class="border rounded bg-white p-2">
+              <div class="text-[11px] font-semibold">{{ displayName(row.name) }} — {{ formatCentral(row.startAt) }} → {{ formatCentral(row.endAt) }}</div>
+              <div class="mt-1 grid grid-cols-2 gap-1 text-[10px]">
+                <div><span class="text-gray-500">Appearance:</span> {{ row.appearanceRatePercent }}%</div>
+                <div><span class="text-gray-500">Reset:</span> {{ resetLabel(row) }}</div>
+                <div v-if="isDailyReset(row)" class="col-span-2">
+                  <span class="text-gray-500">Daily Limit:</span> {{ dailyLimitLabel(row) }}
+                </div>
+                <div v-else><span class="text-gray-500">Cooldown:</span> {{ row.cooldownHours }}h</div>
+                <div class="col-span-2"><span class="text-gray-500">Collection:</span> {{ collectionLabel(row.collectionType) }}</div>
+                <div><span class="text-gray-500">Appearances:</span> {{ row.appearances }}</div>
+                <div><span class="text-gray-500">Captures:</span> {{ row.captures }}</div>
+                <div><span class="text-gray-500">Unique Viewers:</span> {{ row.uniqueViewers }}</div>
+                <div><span class="text-gray-500">Capture Rate:</span> {{ row.captureRate }}%</div>
+              </div>
+            </div>
+            <div v-if="!analytics.searches.length" class="text-[11px] text-gray-500">No searches in this window.</div>
+          </div>
+
+          <div class="hidden sm:block overflow-auto">
+            <table class="min-w-full w-full border rounded text-[11px]">
+              <thead class="bg-gray-50 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">Name</th>
+                  <th class="px-1.5 py-1 border-b">Start (CST)</th>
+                  <th class="px-1.5 py-1 border-b">End (CST)</th>
+                  <th class="px-1.5 py-1 border-b">App %</th>
+                  <th class="px-1.5 py-1 border-b">Reset</th>
+                  <th class="px-1.5 py-1 border-b">Collection</th>
+                  <th class="px-1.5 py-1 border-b">App</th>
+                  <th class="px-1.5 py-1 border-b">Cap</th>
+                  <th class="px-1.5 py-1 border-b">Uniq Viewers</th>
+                  <th class="px-1.5 py-1 border-b">Cap Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in analytics.searches" :key="row.id" class="border-b">
+                  <td class="px-1.5 py-1 font-medium">{{ displayName(row.name) }}</td>
+                  <td class="px-1.5 py-1 whitespace-nowrap">{{ formatCentral(row.startAt) }}</td>
+                  <td class="px-1.5 py-1 whitespace-nowrap">{{ formatCentral(row.endAt) }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ row.appearanceRatePercent }}%</td>
+                  <td class="px-1.5 py-1">
+                    <div>{{ resetLabel(row) }}</div>
+                    <div v-if="isDailyReset(row)" class="text-[10px] text-gray-500">
+                      Daily: {{ dailyLimitLabel(row) }}
+                    </div>
+                    <div v-else class="text-[10px] text-gray-500">{{ row.cooldownHours }}h</div>
+                  </td>
+                  <td class="px-1.5 py-1">{{ collectionLabel(row.collectionType) }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ row.appearances }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ row.captures }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ row.uniqueViewers }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ row.captureRate }}%</td>
+                </tr>
+                <tr v-if="!analytics.searches.length">
+                  <td class="px-1.5 py-1 text-gray-500" colspan="10">No searches in this window.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- Appearance + capture breakdown -->
+        <section>
+          <h2 class="text-sm font-semibold mb-1">cToon Appearance &amp; Capture Breakdown</h2>
+          <div class="text-[10px] text-gray-500 mb-1">
+            Total appearances: {{ breakdown.totals.appearances }} · Total captures: {{ breakdown.totals.captures }}
+          </div>
+          <div class="sm:hidden space-y-1.5">
+            <div v-for="row in breakdown.rows" :key="row.ctoonId" class="border rounded bg-white p-2">
+              <div class="flex items-center justify-between text-[10px] text-gray-500">
+                <span>{{ row.ctoon?.rarity || '—' }}</span>
+                <span>{{ formatPercent(row.captureRate) }} capture rate</span>
+              </div>
+              <div class="mt-0.5 text-[11px] font-medium">{{ row.ctoon?.name || 'Unknown cToon' }}</div>
+              <div class="mt-1 grid grid-cols-2 gap-1 text-[10px]">
+                <div>
+                  <span class="text-gray-500">Appearances:</span>
+                  {{ row.appearances }}
+                  <span class="text-gray-400">({{ formatPercent(row.appearancePercent) }})</span>
+                </div>
+                <div><span class="text-gray-500">Captures:</span> {{ row.captures }}</div>
+                <div><span class="text-gray-500">Capture Rate:</span> {{ formatPercent(row.captureRate) }}</div>
+              </div>
+            </div>
+            <div v-if="!breakdown.rows.length" class="text-[11px] text-gray-500">No appearances found.</div>
+          </div>
+
+          <div class="hidden sm:block overflow-auto">
+            <table class="min-w-full w-full border rounded text-[11px]">
+              <thead class="bg-gray-50 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">cToon</th>
+                  <th class="px-1.5 py-1 border-b">Rarity</th>
+                  <th class="px-1.5 py-1 border-b">Appearances</th>
+                  <th class="px-1.5 py-1 border-b">Captures</th>
+                  <th class="px-1.5 py-1 border-b">Capture Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in breakdown.rows" :key="row.ctoonId" class="border-b">
+                  <td class="px-1.5 py-1">{{ row.ctoon?.name || '—' }}</td>
+                  <td class="px-1.5 py-1">{{ row.ctoon?.rarity || '—' }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">
+                    {{ row.appearances }}
+                    <span class="text-[10px] text-gray-500">({{ formatPercent(row.appearancePercent) }})</span>
+                  </td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ row.captures }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ formatPercent(row.captureRate) }}</td>
+                </tr>
+                <tr v-if="!breakdown.rows.length">
+                  <td class="px-1.5 py-1 text-gray-500" colspan="5">No appearances found.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const days = ref(30)
+const selectedSearchId = ref('')
+const loading = ref(false)
+const downloading = ref(false)
+
+const analytics = ref({
+  totals: { appearances: 0, captures: 0, uniqueViewers: 0, uniqueCaptures: 0, captureRate: 0 },
+  searches: []
+})
+const breakdown = ref({ rows: [], totals: { appearances: 0, captures: 0 } })
+const searchOptions = ref([])
+
+function collectionLabel(value) {
+  if (value === 'ONCE') return 'Once'
+  if (value === 'CUSTOM_PER_CTOON') return 'Custom Per cToon'
+  return 'Multiple Times'
+}
+
+function normalizeResetType(value) {
+  return value === 'DAILY_AT_RESET' ? 'DAILY_AT_RESET' : 'COOLDOWN_HOURS'
+}
+
+function isDailyReset(row) {
+  return normalizeResetType(row?.resetType) === 'DAILY_AT_RESET'
+}
+
+function resetLabel(row) {
+  return isDailyReset(row) ? 'Daily at 8pm CT' : 'Cooldown'
+}
+
+function dailyLimitLabel(row) {
+  const limit = Number(row?.dailyCollectLimit ?? 0)
+  return limit > 0 ? String(limit) : 'Unlimited'
+}
+
+function formatCentral(iso) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('en-US', {
+    timeZone: 'America/Chicago',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZoneName: 'short'
+  })
+}
+
+function displayName(name) {
+  const cleaned = String(name || '').trim()
+  return cleaned || 'Untitled'
+}
+
+const formatPercent = (value) => `${Number(value || 0).toFixed(1)}%`
+
+async function loadSearchOptions() {
+  try {
+    const data = await $fetch('/api/admin/czone-searches', { query: { showAll: '1' } })
+    searchOptions.value = (Array.isArray(data) ? data : []).map((row) => ({
+      id: row.id,
+      label: `${displayName(row.name)} — ${formatCentral(row.startAt)} → ${formatCentral(row.endAt)}`
+    }))
+  } catch {
+    searchOptions.value = []
+  }
+}
+
+async function loadAll() {
+  loading.value = true
+  try {
+    const query = { days: days.value }
+    if (selectedSearchId.value) query.searchId = selectedSearchId.value
+    const [an, ev] = await Promise.all([
+      $fetch('/api/admin/czone-search-logs/analytics', { query }),
+      $fetch('/api/admin/czone-search-logs/events', { query })
+    ])
+    analytics.value = an
+    breakdown.value = ev
+  } finally {
+    loading.value = false
+  }
+}
+
+async function downloadCsv() {
+  downloading.value = true
+  try {
+    const query = new URLSearchParams({ days: days.value })
+    if (selectedSearchId.value) query.set('searchId', selectedSearchId.value)
+    const response = await fetch(`/api/admin/czone-search-logs/download?${query}`)
+    const blob = await response.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'czone-search-logs.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  } finally {
+    downloading.value = false
+  }
+}
+
+onMounted(async () => {
+  await loadSearchOptions()
+  await loadAll()
+})
+</script>
+
+<style scoped>
+.admin-czone-search-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+.btn-primary {
+  background-color: #2563EB;
+  color: #fff;
+  padding: 2px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+}
+.btn-primary:disabled { opacity: 0.5; }
+.btn-secondary {
+  background-color: #6B7280;
+  color: #fff;
+  padding: 2px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+}
+.btn-secondary:disabled { opacity: 0.5; }
+.kpi { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 6px 8px; }
+.kpi-label { font-size: 10px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.04em; }
+.kpi-value { font-size: 14px; font-weight: 600; color: #111827; }
+</style>

--- a/components/newsite/AdminGtoonsClashLogs.vue
+++ b/components/newsite/AdminGtoonsClashLogs.vue
@@ -1,0 +1,248 @@
+<template>
+  <div class="admin-gtoons-clash-logs bg-gray-50">
+    <div class="p-2 space-y-2 text-xs">
+      <h1 class="text-base font-bold mb-1">gToons Clash Logs</h1>
+
+      <!-- Filters -->
+      <div class="mb-2 flex flex-wrap items-end gap-2">
+        <input
+          v-model="searchTerm"
+          type="text"
+          placeholder="Search by username or outcome…"
+          class="flex-1 min-w-[180px] border border-gray-300 rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+        />
+        <div class="flex items-center">
+          <label for="fromDate" class="mr-1 text-[11px] font-medium">From</label>
+          <input id="fromDate" v-model="fromDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+        <div class="flex items-center">
+          <label for="toDate" class="mr-1 text-[11px] font-medium">To</label>
+          <input id="toDate" v-model="toDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+      </div>
+
+      <div class="mb-2 text-[11px] text-gray-600">
+        Total Results: {{ total }} games
+      </div>
+
+      <div v-if="loading" class="text-gray-500">Loading...</div>
+      <div v-else-if="filteredGames.length === 0" class="text-gray-500">No results.</div>
+
+      <div v-else>
+        <!-- Card view (sm/md) -->
+        <div class="lg:hidden space-y-2">
+          <div
+            v-for="g in filteredGames"
+            :key="g.id"
+            class="p-2 border rounded shadow bg-white text-[11px] space-y-0.5"
+          >
+            <p><strong>Start:</strong> {{ formatDate(g.startedAt, true) }}</p>
+            <p><strong>End:</strong> {{ g.endedAt ? formatDate(g.endedAt, true) : '—' }}</p>
+            <p><strong>Player 1:</strong> {{ username(g.player1) }}</p>
+            <p><strong>Player 2:</strong> {{ player2Label(g) }}</p>
+            <p><strong>Outcome:</strong> {{ outcomeLabel(g) }}</p>
+            <p><strong>Winner:</strong> {{ winnerLabel(g) }}</p>
+            <p><strong>Who Left:</strong> {{ whoLeftLabel(g) }}</p>
+          </div>
+        </div>
+
+        <!-- Table view (lg+) -->
+        <div class="hidden lg:block overflow-x-auto">
+          <table class="min-w-full border border-gray-300 text-[11px]">
+            <thead class="bg-gray-100 text-left">
+              <tr>
+                <th class="px-1.5 py-1 border-b">Start</th>
+                <th class="px-1.5 py-1 border-b">End</th>
+                <th class="px-1.5 py-1 border-b">Player 1</th>
+                <th class="px-1.5 py-1 border-b">Player 2</th>
+                <th class="px-1.5 py-1 border-b">Outcome</th>
+                <th class="px-1.5 py-1 border-b">Winner</th>
+                <th class="px-1.5 py-1 border-b">Who Left</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="g in filteredGames" :key="g.id">
+                <td class="px-1.5 py-1 border-b whitespace-nowrap">
+                  {{ formatDate(g.startedAt, true) }}
+                </td>
+                <td class="px-1.5 py-1 border-b whitespace-nowrap">
+                  {{ g.endedAt ? formatDate(g.endedAt, true) : '—' }}
+                </td>
+                <td class="px-1.5 py-1 border-b">
+                  {{ username(g.player1) }}
+                </td>
+                <td class="px-1.5 py-1 border-b">
+                  {{ player2Label(g) }}
+                </td>
+                <td class="px-1.5 py-1 border-b">
+                  {{ outcomeLabel(g) }}
+                </td>
+                <td class="px-1.5 py-1 border-b">
+                  {{ winnerLabel(g) }}
+                </td>
+                <td class="px-1.5 py-1 border-b">{{ whoLeftLabel(g) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Pagination -->
+      <div v-if="!loading && games.length" class="mt-3 flex items-center justify-between">
+        <div class="text-[11px] text-gray-600">
+          Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
+        </div>
+        <div class="space-x-1">
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+
+const games = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = 100
+const loading = ref(false)
+const searchTerm = ref('')
+const fromDate = ref('')
+const toDate = ref('')
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const showingRange = computed(() => {
+  if (!total.value) return '0-0 of 0'
+  const start = (page.value - 1) * pageSize + 1
+  const end = Math.min(page.value * pageSize, total.value)
+  return `${start}-${end} of ${total.value}`
+})
+
+function normalizeDateRange() {
+  if (!fromDate.value || !toDate.value) return
+  if (new Date(fromDate.value) > new Date(toDate.value)) {
+    const tmp = fromDate.value
+    fromDate.value = toDate.value
+    toDate.value = tmp
+  }
+}
+
+async function fetchGames() {
+  if (loading.value) return
+  normalizeDateRange()
+  loading.value = true
+  try {
+    const query = {
+      page: page.value,
+      limit: pageSize,
+      from: fromDate.value || undefined,
+      to: toDate.value || undefined
+    }
+    const res = await $fetch('/api/admin/gtoons-logs', { query })
+    games.value = res.items || []
+    total.value = res.total || 0
+    if (res.page) page.value = res.page
+  } catch {
+    games.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+function whoLeftLabel(g) {
+  return g.whoLeft?.username || '—'
+}
+
+const filteredGames = computed(() => {
+  const q = searchTerm.value.trim().toLowerCase()
+  if (!q) return games.value
+  return games.value.filter(g => {
+    const p1 = username(g.player1).toLowerCase()
+    const p2 = player2Label(g).toLowerCase()
+    const w  = winnerLabel(g).toLowerCase()
+    const oc = outcomeLabel(g).toLowerCase()
+    const wl = whoLeftLabel(g).toLowerCase()
+    return (
+      p1.includes(q) ||
+      p2.includes(q) ||
+      w.includes(q)  ||
+      oc.includes(q) ||
+      wl.includes(q)
+    )
+  })
+})
+
+function username(user) {
+  return user?.username || '—'
+}
+
+function player2Label(g) {
+  return g.player2?.username || 'AI'
+}
+
+function outcomeLabel(g) {
+  if (!g.outcome) return '—'
+  if (g.outcome === 'tie') return 'Tie'
+  if (g.outcome === 'incomplete') return '—'
+  if (g.outcome === 'player') return username(g.player1)
+  if (g.outcome === 'ai') return player2Label(g)
+  return g.outcome
+}
+
+function winnerLabel(g) {
+  if (!g.outcome) return '—'
+  if (g.outcome === 'tie') return 'Tie'
+  if (g.outcome === 'incomplete') return '—'
+  if (g.winner?.username) return g.winner.username
+  if (g.outcome === 'ai') return player2Label(g)
+  if (g.outcome === 'player') return username(g.player1)
+  return '—'
+}
+
+function formatDate(input, withTime = false) {
+  if (!input) return '—'
+  const d = new Date(input)
+  return d.toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: withTime ? 'short' : undefined
+  })
+}
+
+function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  fetchGames()
+}
+
+function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  fetchGames()
+}
+
+let filterDebounceId = null
+watch([fromDate, toDate], () => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  filterDebounceId = setTimeout(() => {
+    page.value = 1
+    fetchGames()
+  }, 300)
+})
+
+onMounted(() => {
+  fetchGames()
+})
+</script>
+
+<style scoped>
+.admin-gtoons-clash-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+th, td { vertical-align: middle; }
+</style>

--- a/components/newsite/AdminLottoLogs.vue
+++ b/components/newsite/AdminLottoLogs.vue
@@ -1,0 +1,358 @@
+<template>
+  <div class="admin-lotto-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <h1 class="text-base font-bold mb-2">Lotto Logs</h1>
+
+      <!-- Filters -->
+      <form class="bg-white border rounded p-2 flex flex-wrap items-end gap-2 mb-2" @submit.prevent="applyRange">
+        <div>
+          <label class="block text-[10px] font-medium mb-0.5">From</label>
+          <input type="date" v-model="from" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+        <div>
+          <label class="block text-[10px] font-medium mb-0.5">To</label>
+          <input type="date" v-model="to" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+        <div class="relative">
+          <label class="block text-[10px] font-medium mb-0.5">User</label>
+          <input
+            v-model="userQuery"
+            type="text"
+            class="border rounded px-1.5 py-0.5 text-xs w-40"
+            placeholder="3+ chars…"
+            autocomplete="off"
+            @input="onUserInput"
+            @blur="hideUserSuggestions"
+            @focus="onUserInput"
+          />
+          <ul
+            v-if="userSuggestions.length && showUserDropdown"
+            class="absolute z-20 left-0 mt-0.5 w-40 bg-white border rounded shadow max-h-40 overflow-y-auto"
+          >
+            <li
+              v-for="u in userSuggestions"
+              :key="u"
+              class="px-2 py-1 text-[11px] cursor-pointer hover:bg-indigo-50"
+              @mousedown.prevent="selectUser(u)"
+            >{{ u }}</li>
+          </ul>
+        </div>
+        <button class="bg-indigo-600 text-white rounded px-2 py-0.5 text-[11px]">Apply</button>
+        <button type="button" class="text-[11px] text-gray-600 underline" @click="setLastNDays(30)">Last 30 days</button>
+        <button v-if="userQuery" type="button" class="text-[11px] text-red-500 underline" @click="clearUser">Clear user</button>
+      </form>
+
+      <!-- Breakdown -->
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-2 mb-2">
+        <div class="bg-white rounded shadow p-2 lg:col-span-2">
+          <h2 class="text-sm font-semibold mb-1">Outcome Breakdown</h2>
+          <p class="text-[11px] text-gray-500 mb-1">Total plays: {{ totalOutcomes }}</p>
+          <div v-if="summaryLoading" class="text-gray-500">Loading…</div>
+          <div v-else-if="totalOutcomes === 0" class="text-gray-500">No plays in this range.</div>
+          <table v-else class="w-full text-[11px]">
+            <thead>
+              <tr class="text-left border-b">
+                <th class="py-1">Outcome</th>
+                <th class="py-1">Count</th>
+                <th class="py-1">% of total</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in summaryRows" :key="row.key" class="border-b">
+                <td class="py-0.5">{{ row.label }}</td>
+                <td class="py-0.5 tabular-nums">{{ row.count }}</td>
+                <td class="py-0.5 tabular-nums">{{ pct(row.count, totalOutcomes) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="bg-white rounded shadow p-2">
+          <h2 class="text-sm font-semibold mb-1">At a Glance</h2>
+          <div class="grid grid-cols-1 gap-1.5">
+            <div v-for="row in summaryRows" :key="`${row.key}-card`" class="border rounded p-1.5 bg-gray-50">
+              <div class="text-[10px] text-gray-500">{{ row.label }}</div>
+              <div class="text-sm font-semibold tabular-nums">{{ row.count }}</div>
+              <div class="text-[10px] text-gray-500">{{ pct(row.count, totalOutcomes) }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Logs list -->
+      <div class="bg-white rounded shadow p-2">
+        <div class="flex items-center justify-between mb-1.5">
+          <h2 class="text-sm font-semibold">Lotto Logs</h2>
+          <div class="text-[11px] text-gray-500">Showing {{ showingRange }}</div>
+        </div>
+
+        <div v-if="logsLoading" class="text-gray-500">Loading…</div>
+        <div v-else-if="logs.length === 0" class="text-gray-500">No logs in this range.</div>
+        <div v-else>
+          <!-- Desktop table -->
+          <div class="hidden md:block overflow-auto">
+            <table class="min-w-full w-full border rounded text-[11px]">
+              <thead class="bg-gray-50 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">Time (CDT)</th>
+                  <th class="px-1.5 py-1 border-b">User</th>
+                  <th class="px-1.5 py-1 border-b">Outcome</th>
+                  <th class="px-1.5 py-1 border-b">Prize</th>
+                  <th class="px-1.5 py-1 border-b">Odds Before</th>
+                  <th class="px-1.5 py-1 border-b">Odds After</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="log in logs" :key="log.id" class="border-b">
+                  <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(log.createdAt) }}</td>
+                  <td class="px-1.5 py-1">{{ displayUser(log.user) }}</td>
+                  <td class="px-1.5 py-1">{{ labelFor(log.outcome) }}</td>
+                  <td class="px-1.5 py-1">{{ formatPrize(log) }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ formatOdds(log.oddsBefore) }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ formatOdds(log.oddsAfter) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Mobile cards -->
+          <div class="md:hidden space-y-1.5">
+            <div v-for="log in logs" :key="log.id" class="border rounded bg-white p-2 text-[11px]">
+              <div class="flex items-center justify-between text-[10px] text-gray-500">
+                <span>{{ formatDate(log.createdAt) }}</span>
+                <span>{{ labelFor(log.outcome) }}</span>
+              </div>
+              <div class="mt-0.5 font-medium">{{ displayUser(log.user) }}</div>
+              <div v-if="log.outcome === 'CTOON' && log.userCtoon" class="mt-0.5 text-indigo-700 font-medium">
+                {{ formatPrize(log) }}
+              </div>
+              <div class="mt-1 grid grid-cols-2 gap-1 text-[10px]">
+                <div><span class="text-gray-500">Odds Before:</span> {{ formatOdds(log.oddsBefore) }}</div>
+                <div><span class="text-gray-500">Odds After:</span> {{ formatOdds(log.oddsAfter) }}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Pagination -->
+        <div class="mt-2 flex items-center justify-between">
+          <div class="text-[11px] text-gray-600">
+            Page {{ page }} of {{ totalPages }} • Showing {{ showingRange }}
+          </div>
+          <div class="space-x-1">
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+const from = ref('')
+const to = ref('')
+const page = ref(1)
+const pageSize = 50
+const userQuery = ref('')
+const userSuggestions = ref([])
+const showUserDropdown = ref(false)
+
+const summaryLoading = ref(false)
+const logsLoading = ref(false)
+const summary = ref([])
+const totalLogs = ref(0)
+const logs = ref([])
+
+const OUTCOMES = [
+  { key: 'NOTHING', label: 'Nothing' },
+  { key: 'POINTS', label: 'Points' },
+  { key: 'CTOON', label: 'cToon' }
+]
+
+const totalOutcomes = computed(() => summary.value.reduce((sum, row) => sum + row.count, 0))
+const summaryRows = computed(() => {
+  const map = new Map(summary.value.map(r => [r.outcome, r.count]))
+  return OUTCOMES.map(o => ({
+    key: o.key,
+    label: o.label,
+    count: map.get(o.key) || 0
+  }))
+})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(totalLogs.value / pageSize)))
+const showingRange = computed(() => {
+  if (!totalLogs.value) return '0–0 of 0'
+  const start = (page.value - 1) * pageSize + 1
+  const end = Math.min(page.value * pageSize, totalLogs.value)
+  return `${start}–${end} of ${totalLogs.value}`
+})
+
+function toYMD(d) {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const da = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${da}`
+}
+
+function setLastNDays(n) {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(end.getDate() - (n - 1))
+  from.value = toYMD(start)
+  to.value = toYMD(end)
+  page.value = 1
+  loadAll()
+}
+
+function pct(count, total) {
+  return total ? `${((count / total) * 100).toFixed(1)}%` : '—'
+}
+
+function formatDate(dt) {
+  return new Date(dt).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Chicago',
+    timeZoneName: 'short'
+  })
+}
+
+function formatOdds(val) {
+  if (val == null || Number.isNaN(Number(val))) return '—'
+  return `${Number(val).toFixed(2)}%`
+}
+
+function labelFor(outcome) {
+  const row = OUTCOMES.find(o => o.key === outcome)
+  return row ? row.label : outcome
+}
+
+function displayUser(user) {
+  return user?.username || user?.discordTag || user?.id || '—'
+}
+
+function formatPrize(log) {
+  if (log.outcome !== 'CTOON' || !log.userCtoon) return '—'
+  const name = log.userCtoon.ctoon?.name || 'Unknown'
+  const mint = log.userCtoon.mintNumber != null ? `#${log.userCtoon.mintNumber}` : ''
+  return mint ? `${name} ${mint}` : name
+}
+
+async function fetchSummary() {
+  summaryLoading.value = true
+  try {
+    const res = await $fetch('/api/admin/lotto-logs-summary', {
+      query: { start: from.value, end: to.value }
+    })
+    summary.value = res.data || []
+  } catch (e) {
+    console.error('Failed to load lotto summary', e)
+    summary.value = []
+  } finally {
+    summaryLoading.value = false
+  }
+}
+
+let userSuggestTimer = null
+async function fetchUserSuggestions() {
+  const term = userQuery.value.trim()
+  if (term.length < 3) {
+    userSuggestions.value = []
+    return
+  }
+  try {
+    const res = await $fetch('/api/admin/user-mentions', { query: { q: term, limit: 10 } })
+    userSuggestions.value = (res.items || []).map(item => item.username).filter(Boolean)
+  } catch {
+    userSuggestions.value = []
+  }
+}
+
+function onUserInput() {
+  showUserDropdown.value = true
+  if (userSuggestTimer) clearTimeout(userSuggestTimer)
+  userSuggestTimer = setTimeout(fetchUserSuggestions, 200)
+}
+
+function hideUserSuggestions() {
+  setTimeout(() => { showUserDropdown.value = false }, 150)
+}
+
+function selectUser(username) {
+  userQuery.value = username
+  showUserDropdown.value = false
+  userSuggestions.value = []
+  page.value = 1
+  fetchLogs()
+}
+
+function clearUser() {
+  userQuery.value = ''
+  userSuggestions.value = []
+  page.value = 1
+  fetchLogs()
+}
+
+async function fetchLogs() {
+  logsLoading.value = true
+  try {
+    const username = userQuery.value.trim()
+    const res = await $fetch('/api/admin/lotto-logs', {
+      query: { start: from.value, end: to.value, page: page.value, limit: pageSize, ...(username && { username }) }
+    })
+    logs.value = res.items || []
+    totalLogs.value = res.total || 0
+  } catch (e) {
+    console.error('Failed to load lotto logs', e)
+    logs.value = []
+    totalLogs.value = 0
+  } finally {
+    logsLoading.value = false
+  }
+}
+
+async function loadAll() {
+  await Promise.all([fetchSummary(), fetchLogs()])
+}
+
+function applyRange() {
+  if (!from.value || !to.value) return
+  if (new Date(from.value) > new Date(to.value)) {
+    const t = from.value
+    from.value = to.value
+    to.value = t
+  }
+  page.value = 1
+  loadAll()
+}
+
+async function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  await fetchLogs()
+}
+
+async function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  await fetchLogs()
+}
+
+onMounted(() => {
+  setLastNDays(30)
+})
+</script>
+
+<style scoped>
+.admin-lotto-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+</style>

--- a/components/newsite/AdminManageUsers.vue
+++ b/components/newsite/AdminManageUsers.vue
@@ -1,19 +1,19 @@
 <template>
-  <div class="admin-manage-users bg-gray-50">
-    <div class="max-w-7xl mx-auto px-4 py-6">
+  <div class="admin-manage-users bg-gray-50 text-xs">
+    <div class="px-2 py-2">
       <!-- Controls -->
-      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between mb-4">
+      <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-2">
         <div class="flex items-center gap-2 w-full md:w-auto">
           <input
             v-model="filter"
             type="text"
             placeholder="Search username or Discord tag"
-            class="w-full md:w-80 border rounded-md px-3 py-2"
+            class="w-full md:w-72 border rounded-md px-1.5 py-0.5 text-xs"
           />
         </div>
 
-        <div class="flex flex-wrap items-center gap-2">
-          <select v-model="statusFilter" class="px-3 py-1 text-sm border rounded-md">
+        <div class="flex flex-wrap items-center gap-1">
+          <select v-model="statusFilter" class="px-1.5 py-0.5 text-xs border rounded-md">
             <option value="all">All users</option>
             <option value="active">Active only</option>
             <option value="inactive">Inactive only</option>
@@ -22,77 +22,77 @@
           <button @click="toggle('onlyGuild')" :class="chip(onlyGuild)">In Discord</button>
           <button @click="toggle('onlyWarned')" :class="chip(onlyWarned)">Warned</button>
 
-          <div class="flex items-center gap-2">
-            <label class="text-sm text-gray-600">Sort:</label>
-            <select v-model="sortField" class="px-3 py-1 text-sm border rounded-md">
+          <div class="flex items-center gap-1">
+            <label class="text-[11px] text-gray-600">Sort:</label>
+            <select v-model="sortField" class="px-1.5 py-0.5 text-xs border rounded-md">
               <option value="lastActivity">Last activity</option>
               <option value="joined">Account created</option>
             </select>
-            <select v-model="sortDir" class="px-3 py-1 text-sm border rounded-md">
+            <select v-model="sortDir" class="px-1.5 py-0.5 text-xs border rounded-md">
               <option value="desc">Newest</option>
               <option value="asc">Oldest</option>
             </select>
           </div>
 
-          <button @click="resetFilters" class="px-3 py-1 text-sm border rounded-md">Reset</button>
+          <button @click="resetFilters" class="px-2 py-0.5 text-[11px] border rounded-md">Reset</button>
         </div>
       </div>
 
       <!-- Unified Card Grid (mobile and desktop) -->
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
         <article
           v-for="u in pagedUsers"
           :key="u.id"
-          class="bg-white border rounded-lg shadow p-4"
+          class="bg-white border rounded-lg shadow p-2"
         >
-          <div class="flex flex-col sm:flex-row-reverse sm:items-start sm:justify-between gap-2">
+          <div class="flex flex-col sm:flex-row-reverse sm:items-start sm:justify-between gap-1">
             <!-- Badges first in DOM: appear above username on mobile, on right on desktop -->
-            <div class="flex items-center gap-2 shrink-0">
+            <div class="flex items-center gap-1 shrink-0">
               <span :class="badgeClass(!!u.inGuild)">{{ u.inGuild ? 'Guild' : 'No guild' }}</span>
               <span :class="badgeClass(!!u.active)">{{ u.active ? 'Active' : 'Disabled' }}</span>
               <div class="relative">
                 <button
-                  class="ml-1 h-7 w-7 grid place-items-center text-gray-500 hover:text-gray-700 rounded hover:bg-gray-100"
+                  class="ml-0.5 h-6 w-6 grid place-items-center text-gray-500 hover:text-gray-700 rounded hover:bg-gray-100"
                   title="More"
                   @click.stop="toggleMenu(u)"
                 >⋮</button>
                 <div
                   v-if="menuOpenId === u.id"
-                  class="absolute right-0 mt-1 w-44 bg-white border rounded-md shadow-lg z-40 py-1"
+                  class="absolute right-0 mt-1 w-40 bg-white border rounded-md shadow-lg z-40 py-1"
                 >
-                  <button class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50" @click="openNotes(u); closeMenu()">Account History</button>
-                  <button class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50" @click="openLockedPoints(u); closeMenu()">See Locked Points</button>
-                  <button class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50" @click="openPendingTrades(u); closeMenu()">View Pending Trades</button>
-                  <button class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50" @click="openAdditionalZones(u); closeMenu()">Additional Zones</button>
-                  <button class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50" @click="openUpdateUsername(u); closeMenu()">Update Username</button>
+                  <button class="w-full text-left px-2 py-1 text-[11px] hover:bg-gray-50" @click="openNotes(u); closeMenu()">Account History</button>
+                  <button class="w-full text-left px-2 py-1 text-[11px] hover:bg-gray-50" @click="openLockedPoints(u); closeMenu()">See Locked Points</button>
+                  <button class="w-full text-left px-2 py-1 text-[11px] hover:bg-gray-50" @click="openPendingTrades(u); closeMenu()">View Pending Trades</button>
+                  <button class="w-full text-left px-2 py-1 text-[11px] hover:bg-gray-50" @click="openAdditionalZones(u); closeMenu()">Additional Zones</button>
+                  <button class="w-full text-left px-2 py-1 text-[11px] hover:bg-gray-50" @click="openUpdateUsername(u); closeMenu()">Update Username</button>
                   <button
                     v-if="!u.isAdmin && !u.banned"
-                    class="w-full text-left px-3 py-2 text-sm text-red-700 hover:bg-red-50"
+                    class="w-full text-left px-2 py-1 text-[11px] text-red-700 hover:bg-red-50"
                     @click="openActionModal(u, 'BAN'); closeMenu()"
                   >Ban user</button>
                   <button
                     v-if="!u.isAdmin && u.banned"
-                    class="w-full text-left px-3 py-2 text-sm text-emerald-700 hover:bg-emerald-50"
+                    class="w-full text-left px-2 py-1 text-[11px] text-emerald-700 hover:bg-emerald-50"
                     @click="openActionModal(u, 'UNBAN'); closeMenu()"
                   >Unban user</button>
                   <button
                     v-if="!u.isAdmin && !u.active && !u.banned"
-                    class="w-full text-left px-3 py-2 text-sm text-emerald-700 hover:bg-emerald-50"
+                    class="w-full text-left px-2 py-1 text-[11px] text-emerald-700 hover:bg-emerald-50"
                     @click="activateUser(u); closeMenu()"
                   >Activate User</button>
                   <button
                     v-if="!u.isAdmin && u.active"
-                    class="w-full text-left px-3 py-2 text-sm text-rose-700 hover:bg-rose-50"
+                    class="w-full text-left px-2 py-1 text-[11px] text-rose-700 hover:bg-rose-50"
                     @click="openDissolveModal(u); closeMenu()"
                   >Dissolve User</button>
                   <button
                     v-if="isSuperAdmin && !u.isAdmin"
-                    class="w-full text-left px-3 py-2 text-sm text-blue-700 hover:bg-blue-50"
+                    class="w-full text-left px-2 py-1 text-[11px] text-blue-700 hover:bg-blue-50"
                     @click="makeAdmin(u); closeMenu()"
                   >Make Admin</button>
                   <button
                     v-if="isSuperAdmin && u.isAdmin && u.discordId !== superAdminId"
-                    class="w-full text-left px-3 py-2 text-sm text-amber-700 hover:bg-amber-50"
+                    class="w-full text-left px-2 py-1 text-[11px] text-amber-700 hover:bg-amber-50"
                     @click="removeAdmin(u); closeMenu()"
                   >Remove Admin</button>
                 </div>
@@ -100,55 +100,55 @@
             </div>
             <!-- Username second in DOM: appears below badges on mobile, on left on desktop -->
             <div class="min-w-0">
-              <div class="font-semibold text-base leading-tight">{{ u.username || '—' }}</div>
-              <div class="text-xs text-gray-500">{{ u.discordTag || 'No tag' }}</div>
+              <div class="font-semibold text-xs leading-tight truncate">{{ u.username || '—' }}</div>
+              <div class="text-[10px] text-gray-500 truncate">{{ u.discordTag || 'No tag' }}</div>
             </div>
           </div>
 
-          <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
-            <div class="p-2 bg-gray-50 rounded">
-              <div class="text-gray-500 text-xs">Unique cToons</div>
+          <div class="mt-1.5 grid grid-cols-3 gap-1 text-[11px]">
+            <div class="p-1 bg-gray-50 rounded">
+              <div class="text-gray-500 text-[10px]">Unique</div>
               <div class="font-medium tabular-nums">{{ u.uniqueCtoons ?? 0 }}</div>
             </div>
-            <div class="p-2 bg-gray-50 rounded">
-              <div class="text-gray-500 text-xs">Total cToons</div>
+            <div class="p-1 bg-gray-50 rounded">
+              <div class="text-gray-500 text-[10px]">Total</div>
               <div class="font-medium tabular-nums">{{ u.totalCtoons ?? 0 }}</div>
             </div>
-            <div class="p-2 bg-gray-50 rounded">
-              <div class="text-gray-500 text-xs">Total Points</div>
+            <div class="p-1 bg-gray-50 rounded">
+              <div class="text-gray-500 text-[10px]">Points</div>
               <div class="font-medium tabular-nums">{{ u.points ?? 0 }}</div>
             </div>
           </div>
 
-          <div class="mt-3 text-xs text-gray-600 space-y-1">
+          <div class="mt-1.5 text-[10px] text-gray-600 space-y-0.5">
             <div><span class="text-gray-500">Joined:</span> {{ formatDate(u.joined) }} • {{ rel(u.joined) }}</div>
             <div><span class="text-gray-500">Last login:</span> {{ formatDate(u.lastLogin) }} • {{ rel(u.lastLogin) }}</div>
-            <div class="flex items-center gap-2">
-              <span class="text-gray-600"><span class="text-gray-500">Last activity:</span> {{ formatDate(u.lastActivity) }} • {{ rel(u.lastActivity) }}</span>
-              <button class="ml-auto text-xs underline" @click="toggleSort()">Sort {{ sortDir==='desc' ? '↓' : '↑' }}</button>
+            <div class="flex items-center gap-1">
+              <span class="text-gray-600 truncate"><span class="text-gray-500">Last activity:</span> {{ formatDate(u.lastActivity) }} • {{ rel(u.lastActivity) }}</span>
+              <button class="ml-auto text-[10px] underline shrink-0" @click="toggleSort()">Sort {{ sortDir==='desc' ? '↓' : '↑' }}</button>
             </div>
           </div>
 
-          <div class="mt-3 flex flex-wrap gap-2">
+          <div class="mt-1.5 flex flex-wrap gap-1">
             <span :class="warnClass(!!u.warning180,'amber')">180d</span>
             <span :class="warnClass(!!u.warning210,'amber')">210d</span>
             <span :class="warnClass(!!u.warning240,'red')">240d</span>
           </div>
         </article>
 
-        <div v-if="!filteredSorted.length" class="col-span-full text-center text-gray-500 py-8">
+        <div v-if="!filteredSorted.length" class="col-span-full text-center text-gray-500 py-6">
           No users match your filters.
         </div>
       </div>
 
       <!-- Pagination -->
-      <div v-if="filteredSorted.length" class="mt-6 flex items-center justify-between">
-        <div class="text-sm text-gray-600">
+      <div v-if="filteredSorted.length" class="mt-3 flex items-center justify-between">
+        <div class="text-[11px] text-gray-600">
           Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
         </div>
-        <div class="space-x-2">
-          <button class="px-3 py-1 text-sm border rounded-md" :disabled="page <= 1" @click="prevPage">Prev</button>
-          <button class="px-3 py-1 text-sm border rounded-md" :disabled="page >= totalPages" @click="nextPage">Next</button>
+        <div class="space-x-1">
+          <button class="px-2 py-0.5 text-[11px] border rounded-md" :disabled="page <= 1" @click="prevPage">Prev</button>
+          <button class="px-2 py-0.5 text-[11px] border rounded-md" :disabled="page >= totalPages" @click="nextPage">Next</button>
         </div>
       </div>
     </div>
@@ -602,7 +602,7 @@ const pagedUsers = computed(() => {
 
 const chip = (on) =>
   [
-    'px-3 py-1 text-sm rounded-md border',
+    'px-2 py-0.5 text-[11px] rounded-md border',
     on ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-700 border-gray-300'
   ].join(' ')
 
@@ -653,7 +653,7 @@ const rel = dt => {
 
 const badgeClass = (ok) =>
   [
-    'px-2 py-0.5 rounded text-xs font-medium',
+    'px-1.5 py-0 rounded text-[10px] font-medium',
     ok ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
   ].join(' ')
 
@@ -662,7 +662,7 @@ const warnClass = (on, tone = 'amber') => {
     ? 'bg-red-100 text-red-800 border-red-200'
     : 'bg-amber-100 text-amber-800 border-amber-200'
   return [
-    'px-2 py-0.5 rounded text-xs border',
+    'px-1.5 py-0 rounded text-[10px] border',
     on ? onCls : 'bg-gray-100 text-gray-700 border-gray-300'
   ].join(' ')
 }

--- a/components/newsite/AdminMonsterBattleLogs.vue
+++ b/components/newsite/AdminMonsterBattleLogs.vue
@@ -1,0 +1,262 @@
+<template>
+  <div class="admin-monster-battle-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <div class="flex items-center justify-between mb-2">
+        <h1 class="text-base font-bold">Monster Battles</h1>
+        <div class="text-[11px] text-gray-500">Showing {{ showingRange }}</div>
+      </div>
+
+      <div class="bg-white rounded shadow p-2 mb-2">
+        <div class="flex flex-wrap items-end gap-2">
+          <input
+            v-model="searchTerm"
+            type="text"
+            placeholder="Search by username..."
+            class="flex-1 min-w-[180px] border border-gray-300 rounded px-1.5 py-0.5 text-xs focus:ring-indigo-500 focus:border-indigo-500"
+          />
+          <div class="flex items-center">
+            <label for="fromDate" class="mr-1 text-[11px] font-medium">Start</label>
+            <input id="fromDate" v-model="fromDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+          </div>
+          <div class="flex items-center">
+            <label for="toDate" class="mr-1 text-[11px] font-medium">End</label>
+            <input id="toDate" v-model="toDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-white rounded shadow p-2">
+        <div v-if="loading" class="text-gray-500">Loading...</div>
+        <div v-else-if="battles.length === 0" class="text-gray-500">No battles found.</div>
+        <div v-else>
+          <!-- Desktop table -->
+          <div class="hidden lg:block overflow-auto">
+            <table class="min-w-full w-full border rounded text-[11px]">
+              <thead class="bg-gray-50 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">Created At (CDT)</th>
+                  <th class="px-1.5 py-1 border-b">User</th>
+                  <th class="px-1.5 py-1 border-b">Selected Monster</th>
+                  <th class="px-1.5 py-1 border-b">AI Monster</th>
+                  <th class="px-1.5 py-1 border-b">Outcome</th>
+                  <th class="px-1.5 py-1 border-b"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="battle in battles" :key="battle.id" class="border-b">
+                  <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(battle.startedAt) }}</td>
+                  <td class="px-1.5 py-1">
+                    <div class="font-medium">{{ displayUser(battle.player) }}</div>
+                    <div class="text-[10px] text-gray-500">{{ battle.player?.id || '-' }}</div>
+                  </td>
+                  <td class="px-1.5 py-1">{{ monsterName(battle.playerMonster) }}</td>
+                  <td class="px-1.5 py-1">{{ battle.aiMonsterName || '-' }}</td>
+                  <td class="px-1.5 py-1">{{ outcomeLabel(battle) }}</td>
+                  <td class="px-1.5 py-1">
+                    <button
+                      class="px-2 py-0.5 border rounded text-[11px] text-red-600 border-red-200 hover:bg-red-50 disabled:opacity-50"
+                      :disabled="isDeleting(battle.id)"
+                      @click="deleteBattle(battle)"
+                    >
+                      {{ isDeleting(battle.id) ? 'Deleting...' : 'Delete' }}
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Mobile cards -->
+          <div class="lg:hidden space-y-2">
+            <div v-for="battle in battles" :key="battle.id" class="border rounded bg-white p-2 text-[11px]">
+              <div class="flex items-center justify-between text-[10px] text-gray-500">
+                <span>{{ formatDate(battle.startedAt) }}</span>
+                <span>{{ outcomeLabel(battle) }}</span>
+              </div>
+              <div class="mt-1">
+                <div class="font-semibold">{{ displayUser(battle.player) }}</div>
+                <div class="text-[10px] text-gray-500">{{ battle.player?.id || '-' }}</div>
+              </div>
+              <div class="mt-1.5 space-y-0.5">
+                <div><span class="text-gray-500">Selected:</span> {{ monsterName(battle.playerMonster) }}</div>
+                <div><span class="text-gray-500">AI:</span> {{ battle.aiMonsterName || '-' }}</div>
+              </div>
+              <div class="mt-1.5">
+                <button
+                  class="px-2 py-0.5 border rounded text-[11px] text-red-600 border-red-200 hover:bg-red-50 disabled:opacity-50"
+                  :disabled="isDeleting(battle.id)"
+                  @click="deleteBattle(battle)"
+                >
+                  {{ isDeleting(battle.id) ? 'Deleting...' : 'Delete' }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-3 flex items-center justify-between">
+          <div class="text-[11px] text-gray-600">
+            Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
+          </div>
+          <div class="space-x-1">
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+
+const battles = ref([])
+const total = ref(0)
+const loading = ref(false)
+const page = ref(1)
+const pageSize = 100
+const searchTerm = ref('')
+const fromDate = ref('')
+const toDate = ref('')
+const deletingIds = ref(new Set())
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const showingRange = computed(() => {
+  if (!total.value) return '0-0 of 0'
+  const start = (page.value - 1) * pageSize + 1
+  const end = Math.min(page.value * pageSize, total.value)
+  return `${start}-${end} of ${total.value}`
+})
+
+function normalizeDateRange() {
+  if (!fromDate.value || !toDate.value) return
+  if (new Date(fromDate.value) > new Date(toDate.value)) {
+    const tmp = fromDate.value
+    fromDate.value = toDate.value
+    toDate.value = tmp
+  }
+}
+
+function formatDate(dt) {
+  if (!dt) return '-'
+  return new Date(dt).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Chicago',
+    timeZoneName: 'short'
+  })
+}
+
+function displayUser(user) {
+  return user?.username || user?.discordTag || user?.id || '-'
+}
+
+function monsterName(monster) {
+  return monster?.customName || monster?.name || '-'
+}
+
+function outcomeLabel(battle) {
+  if (!battle.endedAt) return 'In Progress'
+  const reason = battle.endReason || '-'
+  if (battle.winnerIsAi) return `AI Win (${reason})`
+  if (battle.winnerUserId) {
+    if (battle.player?.id && battle.winnerUserId !== battle.player.id) {
+      return `Opponent Win (${reason})`
+    }
+    return `User Win (${reason})`
+  }
+  return reason
+}
+
+function isDeleting(id) {
+  return deletingIds.value.has(id)
+}
+
+function setDeleting(id, nextVal) {
+  const next = new Set(deletingIds.value)
+  if (nextVal) next.add(id)
+  else next.delete(id)
+  deletingIds.value = next
+}
+
+async function fetchBattles() {
+  if (loading.value) return
+  normalizeDateRange()
+  loading.value = true
+  try {
+    const res = await $fetch('/api/admin/monster-battles', {
+      query: {
+        page: page.value,
+        limit: pageSize,
+        username: searchTerm.value.trim() || undefined,
+        from: fromDate.value || undefined,
+        to: toDate.value || undefined
+      }
+    })
+    battles.value = res.items || []
+    total.value = res.total || 0
+    if (res.page) page.value = res.page
+  } catch (e) {
+    console.error('Failed to load monster battles', e)
+    battles.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+async function deleteBattle(battle) {
+  if (!battle?.id) return
+  if (!confirm('Delete this battle? This cannot be undone.')) return
+  setDeleting(battle.id, true)
+  try {
+    await $fetch(`/api/admin/monster-battles/${battle.id}`, { method: 'DELETE' })
+    battles.value = battles.value.filter(row => row.id !== battle.id)
+    total.value = Math.max(0, total.value - 1)
+    if (battles.value.length === 0 && page.value > 1) {
+      page.value -= 1
+      await fetchBattles()
+    }
+  } catch (e) {
+    console.error('Failed to delete battle', e)
+    alert(e?.data?.statusMessage || e?.message || 'Failed to delete battle')
+  } finally {
+    setDeleting(battle.id, false)
+  }
+}
+
+async function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  await fetchBattles()
+}
+
+async function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  await fetchBattles()
+}
+
+let filterDebounceId = null
+watch([searchTerm, fromDate, toDate], () => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  filterDebounceId = setTimeout(() => {
+    page.value = 1
+    fetchBattles()
+  }, 300)
+})
+
+onMounted(fetchBattles)
+</script>
+
+<style scoped>
+.admin-monster-battle-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+</style>

--- a/components/newsite/AdminNav.vue
+++ b/components/newsite/AdminNav.vue
@@ -1,19 +1,24 @@
 <template>
   <div class="admin-nav">
-    <div class="admin-nav-dropdown" ref="dropdownRef">
-      <BlueButton :style="{ height: buttonHeight }" @click.stop="toggleOpen">Admin Core ▾</BlueButton>
-      <div v-if="open" class="admin-nav-menu">
-        <template v-for="item in items" :key="item.id">
+    <div
+      v-for="menu in menus"
+      :key="menu.id"
+      class="admin-nav-dropdown"
+      :ref="el => (dropdownRefs[menu.id] = el)"
+    >
+      <BlueButton :style="{ height: buttonHeight }" @click.stop="toggle(menu.id)">{{ menu.label }} ▾</BlueButton>
+      <div v-if="openDropdown === menu.id" class="admin-nav-menu">
+        <template v-for="item in menu.items" :key="item.id">
           <NuxtLink
             v-if="item.to"
             :to="item.to"
             class="admin-nav-menu-item"
-            @click="open = false"
+            @click="openDropdown = null"
           >{{ item.label }}</NuxtLink>
           <button
             v-else
             class="admin-nav-menu-item"
-            @click="open = false"
+            @click="openDropdown = null"
           >{{ item.label }}</button>
         </template>
       </div>
@@ -37,30 +42,55 @@ const props = defineProps({
   }
 })
 
-const items = [
-  { id: 'analytics',   label: 'Analytics',    to: '/newsite/admin' },
-  { id: 'manageUsers', label: 'Manage Users', to: '/newsite/admin/manageUsers' },
-  { id: 'placeholder-1', label: 'Placeholder', to: null },
-  { id: 'placeholder-2', label: 'Placeholder', to: null },
-  { id: 'placeholder-3', label: 'Placeholder', to: null },
-  { id: 'placeholder-4', label: 'Placeholder', to: null },
-  { id: 'placeholder-5', label: 'Placeholder', to: null },
-  { id: 'placeholder-6', label: 'Placeholder', to: null },
-  { id: 'placeholder-7', label: 'Placeholder', to: null },
-  { id: 'placeholder-8', label: 'Placeholder', to: null }
+const menus = [
+  {
+    id: 'core',
+    label: 'Admin Core',
+    items: [
+      { id: 'analytics',     label: 'Analytics',    to: '/newsite/admin' },
+      { id: 'manageUsers',   label: 'Manage Users', to: '/newsite/admin/manageUsers' },
+      { id: 'core-placeholder-1', label: 'Placeholder', to: null },
+      { id: 'core-placeholder-2', label: 'Placeholder', to: null },
+      { id: 'core-placeholder-3', label: 'Placeholder', to: null },
+      { id: 'core-placeholder-4', label: 'Placeholder', to: null },
+      { id: 'core-placeholder-5', label: 'Placeholder', to: null },
+      { id: 'core-placeholder-6', label: 'Placeholder', to: null },
+      { id: 'core-placeholder-7', label: 'Placeholder', to: null },
+      { id: 'core-placeholder-8', label: 'Placeholder', to: null }
+    ]
+  },
+  {
+    id: 'logs',
+    label: 'Admin Logs',
+    items: [
+      { id: 'cheatFinder',        label: 'Cheat Finder',       to: '/newsite/admin/cheatFinder' },
+      { id: 'authLogs',           label: 'Auth Logs',          to: '/newsite/admin/authLogs' },
+      { id: 'tradeLogs',          label: 'Trade Logs',         to: '/newsite/admin/tradeLogs' },
+      { id: 'auctionLogs',        label: 'Auction Logs',       to: '/newsite/admin/auctionLogs' },
+      { id: 'ctoonOwnerLogs',     label: 'cToon Owner Logs',   to: '/newsite/admin/ctoonOwnerLogs' },
+      { id: 'czoneSearchLogs',    label: 'cZone Search Logs',  to: '/newsite/admin/czoneSearchLogs' },
+      { id: 'pointLogs',          label: 'Point Logs',         to: '/newsite/admin/pointLogs' },
+      { id: 'achievementLogs',    label: 'Achievement Logs',   to: '/newsite/admin/achievementLogs' },
+      { id: 'gtoonsClashLogs',    label: 'gToons Clash Logs',  to: '/newsite/admin/gtoonsClashLogs' },
+      { id: 'monsterBattleLogs',  label: 'Monster Battle Logs', to: '/newsite/admin/monsterBattleLogs' },
+      { id: 'lottoLogs',          label: 'Lotto Logs',         to: '/newsite/admin/lottoLogs' },
+      { id: 'winWheelLogs',       label: 'Win Wheel Logs',     to: '/newsite/admin/winWheelLogs' },
+      { id: 'scavengerLogs',      label: 'Scavenger Logs',     to: '/newsite/admin/scavengerLogs' }
+    ]
+  }
 ]
 
-const open = ref(false)
-const dropdownRef = ref(null)
+const openDropdown = ref(null)
+const dropdownRefs = {}
 
-function toggleOpen() {
-  open.value = !open.value
+function toggle(id) {
+  openDropdown.value = openDropdown.value === id ? null : id
 }
 
 function onGlobalClick(e) {
-  if (!open.value) return
-  const root = dropdownRef.value
-  if (root && !root.contains(e.target)) open.value = false
+  if (!openDropdown.value) return
+  const active = dropdownRefs[openDropdown.value]
+  if (active && !active.contains(e.target)) openDropdown.value = null
 }
 
 onMounted(() => {

--- a/components/newsite/AdminPointLogs.vue
+++ b/components/newsite/AdminPointLogs.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="admin-point-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <div class="bg-white rounded-lg shadow p-3">
+        <div class="flex items-center justify-between mb-2">
+          <h1 class="text-base font-semibold">Points Log</h1>
+        </div>
+
+        <!-- FILTER BAR -->
+        <div class="flex flex-wrap items-end gap-2 mb-2">
+          <input
+            type="text"
+            v-model="searchTerm"
+            placeholder="Search by username…"
+            class="flex-1 min-w-[160px] border border-gray-300 rounded px-1.5 py-0.5 text-xs focus:ring-indigo-500 focus:border-indigo-500"
+          />
+          <div class="flex items-center">
+            <label for="fromDate" class="mr-1 text-[11px] font-medium">From</label>
+            <input id="fromDate" v-model="fromDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+          </div>
+          <div class="flex items-center">
+            <label for="toDate" class="mr-1 text-[11px] font-medium">To</label>
+            <input id="toDate" v-model="toDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+          </div>
+        </div>
+
+        <div class="mb-2 text-[11px] text-gray-600">
+          Total Results: {{ total }} logs
+        </div>
+
+        <div v-if="loading" class="text-center py-2">Loading…</div>
+        <div v-else-if="logs.length === 0" class="text-center py-2 text-gray-500">No logs found.</div>
+        <div v-else>
+          <!-- TABLE VIEW (desktop) -->
+          <div class="overflow-x-auto hidden sm:block">
+            <table class="min-w-full table-auto border-collapse text-[11px]">
+              <thead>
+                <tr class="bg-gray-100">
+                  <th class="px-1.5 py-1 text-left">User</th>
+                  <th class="px-1.5 py-1 text-left">Direction</th>
+                  <th class="px-1.5 py-1 text-right">Points</th>
+                  <th class="px-1.5 py-1 text-right">New Total</th>
+                  <th class="px-1.5 py-1 text-left">Method</th>
+                  <th class="px-1.5 py-1 text-left">Created At (CDT)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="log in logs"
+                  :key="log.id"
+                  class="border-b hover:bg-gray-50"
+                >
+                  <td class="px-1.5 py-1">{{ log.user?.username ?? '—' }}</td>
+                  <td class="px-1.5 py-1 capitalize">{{ log.direction }}</td>
+                  <td class="px-1.5 py-1 text-right tabular-nums">{{ log.points }}</td>
+                  <td class="px-1.5 py-1 text-right tabular-nums">{{ log.total }}</td>
+                  <td class="px-1.5 py-1">{{ log.method || '—' }}</td>
+                  <td class="px-1.5 py-1 whitespace-nowrap">
+                    {{ new Date(log.createdAt).toLocaleString('en-US', {
+                      year: 'numeric', month: 'short', day: 'numeric',
+                      hour: '2-digit', minute: '2-digit',
+                      timeZone: 'America/Chicago', timeZoneName: 'short'
+                    }) }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- CARD VIEW (mobile) -->
+          <div class="space-y-2 block sm:hidden">
+            <div
+              v-for="log in logs"
+              :key="log.id"
+              class="bg-gray-100 rounded-lg p-2 flex flex-col text-[11px]"
+            >
+              <div class="flex justify-between">
+                <div>
+                  <p class="font-semibold">{{ log.user?.username ?? '—' }}</p>
+                  <p class="capitalize">{{ log.direction }}</p>
+                  <p>Points: {{ log.points }}</p>
+                  <p>Method: {{ log.method || '—' }}</p>
+                </div>
+                <p class="text-[10px] whitespace-nowrap">
+                  {{ new Date(log.createdAt).toLocaleString('en-US', {
+                    year: 'numeric', month: 'short', day: 'numeric',
+                    hour: '2-digit', minute: '2-digit',
+                    timeZone: 'America/Chicago'
+                  }) }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Pagination -->
+        <div v-if="!loading && logs.length" class="mt-3 flex items-center justify-between">
+          <div class="text-[11px] text-gray-600">
+            Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
+          </div>
+          <div class="space-x-1">
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+
+const logs = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = 100
+const loading = ref(false)
+
+const searchTerm = ref('')
+const fromDate = ref('')
+const toDate = ref('')
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const showingRange = computed(() => {
+  if (!total.value) return '0-0 of 0'
+  const start = (page.value - 1) * pageSize + 1
+  const end = Math.min(page.value * pageSize, total.value)
+  return `${start}-${end} of ${total.value}`
+})
+
+function normalizeDateRange() {
+  if (!fromDate.value || !toDate.value) return
+  if (new Date(fromDate.value) > new Date(toDate.value)) {
+    const tmp = fromDate.value
+    fromDate.value = toDate.value
+    toDate.value = tmp
+  }
+}
+
+async function fetchLogs() {
+  if (loading.value) return
+  normalizeDateRange()
+  loading.value = true
+  try {
+    const query = {
+      page: page.value,
+      limit: pageSize,
+      username: searchTerm.value.trim() || undefined,
+      from: fromDate.value || undefined,
+      to: toDate.value || undefined
+    }
+    const res = await $fetch('/api/admin/points-log', { query })
+    logs.value = res.items || []
+    total.value = res.total || 0
+    if (res.page) page.value = res.page
+  } catch {
+    logs.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  fetchLogs()
+}
+
+function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  fetchLogs()
+}
+
+let filterDebounceId = null
+watch([searchTerm, fromDate, toDate], () => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  filterDebounceId = setTimeout(() => {
+    page.value = 1
+    fetchLogs()
+  }, 300)
+})
+
+onMounted(() => {
+  fetchLogs()
+})
+</script>
+
+<style scoped>
+.admin-point-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+th, td { vertical-align: middle; }
+</style>

--- a/components/newsite/AdminScavengerLogs.vue
+++ b/components/newsite/AdminScavengerLogs.vue
@@ -1,0 +1,215 @@
+<template>
+  <div class="admin-scavenger-logs bg-gray-100">
+    <div class="p-2 text-xs">
+      <h1 class="text-base font-bold mb-2">Scavenger Logs</h1>
+
+      <div class="bg-white rounded-lg shadow-md p-2 space-y-3">
+        <div class="flex items-center gap-2">
+          <label class="text-[11px] font-medium">Window:</label>
+          <select v-model.number="days" class="border rounded px-1.5 py-0.5 text-xs">
+            <option :value="7">7 days</option>
+            <option :value="30">30 days</option>
+            <option :value="90">90 days</option>
+          </select>
+          <button class="btn-primary" @click="loadAll" :disabled="loading">{{ loading ? 'Loading…' : 'Refresh' }}</button>
+        </div>
+
+        <!-- KPIs -->
+        <section class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
+          <div class="kpi"><div class="kpi-label">Starts</div><div class="kpi-value">{{ analytics.startedCount }}</div></div>
+          <div class="kpi">
+            <div class="kpi-label">Nothing</div>
+            <div class="kpi-value">{{ analytics.outcomes.NOTHING }}</div>
+            <div class="kpi-sub">{{ rate(analytics.outcomes.NOTHING, completedTotal) }}%</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Points</div>
+            <div class="kpi-value">{{ analytics.outcomes.POINTS }}</div>
+            <div class="kpi-sub">{{ rate(analytics.outcomes.POINTS, completedTotal) }}%</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Exclusives</div>
+            <div class="kpi-value">{{ analytics.outcomes.EXCLUSIVE_CTOON }}</div>
+            <div class="kpi-sub">{{ rate(analytics.outcomes.EXCLUSIVE_CTOON, completedTotal) }}%</div>
+          </div>
+          <div class="kpi"><div class="kpi-label">Completion Rate</div><div class="kpi-value">{{ completionRate }}%</div></div>
+        </section>
+
+        <!-- Triggers breakdown -->
+        <section>
+          <h2 class="text-sm font-semibold mb-1">Triggers</h2>
+          <div class="sm:hidden space-y-1.5">
+            <div v-for="t in analytics.triggers" :key="t.trigger" class="border rounded bg-white p-2">
+              <div class="text-[11px] font-semibold">{{ t.trigger }}</div>
+              <div class="mt-1 grid grid-cols-2 gap-1 text-[10px]">
+                <div><span class="text-gray-500">Starts:</span> {{ t.starts }}</div>
+                <div><span class="text-gray-500">Completions:</span> {{ t.completions || 0 }}</div>
+                <div><span class="text-gray-500">Completion Rate:</span> {{ rate(t.completions || 0, t.starts) }}%</div>
+              </div>
+            </div>
+          </div>
+          <div class="hidden sm:block overflow-auto">
+            <table class="min-w-full w-full border rounded text-[11px]">
+              <thead class="bg-gray-50 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">Trigger</th>
+                  <th class="px-1.5 py-1 border-b">Starts</th>
+                  <th class="px-1.5 py-1 border-b">Completions</th>
+                  <th class="px-1.5 py-1 border-b">Completion Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="t in analytics.triggers" :key="t.trigger" class="border-b">
+                  <td class="px-1.5 py-1">{{ t.trigger }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ t.starts }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ t.completions || 0 }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ rate(t.completions || 0, t.starts) }}%</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- Reasons breakdown -->
+        <section>
+          <h2 class="text-sm font-semibold mb-1">Attempt Outcomes</h2>
+          <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            <li class="bg-gray-50 border rounded p-2">
+              <div class="flex items-baseline justify-between text-[11px]">
+                <span class="font-medium">No stories</span>
+                <strong class="text-xs">{{ analytics.reasonCounts.no_stories || 0 }}</strong>
+              </div>
+              <div class="text-[10px] text-gray-500 mt-0.5">There were no active Scavenger stories available to run.</div>
+            </li>
+            <li class="bg-gray-50 border rounded p-2">
+              <div class="flex items-baseline justify-between text-[11px]">
+                <span class="font-medium">Disabled</span>
+                <strong class="text-xs">{{ analytics.reasonCounts.disabled || 0 }}</strong>
+              </div>
+              <div class="text-[10px] text-gray-500 mt-0.5">The feature is effectively off (chance set to 0%).</div>
+            </li>
+            <li class="bg-gray-50 border rounded p-2">
+              <div class="flex items-baseline justify-between text-[11px]">
+                <span class="font-medium">Resumed (not counted)</span>
+                <strong class="text-xs">{{ analytics.reasonCounts.resumed || 0 }}</strong>
+              </div>
+              <div class="text-[10px] text-gray-500 mt-0.5">An existing pending hunt was resumed instead of starting a new one.</div>
+            </li>
+          </ul>
+        </section>
+
+        <!-- Recent Sessions -->
+        <section>
+          <h2 class="text-sm font-semibold mb-1">Recent Sessions</h2>
+          <div class="sm:hidden space-y-1.5">
+            <div v-for="s in sessions" :key="s.id" class="border rounded bg-white p-2">
+              <div class="flex items-center justify-between text-[10px] text-gray-500">
+                <span>{{ fmt(s.createdAt) }}</span>
+                <span>{{ s.status }}</span>
+              </div>
+              <div class="mt-0.5 text-[11px] font-medium">{{ s.user?.username || s.user?.id }}</div>
+              <div class="mt-1 grid grid-cols-2 gap-1 text-[10px]">
+                <div><span class="text-gray-500">Trigger:</span> {{ s.triggerSource }}</div>
+                <div><span class="text-gray-500">Result:</span> {{ s.resultType || '—' }}</div>
+                <div><span class="text-gray-500">Points:</span> {{ s.pointsAwarded }}</div>
+                <div class="col-span-2"><span class="text-gray-500">cToon:</span> <span v-if="s.ctoon">{{ s.ctoon.name }}</span><span v-else>—</span></div>
+              </div>
+            </div>
+          </div>
+          <div class="hidden sm:block overflow-auto">
+            <table class="min-w-full w-full border rounded text-[11px]">
+              <thead class="bg-gray-50 text-left">
+                <tr>
+                  <th class="px-1.5 py-1 border-b">Time</th>
+                  <th class="px-1.5 py-1 border-b">User</th>
+                  <th class="px-1.5 py-1 border-b">Trigger</th>
+                  <th class="px-1.5 py-1 border-b">Status</th>
+                  <th class="px-1.5 py-1 border-b">Result</th>
+                  <th class="px-1.5 py-1 border-b">Points</th>
+                  <th class="px-1.5 py-1 border-b">cToon</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="s in sessions" :key="s.id" class="border-b">
+                  <td class="px-1.5 py-1 whitespace-nowrap">{{ fmt(s.createdAt) }}</td>
+                  <td class="px-1.5 py-1">{{ s.user?.username || s.user?.id }}</td>
+                  <td class="px-1.5 py-1">{{ s.triggerSource }}</td>
+                  <td class="px-1.5 py-1">{{ s.status }}</td>
+                  <td class="px-1.5 py-1">{{ s.resultType || '—' }}</td>
+                  <td class="px-1.5 py-1 tabular-nums">{{ s.pointsAwarded }}</td>
+                  <td class="px-1.5 py-1">
+                    <span v-if="s.ctoon">{{ s.ctoon.name }}</span>
+                    <span v-else>—</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+const days = ref(30)
+const analytics = ref({ startedCount: 0, outcomes: { NOTHING: 0, POINTS: 0, EXCLUSIVE_CTOON: 0 }, reasonCounts: {}, triggers: [] })
+const sessions = ref([])
+const loading = ref(false)
+
+const completedTotal = computed(() => {
+  const oc = analytics.value?.outcomes || {}
+  return (oc.NOTHING || 0) + (oc.POINTS || 0) + (oc.EXCLUSIVE_CTOON || 0)
+})
+const completionRate = computed(() => {
+  const oc = analytics.value?.outcomes || {}
+  const completed = (oc.NOTHING || 0) + (oc.POINTS || 0) + (oc.EXCLUSIVE_CTOON || 0)
+  return rate(completed, analytics.value.startedCount)
+})
+
+function rate(a, b) {
+  if (!b) return 0
+  return Math.round((a / b) * 100)
+}
+function fmt(dt) {
+  return new Date(dt).toLocaleString()
+}
+
+async function loadAll() {
+  loading.value = true
+  try {
+    const [an, sess] = await Promise.all([
+      $fetch('/api/admin/scavenger/analytics', { query: { days: days.value } }),
+      $fetch('/api/admin/scavenger/sessions', { query: { days: days.value, limit: 100 } })
+    ])
+    analytics.value = an
+    sessions.value = sess
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadAll)
+</script>
+
+<style scoped>
+.admin-scavenger-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+.btn-primary {
+  background-color: #6366F1;
+  color: white;
+  padding: 2px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+}
+.btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+.kpi { background: #F9FAFB; border: 1px solid #E5E7EB; border-radius: 6px; padding: 6px 8px; }
+.kpi-label { font-size: 10px; color: #6B7280; }
+.kpi-value { font-size: 14px; font-weight: 700; color: #111827; }
+.kpi-sub { font-size: 10px; color: #6B7280; }
+</style>

--- a/components/newsite/AdminTradeLogs.vue
+++ b/components/newsite/AdminTradeLogs.vue
@@ -1,0 +1,356 @@
+<template>
+  <div class="admin-trade-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <!-- Filter Dropdowns -->
+      <div class="mb-2 flex flex-wrap items-end gap-2">
+        <!-- User Filter -->
+        <div class="flex items-center">
+          <label for="userFilter" class="mr-1 font-medium">User:</label>
+          <input
+            id="userFilter"
+            v-model="userQuery"
+            list="userSuggestions"
+            type="text"
+            placeholder="Type a username..."
+            class="border rounded px-1.5 py-0.5 text-xs"
+          />
+          <datalist id="userSuggestions">
+            <option v-for="user in userSuggestions" :key="user" :value="user" />
+          </datalist>
+        </div>
+
+        <!-- Status Filter -->
+        <div class="flex items-center">
+          <label for="statusFilter" class="mr-1 font-medium">Status:</label>
+          <select id="statusFilter" v-model="selectedStatus" class="border rounded px-1.5 py-0.5 text-xs">
+            <option value="">All</option>
+            <option v-for="status in statusOptions" :key="status" :value="status">
+              {{ status }}
+            </option>
+          </select>
+        </div>
+
+        <!-- Date Range -->
+        <div class="flex items-center">
+          <label for="fromDate" class="mr-1 font-medium">From:</label>
+          <input id="fromDate" v-model="fromDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+        <div class="flex items-center">
+          <label for="toDate" class="mr-1 font-medium">To:</label>
+          <input id="toDate" v-model="toDate" type="date" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+      </div>
+
+      <div class="mb-2 text-[11px] text-gray-600">
+        Total Results: {{ total }} trades
+      </div>
+
+      <!-- Desktop + Mobile -->
+      <div v-if="loading" class="text-gray-500">Loading...</div>
+      <div v-else-if="trades.length === 0" class="text-gray-500">No trades found.</div>
+      <div v-else>
+        <!-- Desktop Table -->
+        <div class="hidden md:block overflow-x-auto">
+          <table class="min-w-full bg-white rounded shadow text-[11px]">
+            <thead class="bg-gray-100">
+              <tr>
+                <th class="px-1.5 py-1 text-left">Users</th>
+                <th class="px-1.5 py-1 text-left">Status</th>
+                <th class="px-1.5 py-1 text-left">Created (CST)</th>
+                <th class="px-1.5 py-1 text-left">Accepted/Denied (CST)</th>
+                <th class="px-1.5 py-1 text-right">Pts</th>
+                <th class="px-1.5 py-1 text-right"># Off</th>
+                <th class="px-1.5 py-1 text-right"># Req</th>
+                <th class="px-1.5 py-1 text-right">Off Val</th>
+                <th class="px-1.5 py-1 text-right">Req Val</th>
+                <th class="px-1.5 py-1"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="trade in trades"
+                :key="trade.id"
+                class="border-t"
+                :class="{
+                  'bg-yellow-100':
+                    computeTotalValue(trade.ctoonsOffered) <
+                    (trade.pointsOffered + computeTotalValue(trade.ctoonsRequested)) * 0.8
+                }"
+              >
+                <td class="px-1.5 py-1 align-top">
+                  <div class="flex flex-col leading-tight">
+                    <span class="font-medium">{{ trade.initiator.username }}</span>
+                    <span class="text-[9px] text-gray-500">↓</span>
+                    <span class="font-medium">{{ trade.recipient.username }}</span>
+                  </div>
+                </td>
+                <td class="px-1.5 py-1">{{ trade.status }}</td>
+                <td class="px-1.5 py-1 whitespace-nowrap">{{ formatCST(trade.createdAt) }}</td>
+                <td class="px-1.5 py-1 whitespace-nowrap">
+                  <span v-if="trade.decisionAt">{{ formatCST(trade.decisionAt) }}</span>
+                  <span v-else>-</span>
+                </td>
+                <td class="px-1.5 py-1 text-right tabular-nums">{{ trade.pointsOffered }}</td>
+                <td class="px-1.5 py-1 text-right tabular-nums">{{ trade.ctoonsOffered.length }}</td>
+                <td class="px-1.5 py-1 text-right tabular-nums">{{ trade.ctoonsRequested.length }}</td>
+                <td class="px-1.5 py-1 text-right tabular-nums">
+                  {{ trade.pointsOffered + computeTotalValue(trade.ctoonsOffered) }}
+                </td>
+                <td class="px-1.5 py-1 text-right tabular-nums">
+                  {{ computeTotalValue(trade.ctoonsRequested) }}
+                </td>
+                <td class="px-1.5 py-1">
+                  <button @click="openModal(trade)" class="bg-blue-500 text-white px-2 py-0.5 rounded text-[11px]">
+                    View
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile Cards (md and below) -->
+        <div class="md:hidden grid grid-cols-1 gap-2">
+          <div
+            v-for="trade in trades"
+            :key="trade.id"
+            class="border rounded p-2 shadow break-words text-[11px]"
+            :class="{
+              'bg-yellow-100':
+                computeTotalValue(trade.ctoonsOffered) <
+                (trade.pointsOffered + computeTotalValue(trade.ctoonsRequested)) * 0.8
+            }"
+          >
+            <div class="mb-1">
+              <span class="font-medium">{{ trade.initiator.username }}</span>
+              <span class="mx-1">→</span>
+              <span class="font-medium">{{ trade.recipient.username }}</span>
+            </div>
+
+            <div class="mb-1 text-gray-700 space-y-0.5">
+              <div><span class="font-medium">Status:</span> {{ trade.status }}</div>
+              <div><span class="font-medium">Created:</span> {{ formatCST(trade.createdAt) }}</div>
+              <div>
+                <span class="font-medium">Decision:</span>
+                <span v-if="trade.decisionAt">{{ formatCST(trade.decisionAt) }}</span>
+                <span v-else>-</span>
+              </div>
+            </div>
+
+            <div class="space-y-0.5">
+              <div><span class="font-medium">Points:</span> {{ trade.pointsOffered }}</div>
+              <div><span class="font-medium">Offered:</span> {{ trade.ctoonsOffered.length }}</div>
+              <div><span class="font-medium">Requested:</span> {{ trade.ctoonsRequested.length }}</div>
+              <div><span class="font-medium">Total Offered Value:</span> {{ trade.pointsOffered + computeTotalValue(trade.ctoonsOffered) }}</div>
+              <div><span class="font-medium">Total Requested Value:</span> {{ computeTotalValue(trade.ctoonsRequested) }}</div>
+            </div>
+
+            <button @click="openModal(trade)" class="mt-2 bg-blue-500 text-white px-2 py-0.5 rounded text-[11px]">
+              View Trade
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Pagination -->
+      <div v-if="!loading" class="mt-3 flex items-center justify-between">
+        <div class="text-[11px] text-gray-600">
+          Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
+        </div>
+        <div class="space-x-1">
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+        </div>
+      </div>
+
+      <!-- Trade Details Modal -->
+      <div v-if="showModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-3 overflow-auto z-50">
+        <div class="bg-white rounded shadow-lg w-full max-w-xl relative max-h-[80vh] flex flex-col text-xs">
+          <div class="sticky top-0 z-20 bg-white flex justify-between items-center px-3 py-2 border-b shrink-0">
+            <h2 class="text-sm font-semibold">Trade Details</h2>
+            <button @click="closeModal" class="text-gray-500 hover:text-gray-800 text-base leading-none">×</button>
+          </div>
+          <div class="p-3 overflow-y-auto flex-1 min-h-0">
+            <div class="mb-2 text-gray-700 space-y-0.5">
+              <div><span class="font-medium">Created (CST):</span> {{ formatCST(selectedTrade.createdAt) }}</div>
+              <div>
+                <span class="font-medium">Accepted/Denied (CST):</span>
+                <span v-if="selectedTrade.decisionAt">{{ formatCST(selectedTrade.decisionAt) }}</span>
+                <span v-else>-</span>
+              </div>
+            </div>
+
+            <!-- Initiator & Offers -->
+            <div class="mb-3 p-2 border rounded">
+              <h3 class="font-medium mb-1">Initiator &amp; Offers</h3>
+              <div><span class="font-medium">Initiator:</span> {{ selectedTrade.initiator.username }}</div>
+              <div class="mt-1"><span class="font-medium">Points Offered:</span> {{ selectedTrade.pointsOffered }}</div>
+              <div><span class="font-medium">cToon Value:</span> {{ computeTotalValue(selectedTrade.ctoonsOffered) }}</div>
+              <div><span class="font-medium">Total Offered Value:</span> {{ selectedTrade.pointsOffered + computeTotalValue(selectedTrade.ctoonsOffered) }}</div>
+              <div class="font-medium mt-2">cToons Offered:</div>
+              <div class="grid grid-cols-4 gap-2 mt-1">
+                <div v-for="item in selectedTrade.ctoonsOffered" :key="item.id" class="text-center">
+                  <img :src="item.assetPath" alt class="max-w-[60px] h-auto object-contain rounded mx-auto" />
+                  <div class="mt-1 font-medium leading-tight">{{ item.name }}</div>
+                  <div class="text-[10px] text-gray-600">{{ item.rarity }}</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Recipient & Requests -->
+            <div class="p-2 border rounded">
+              <div><span class="font-medium">Recipient:</span> {{ selectedTrade.recipient.username }}</div>
+              <div class="font-medium mt-2">cToons Requested:</div>
+              <div class="grid grid-cols-4 gap-2 mt-1">
+                <div v-for="item in selectedTrade.ctoonsRequested" :key="item.id" class="text-center">
+                  <img :src="item.assetPath" alt class="max-w-[60px] h-auto object-contain rounded mx-auto" />
+                  <div class="mt-1 font-medium leading-tight">{{ item.name }}</div>
+                  <div class="text-[10px] text-gray-600">{{ item.rarity }}</div>
+                </div>
+              </div>
+              <div class="mt-2"><span class="font-medium">Total Requested Value:</span> {{ computeTotalValue(selectedTrade.ctoonsRequested) }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+
+const rarityValues = { Common: 100, Uncommon: 200, Rare: 400, 'Very Rare': 750, 'Crazy Rare': 1250 }
+
+// Data
+const trades = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = 100
+const loading = ref(false)
+
+// Filters
+const userQuery = ref('')
+const userSuggestions = ref([])
+const selectedStatus = ref('')
+const fromDate = ref('')
+const toDate = ref('')
+const statusOptions = ['PENDING', 'ACCEPTED', 'REJECTED', 'WITHDRAWN']
+
+// Derived
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const showingRange = computed(() => {
+  if (!total.value) return '0-0 of 0'
+  const start = (page.value - 1) * pageSize + 1
+  const end = Math.min(page.value * pageSize, total.value)
+  return `${start}-${end} of ${total.value}`
+})
+
+function normalizeDateRange() {
+  if (!fromDate.value || !toDate.value) return
+  if (new Date(fromDate.value) > new Date(toDate.value)) {
+    const tmp = fromDate.value
+    fromDate.value = toDate.value
+    toDate.value = tmp
+  }
+}
+
+async function fetchTrades() {
+  normalizeDateRange()
+  loading.value = true
+  try {
+    const query = {
+      page: page.value,
+      limit: pageSize,
+      status: selectedStatus.value || undefined,
+      user: userQuery.value.trim() || undefined,
+      from: fromDate.value || undefined,
+      to: toDate.value || undefined
+    }
+    const res = await $fetch('/api/admin/trades', { query })
+    trades.value = res.items || []
+    total.value = res.total || 0
+    if (res.page) page.value = res.page
+  } catch (err) {
+    trades.value = []
+    total.value = 0
+    console.error('Failed to load trades', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function fetchUserSuggestions() {
+  const term = userQuery.value.trim()
+  if (!term) {
+    userSuggestions.value = []
+    return
+  }
+  try {
+    const res = await $fetch('/api/admin/user-mentions', { query: { q: term, limit: 10 } })
+    userSuggestions.value = (res.items || []).map(item => item.username).filter(Boolean)
+  } catch {
+    userSuggestions.value = []
+  }
+}
+
+// Modal
+const showModal = ref(false)
+const selectedTrade = ref(null)
+function openModal(trade) { selectedTrade.value = trade; showModal.value = true }
+function closeModal() { showModal.value = false }
+
+// Helpers
+function computeTotalValue(arr) {
+  return arr.reduce((sum, item) => sum + (rarityValues[item.rarity] || 1250), 0)
+}
+function formatCST(dateLike) {
+  if (!dateLike) return '-'
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'America/Chicago'
+    }).format(new Date(dateLike))
+  } catch { return '-' }
+}
+
+function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  fetchTrades()
+}
+
+function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  fetchTrades()
+}
+
+let filterDebounceId = null
+watch([userQuery, selectedStatus, fromDate, toDate], () => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  filterDebounceId = setTimeout(() => {
+    page.value = 1
+    fetchTrades()
+  }, 300)
+})
+
+let suggestionDebounceId = null
+watch(userQuery, () => {
+  if (suggestionDebounceId) clearTimeout(suggestionDebounceId)
+  suggestionDebounceId = setTimeout(fetchUserSuggestions, 200)
+})
+
+onMounted(() => {
+  fetchTrades()
+})
+</script>
+
+<style scoped>
+.admin-trade-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+</style>

--- a/components/newsite/AdminWinWheelLogs.vue
+++ b/components/newsite/AdminWinWheelLogs.vue
@@ -1,0 +1,185 @@
+<template>
+  <div class="admin-win-wheel-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <h1 class="text-base font-bold mb-2">Win Wheel Logs</h1>
+
+      <!-- Date range filter -->
+      <form class="bg-white border rounded p-2 flex flex-wrap items-end gap-2 mb-2" @submit.prevent="applyRange">
+        <div>
+          <label class="block text-[10px] font-medium mb-0.5">From</label>
+          <input type="date" v-model="from" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+        <div>
+          <label class="block text-[10px] font-medium mb-0.5">To</label>
+          <input type="date" v-model="to" class="border rounded px-1.5 py-0.5 text-xs" />
+        </div>
+        <button class="bg-indigo-600 text-white rounded px-2 py-0.5 text-[11px]">Apply</button>
+        <button type="button" class="text-[11px] text-gray-600 underline" @click="setLastNDays(30)">Last 30 days</button>
+      </form>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-2">
+        <!-- Pie chart -->
+        <div class="bg-white rounded shadow p-2">
+          <h2 class="text-sm font-semibold mb-1">Results Distribution</h2>
+          <p class="text-[11px] text-gray-500 mb-1">Total spins: {{ total }}</p>
+          <div class="chart-container"><canvas ref="pieCanvas"></canvas></div>
+        </div>
+
+        <!-- Breakdown table -->
+        <div class="bg-white rounded shadow p-2">
+          <h2 class="text-sm font-semibold mb-1">Breakdown</h2>
+          <div v-if="loading" class="text-gray-500">Loading…</div>
+          <div v-else-if="rows.length === 0" class="text-gray-500">No spins in this range.</div>
+          <table v-else class="w-full text-[11px]">
+            <thead>
+              <tr class="text-left border-b">
+                <th class="py-1">Result</th>
+                <th class="py-1">Count</th>
+                <th class="py-1">% of total</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="r in rows" :key="r.result" class="border-b">
+                <td class="py-0.5">
+                  <span class="inline-block w-2.5 h-2.5 rounded mr-1.5" :style="{ backgroundColor: colorFor(r.result) }"></span>
+                  {{ labelFor(r.result) }}
+                </td>
+                <td class="py-0.5 tabular-nums">{{ r.count }}</td>
+                <td class="py-0.5 tabular-nums">{{ pct(r.count) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { Chart, PieController, ArcElement, Tooltip, Legend } from 'chart.js'
+import ChartDataLabels from 'chartjs-plugin-datalabels'
+
+Chart.register(PieController, ArcElement, Tooltip, Legend, ChartDataLabels)
+
+const from = ref('')
+const to = ref('')
+
+function toYMD(d) {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const da = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${da}`
+}
+function setLastNDays(n) {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(end.getDate() - (n - 1))
+  from.value = toYMD(start)
+  to.value = toYMD(end)
+}
+
+const pieCanvas = ref(null)
+let pieChart
+const rows = ref([])
+const loading = ref(false)
+const total = computed(() => rows.value.reduce((s, r) => s + r.count, 0))
+
+const LABELS = {
+  nothing: 'Nothing',
+  points: 'Points',
+  ctoonLeast: 'cToon (Least Rare)',
+  ctoonExclusive: 'cToon (Exclusive)'
+}
+const COLORS = {
+  nothing: '#9CA3AF',
+  points: '#F59E0B',
+  ctoonLeast: '#3B82F6',
+  ctoonExclusive: '#8B5CF6',
+  default: '#10B981'
+}
+const labelFor = key => LABELS[key] || key
+const colorFor = key => COLORS[key] || COLORS.default
+const pct = count => (total.value ? ((count / total.value) * 100).toFixed(1) + '%' : '—')
+
+async function fetchDistribution() {
+  loading.value = true
+  try {
+    const params = new URLSearchParams({ start: from.value, end: to.value })
+    const res = await fetch(`/api/admin/win-wheel-logs?${params.toString()}`, { credentials: 'include' })
+    const data = await res.json()
+
+    rows.value = (data.data || [])
+      .map(d => ({ result: d.result, count: d.count }))
+      .sort((a, b) => b.count - a.count)
+
+    const labels = rows.value.map(r => labelFor(r.result))
+    const counts = rows.value.map(r => r.count)
+    const colors = rows.value.map(r => colorFor(r.result))
+
+    pieChart.data.labels = labels
+    pieChart.data.datasets = [{
+      data: counts,
+      backgroundColor: colors,
+      borderColor: colors,
+      borderWidth: 1
+    }]
+    pieChart.update()
+  } catch (e) {
+    console.error(e)
+    rows.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+function applyRange() {
+  if (!from.value || !to.value) return
+  if (new Date(from.value) > new Date(to.value)) {
+    const t = from.value
+    from.value = to.value
+    to.value = t
+  }
+  fetchDistribution()
+}
+
+onMounted(() => {
+  setLastNDays(30)
+  pieChart = new Chart(pieCanvas.value.getContext('2d'), {
+    type: 'pie',
+    data: { labels: [], datasets: [] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: { color: '#000', font: { size: 10 } }
+        },
+        datalabels: {
+          color: '#fff',
+          font: { size: 10 },
+          formatter: (val, ctx) => {
+            const total = ctx.chart.data.datasets[0].data.reduce((s, v) => s + v, 0)
+            const p = total ? (val / total * 100).toFixed(1) : 0
+            return `${val} (${p}%)`
+          }
+        }
+      }
+    }
+  })
+  fetchDistribution()
+})
+</script>
+
+<style scoped>
+.admin-win-wheel-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+.chart-container {
+  height: 240px;
+  position: relative;
+}
+</style>

--- a/pages/newsite/admin/[[section]].vue
+++ b/pages/newsite/admin/[[section]].vue
@@ -6,6 +6,19 @@
     <div class="newsite-admin-body">
       <AdminAnalytics v-if="!section" />
       <AdminManageUsers v-else-if="section === 'manageUsers'" />
+      <AdminCheatFinder v-else-if="section === 'cheatFinder'" />
+      <AdminAuthLogs v-else-if="section === 'authLogs'" />
+      <AdminTradeLogs v-else-if="section === 'tradeLogs'" />
+      <AdminAuctionLogs v-else-if="section === 'auctionLogs'" />
+      <AdminCtoonOwnerLogs v-else-if="section === 'ctoonOwnerLogs'" />
+      <AdminCzoneSearchLogs v-else-if="section === 'czoneSearchLogs'" />
+      <AdminPointLogs v-else-if="section === 'pointLogs'" />
+      <AdminAchievementLogs v-else-if="section === 'achievementLogs'" />
+      <AdminGtoonsClashLogs v-else-if="section === 'gtoonsClashLogs'" />
+      <AdminMonsterBattleLogs v-else-if="section === 'monsterBattleLogs'" />
+      <AdminLottoLogs v-else-if="section === 'lottoLogs'" />
+      <AdminWinWheelLogs v-else-if="section === 'winWheelLogs'" />
+      <AdminScavengerLogs v-else-if="section === 'scavengerLogs'" />
       <div v-else class="newsite-admin-placeholder">
         <h1 class="newsite-admin-title">Unknown section</h1>
       </div>

--- a/server/api/admin/duplicate-users.get.js
+++ b/server/api/admin/duplicate-users.get.js
@@ -54,9 +54,15 @@ export default defineEventHandler(async (event) => {
 
     const name = user.username || '__unknown__'
     byIp[ip] = byIp[ip] || {}
-    // for each alias keep the latest timestamp
-    if (!byIp[ip][name] || ts > byIp[ip][name]) {
-      byIp[ip][name] = ts
+    // for each alias keep the latest login timestamp + user metadata
+    const existing = byIp[ip][name]
+    if (!existing || ts > existing.ts) {
+      byIp[ip][name] = {
+        ts,
+        joined: user.createdAt,
+        discordTag: user.discordTag,
+        discordCreatedAt: user.discordCreatedAt
+      }
     }
   }
 
@@ -67,11 +73,14 @@ export default defineEventHandler(async (event) => {
       Object.keys(nameMap).length > 1
     )
     .map(([ip, nameMap]) => {
-      const aliases = Object.entries(nameMap).map(([username, ts]) => ({
+      const aliases = Object.entries(nameMap).map(([username, info]) => ({
         username,
-        lastLogin: new Date(ts)
+        lastLogin: new Date(info.ts),
+        joined: info.joined,
+        discordTag: info.discordTag,
+        discordCreatedAt: info.discordCreatedAt
       }))
-      const lastLoginTs = Object.values(nameMap).reduce((max, ts) => Math.max(max, ts), 0)
+      const lastLoginTs = Object.values(nameMap).reduce((max, info) => Math.max(max, info.ts), 0)
       return { ip, aliases, lastLogin: new Date(lastLoginTs) }
     })
     .sort((a, b) => b.lastLogin.getTime() - a.lastLogin.getTime())


### PR DESCRIPTION
Builds out the Admin Logs section of the new-template admin shell. Twelve sub-pages are migrated from the legacy /admin/* pages into dedicated newsite components, plus a new Cheat Finder split out from what was the Duplicate Users tab on the old Auth Logs page.

AdminNav (Admin Logs dropdown)
- Replaced the placeholder slots with 13 actionable entries: Cheat Finder, Auth Logs, Trade Logs, Auction Logs, cToon Owner Logs, cZone Search Logs, Point Logs, Achievement Logs, gToons Clash Logs, Monster Battle Logs, Lotto Logs, Win Wheel Logs, Scavenger Logs.

Migrations (each is a faithful port of the matching /admin page with the page-level shell stripped: <Nav />, definePageMeta, fixed-nav top spacer. All fetch logic, watchers, modals, pagination, KPIs, charts, and helpers are preserved.):
- AdminAuthLogs            <- pages/admin/auth-logs.vue (minus the
                              Duplicates tab — moved to Cheat Finder)
- AdminTradeLogs           <- pages/admin/trades.vue
- AdminAuctionLogs         <- pages/admin/auctions.vue
- AdminCtoonOwnerLogs      <- pages/admin/ctoonOwnerLogs.vue
- AdminCzoneSearchLogs     <- pages/admin/czone-search-logs.vue
- AdminPointLogs           <- pages/admin/points-log.vue
- AdminAchievementLogs     <- pages/admin/achievement-logs.vue
- AdminGtoonsClashLogs     <- pages/admin/gtoons-logs.vue
- AdminMonsterBattleLogs   <- pages/admin/manage-monster-battles.vue
- AdminLottoLogs           <- pages/admin/lotto-logs.vue
- AdminWinWheelLogs        <- pages/admin/winwheellogs.vue
- AdminScavengerLogs       <- pages/admin/scavenger-logs.vue

Suspicious Activity, Check Cheating, and Cheating Tool were intentionally skipped per scope.

Cheat Finder (new)
- AdminCheatFinder.vue with a 6-tab top: Duplicate IPs (active) plus 5 Placeholder tabs.
- Duplicate IPs shows one card per IP (only IPs with >1 user). Card title is the IP; each row lists username, joined date, Discord username, Discord account creation date.
- Backed by /api/admin/duplicate-users; the endpoint already loaded user.createdAt / discordTag / discordCreatedAt but only returned username + lastLogin — widened the response so all four fields reach the alias objects.

Existing newsite admin components
- AdminAnalytics and AdminManageUsers tightened to the same density pass already applied to AdminTradeLogs/AdminAuthLogs: text-xs base, text-[11px] tables, text-[10px] labels, px-1.5 py-1 cells, px-1.5 py-0.5 inputs, tabular-nums on numeric columns, smaller chart heights, compacted gap/padding throughout. Modals left at their larger sizes since overlays don't compete with maincontent width.

Routing
- pages/newsite/admin/[[section]].vue picks up 13 new section keys: cheatFinder, authLogs, tradeLogs, auctionLogs, ctoonOwnerLogs, czoneSearchLogs, pointLogs, achievementLogs, gtoonsClashLogs, monsterBattleLogs, lottoLogs, winWheelLogs, scavengerLogs.