### PR TITLE
Show IP WHOIS in Cheat Finder + seed script for auth-log testing

### DIFF
--- a/components/newsite/AdminCheatFinder.vue
+++ b/components/newsite/AdminCheatFinder.vue
@@ -38,9 +38,12 @@
           :key="group.ip"
           class="bg-white border rounded shadow p-2"
         >
-          <div class="flex items-center justify-between mb-1">
-            <h2 class="font-mono font-semibold text-xs">{{ group.ip }}</h2>
-            <span class="text-[10px] text-gray-500">{{ group.aliases.length }} accounts</span>
+          <div class="flex items-center justify-between gap-2 mb-1 flex-wrap">
+            <div class="flex items-baseline gap-2 min-w-0">
+              <h2 class="font-mono font-semibold text-xs shrink-0">{{ group.ip }}</h2>
+              <span class="text-[10px] text-gray-500 truncate">{{ whoisDisplay(group.ip) }}</span>
+            </div>
+            <span class="text-[10px] text-gray-500 shrink-0">{{ group.aliases.length }} accounts</span>
           </div>
 
           <!-- Desktop table -->
@@ -121,6 +124,18 @@ const page = ref(1)
 const pageSize = 100
 const loading = ref(false)
 const searchTerm = ref('')
+const whoisByIp = ref({})
+
+function whoisDisplay(ip) {
+  const w = whoisByIp.value[ip]
+  if (!w) return ''
+  if (w.error) return `(${w.error})`
+  const place = [w.city, w.region, w.country].filter(Boolean).join(', ')
+  const parts = []
+  if (w.isp) parts.push(w.isp)
+  if (place) parts.push(place)
+  return parts.join(' · ')
+}
 
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
 const showingRange = computed(() => {
@@ -159,12 +174,30 @@ async function fetchGroups() {
     groups.value = data.groups || []
     total.value = data.total || 0
     if (data.page) page.value = data.page
+    fetchWhois()
   } catch (e) {
     console.error('Failed to load duplicate users', e)
     groups.value = []
     total.value = 0
   } finally {
     loading.value = false
+  }
+}
+
+async function fetchWhois() {
+  // Only look up IPs not already cached client-side
+  const missing = groups.value
+    .map(g => g.ip)
+    .filter(ip => ip && !whoisByIp.value[ip])
+  if (!missing.length) return
+  try {
+    const params = new URLSearchParams({ ips: missing.join(',') })
+    const res = await fetch(`/api/admin/ip-whois?${params.toString()}`, { credentials: 'include' })
+    if (!res.ok) return
+    const data = await res.json()
+    whoisByIp.value = { ...whoisByIp.value, ...data }
+  } catch (e) {
+    console.error('Failed to load IP whois', e)
   }
 }
 

--- a/components/newsite/AdminCheatFinder.vue
+++ b/components/newsite/AdminCheatFinder.vue
@@ -36,7 +36,8 @@
         <div
           v-for="group in groups"
           :key="group.ip"
-          class="bg-white border rounded shadow p-2"
+          class="border rounded shadow p-2"
+          :class="group.hasInternalTrades ? 'bg-yellow-100' : 'bg-white'"
         >
           <div class="flex items-center justify-between gap-2 mb-1 flex-wrap">
             <div class="flex items-baseline gap-2 min-w-0">
@@ -53,16 +54,26 @@
                 <tr>
                   <th class="px-1.5 py-1 border-b">Username</th>
                   <th class="px-1.5 py-1 border-b">Joined</th>
-                  <th class="px-1.5 py-1 border-b">Discord Username</th>
-                  <th class="px-1.5 py-1 border-b">Discord Account Created</th>
+                  <th class="px-1.5 py-1 border-b">Disc. Disp. Name</th>
+                  <th class="px-1.5 py-1 border-b">Disc. Acct.</th>
+                  <th class="px-1.5 py-1 border-b">Disc. Acct. Created</th>
+                  <th class="px-1.5 py-1 border-b">Traded With</th>
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="alias in group.aliases" :key="alias.username" class="border-b last:border-b-0">
-                  <td class="px-1.5 py-1 font-medium">{{ alias.username }}</td>
+                <tr v-for="alias in group.aliases" :key="alias.username" class="border-b last:border-b-0 align-top">
+                  <td class="px-1.5 py-1">
+                    <div class="font-medium">{{ alias.username }}</div>
+                    <div class="text-[10px] text-gray-400 leading-tight">{{ aliasMeta(alias) }}</div>
+                  </td>
                   <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(alias.joined) }}</td>
                   <td class="px-1.5 py-1">{{ alias.discordTag || '—' }}</td>
+                  <td class="px-1.5 py-1 font-mono">{{ alias.discordId || '—' }}</td>
                   <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(alias.discordCreatedAt) }}</td>
+                  <td class="px-1.5 py-1">
+                    <span v-if="alias.tradedWith && alias.tradedWith.length">{{ alias.tradedWith.join(', ') }}</span>
+                    <span v-else class="text-gray-400">—</span>
+                  </td>
                 </tr>
               </tbody>
             </table>
@@ -76,10 +87,17 @@
               class="border rounded p-1.5 bg-gray-50"
             >
               <div class="font-medium text-[11px]">{{ alias.username }}</div>
+              <div class="text-[10px] text-gray-400 leading-tight">{{ aliasMeta(alias) }}</div>
               <div class="mt-0.5 grid grid-cols-1 gap-0.5 text-[10px] text-gray-700">
                 <div><span class="text-gray-500">Joined:</span> {{ formatDate(alias.joined) }}</div>
-                <div><span class="text-gray-500">Discord:</span> {{ alias.discordTag || '—' }}</div>
-                <div><span class="text-gray-500">Discord Created:</span> {{ formatDate(alias.discordCreatedAt) }}</div>
+                <div><span class="text-gray-500">Disc. Disp. Name:</span> {{ alias.discordTag || '—' }}</div>
+                <div><span class="text-gray-500">Disc. Acct.:</span> <span class="font-mono">{{ alias.discordId || '—' }}</span></div>
+                <div><span class="text-gray-500">Disc. Acct. Created:</span> {{ formatDate(alias.discordCreatedAt) }}</div>
+                <div>
+                  <span class="text-gray-500">Traded With:</span>
+                  <span v-if="alias.tradedWith && alias.tradedWith.length">{{ alias.tradedWith.join(', ') }}</span>
+                  <span v-else>—</span>
+                </div>
               </div>
             </div>
           </div>
@@ -109,7 +127,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 
 const tabs = [
-  { id: 'duplicateIps', label: 'Duplicate IPs' },
+  { id: 'duplicateIps', label: 'Dashboard' },
   { id: 'placeholder-1', label: 'Placeholder' },
   { id: 'placeholder-2', label: 'Placeholder' },
   { id: 'placeholder-3', label: 'Placeholder' },
@@ -152,6 +170,14 @@ function formatDate(dt) {
     month: 'short',
     day: 'numeric'
   })
+}
+
+function aliasMeta(alias) {
+  const parts = []
+  parts.push(`${Number(alias.points ?? 0).toLocaleString()} pts`)
+  parts.push(`${Number(alias.ctoonCount ?? 0).toLocaleString()} cToons`)
+  parts.push(`last login ${formatDate(alias.lastLogin)}`)
+  return parts.join(' · ')
 }
 
 async function fetchGroups() {

--- a/prisma/seedAuthLogs.js
+++ b/prisma/seedAuthLogs.js
@@ -1,0 +1,122 @@
+// prisma/seedAuthLogs.js
+// Seed fake LoginLog rows against existing non-admin users so the Auth
+// Logs view has data and the Cheat Finder's Duplicate IPs tab shows cards.
+//
+// Run:    node prisma/seedAuthLogs.js
+// Reset:  node prisma/seedAuthLogs.js --reset
+//
+// --reset deletes previously seeded logs first (recognized by IPs in the
+// SHARED_IPS / UNIQUE_IP_POOL sets defined below).
+
+import 'dotenv/config'
+import { randomInt } from 'node:crypto'
+import { prisma } from '../server/prisma.js'
+
+// IPs that will host multiple users (drive the Cheat Finder cards).
+// These are routable so ip-api.com returns real WHOIS / ISP / geo info.
+const SHARED_IPS = [
+  '73.231.42.119',
+  '24.16.142.55',
+  '208.67.222.222'
+]
+
+// Additional unique IPs for singletons (populate All Logs).
+const UNIQUE_IP_POOL = [
+  '8.8.8.8',
+  '1.1.1.1',
+  '4.4.4.4',
+  '9.9.9.9',
+  '76.102.34.89',
+  '70.176.55.12',
+  '174.255.91.7',
+  '99.234.18.44'
+]
+
+const SEED_IPS = [...SHARED_IPS, ...UNIQUE_IP_POOL]
+
+const DAYS_BACK = 60
+const LOGS_PER_USER_IP = 3
+const SHARED_MIN_USERS = 2
+const SHARED_MAX_USERS = 4
+
+function randomDateWithinDays(days) {
+  const ms = randomInt(days * 24 * 60 * 60 * 1000)
+  return new Date(Date.now() - ms)
+}
+
+function sampleN(arr, n) {
+  const a = [...arr]
+  const out = []
+  const k = Math.min(n, a.length)
+  for (let i = 0; i < k; i++) {
+    const j = i + randomInt(a.length - i)
+    ;[a[i], a[j]] = [a[j], a[i]]
+    out.push(a[i])
+  }
+  return out
+}
+
+async function main() {
+  const reset = process.argv.includes('--reset')
+
+  const users = await prisma.user.findMany({
+    where: { isAdmin: false, username: { not: null } },
+    select: { id: true, username: true }
+  })
+
+  if (!users.length) {
+    console.error('No non-admin users with usernames found. Aborting.')
+    process.exit(1)
+  }
+
+  if (reset) {
+    const deleted = await prisma.loginLog.deleteMany({ where: { ip: { in: SEED_IPS } } })
+    console.log(`Cleared ${deleted.count} previously seeded LoginLog rows`)
+  }
+
+  // Assignments: each SHARED_IP gets a random 2-4 user subset (sampled
+  // independently, so overlap between shared groups is possible).
+  const assignments = []
+  for (const ip of SHARED_IPS) {
+    const desired = SHARED_MIN_USERS + randomInt(SHARED_MAX_USERS - SHARED_MIN_USERS + 1)
+    const chosen = sampleN(users, desired)
+    for (const u of chosen) {
+      assignments.push({ userId: u.id, username: u.username, ip })
+    }
+  }
+
+  // Every user also gets a unique IP so the All Logs view has variety.
+  for (const u of users) {
+    const ip = UNIQUE_IP_POOL[randomInt(UNIQUE_IP_POOL.length)]
+    assignments.push({ userId: u.id, username: u.username, ip })
+  }
+
+  const rows = []
+  for (const a of assignments) {
+    for (let i = 0; i < LOGS_PER_USER_IP; i++) {
+      rows.push({
+        userId: a.userId,
+        ip: a.ip,
+        createdAt: randomDateWithinDays(DAYS_BACK)
+      })
+    }
+  }
+
+  await prisma.loginLog.createMany({ data: rows })
+
+  console.log(`Inserted ${rows.length} LoginLog rows for ${assignments.length} (user, ip) pairs`)
+  console.log('Shared IPs (should appear in Cheat Finder):')
+  for (const ip of SHARED_IPS) {
+    const usernames = Array.from(new Set(
+      assignments.filter(a => a.ip === ip).map(a => a.username)
+    ))
+    console.log(`  ${ip} -> ${usernames.length} users: ${usernames.join(', ')}`)
+  }
+}
+
+main()
+  .catch(e => {
+    console.error('Seed failed:', e)
+    process.exit(1)
+  })
+  .finally(() => {})

--- a/prisma/seedTestActivity.js
+++ b/prisma/seedTestActivity.js
@@ -1,0 +1,222 @@
+// prisma/seedTestActivity.js
+// Seeds activity for testing the Cheat Finder + Trade Logs views.
+//
+// For every non-admin user:
+//   - Adds 100-10000 points (with a PointsLog entry)
+//   - Mints 1-3 random cMart cToons (atomic increment of totalMinted,
+//     CtoonOwnerLog + CmartPurchaseLog written; points NOT deducted)
+//   - Issues 3-4 TradeOffers as initiator.
+//     * Most users trade only with peers that DO NOT share their IP.
+//     * Two "cheater" users (picked from the largest shared-IP group)
+//       send 1-2 of their trades to a same-IP peer — these will surface
+//       as yellow cards in Cheat Finder.
+//
+// Run:  node prisma/seedTestActivity.js
+
+import 'dotenv/config'
+import { randomInt } from 'node:crypto'
+import { prisma } from '../server/prisma.js'
+
+function pickN(arr, n) {
+  const pool = [...arr]
+  const out = []
+  while (out.length < n && pool.length) {
+    out.push(pool.splice(randomInt(pool.length), 1)[0])
+  }
+  return out
+}
+
+async function mintCtoonForUser(userId, ctoonId) {
+  return prisma.$transaction(async (tx) => {
+    const updated = await tx.ctoon.update({
+      where: { id: ctoonId },
+      data: { totalMinted: { increment: 1 } },
+      select: { totalMinted: true, initialQuantity: true, quantity: true }
+    })
+    const mintNumber = updated.totalMinted
+    if (updated.quantity !== null && mintNumber > updated.quantity) {
+      throw new Error('sold out')
+    }
+    const isFirstEdition =
+      updated.initialQuantity === null || mintNumber <= updated.initialQuantity
+
+    const uc = await tx.userCtoon.create({
+      data: { userId, ctoonId, mintNumber, isFirstEdition },
+      select: { id: true, mintNumber: true }
+    })
+    await tx.ctoonOwnerLog.create({
+      data: { userId, ctoonId, userCtoonId: uc.id, mintNumber: uc.mintNumber }
+    })
+    await tx.cmartPurchaseLog.create({ data: { userId, ctoonId } })
+    return uc
+  })
+}
+
+async function main() {
+  // 1) Non-admin users with usernames
+  const users = await prisma.user.findMany({
+    where: { isAdmin: false, username: { not: null } },
+    select: { id: true, username: true }
+  })
+  if (!users.length) {
+    console.error('No non-admin users found.')
+    process.exit(1)
+  }
+  const userIdSet = new Set(users.map(u => u.id))
+  console.log(`Found ${users.length} non-admin users`)
+
+  // 2) Build IP-sharing graph from LoginLog (last 90 days)
+  const since = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
+  const logs = await prisma.loginLog.findMany({
+    where: { createdAt: { gte: since } },
+    select: { userId: true, ip: true }
+  })
+
+  const userIps = new Map()    // userId -> Set<ip>
+  const ipUsers = new Map()    // ip -> Set<userId>
+  for (const { userId, ip } of logs) {
+    if (!userIps.has(userId)) userIps.set(userId, new Set())
+    userIps.get(userId).add(ip)
+    if (!ipUsers.has(ip)) ipUsers.set(ip, new Set())
+    ipUsers.get(ip).add(userId)
+  }
+
+  function sharesIp(a, b) {
+    const ipsA = userIps.get(a)
+    if (!ipsA) return false
+    for (const ip of ipsA) {
+      if (ipUsers.get(ip)?.has(b)) return true
+    }
+    return false
+  }
+
+  // 3) Pick cheaters from up to 2 of the largest shared-IP groups
+  const sharedIpGroups = Array.from(ipUsers.entries())
+    .map(([ip, peers]) => ({
+      ip,
+      peers: Array.from(peers).filter(id => userIdSet.has(id))
+    }))
+    .filter(g => g.peers.length > 1)
+    .sort((a, b) => b.peers.length - a.peers.length)
+
+  const cheaterPairs = []
+  const cheaterIds = new Set()
+  for (const grp of sharedIpGroups.slice(0, 2)) {
+    cheaterPairs.push({ ip: grp.ip, users: [grp.peers[0], grp.peers[1]] })
+    cheaterIds.add(grp.peers[0])
+    cheaterIds.add(grp.peers[1])
+  }
+
+  // 4) cMart ctoons available for purchase
+  const allCmart = await prisma.ctoon.findMany({
+    where: {
+      inCmart: true,
+      codeOnly: false,
+      releaseDate: { lte: new Date() },
+      holidayItems: { none: {} }
+    },
+    select: {
+      id: true, name: true, price: true,
+      quantity: true, totalMinted: true
+    }
+  })
+  const availableCmart = allCmart.filter(c =>
+    c.quantity === null || c.totalMinted < c.quantity
+  )
+  if (!availableCmart.length) {
+    console.warn('No cmart ctoons available — skipping purchases')
+  }
+
+  // 5) Per-user seed loop
+  let pointsAwarded = 0
+  let ctoonsMinted = 0
+  let tradesCreated = 0
+
+  for (const user of users) {
+    // -- Points: add 100-10000, log it
+    const gain = 100 + randomInt(9901)
+    const updated = await prisma.userPoints.upsert({
+      where: { userId: user.id },
+      update: { points: { increment: gain } },
+      create: { userId: user.id, points: gain }
+    })
+    await prisma.pointsLog.create({
+      data: {
+        userId: user.id,
+        points: gain,
+        total: updated.points,
+        method: 'seed grant',
+        direction: 'increase'
+      }
+    })
+    pointsAwarded += gain
+
+    // -- cToons: 1-3 random from cmart (no payment for the seed)
+    if (availableCmart.length) {
+      const count = 1 + randomInt(3)
+      const picks = pickN(availableCmart, Math.min(count, availableCmart.length))
+      for (const c of picks) {
+        try {
+          await mintCtoonForUser(user.id, c.id)
+          ctoonsMinted++
+        } catch (e) {
+          // sold out or transient — skip silently
+        }
+      }
+    }
+
+    // -- Trades: at least 3 as initiator
+    const peers = users.filter(u => u.id !== user.id)
+    const intraPeers = peers.filter(p => sharesIp(user.id, p.id))
+    const interPeers = peers.filter(p => !sharesIp(user.id, p.id))
+
+    let recipients
+    if (cheaterIds.has(user.id) && intraPeers.length) {
+      // Cheater: 1-2 to intra-IP peers, plus enough inter-IP trades to reach 3-4 total
+      const intraCount = Math.min(intraPeers.length, 1 + randomInt(2))
+      const interCount = Math.max(0, 3 + randomInt(2) - intraCount)
+      recipients = [
+        ...pickN(intraPeers, intraCount),
+        ...pickN(interPeers, Math.min(interCount, interPeers.length))
+      ]
+    } else {
+      // Normal user: 3-4 trades to non-IP-shared peers (fall back to any peer if pool is empty)
+      const count = 3 + randomInt(2)
+      const pool = interPeers.length ? interPeers : peers
+      recipients = pickN(pool, Math.min(count, pool.length))
+    }
+
+    for (const r of recipients) {
+      await prisma.tradeOffer.create({
+        data: {
+          initiatorId: user.id,
+          recipientId: r.id,
+          pointsOffered: 0,
+          status: 'PENDING'
+        }
+      })
+      tradesCreated++
+    }
+  }
+
+  console.log('\nSeeded:')
+  console.log(`  Points awarded: ${pointsAwarded.toLocaleString()}`)
+  console.log(`  cToons minted:  ${ctoonsMinted}`)
+  console.log(`  TradeOffers:    ${tradesCreated}`)
+  if (cheaterPairs.length) {
+    console.log('\nCheater pairs (will turn Cheat Finder cards yellow):')
+    for (const p of cheaterPairs) {
+      const names = p.users.map(id => users.find(u => u.id === id)?.username || id)
+      console.log(`  ${p.ip} -> ${names.join(' <-> ')}`)
+    }
+  } else {
+    console.log('\n(No shared-IP groups found — run prisma/seedAuthLogs.js first if you want yellow-card cheaters.)')
+  }
+}
+
+main()
+  .catch(e => {
+    console.error('Seed failed:', e)
+    process.exit(1)
+  })
+  .finally(() => {})

--- a/server/api/admin/duplicate-users.get.js
+++ b/server/api/admin/duplicate-users.get.js
@@ -32,6 +32,7 @@ export default defineEventHandler(async (event) => {
           username: true,
           isAdmin: true,
           createdAt: true,
+          discordId: true,
           discordTag: true,
           discordCreatedAt: true
         }
@@ -59,7 +60,9 @@ export default defineEventHandler(async (event) => {
     if (!existing || ts > existing.ts) {
       byIp[ip][name] = {
         ts,
+        userId: user.id,
         joined: user.createdAt,
+        discordId: user.discordId,
         discordTag: user.discordTag,
         discordCreatedAt: user.discordCreatedAt
       }
@@ -75,8 +78,10 @@ export default defineEventHandler(async (event) => {
     .map(([ip, nameMap]) => {
       const aliases = Object.entries(nameMap).map(([username, info]) => ({
         username,
+        userId: info.userId,
         lastLogin: new Date(info.ts),
         joined: info.joined,
+        discordId: info.discordId,
         discordTag: info.discordTag,
         discordCreatedAt: info.discordCreatedAt
       }))
@@ -115,5 +120,76 @@ export default defineEventHandler(async (event) => {
   const total = filteredGroups.length
   const paged = filteredGroups.slice(skip, skip + limit)
 
-  return { groups: paged, total, page, limit }
+  // Enrich only the paged aliases with points and cToon count (single
+  // batched query each, scoped to the user IDs visible on this page).
+  const visibleUserIds = Array.from(new Set(
+    paged.flatMap(g => g.aliases.map(a => a.userId).filter(Boolean))
+  ))
+
+  let pointsByUser = new Map()
+  let ctoonCountByUser = new Map()
+  // tradePartners.get(userId) = Set of other userIds they have any
+  // TradeOffer record with (initiator OR recipient on either side).
+  const tradePartners = new Map()
+
+  if (visibleUserIds.length) {
+    const [pointsRows, ctoonRows, tradeRows] = await Promise.all([
+      prisma.userPoints.findMany({
+        where: { userId: { in: visibleUserIds } },
+        select: { userId: true, points: true }
+      }),
+      prisma.userCtoon.groupBy({
+        by: ['userId'],
+        where: { userId: { in: visibleUserIds }, burnedAt: null },
+        _count: { _all: true }
+      }),
+      prisma.tradeOffer.findMany({
+        where: {
+          initiatorId: { in: visibleUserIds },
+          recipientId: { in: visibleUserIds }
+        },
+        select: { initiatorId: true, recipientId: true }
+      })
+    ])
+    pointsByUser = new Map(pointsRows.map(p => [p.userId, p.points]))
+    ctoonCountByUser = new Map(ctoonRows.map(c => [c.userId, c._count._all]))
+    for (const t of tradeRows) {
+      if (t.initiatorId === t.recipientId) continue
+      if (!tradePartners.has(t.initiatorId)) tradePartners.set(t.initiatorId, new Set())
+      if (!tradePartners.has(t.recipientId)) tradePartners.set(t.recipientId, new Set())
+      tradePartners.get(t.initiatorId).add(t.recipientId)
+      tradePartners.get(t.recipientId).add(t.initiatorId)
+    }
+  }
+
+  const enriched = paged.map(group => {
+    // For each alias, find which other aliases in THIS group they've
+    // traded with. Trades with users outside the group don't count.
+    const groupUserIds = new Set(group.aliases.map(a => a.userId).filter(Boolean))
+    const usernameByUserId = new Map(group.aliases.map(a => [a.userId, a.username]))
+
+    let hasInternalTrades = false
+    const aliases = group.aliases.map(a => {
+      const partners = tradePartners.get(a.userId) || new Set()
+      const tradedWith = []
+      for (const otherId of partners) {
+        if (otherId === a.userId) continue
+        if (!groupUserIds.has(otherId)) continue
+        const name = usernameByUserId.get(otherId)
+        if (name) tradedWith.push(name)
+      }
+      tradedWith.sort()
+      if (tradedWith.length) hasInternalTrades = true
+      return {
+        ...a,
+        points: pointsByUser.get(a.userId) ?? 0,
+        ctoonCount: ctoonCountByUser.get(a.userId) ?? 0,
+        tradedWith
+      }
+    })
+
+    return { ...group, aliases, hasInternalTrades }
+  })
+
+  return { groups: enriched, total, page, limit }
 })

--- a/server/api/admin/ip-whois.get.js
+++ b/server/api/admin/ip-whois.get.js
@@ -1,0 +1,82 @@
+// Batch WHOIS / IP-geo lookups via ip-api.com (no API key, free tier:
+// 45 req/min per origin, batch endpoint takes up to 100 IPs per call).
+// 24h in-memory cache keyed by IP keeps repeat loads cheap.
+
+import { defineEventHandler, getRequestHeader, getQuery, createError } from 'h3'
+
+const cache = new Map() // ip -> { data, expiresAt }
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+export default defineEventHandler(async (event) => {
+  // Admin auth (mirrors other /api/admin/* endpoints)
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const query = getQuery(event)
+  const ipsParam = String(query.ips || '').trim()
+  if (!ipsParam) return {}
+
+  const unique = Array.from(new Set(
+    ipsParam.split(',').map(s => s.trim()).filter(Boolean)
+  ))
+
+  const now = Date.now()
+  const result = {}
+  const toFetch = []
+
+  for (const ip of unique) {
+    const cached = cache.get(ip)
+    if (cached && cached.expiresAt > now) {
+      result[ip] = cached.data
+    } else {
+      toFetch.push(ip)
+    }
+  }
+
+  if (toFetch.length) {
+    const fields = 'status,message,query,country,regionName,city,isp,org'
+    const BATCH = 100
+
+    for (let i = 0; i < toFetch.length; i += BATCH) {
+      const chunk = toFetch.slice(i, i + BATCH)
+      try {
+        const res = await $fetch('http://ip-api.com/batch', {
+          method: 'POST',
+          query: { fields },
+          body: chunk
+        })
+
+        for (const entry of (Array.isArray(res) ? res : [])) {
+          const ip = entry.query
+          const data = entry.status === 'success'
+            ? {
+                country: entry.country || null,
+                region: entry.regionName || null,
+                city: entry.city || null,
+                isp: entry.isp || null,
+                org: entry.org || null
+              }
+            : { error: entry.message || 'lookup failed' }
+          cache.set(ip, { data, expiresAt: now + CACHE_TTL_MS })
+          result[ip] = data
+        }
+      } catch (e) {
+        // network / rate limit failure — return error markers for this chunk
+        // without caching, so a subsequent reload can retry.
+        for (const ip of chunk) {
+          if (!result[ip]) result[ip] = { error: 'lookup failed' }
+        }
+      }
+    }
+  }
+
+  return result
+})


### PR DESCRIPTION
Adds a thin admin-only WHOIS endpoint and renders ISP / city / region / country alongside each IP on the Cheat Finder cards.

server/api/admin/ip-whois.get.js
- Accepts ?ips=ip1,ip2,... and returns { ip: { country, region, city, isp, org } | { error } }.
- Batches uncached IPs through ip-api.com/batch (free, no API key, up to 100 per request) with a 24h in-memory cache. Cache hits skip the network entirely. Network/rate-limit failures fall through as { error: 'lookup failed' } per-IP without poisoning the cache so a later reload can retry.

components/newsite/AdminCheatFinder.vue
- Calls /api/admin/ip-whois after duplicate-users loads, merging results into whoisByIp keyed by IP.
- Card header now shows the IP in monospace plus a smaller gray secondary line with "ISP · City, Region, Country" (parts omitted when missing). Private/reserved IPs surface the upstream message in parens.

prisma/seedAuthLogs.js (new utility)
- Seeds fake LoginLog rows against existing non-admin users so the Auth Logs view has data and the Cheat Finder's Duplicate IPs tab shows cards. Three routable shared IPs (so ip-api returns real WHOIS) get 2-4 users each; every user also gets one log on a unique IP from a small pool. Each (user, IP) pair yields 3 LoginLog rows spread across the last 60 days.
- `--reset` clears previously seeded rows (matched by the seed IP set) before inserting.