### PR TITLE
Add mint-adjusted valuations to owner list and fix trade fairness perspective

### DIFF
--- a/components/CtoonInfoModal.vue
+++ b/components/CtoonInfoModal.vue
@@ -234,7 +234,7 @@
             <li
               v-for="owner in sortedOwners"
               :key="owner.userId + '-' + owner.mintNumber"
-              class="grid grid-cols-[auto,1fr,auto] items-center gap-3 rounded bg-gray-800/60 px-3 py-2"
+              class="grid grid-cols-[auto,1fr,auto,auto] items-center gap-3 rounded bg-gray-800/60 px-3 py-2"
             >
               <span class="text-gray-300 whitespace-nowrap">
                 <span v-if="!owner.isHolidayItem">Mint #{{ owner.mintNumber ?? 'N/A' }}</span>
@@ -254,6 +254,17 @@
                 Tradeable
               </NuxtLink>
               <span v-else class="text-xs text-gray-500 whitespace-nowrap w-16">&nbsp;</span>
+              <span class="text-xs font-semibold whitespace-nowrap text-right min-w-[72px]">
+                <template v-if="ownerValuationsLoading">
+                  <span class="text-gray-500">…</span>
+                </template>
+                <template v-else-if="getMintAdjustedValue(ownerValuations[owner.userCtoonId]) != null">
+                  <span class="text-yellow-300">~{{ getMintAdjustedValue(ownerValuations[owner.userCtoonId]).toLocaleString() }} pts</span>
+                </template>
+                <template v-else>
+                  <span class="text-gray-600">—</span>
+                </template>
+              </span>
             </li>
           </ul>
         </template>
@@ -496,6 +507,18 @@ const ownersLoading = ref(false)
 const ownersError = ref('')
 const ownersList = ref([])
 const lastOwnersCtoonId = ref(null)
+const ownerValuations = ref({})
+const ownerValuationsLoading = ref(false)
+
+function getMintAdjustedValue(valuation) {
+  if (!valuation) return null
+  const { avgSale, mintNumber, highestMint, cMartPrice } = valuation
+  const base = avgSale ?? cMartPrice ?? 0
+  if (!base) return 0
+  if (mintNumber == null || !highestMint || highestMint <= 1) return base
+  const multiplier = 1 + (highestMint - mintNumber) / highestMint
+  return Math.round(base * multiplier)
+}
 
 const holidayEvent = ref(null)
 const openingHoliday = ref(false)
@@ -662,6 +685,8 @@ watch(isOpen, (open) => {
     ownersError.value = ''
     ownersList.value = []
     lastOwnersCtoonId.value = null
+    ownerValuations.value = {}
+    ownerValuationsLoading.value = false
     if (audioEl.value) { audioEl.value.pause(); audioEl.value.currentTime = 0 }
     return
   }
@@ -774,12 +799,30 @@ onBeforeUnmount(() => {
 async function loadOwners(ctoonId) {
   ownersLoading.value = true
   ownersError.value = ''
+  ownerValuations.value = {}
   try {
     const res = await $fetch('/api/collections/owners', {
       query: { cToonId: ctoonId }
     })
     ownersList.value = Array.isArray(res) ? res : []
     lastOwnersCtoonId.value = ctoonId
+
+    // Fetch mint-adjusted valuations for all owners
+    const ids = ownersList.value.map(o => o.userCtoonId).filter(Boolean)
+    if (ids.length) {
+      ownerValuationsLoading.value = true
+      try {
+        const vals = await $fetch('/api/ctoon/valuations', {
+          method: 'POST',
+          body: { userCtoonIds: ids }
+        })
+        ownerValuations.value = vals || {}
+      } catch {
+        ownerValuations.value = {}
+      } finally {
+        ownerValuationsLoading.value = false
+      }
+    }
   } catch (err) {
     ownersError.value = 'Failed to load owners.'
     ownersList.value = []

--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -1,7 +1,7 @@
 <!-- components/Modal.vue -->
 <template>
   <div
-    class="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50"
+    class="fixed inset-0 flex items-center justify-center z-[1001] bg-black bg-opacity-50"
     @click.self="handleBackdrop"
   >
     <div :class="['bg-gray-800 rounded-lg p-6 w-11/12 max-w-md max-h-[90vh]', overflowVisible ? 'overflow-visible' : 'overflow-y-auto']">

--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -352,38 +352,38 @@
             </div>
           </div>
 
-          <!-- Value preview banner: what the recipient will see -->
+          <!-- Trade value summary from the initiator's perspective -->
           <div class="tr-create-preview">
             <div class="tr-create-preview-header">
-              Preview — what <strong>{{ tradeTargetUser.username }}</strong> will see:
+              Trade Summary
             </div>
             <div v-if="isLoadingCreateValuations" class="tm-val-loading">Estimating values…</div>
             <template v-else-if="createFairnessData">
               <div class="tm-val-row">
                 <div class="tm-val-side">
-                  <div class="tm-val-label">They receive (cToons + pts)</div>
-                  <div class="tm-val-amount">~{{ createFairnessData.offeredTotal.toLocaleString() }} pts</div>
+                  <div class="tm-val-label">You receive (cToons)</div>
+                  <div class="tm-val-amount">~{{ createFairnessData.requestedTotal.toLocaleString() }} pts</div>
                 </div>
                 <div class="tm-val-bar-wrap">
                   <div class="tm-val-bar">
-                    <div class="tm-val-bar-fill" :style="{ width: createFairnessData.offeredBarPct + '%' }"></div>
+                    <div class="tm-val-bar-fill" :style="{ width: createFairnessData.receivedBarPct + '%' }"></div>
                   </div>
                   <div class="tm-val-bar-labels">
-                    <span>They receive</span>
-                    <span>They give up</span>
+                    <span>You receive</span>
+                    <span>You give</span>
                   </div>
                 </div>
                 <div class="tm-val-side tm-val-side-right">
-                  <div class="tm-val-label">They give up (cToons)</div>
-                  <div class="tm-val-amount">~{{ createFairnessData.requestedTotal.toLocaleString() }} pts</div>
+                  <div class="tm-val-label">You give (cToons + pts)</div>
+                  <div class="tm-val-amount">~{{ createFairnessData.offeredTotal.toLocaleString() }} pts</div>
                 </div>
               </div>
               <div class="tm-val-verdict" :class="'tm-verdict--' + createFairnessData.verdictClass">
                 {{ createFairnessData.verdict }}
               </div>
-              <div v-if="createFairnessData.pct < 0" class="tm-val-suggestion">
-                💡 Consider adding <strong>~{{ createFairnessData.shortfall.toLocaleString() }} pts</strong>
-                (or cToons worth that amount) to your offer to make this fair for {{ tradeTargetUser.username }}.
+              <div v-if="createFairnessData.pct > 0" class="tm-val-suggestion">
+                💡 You're requesting <strong>~{{ createFairnessData.shortfall.toLocaleString() }} pts</strong>
+                more than you're offering. {{ tradeTargetUser.username }} may want a more balanced offer.
               </div>
               <div class="tm-val-note">
                 Est. based on avg. auction prices, adjusted for mint #. Treat as a guide, not a guarantee.
@@ -875,17 +875,19 @@ const createOfferedTotal = computed(() => {
 const createRequestedTotal = computed(() => step1SelectedTotal.value)
 
 /**
- * Fairness as the RECIPIENT will see it.
- * youGet = offered (they receive), youGive = requested (they give up).
- * pct < 0 means the trade is net bad for the recipient → suggest the creator adds more.
+ * Fairness from the INITIATOR'S (current user's) perspective.
+ * youGet = requested (the cToons you'll receive), youGive = offered (cToons + pts you're giving).
+ * pct > 0 means you receive more than you give → trade favors you, but recipient may reject.
+ * pct < 0 means you give more than you receive → generous offer.
  */
 const createFairnessData = computed(() => {
   if (createOfferedTotal.value == null || createRequestedTotal.value == null) return null
   const offered = createOfferedTotal.value
   const requested = createRequestedTotal.value
 
-  const youGet = offered
-  const youGive = requested
+  // Initiator's perspective: you give offered, you receive requested
+  const youGet = requested
+  const youGive = offered
 
   const pct = youGive > 0
     ? ((youGet - youGive) / youGive) * 100
@@ -909,7 +911,8 @@ const createFairnessData = computed(() => {
     verdictClass = 'bad'
   }
 
-  const shortfall = pct < 0 ? Math.round(youGive - youGet) : 0
+  // shortfall: how much more you're requesting vs offering (shown when trade favors you)
+  const shortfall = pct > 0 ? Math.round(youGet - youGive) : 0
   const barTotal = offered + requested
   return {
     offeredTotal: offered,
@@ -918,7 +921,8 @@ const createFairnessData = computed(() => {
     verdict,
     verdictClass,
     shortfall,
-    offeredBarPct: barTotal > 0 ? Math.round((offered / barTotal) * 100) : 50,
+    // Bar fill represents your received value as a proportion of the total trade
+    receivedBarPct: barTotal > 0 ? Math.round((requested / barTotal) * 100) : 50,
   }
 })
 

--- a/pages/newsite/trade.vue
+++ b/pages/newsite/trade.vue
@@ -1,5 +1,6 @@
 <template>
   <Trade />
+  <CtoonInfoModal />
 </template>
 
 <script setup>


### PR DESCRIPTION
## Summary
This PR enhances the cToon info modal with mint-adjusted valuations for each owner, and corrects the trade fairness calculation to reflect the initiator's perspective rather than the recipient's. It also includes minor UI/UX improvements to the trade summary display.

## Key Changes

- **Owner Valuations Display**: Added a new column to the owners list in `CtoonInfoModal.vue` that displays mint-adjusted valuations for each owner's cToon. The valuations are fetched via a new `/api/ctoon/valuations` endpoint and include loading states and fallback displays.

- **Mint Adjustment Logic**: Implemented `getMintAdjustedValue()` function that calculates adjusted valuations based on mint number, using the formula: `base * (1 + (highestMint - mintNumber) / highestMint)`. This accounts for rarity differences between mint numbers.

- **Trade Fairness Perspective Fix**: Corrected the `createFairnessData` computed property in `Trade.vue` to calculate fairness from the initiator's (current user's) perspective instead of the recipient's. This includes:
  - Swapping the meaning of `youGet` and `youGive` 
  - Updating the fairness verdict logic accordingly
  - Correcting the suggestion message to reflect when the initiator is requesting more than offering

- **Trade Summary UI Improvements**: Updated the trade summary section header and labels to use first-person perspective ("You receive", "You give") instead of third-person, making it clearer what the current user is doing in the trade.

- **Modal Z-Index Fix**: Increased the z-index of `Modal.vue` from `z-50` to `z-[1001]` to ensure proper stacking context.

- **Trade Page Enhancement**: Added `CtoonInfoModal` component to the trade page template to enable viewing cToon details during trade creation.

## Implementation Details

- Valuations are fetched asynchronously after owners are loaded, with proper error handling and loading state management
- The mint adjustment multiplier increases value for lower mint numbers, reflecting their greater rarity
- Trade fairness calculations now correctly show when an initiator is being generous (pct < 0) vs. requesting more value (pct > 0)

https://claude.ai/code/session_01UE2Eh78eoSiAFzaZUp7uqr