### PR TITLE
Enrich Cheat Finder duplicate-IP aliases with usage footnote

### DIFF
--- a/components/newsite/AdminCheatFinder.vue
+++ b/components/newsite/AdminCheatFinder.vue
@@ -52,21 +52,38 @@
                   <th class="px-1.5 py-1 border-b">Joined</th>
                   <th class="px-1.5 py-1 border-b">Discord Username</th>
                   <th class="px-1.5 py-1 border-b">Discord Account Created</th>
+                  <th class="px-1.5 py-1 border-b">Latest Device</th>
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="alias in group.aliases" :key="alias.username" class="border-b last:border-b-0">
-                  <td class="px-1.5 py-1 font-medium">
-                    {{ alias.username }}
-                    <span
-                      v-if="alias.isAdmin"
-                      class="ml-1 px-1 py-0.5 text-[9px] uppercase tracking-wide rounded bg-amber-100 text-amber-800 border border-amber-300"
-                      title="This account is an admin — likely legitimate testing"
-                    >Admin</span>
+                <tr v-for="alias in group.aliases" :key="alias.username" class="border-b last:border-b-0 align-top">
+                  <td class="px-1.5 py-1">
+                    <div class="font-medium">
+                      {{ alias.username }}
+                      <span
+                        v-if="alias.isAdmin"
+                        class="ml-1 px-1 py-0.5 text-[9px] uppercase tracking-wide rounded bg-amber-100 text-amber-800 border border-amber-300"
+                        title="This account is an admin — likely legitimate testing"
+                      >Admin</span>
+                    </div>
+                    <div class="text-[10px] text-gray-500 mt-0.5">
+                      {{ formatNumber(alias.points) }} pts · {{ formatNumber(alias.ctoonCount) }} ctoons · Last login {{ formatDateTime(alias.lastLogin) }}
+                    </div>
+                    <div
+                      v-if="alias.latestVisitorId"
+                      class="text-[10px] text-gray-500 font-mono break-all"
+                      :title="alias.latestVisitorAt ? `Captured ${formatDateTime(alias.latestVisitorAt)}` : ''"
+                    >
+                      Browser: {{ alias.latestVisitorId }}
+                    </div>
                   </td>
                   <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(alias.joined) }}</td>
                   <td class="px-1.5 py-1">{{ alias.discordTag || '—' }}</td>
                   <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(alias.discordCreatedAt) }}</td>
+                  <td class="px-1.5 py-1 whitespace-nowrap">
+                    <span v-if="alias.latestDeviceType">{{ alias.latestDeviceType }}</span>
+                    <span v-else class="text-gray-400">—</span>
+                  </td>
                 </tr>
               </tbody>
             </table>
@@ -86,10 +103,25 @@
                   class="ml-1 px-1 py-0.5 text-[9px] uppercase tracking-wide rounded bg-amber-100 text-amber-800 border border-amber-300"
                 >Admin</span>
               </div>
-              <div class="mt-0.5 grid grid-cols-1 gap-0.5 text-[10px] text-gray-700">
+              <div class="text-[10px] text-gray-500 mt-0.5">
+                {{ formatNumber(alias.points) }} pts · {{ formatNumber(alias.ctoonCount) }} ctoons · Last login {{ formatDateTime(alias.lastLogin) }}
+              </div>
+              <div
+                v-if="alias.latestVisitorId"
+                class="text-[10px] text-gray-500 font-mono break-all"
+                :title="alias.latestVisitorAt ? `Captured ${formatDateTime(alias.latestVisitorAt)}` : ''"
+              >
+                Browser: {{ alias.latestVisitorId }}
+              </div>
+              <div class="mt-1 grid grid-cols-1 gap-0.5 text-[10px] text-gray-700">
                 <div><span class="text-gray-500">Joined:</span> {{ formatDate(alias.joined) }}</div>
                 <div><span class="text-gray-500">Discord:</span> {{ alias.discordTag || '—' }}</div>
                 <div><span class="text-gray-500">Discord Created:</span> {{ formatDate(alias.discordCreatedAt) }}</div>
+                <div>
+                  <span class="text-gray-500">Latest Device:</span>
+                  <span v-if="alias.latestDeviceType">{{ alias.latestDeviceType }}</span>
+                  <span v-else class="text-gray-400">—</span>
+                </div>
               </div>
             </div>
           </div>
@@ -150,6 +182,22 @@ function formatDate(dt) {
     month: 'short',
     day: 'numeric'
   })
+}
+
+function formatDateTime(dt) {
+  if (!dt) return '—'
+  return new Date(dt).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+function formatNumber(n) {
+  if (n == null) return '—'
+  return Number(n).toLocaleString('en-US')
 }
 
 async function fetchGroups() {

--- a/server/api/admin/duplicate-users.get.js
+++ b/server/api/admin/duplicate-users.get.js
@@ -53,6 +53,7 @@ export default defineEventHandler(async (event) => {
     if (!existing || ts > existing.ts) {
       byIp[ip][name] = {
         ts,
+        userId: user.id,
         joined: user.createdAt,
         discordTag: user.discordTag,
         discordCreatedAt: user.discordCreatedAt,
@@ -67,6 +68,7 @@ export default defineEventHandler(async (event) => {
     .map(([ip, nameMap]) => {
       const aliases = Object.entries(nameMap).map(([username, info]) => ({
         username,
+        userId: info.userId,
         lastLogin: new Date(info.ts),
         joined: info.joined,
         discordTag: info.discordTag,
@@ -107,6 +109,60 @@ export default defineEventHandler(async (event) => {
 
   const total = filteredGroups.length
   const paged = filteredGroups.slice(skip, skip + limit)
+
+  // 5. Enrich aliases on the paged groups with points, ctoon count, and
+  //    latest fingerprint visitorId. Batch by userId so we don't fan out
+  //    queries per alias.
+  const userIds = Array.from(
+    new Set(paged.flatMap((g) => g.aliases.map((a) => a.userId).filter(Boolean)))
+  )
+
+  if (userIds.length) {
+    const [pointsRows, ctoonGroups, fingerprintRows] = await Promise.all([
+      prisma.userPoints.findMany({
+        where: { userId: { in: userIds } },
+        select: { userId: true, points: true }
+      }),
+      prisma.userCtoon.groupBy({
+        by: ['userId'],
+        where: { userId: { in: userIds }, burnedAt: null },
+        _count: { _all: true }
+      }),
+      prisma.deviceFingerprintLog.findMany({
+        where: { userId: { in: userIds } },
+        orderBy: { createdAt: 'desc' },
+        select: { userId: true, visitorId: true, deviceType: true, createdAt: true }
+      })
+    ])
+
+    const pointsByUser = Object.fromEntries(
+      pointsRows.map((r) => [r.userId, r.points])
+    )
+    const ctoonsByUser = Object.fromEntries(
+      ctoonGroups.map((r) => [r.userId, r._count._all])
+    )
+    const latestFingerprintByUser = {}
+    for (const row of fingerprintRows) {
+      if (!latestFingerprintByUser[row.userId]) {
+        latestFingerprintByUser[row.userId] = {
+          visitorId: row.visitorId,
+          deviceType: row.deviceType,
+          capturedAt: row.createdAt
+        }
+      }
+    }
+
+    for (const group of paged) {
+      for (const alias of group.aliases) {
+        const fp = latestFingerprintByUser[alias.userId]
+        alias.points = pointsByUser[alias.userId] ?? 0
+        alias.ctoonCount = ctoonsByUser[alias.userId] ?? 0
+        alias.latestVisitorId = fp?.visitorId || null
+        alias.latestDeviceType = fp?.deviceType || null
+        alias.latestVisitorAt = fp?.capturedAt || null
+      }
+    }
+  }
 
   return { groups: paged, total, page, limit }
 })


### PR DESCRIPTION
Each alias now shows points, ctoon count, last login, and the latest captured Browser ID as a small gray footnote under the username, plus a Latest Device column derived from DeviceFingerprintLog.deviceType.

Enrichment runs only on the paged groups and batches three queries (UserPoints, UserCtoon count, latest DeviceFingerprintLog) by userId to keep the per-page cost bounded.