### PR TITLE
Add device fingerprinting + admin Device Fingerprint Logs view

### DIFF
--- a/components/newsite/AdminDeviceFingerprintLogs.vue
+++ b/components/newsite/AdminDeviceFingerprintLogs.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="admin-device-fingerprint-logs bg-gray-50">
+    <div class="p-2 text-xs">
+      <h1 class="text-base font-bold mb-2">Device Fingerprint Logs</h1>
+
+      <!-- Filters -->
+      <div class="mb-2 flex flex-wrap items-end gap-2">
+        <div class="flex items-center">
+          <label for="usernameFilter" class="mr-1 font-medium">User:</label>
+          <input
+            id="usernameFilter"
+            v-model="usernameQuery"
+            type="text"
+            placeholder="Username contains…"
+            class="border rounded px-1.5 py-0.5 text-xs"
+          />
+        </div>
+        <div class="flex items-center">
+          <label for="visitorIdFilter" class="mr-1 font-medium">Visitor ID:</label>
+          <input
+            id="visitorIdFilter"
+            v-model="visitorIdQuery"
+            type="text"
+            placeholder="Exact match…"
+            class="border rounded px-1.5 py-0.5 text-xs w-56 font-mono"
+          />
+        </div>
+        <div class="flex items-center">
+          <label for="ipFilter" class="mr-1 font-medium">IP:</label>
+          <input
+            id="ipFilter"
+            v-model="ipQuery"
+            type="text"
+            placeholder="Exact match…"
+            class="border rounded px-1.5 py-0.5 text-xs w-40 font-mono"
+          />
+        </div>
+        <button
+          v-if="usernameQuery || visitorIdQuery || ipQuery"
+          class="px-2 py-0.5 text-[11px] border rounded"
+          @click="clearFilters"
+        >Reset</button>
+      </div>
+
+      <div class="mb-2 text-[11px] text-gray-600">
+        Total Results: {{ total }} logs
+      </div>
+
+      <div v-if="loading" class="text-gray-500">Loading…</div>
+      <div v-else-if="items.length === 0" class="text-gray-500">No fingerprint logs found.</div>
+      <div v-else>
+        <!-- Desktop table -->
+        <div class="hidden md:block overflow-x-auto">
+          <table class="min-w-full bg-white rounded shadow text-[11px]">
+            <thead class="bg-gray-100 text-left">
+              <tr>
+                <th class="px-1.5 py-1 border-b">Captured At</th>
+                <th class="px-1.5 py-1 border-b">Username</th>
+                <th class="px-1.5 py-1 border-b">DiscordID</th>
+                <th class="px-1.5 py-1 border-b">IP</th>
+                <th class="px-1.5 py-1 border-b">Visitor ID (fingerprint)</th>
+                <th class="px-1.5 py-1 border-b"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in items" :key="row.id" class="border-t align-top">
+                <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(row.createdAt) }}</td>
+                <td class="px-1.5 py-1 font-medium">{{ row.user?.username || '—' }}</td>
+                <td class="px-1.5 py-1">
+                  <span v-if="row.user?.discordUsername">{{ row.user.discordUsername }}</span>
+                  <span v-else class="font-mono text-gray-500" :title="'Snowflake — user has not re-logged in since discordUsername was added'">{{ row.user?.discordId || '—' }}</span>
+                </td>
+                <td class="px-1.5 py-1 font-mono">{{ row.ip || '—' }}</td>
+                <td class="px-1.5 py-1 font-mono break-all">{{ row.visitorId }}</td>
+                <td class="px-1.5 py-1">
+                  <button
+                    class="px-2 py-0.5 text-[11px] border rounded hover:bg-gray-100"
+                    title="Filter to all rows sharing this fingerprint"
+                    @click="filterByVisitor(row.visitorId)"
+                  >Match</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile cards -->
+        <div class="md:hidden grid grid-cols-1 gap-2">
+          <div v-for="row in items" :key="row.id" class="border rounded p-2 shadow text-[11px] space-y-0.5">
+            <div class="text-[10px] text-gray-500">{{ formatDate(row.createdAt) }}</div>
+            <div><span class="text-gray-500">User:</span> <span class="font-medium">{{ row.user?.username || '—' }}</span></div>
+            <div><span class="text-gray-500">DiscordID:</span> <span class="font-mono">{{ row.user?.discordId || '—' }}</span></div>
+            <div><span class="text-gray-500">IP:</span> <span class="font-mono">{{ row.ip || '—' }}</span></div>
+            <div><span class="text-gray-500">Visitor ID:</span> <span class="font-mono break-all">{{ row.visitorId }}</span></div>
+            <div class="pt-1">
+              <button
+                class="px-2 py-0.5 text-[11px] border rounded hover:bg-gray-100"
+                @click="filterByVisitor(row.visitorId)"
+              >Match</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Pagination -->
+      <div v-if="!loading && items.length" class="mt-3 flex items-center justify-between">
+        <div class="text-[11px] text-gray-600">
+          Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
+        </div>
+        <div class="space-x-1">
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="prevPage">Prev</button>
+          <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="nextPage">Next</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+
+const items = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = 100
+const loading = ref(false)
+
+const usernameQuery  = ref('')
+const visitorIdQuery = ref('')
+const ipQuery        = ref('')
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const showingRange = computed(() => {
+  if (!total.value) return '0-0 of 0'
+  const start = (page.value - 1) * pageSize + 1
+  const end = Math.min(page.value * pageSize, total.value)
+  return `${start}-${end} of ${total.value}`
+})
+
+function formatDate(dt) {
+  if (!dt) return '—'
+  return new Date(dt).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Chicago',
+    timeZoneName: 'short'
+  })
+}
+
+async function fetchLogs() {
+  if (loading.value) return
+  loading.value = true
+  try {
+    const query = {
+      page: page.value,
+      limit: pageSize,
+      username:  usernameQuery.value.trim()  || undefined,
+      visitorId: visitorIdQuery.value.trim() || undefined,
+      ip:        ipQuery.value.trim()        || undefined
+    }
+    const res = await $fetch('/api/admin/device-fingerprint-logs', { query })
+    items.value = res.items || []
+    total.value = res.total || 0
+    if (res.page) page.value = res.page
+  } catch (e) {
+    console.error('Failed to load device fingerprint logs', e)
+    items.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+function nextPage() {
+  if (page.value >= totalPages.value) return
+  page.value += 1
+  fetchLogs()
+}
+
+function prevPage() {
+  if (page.value <= 1) return
+  page.value -= 1
+  fetchLogs()
+}
+
+function filterByVisitor(visitorId) {
+  visitorIdQuery.value = visitorId
+  usernameQuery.value = ''
+  ipQuery.value = ''
+  // watcher handles the refetch
+}
+
+function clearFilters() {
+  usernameQuery.value = ''
+  visitorIdQuery.value = ''
+  ipQuery.value = ''
+}
+
+let filterDebounceId = null
+watch([usernameQuery, visitorIdQuery, ipQuery], () => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  filterDebounceId = setTimeout(() => {
+    page.value = 1
+    fetchLogs()
+  }, 300)
+})
+
+onMounted(fetchLogs)
+</script>
+
+<style scoped>
+.admin-device-fingerprint-logs {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+</style>

--- a/components/newsite/AdminNav.vue
+++ b/components/newsite/AdminNav.vue
@@ -64,6 +64,7 @@ const menus = [
     label: 'Admin Logs',
     items: [
       { id: 'cheatFinder',        label: 'Cheat Finder',       to: '/newsite/admin/cheatFinder' },
+      { id: 'deviceFingerprints', label: 'Device Fingerprints', to: '/newsite/admin/deviceFingerprints' },
       { id: 'authLogs',           label: 'Auth Logs',          to: '/newsite/admin/authLogs' },
       { id: 'tradeLogs',          label: 'Trade Logs',         to: '/newsite/admin/tradeLogs' },
       { id: 'auctionLogs',        label: 'Auction Logs',       to: '/newsite/admin/auctionLogs' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@fingerprintjs/fingerprintjs": "^5.2.0",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "@prisma/client": "^6.19.0",
         "@prisma/nuxt": "^0.3.0",
@@ -1278,6 +1279,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/@fingerprintjs/fingerprintjs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs/-/fingerprintjs-5.2.0.tgz",
+      "integrity": "sha512-j+2nInkwCQNTJcNhOjvkGM/nLRTuGJTC6xai4quqvUpjob2ssrGwBZjS7k55nOmKvge7qvJT2nS3i/IRvQSTQA==",
+      "license": "MIT"
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.33.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "description": "",
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@fingerprintjs/fingerprintjs": "^5.2.0",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@prisma/client": "^6.19.0",
     "@prisma/nuxt": "^0.3.0",

--- a/pages/newsite/admin/[[section]].vue
+++ b/pages/newsite/admin/[[section]].vue
@@ -7,6 +7,7 @@
       <AdminAnalytics v-if="!section" />
       <AdminManageUsers v-else-if="section === 'manageUsers'" />
       <AdminCheatFinder v-else-if="section === 'cheatFinder'" />
+      <AdminDeviceFingerprintLogs v-else-if="section === 'deviceFingerprints'" />
       <AdminAuthLogs v-else-if="section === 'authLogs'" />
       <AdminTradeLogs v-else-if="section === 'tradeLogs'" />
       <AdminAuctionLogs v-else-if="section === 'auctionLogs'" />

--- a/plugins/device-fingerprint.client.js
+++ b/plugins/device-fingerprint.client.js
@@ -1,0 +1,57 @@
+// plugins/device-fingerprint.client.js
+//
+// Computes a FingerprintJS visitorId once per browser session for the
+// currently authenticated user and POSTs it to /api/auth/device-fingerprint
+// so admins can correlate accounts that share the same device.
+//
+// - Runs only on the client.
+// - Skips if no user is logged in (waits up to ~5s for auth hydration).
+// - Skips if already captured this browser session (sessionStorage flag).
+// - All errors are swallowed; capture is best-effort and must never block
+//   page rendering or auth flows.
+
+const SESSION_FLAG = 'cr_df_captured_v1'
+
+export default defineNuxtPlugin(() => {
+  if (typeof window === 'undefined') return
+
+  // Defer to idle so we never compete with the initial paint.
+  const schedule = (cb) => {
+    if (typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(cb, { timeout: 4000 })
+    } else {
+      window.setTimeout(cb, 1500)
+    }
+  }
+
+  schedule(async () => {
+    try {
+      if (sessionStorage.getItem(SESSION_FLAG) === '1') return
+
+      // Wait briefly for auth to hydrate. useAuth's user ref may be null
+      // for a moment after navigation finishes.
+      const { user, fetchSelf } = useAuth()
+      if (!user.value) {
+        try { await fetchSelf() } catch {}
+      }
+      if (!user.value) return
+
+      // Lazy-import so FingerprintJS doesn't bloat the initial bundle for
+      // unauthenticated visitors or SSR.
+      const FingerprintJS = (await import('@fingerprintjs/fingerprintjs')).default
+      const fp = await FingerprintJS.load()
+      const { visitorId } = await fp.get()
+      if (!visitorId) return
+
+      await $fetch('/api/auth/device-fingerprint', {
+        method: 'POST',
+        body: { visitorId }
+      })
+
+      sessionStorage.setItem(SESSION_FLAG, '1')
+    } catch (e) {
+      // Best-effort — never block the page on a fingerprint failure.
+      if (process.dev) console.warn('[device-fingerprint] capture failed', e)
+    }
+  })
+})

--- a/prisma/migrations/20260523000000_add_device_fingerprint_log/migration.sql
+++ b/prisma/migrations/20260523000000_add_device_fingerprint_log/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "DeviceFingerprintLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "ip" TEXT NOT NULL,
+    "visitorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DeviceFingerprintLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "DeviceFingerprintLog_userId_idx" ON "DeviceFingerprintLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "DeviceFingerprintLog_visitorId_idx" ON "DeviceFingerprintLog"("visitorId");
+
+-- CreateIndex
+CREATE INDEX "DeviceFingerprintLog_ip_idx" ON "DeviceFingerprintLog"("ip");
+
+-- CreateIndex
+CREATE INDEX "DeviceFingerprintLog_createdAt_idx" ON "DeviceFingerprintLog"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "DeviceFingerprintLog" ADD CONSTRAINT "DeviceFingerprintLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260523010000_add_discord_username/migration.sql
+++ b/prisma/migrations/20260523010000_add_discord_username/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "discordUsername" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -349,6 +349,7 @@ model User {
   id                                String    @id @default(uuid())
   username                          String?   @unique
   discordId                         String    @unique
+  discordUsername                   String?
   discordTag                        String?
   discordAvatar                     String?
   email                             String?   @unique
@@ -379,6 +380,7 @@ model User {
   cZones                   CZone[]
   clashDecks               ClashDeck[]
   logins                   LoginLog[]
+  deviceFingerprintLogs    DeviceFingerprintLog[]
   gamePointLogs            GamePointLog[]
   pointsLogs               PointsLog[]
   lockedPoints             LockedPoints[]
@@ -759,6 +761,21 @@ model LoginLog {
   user User @relation(fields: [userId], references: [id])
 
   @@index([ip])
+}
+
+model DeviceFingerprintLog {
+  id        String   @id @default(uuid())
+  userId    String
+  ip        String
+  visitorId String
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId])
+  @@index([visitorId])
+  @@index([ip])
+  @@index([createdAt])
 }
 
 model GamePointLog {

--- a/server/api/admin/device-fingerprint-logs.get.js
+++ b/server/api/admin/device-fingerprint-logs.get.js
@@ -1,0 +1,71 @@
+// server/api/admin/device-fingerprint-logs.get.js
+// Admin-only paginated listing of DeviceFingerprintLog rows joined with
+// the user (for username + discordId display in AdminDeviceFingerprintLogs).
+//
+// Query params:
+//   page=N        (1-indexed; default 1)
+//   limit=N       (1..200; default 100)
+//   username=...  (case-insensitive substring match on User.username)
+//   visitorId=... (exact match — useful for clicking a row to "show all
+//                  accounts that share this fingerprint")
+//   ip=...        (exact match)
+
+import {
+  defineEventHandler,
+  getRequestHeader,
+  getQuery,
+  createError
+} from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const query = getQuery(event)
+  const page = Math.max(parseInt(query.page || '1', 10), 1)
+  const limit = Math.min(Math.max(parseInt(query.limit || '100', 10), 1), 200)
+  const skip = (page - 1) * limit
+
+  const username  = String(query.username  || '').trim()
+  const visitorId = String(query.visitorId || '').trim()
+  const ip        = String(query.ip        || '').trim()
+
+  const where = {}
+  if (username) {
+    where.user = { username: { contains: username, mode: 'insensitive' } }
+  }
+  if (visitorId) where.visitorId = visitorId
+  if (ip) where.ip = ip
+
+  const [items, total] = await Promise.all([
+    prisma.deviceFingerprintLog.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take: limit,
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            discordId: true,
+            discordUsername: true,
+            discordTag: true
+          }
+        }
+      }
+    }),
+    prisma.deviceFingerprintLog.count({ where })
+  ])
+
+  return { items, total, page, limit }
+})

--- a/server/api/auth/device-fingerprint.post.js
+++ b/server/api/auth/device-fingerprint.post.js
@@ -1,0 +1,53 @@
+// server/api/auth/device-fingerprint.post.js
+// Records a DeviceFingerprintLog row tying the current authenticated
+// user + request IP to a client-computed FingerprintJS visitorId.
+//
+// Called by plugins/device-fingerprint.client.js once per browser session.
+
+import {
+  defineEventHandler,
+  readBody,
+  getRequestHeader,
+  createError
+} from 'h3'
+import { prisma } from '@/server/prisma'
+
+function getRequestIP(event) {
+  return (
+    event.node.req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+    event.node.req.connection?.remoteAddress ||
+    event.node.req.socket?.remoteAddress ||
+    ''
+  )
+}
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.id) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const body = await readBody(event)
+  const visitorId = typeof body?.visitorId === 'string' ? body.visitorId.trim() : ''
+  if (!visitorId || visitorId.length < 8 || visitorId.length > 128) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid visitorId' })
+  }
+
+  const ip = getRequestIP(event)
+
+  await prisma.deviceFingerprintLog.create({
+    data: {
+      userId: me.id,
+      ip,
+      visitorId
+    }
+  })
+
+  return { ok: true }
+})

--- a/server/api/auth/discord/callback.get.js
+++ b/server/api/auth/discord/callback.get.js
@@ -111,6 +111,7 @@ export default defineEventHandler(async (event) => {
       const created = await tx.user.create({
         data: {
           discordId: discordUser.id,
+          discordUsername: discordUser.username || null,
           discordTag: displayName,
           discordAvatar: discordUser.avatar,
           email: emailInUseByInactive ? null : discordUser.email,
@@ -129,6 +130,7 @@ export default defineEventHandler(async (event) => {
     const updated = await tx.user.update({
       where: { id: activeUser.id },
       data: {
+        discordUsername: discordUser.username || null,
         discordTag: displayName,
         discordAvatar: discordUser.avatar,
         // keep email unique; only update if email is free or belongs to this user


### PR DESCRIPTION
Captures a FingerprintJS visitorId once per browser session for authenticated users and joins it with userId/IP so admins can detect multiple Discord accounts sharing one device. Adds a new "Device Fingerprints" entry under Admin Logs with username/visitorId/IP filters. Also captures discordUsername (the immutable-ish @handle) on login separately from discordTag (display name) so the admin views can show the handle instead of a snowflake.