### PR TITLE
Fix fingerprint dedup + show admin-touched IPs in Cheat Finder

### DIFF
--- a/components/newsite/AdminCheatFinder.vue
+++ b/components/newsite/AdminCheatFinder.vue
@@ -56,7 +56,14 @@
               </thead>
               <tbody>
                 <tr v-for="alias in group.aliases" :key="alias.username" class="border-b last:border-b-0">
-                  <td class="px-1.5 py-1 font-medium">{{ alias.username }}</td>
+                  <td class="px-1.5 py-1 font-medium">
+                    {{ alias.username }}
+                    <span
+                      v-if="alias.isAdmin"
+                      class="ml-1 px-1 py-0.5 text-[9px] uppercase tracking-wide rounded bg-amber-100 text-amber-800 border border-amber-300"
+                      title="This account is an admin — likely legitimate testing"
+                    >Admin</span>
+                  </td>
                   <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(alias.joined) }}</td>
                   <td class="px-1.5 py-1">{{ alias.discordTag || '—' }}</td>
                   <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(alias.discordCreatedAt) }}</td>
@@ -72,7 +79,13 @@
               :key="alias.username"
               class="border rounded p-1.5 bg-gray-50"
             >
-              <div class="font-medium text-[11px]">{{ alias.username }}</div>
+              <div class="font-medium text-[11px]">
+                {{ alias.username }}
+                <span
+                  v-if="alias.isAdmin"
+                  class="ml-1 px-1 py-0.5 text-[9px] uppercase tracking-wide rounded bg-amber-100 text-amber-800 border border-amber-300"
+                >Admin</span>
+              </div>
               <div class="mt-0.5 grid grid-cols-1 gap-0.5 text-[10px] text-gray-700">
                 <div><span class="text-gray-500">Joined:</span> {{ formatDate(alias.joined) }}</div>
                 <div><span class="text-gray-500">Discord:</span> {{ alias.discordTag || '—' }}</div>

--- a/plugins/device-fingerprint.client.js
+++ b/plugins/device-fingerprint.client.js
@@ -1,21 +1,42 @@
 // plugins/device-fingerprint.client.js
 //
-// Computes a FingerprintJS visitorId once per browser session for the
-// currently authenticated user and POSTs it to /api/auth/device-fingerprint
-// so admins can correlate accounts that share the same device.
+// Computes a FingerprintJS visitorId for the currently authenticated user
+// and POSTs it to /api/auth/device-fingerprint so admins can correlate
+// accounts that share the same device.
 //
-// - Runs only on the client.
-// - Skips if no user is logged in (waits up to ~5s for auth hydration).
-// - Skips if already captured this browser session (sessionStorage flag).
-// - All errors are swallowed; capture is best-effort and must never block
-//   page rendering or auth flows.
+// Re-captures whenever the logged-in user changes (watch on user.id), so
+// logging out + logging in as a different account in the same tab still
+// produces a fingerprint row for the second account. The sessionStorage
+// flag is scoped to userId so each distinct user captures at most once
+// per browser session.
 
-const SESSION_FLAG = 'cr_df_captured_v1'
+const SESSION_FLAG_PREFIX = 'cr_df_captured_v1:'
+
+async function captureFor(userId) {
+  try {
+    if (!userId) return
+    const flag = SESSION_FLAG_PREFIX + userId
+    if (sessionStorage.getItem(flag) === '1') return
+
+    const FingerprintJS = (await import('@fingerprintjs/fingerprintjs')).default
+    const fp = await FingerprintJS.load()
+    const { visitorId } = await fp.get()
+    if (!visitorId) return
+
+    await $fetch('/api/auth/device-fingerprint', {
+      method: 'POST',
+      body: { visitorId }
+    })
+
+    sessionStorage.setItem(flag, '1')
+  } catch (e) {
+    if (process.dev) console.warn('[device-fingerprint] capture failed', e)
+  }
+}
 
 export default defineNuxtPlugin(() => {
   if (typeof window === 'undefined') return
 
-  // Defer to idle so we never compete with the initial paint.
   const schedule = (cb) => {
     if (typeof window.requestIdleCallback === 'function') {
       window.requestIdleCallback(cb, { timeout: 4000 })
@@ -25,33 +46,16 @@ export default defineNuxtPlugin(() => {
   }
 
   schedule(async () => {
-    try {
-      if (sessionStorage.getItem(SESSION_FLAG) === '1') return
-
-      // Wait briefly for auth to hydrate. useAuth's user ref may be null
-      // for a moment after navigation finishes.
-      const { user, fetchSelf } = useAuth()
-      if (!user.value) {
-        try { await fetchSelf() } catch {}
-      }
-      if (!user.value) return
-
-      // Lazy-import so FingerprintJS doesn't bloat the initial bundle for
-      // unauthenticated visitors or SSR.
-      const FingerprintJS = (await import('@fingerprintjs/fingerprintjs')).default
-      const fp = await FingerprintJS.load()
-      const { visitorId } = await fp.get()
-      if (!visitorId) return
-
-      await $fetch('/api/auth/device-fingerprint', {
-        method: 'POST',
-        body: { visitorId }
-      })
-
-      sessionStorage.setItem(SESSION_FLAG, '1')
-    } catch (e) {
-      // Best-effort — never block the page on a fingerprint failure.
-      if (process.dev) console.warn('[device-fingerprint] capture failed', e)
+    const { user, fetchSelf } = useAuth()
+    if (!user.value) {
+      try { await fetchSelf() } catch {}
     }
+
+    if (user.value?.id) captureFor(user.value.id)
+
+    watch(
+      () => user.value?.id || null,
+      (newId) => { if (newId) captureFor(newId) }
+    )
   })
 })

--- a/server/api/admin/duplicate-users.get.js
+++ b/server/api/admin/duplicate-users.get.js
@@ -39,19 +39,13 @@ export default defineEventHandler(async (event) => {
     }
   })
 
-  // 3. Track IPs used by any admin, and build map of user aliases per IP
-  const ipsWithAdmin = new Set()
+  // 3. Build map of user aliases per IP. We keep admin logins in the
+  //    grouping (with an isAdmin flag on the alias) so admins testing
+  //    other accounts on shared devices still surface in Cheat Finder.
   const byIp = {}
 
   for (const { ip, createdAt, user } of logs) {
     const ts = createdAt.getTime()
-
-    if (user.isAdmin) {
-      // mark this IP and skip grouping it
-      ipsWithAdmin.add(ip)
-      continue
-    }
-
     const name = user.username || '__unknown__'
     byIp[ip] = byIp[ip] || {}
     // for each alias keep the latest login timestamp + user metadata
@@ -61,24 +55,23 @@ export default defineEventHandler(async (event) => {
         ts,
         joined: user.createdAt,
         discordTag: user.discordTag,
-        discordCreatedAt: user.discordCreatedAt
+        discordCreatedAt: user.discordCreatedAt,
+        isAdmin: !!user.isAdmin
       }
     }
   }
 
-  // 4. Build only those IP groups with >1 distinct username and no admin on that IP
+  // 4. Build only those IP groups with >1 distinct username
   const groups = Object.entries(byIp)
-    .filter(([ip, nameMap]) =>
-      !ipsWithAdmin.has(ip) &&
-      Object.keys(nameMap).length > 1
-    )
+    .filter(([, nameMap]) => Object.keys(nameMap).length > 1)
     .map(([ip, nameMap]) => {
       const aliases = Object.entries(nameMap).map(([username, info]) => ({
         username,
         lastLogin: new Date(info.ts),
         joined: info.joined,
         discordTag: info.discordTag,
-        discordCreatedAt: info.discordCreatedAt
+        discordCreatedAt: info.discordCreatedAt,
+        isAdmin: info.isAdmin
       }))
       const lastLoginTs = Object.values(nameMap).reduce((max, info) => Math.max(max, info.ts), 0)
       return { ip, aliases, lastLogin: new Date(lastLoginTs) }


### PR DESCRIPTION
Fingerprint plugin keyed its sessionStorage dedup flag globally, so a second login in the same tab (logout -> different account) was never captured. Now scoped per userId and re-runs on user.id change via a watcher.

Cheat Finder previously hid any IP that had ever seen an admin login, which silently dropped exactly the cases admins want to verify. The admin exclusion is removed; each alias now carries an isAdmin flag and the UI shows an amber "Admin" badge so legitimate admin activity stays distinguishable.