### PR TITLE
Show loading skeletons for cZone owner info during nav

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -7,23 +7,32 @@
         <OrangeButton v-if="isOwnZone" @click="toggleBuild" :disabled="buildLoading">
           {{ cz.buildMode ? 'Exit Build' : buildLoading ? 'Loading…' : 'Build' }}
         </OrangeButton>
-        <NuxtLink v-else-if="viewedOwner" :to="`/newsite/trade?username=${encodeURIComponent(viewedOwner.username)}`" style="text-decoration:none;display:contents;">
+        <NuxtLink v-else-if="viewedUsername" :to="`/newsite/trade?username=${encodeURIComponent(viewedUsername)}`" style="text-decoration:none;display:contents;">
           <OrangeButton>Trade</OrangeButton>
         </NuxtLink>
         <template v-for="(zone, i) in cz.zones" :key="i">
           <button
-            v-if="cz.buildMode || zone.toons.length > 0"
+            v-if="!zoneLoading && (cz.buildMode || zone.toons.length > 0)"
             class="cz-zone-tab" :class="{ active: cz.activeZone === i }"
             @click="cz.activeZone = i"
           >{{ i + 1 }}</button>
         </template>
       </div>
-      <div class="cz-owner-info" v-if="viewedOwner">
-        <img :src="`/avatars/${viewedOwner.avatar || 'default.png'}`" class="cz-owner-avatar" />
-        <div class="cz-owner-label">
-          <div><span class="cz-owner-prefix">Owner</span> {{ viewedOwner.username }}</div>
-          <div v-if="lastOnlineText" class="cz-owner-lastseen">{{ lastOnlineText }}</div>
-        </div>
+      <div class="cz-owner-info" v-if="zoneLoading || viewedOwner">
+        <template v-if="zoneLoading">
+          <div class="cz-owner-avatar cz-skeleton cz-skeleton-avatar"></div>
+          <div class="cz-owner-label">
+            <div class="cz-skeleton cz-skeleton-line cz-skeleton-username"></div>
+            <div class="cz-skeleton cz-skeleton-line cz-skeleton-lastseen"></div>
+          </div>
+        </template>
+        <template v-else>
+          <img :src="`/avatars/${viewedOwner.avatar || 'default.png'}`" class="cz-owner-avatar" />
+          <div class="cz-owner-label">
+            <div><span class="cz-owner-prefix">Owner</span> {{ viewedOwner.username }}</div>
+            <div v-if="lastOnlineText" class="cz-owner-lastseen">{{ lastOnlineText }}</div>
+          </div>
+        </template>
       </div>
     </div>
 
@@ -262,6 +271,9 @@ const viewedUsername = ref(null)   // username whose zone is currently displayed
 
 // True while build-mode data is loading (prevents double-click and shows spinner on button)
 const buildLoading = ref(false)
+
+// True while a zone is being fetched – drives skeleton placeholders in the topbar
+const zoneLoading = ref(false)
 
 // Local drag: repositioning toons already on the canvas
 const localDrag = ref(null)  // { toon, offsetX, offsetY }
@@ -554,12 +566,15 @@ onUnmounted(() => {
 async function loadZone(username) {
   const target = username ?? user.value?.username
   if (!target) return
+  // Set viewedUsername immediately so the Trade/Build button stays visible
+  // (and stable in place) while the zone data loads.
+  viewedUsername.value = target
+  zoneLoading.value    = true
   try {
     const data = await $fetch(`/api/czone/${target}`)
     cz.value.zones       = data.cZone.zones
     const firstActive    = data.cZone.zones.findIndex(z => z.toons.length > 0)
     cz.value.activeZone  = firstActive >= 0 ? firstActive : 0
-    viewedUsername.value = target
     viewedOwner.value    = { username: data.ownerName, avatar: data.avatar, lastActivity: data.lastActivity ?? null }
     loadCzoneSearchItems()
 
@@ -568,6 +583,8 @@ async function loadZone(username) {
     }
   } catch (e) {
     console.error('MyCzone: failed to load zone', e)
+  } finally {
+    zoneLoading.value = false
   }
 }
 
@@ -981,6 +998,20 @@ defineExpose({ save, clearZone })
 .cz-owner-label  { font-size: 0.68rem; color: #fff; white-space: nowrap; }
 .cz-owner-prefix  { font-size: 0.6rem; text-transform: uppercase; color: rgba(255,255,255,0.55); margin-right: 3px; }
 .cz-owner-lastseen { font-size: 0.58rem; color: rgba(255,255,255,0.5); white-space: nowrap; }
+
+/* ── Skeleton placeholders (shown while a new cZone is loading) ── */
+.cz-skeleton {
+  background: rgba(255, 255, 255, 0.18);
+  animation: cz-skeleton-pulse 1.2s ease-in-out infinite;
+}
+.cz-skeleton-avatar { border-radius: 50%; }
+.cz-skeleton-line { border-radius: 3px; margin: 2px 0; }
+.cz-skeleton-username { width: 88px; height: 9px; }
+.cz-skeleton-lastseen { width: 64px; height: 7px; }
+@keyframes cz-skeleton-pulse {
+  0%, 100% { opacity: 1;   }
+  50%      { opacity: 0.4; }
+}
 
 @media (max-width: 768px) {
   .cz-topbar {

--- a/server/api/cmart/packs/buy.post.js
+++ b/server/api/cmart/packs/buy.post.js
@@ -20,6 +20,7 @@ import {
 } from 'h3'
 
 import { prisma as db } from '@/server/prisma'
+import { checkPackDepletion } from '@/server/utils/packAvailability'
 
 /**
  * Returns the start of the current 8pm–7:59pm CST daily window as a UTC Date.
@@ -116,7 +117,22 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Not enough available points' })
   }
 
-  /* 4.  daily purchase limit check --------------------------------------- */
+  /* 4.  pack rarity depletion check -------------------------------------- */
+  // Some cToons in a pack can also be bought directly via the cToons
+  // section. When that happens, a rarity can become unsatisfiable without
+  // anyone opening the pack — so the pack's inCmart flag may still be true
+  // even though the pack is effectively sold out. Re-check depletion here
+  // and unlist the pack if it can no longer be filled.
+  const depletion = await checkPackDepletion(pack.id)
+  if (depletion.shouldUnlist) {
+    await db.pack.update({ where: { id: pack.id }, data: { inCmart: false } }).catch(() => {})
+    throw createError({
+      statusCode: 410,
+      statusMessage: 'This pack is sold out.'
+    })
+  }
+
+  /* 5.  daily purchase limit check --------------------------------------- */
   if (pack.dailyPurchaseLimit != null) {
     const windowStart = getDailyWindowStart()
     const purchasedToday = await db.userPack.count({
@@ -134,9 +150,9 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  /* 5.  transaction: deduct points + create sealed pack ----------------- */
+  /* 6.  transaction: deduct points + create sealed pack ----------------- */
   const result = await db.$transaction(async (tx) => {
-    // 5-a  deduct points
+    // 6-a  deduct points
     const updated = await tx.userPoints.update({
       where: { userId: me.id },
       data:  { points: { decrement: effectivePackPrice } }
@@ -146,7 +162,7 @@ export default defineEventHandler(async (event) => {
       data: { userId: me.id, points: effectivePackPrice, total: updated.points, method: "Bought Pack", direction: 'decrease' }
     })
 
-    // 5-b  create UserPack (sealed)
+    // 6-b  create UserPack (sealed)
     const userPack = await tx.userPack.create({
       data: {
         userId: me.id,
@@ -158,6 +174,6 @@ export default defineEventHandler(async (event) => {
     return userPack
   })
 
-  /* 6.  success response ------------------------------------------------- */
+  /* 7.  success response ------------------------------------------------- */
   return { success: true, userPackId: result.id }
 })

--- a/server/utils/packAvailability.js
+++ b/server/utils/packAvailability.js
@@ -1,0 +1,109 @@
+// server/utils/packAvailability.js
+// ---------------------------------------------------------------------------
+// Shared depletion check for Packs.
+//
+// A pack contains one or more rarities (PackRarityConfig). Each rarity is
+// satisfied at open time by picking from the pack's PackCtoonOptions whose
+// underlying Ctoon has the same rarity. A Ctoon is "out" once its minted
+// count (plus any pending mints we're about to perform) hits its quantity.
+//
+// Because some cToons in a pack can also be sold directly in the cToons
+// section, a rarity can become unsatisfiable without anyone ever opening
+// the pack. This helper computes whether a Pack should currently be
+// considered sold out based on its sellOutBehavior, so the buy endpoint
+// can refuse the purchase (and the open-pack endpoint can reuse the same
+// logic).
+// ---------------------------------------------------------------------------
+import { prisma as defaultPrisma } from '../prisma.js'
+
+/**
+ * Compute current depletion state for a pack.
+ *
+ * @param {string} packId
+ * @param {object} [opts]
+ * @param {import('@prisma/client').PrismaClient | object} [opts.tx]
+ *        Prisma client or transaction client. Defaults to the global client.
+ * @param {Record<string, number>} [opts.pendingMintCounts]
+ *        Map of ctoonId → count of mints that are about to happen but
+ *        haven't been recorded yet (used during open-pack to account for
+ *        the cToons being minted in the current transaction).
+ * @returns {Promise<{
+ *   pack: { id: string, sellOutBehavior: string } | null,
+ *   rarityStatuses: Array<{ rarity: string, total: number, remaining: number, depleted: boolean }>,
+ *   anyRarityEmpty: boolean,
+ *   allRaritiesEmpty: boolean,
+ *   shouldUnlist: boolean
+ * }>}
+ */
+export async function checkPackDepletion(packId, opts = {}) {
+  const tx      = opts.tx || defaultPrisma
+  const pending = opts.pendingMintCounts || {}
+
+  const pack = await tx.pack.findUnique({
+    where: { id: packId },
+    select: {
+      id: true,
+      sellOutBehavior: true,
+      rarityConfigs: { select: { rarity: true } },
+      ctoonOptions: {
+        select: {
+          ctoonId: true,
+          ctoon: { select: { id: true, rarity: true, quantity: true } }
+        }
+      }
+    }
+  })
+
+  if (!pack) {
+    return {
+      pack: null,
+      rarityStatuses: [],
+      anyRarityEmpty: false,
+      allRaritiesEmpty: false,
+      shouldUnlist: false
+    }
+  }
+
+  const optionsByRarity = {}
+  for (const opt of pack.ctoonOptions) {
+    if (!opt.ctoon) continue
+    ;(optionsByRarity[opt.ctoon.rarity] ||= []).push(opt)
+  }
+
+  const rarityStatuses = []
+  for (const rc of pack.rarityConfigs) {
+    const options = optionsByRarity[rc.rarity] || []
+    let remaining = 0
+    for (const opt of options) {
+      const c = opt.ctoon
+      if (c.quantity === null) {
+        remaining += 1
+        continue
+      }
+      const minted     = await tx.userCtoon.count({ where: { ctoonId: c.id } })
+      const pendingFor = pending[c.id] || 0
+      if (minted + pendingFor < c.quantity) remaining += 1
+    }
+    rarityStatuses.push({
+      rarity:   rc.rarity,
+      total:    options.length,
+      remaining,
+      depleted: remaining === 0
+    })
+  }
+
+  const anyRarityEmpty   = rarityStatuses.some(r => r.depleted)
+  const allRaritiesEmpty = rarityStatuses.length > 0 && rarityStatuses.every(r => r.depleted)
+  const sellOutBehavior  = pack.sellOutBehavior || 'REMOVE_ON_ANY_RARITY_EMPTY'
+  const shouldUnlist     = sellOutBehavior === 'KEEP_IF_SINGLE_RARITY_EMPTY'
+    ? allRaritiesEmpty
+    : anyRarityEmpty
+
+  return {
+    pack: { id: pack.id, sellOutBehavior },
+    rarityStatuses,
+    anyRarityEmpty,
+    allRaritiesEmpty,
+    shouldUnlist
+  }
+}


### PR DESCRIPTION
When clicking next/previous/random on the newsite cZone page, the
username/last-seen block and Trade button briefly disappeared while the
new zone was being fetched, which shifted the surrounding controls.

Replace the owner username and last-seen text with shimmer skeletons
during the fetch, and set viewedUsername immediately so the Trade/Build
button stays mounted in place. The zone tabs are also hidden during
load to avoid flashing the previous user's zones.