### PR TITLE
Make cMart purchase error toasts explain why the buy failed

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -488,10 +488,52 @@ onUnmounted(() => {
   if (_refreshTimer) clearTimeout(_refreshTimer)
 })
 
+function describePurchaseError(err, kind = 'cToon') {
+  const status = err?.statusCode || err?.response?.status || err?.data?.statusCode
+  const raw   = err?.data?.statusMessage || err?.statusMessage || err?.message || ''
+  const low   = raw.toLowerCase()
+
+  if (status === 401 || /not authenticated|unauthorized/.test(low)) {
+    return 'You need to be signed in to make a purchase.'
+  }
+  if (/not enough available points|insufficient points/.test(low)) {
+    return `Not enough available points — some of your points may be locked in active trades or auctions.`
+  }
+  if (status === 429 || /daily limit/.test(low)) {
+    return raw || 'Daily purchase limit reached (resets at 8pm CST).'
+  }
+  if (/not released/.test(low)) {
+    return `This ${kind} has not been released yet.`
+  }
+  if (/holiday item/.test(low)) {
+    return 'This item can only be minted while its holiday event is active.'
+  }
+  if (/initial window sold out/.test(low)) {
+    return 'The initial release is sold out — please wait for the final release.'
+  }
+  if (/sold out/.test(low)) {
+    return `This ${kind} is sold out.`
+  }
+  if (/minting period/.test(low)) {
+    return `The minting period for this ${kind} has ended.`
+  }
+  if (/purchase limit/.test(low)) {
+    return raw
+  }
+  if (status === 404 || /not for sale|not found|invalid or not-for-sale/.test(low)) {
+    return `This ${kind} is no longer available for purchase.`
+  }
+  if (status === 400 && /missing|required/.test(low)) {
+    return `Something went wrong sending the purchase request. Please refresh and try again.`
+  }
+  return raw || `Couldn't complete the ${kind} purchase. Please try again.`
+}
+
 async function buy(ctoon) {
   if (buyingIds.value.includes(ctoon.id)) return
-  if (user.value && user.value.points < displayPrice(ctoon.price)) {
-    showToast("You don't have enough points", 'error')
+  const price = displayPrice(ctoon.price)
+  if (user.value && user.value.points < price) {
+    showToast(`Not enough points — this cToon costs ${price.toLocaleString()} pts.`, 'error')
     return
   }
   buyingIds.value = [...buyingIds.value, ctoon.id]
@@ -510,8 +552,7 @@ async function buy(ctoon) {
     allCtoons.value = ctoonRes
     scheduleNextRefresh()
   } catch (err) {
-    const msg = err?.data?.statusMessage || err?.message || 'Purchase failed.'
-    showToast(msg, 'error')
+    showToast(describePurchaseError(err, 'cToon'), 'error')
   } finally {
     buyingIds.value = buyingIds.value.filter(id => id !== ctoon.id)
   }
@@ -528,8 +569,9 @@ function resetPackSequence() {
 
 async function buyPack(pack) {
   if (buyingPackIds.value.includes(pack.id)) return
-  if (user.value && user.value.points < displayPrice(pack.price)) {
-    showToast("You don't have enough points", 'error')
+  const price = displayPrice(pack.price)
+  if (user.value && user.value.points < price) {
+    showToast(`Not enough points — this pack costs ${price.toLocaleString()} pts.`, 'error')
     return
   }
   buyingPackIds.value = [...buyingPackIds.value, pack.id]
@@ -569,8 +611,7 @@ async function buyPack(pack) {
     await fetchSelf({ force: true })
     await loadOwnedCtoonIds()
   } catch (err) {
-    const msg = err?.data?.statusMessage || err?.message || 'Purchase failed.'
-    showToast(msg, 'error')
+    showToast(describePurchaseError(err, 'pack'), 'error')
   } finally {
     buyingPackIds.value = buyingPackIds.value.filter(id => id !== pack.id)
   }


### PR DESCRIPTION
Replaces the generic "You don't have enough points" / "Purchase failed."
toasts in the newsite cMart with a describePurchaseError() helper that
maps the API's statusMessage to a clear, user-facing reason (sold out,
not yet released, locked points, daily pack limit, holiday window,
purchase-limit cap, etc.) for both buy() and buyPack().