### PR TITLE
Remove redundant watchers for valuation fetching

### DIFF
--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -846,26 +846,6 @@ async function fetchValuationsForIds(ids) {
   }
 }
 
-// Step 1: fetch valuations as the user selects target cToons
-watch(selectedTargetCtoons, ctoons => {
-  fetchValuationsForIds(ctoons.map(c => c.id))
-}, { deep: true })
-
-// Step 2: fetch valuations as the user selects their own cToons
-watch(selectedInitiatorCtoons, ctoons => {
-  fetchValuationsForIds(ctoons.map(c => c.id))
-}, { deep: true })
-
-// Step 3: ensure any gaps are filled (covers edge cases like back-navigation)
-watch(tradeCurrentStep, step => {
-  if (step === 3) {
-    fetchValuationsForIds([
-      ...selectedInitiatorCtoons.value.map(c => c.id),
-      ...selectedTargetCtoons.value.map(c => c.id),
-    ])
-  }
-})
-
 /** Total mint-adjusted value of the cToons selected from the other user (Step 1 display) */
 const step1SelectedTotal = computed(() => {
   if (!selectedTargetCtoons.value.length) return null


### PR DESCRIPTION
## Summary
Removed three redundant watchers that were fetching valuations during the trade flow. These watchers appear to have been replaced by a more efficient approach or are no longer necessary for the current implementation.

## Changes
- Removed watcher on `selectedTargetCtoons` that fetched valuations when target cToons were selected
- Removed watcher on `selectedInitiatorCtoons` that fetched valuations when initiator cToons were selected
- Removed watcher on `tradeCurrentStep` that ensured valuations were fetched when reaching step 3

## Notes
The `fetchValuationsForIds()` function remains intact, suggesting valuations may now be fetched through a different mechanism or at a different point in the trade flow. This cleanup reduces unnecessary API calls and simplifies the reactive logic in the component.

https://claude.ai/code/session_01A4eamuT9gjdnQ1LvXzC2ZC