### PR TITLE
Reorganize Trade.vue watchers to follow variable declarations

### DIFF
--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -846,26 +846,6 @@ async function fetchValuationsForIds(ids) {
   }
 }
 
-// Step 1: fetch valuations as the user selects target cToons
-watch(selectedTargetCtoons, ctoons => {
-  fetchValuationsForIds(ctoons.map(c => c.id))
-}, { deep: true })
-
-// Step 2: fetch valuations as the user selects their own cToons
-watch(selectedInitiatorCtoons, ctoons => {
-  fetchValuationsForIds(ctoons.map(c => c.id))
-}, { deep: true })
-
-// Step 3: ensure any gaps are filled (covers edge cases like back-navigation)
-watch(tradeCurrentStep, step => {
-  if (step === 3) {
-    fetchValuationsForIds([
-      ...selectedInitiatorCtoons.value.map(c => c.id),
-      ...selectedTargetCtoons.value.map(c => c.id),
-    ])
-  }
-})
-
 /** Total mint-adjusted value of the cToons selected from the other user (Step 1 display) */
 const step1SelectedTotal = computed(() => {
   if (!selectedTargetCtoons.value.length) return null
@@ -1231,6 +1211,26 @@ const selectedTargetCtoons = ref([])
 const selectedInitiatorCtoons = ref([])
 const selectedTargetCtoonsMap = computed(() => new Set(selectedTargetCtoons.value.map(c => c.id)))
 const selectedInitiatorCtoonsMap = computed(() => new Set(selectedInitiatorCtoons.value.map(c => c.id)))
+
+// Step 1: fetch valuations as the user selects target cToons
+watch(selectedTargetCtoons, ctoons => {
+  fetchValuationsForIds(ctoons.map(c => c.id))
+}, { deep: true })
+
+// Step 2: fetch valuations as the user selects their own cToons
+watch(selectedInitiatorCtoons, ctoons => {
+  fetchValuationsForIds(ctoons.map(c => c.id))
+}, { deep: true })
+
+// Step 3: ensure any gaps are filled (covers edge cases like back-navigation)
+watch(tradeCurrentStep, step => {
+  if (step === 3) {
+    fetchValuationsForIds([
+      ...selectedInitiatorCtoons.value.map(c => c.id),
+      ...selectedTargetCtoons.value.map(c => c.id),
+    ])
+  }
+})
 
 function applyPreselectedTargetCtoon() {
   const preselectId = manualPreselectUserCtoonId.value || (route.query.userCtoonId ? String(route.query.userCtoonId) : null)


### PR DESCRIPTION
## Summary
Moved the three watcher definitions in Trade.vue to appear after their dependent reactive variables are declared, improving code organization and readability.

## Key Changes
- Relocated three `watch()` calls that monitor `selectedTargetCtoons`, `selectedInitiatorCtoons`, and `tradeCurrentStep` from lines 849-867 to lines 1215-1233
- The watchers now appear immediately after the declaration of `selectedInitiatorCtoonsMap` computed property, which depends on `selectedInitiatorCtoons`
- No functional changes to the watchers themselves or their behavior

## Implementation Details
This is a pure refactoring that improves code organization by following a logical structure where:
1. Reactive variables and computed properties are declared first
2. Watchers that depend on those variables are defined immediately after
3. Other functions and logic follow

This makes the code easier to follow and reduces the cognitive load when reading the component, as related reactive state and its observers are now grouped together.

https://claude.ai/code/session_0136LS2WV83hwHAGRPeZfQCP