### PR TITLE
Add mint-number premium calculation to cToon valuation

### DIFF
--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -1,4 +1,5 @@
 <template>
+  <Teleport to="body">
   <div class="ctic-overlay" @click.self="close">
     <div class="ctic-panel">
       <!-- Status banner image -->
@@ -331,6 +332,7 @@
       </div>
     </div>
   </div>
+  </Teleport>
 </template>
 
 <script setup>

--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -627,12 +627,34 @@ async function loadOwners(ctoonId) {
   }
 }
 
+/**
+ * Applies a mint-number premium to the base average sale price,
+ * matching the formula used in the Create Trade tab of trade.vue.
+ *
+ * Formula:  adjustedValue = baseValue × (1 + (highestMint - mintNumber) / highestMint)
+ *   – Mint #1 of 500  → 1 + 499/500 ≈ 1.998× base
+ *   – Mint #250 of 500 → 1 + 250/500 = 1.5× base
+ *   – Mint #500 of 500 → 1 + 0/500  = 1.0× base  (no premium)
+ *
+ * Falls back to cMart price when no auction history exists.
+ */
+function getMintAdjustedValue(valuation) {
+  if (!valuation) return null
+  const { avgSale, mintNumber, highestMint, cMartPrice } = valuation
+  const base = avgSale ?? cMartPrice ?? 0
+  if (!base) return 0
+  // No mint adjustment for unlimited-edition cToons (mintNumber null) or single-mint sets
+  if (mintNumber == null || !highestMint || highestMint <= 1) return base
+  const multiplier = 1 + (highestMint - mintNumber) / highestMint
+  return Math.round(base * multiplier)
+}
+
 function ownerValuation(userCtoonId) {
   const v = valuationsMap.value?.[userCtoonId]
   if (!v) return '—'
-  const pts = v.avgSale ?? v.cMartPrice ?? null
-  if (pts === null) return '—'
-  return `${Math.round(pts).toLocaleString()} pts`
+  const pts = getMintAdjustedValue(v)
+  if (pts === null || pts === 0) return '—'
+  return `${pts.toLocaleString()} pts`
 }
 
 async function submitSuggestion() {


### PR DESCRIPTION
## Summary
Updated the CtoonInfoCard component to calculate mint-adjusted valuations for cToons, applying a premium based on mint rarity that matches the formula used in the trade interface.

## Key Changes
- Wrapped the component template in a `<Teleport>` to render the overlay at the body level, improving z-index stacking and modal behavior
- Added `getMintAdjustedValue()` function that applies a mint-number premium to base average sale prices using the formula: `adjustedValue = baseValue × (1 + (highestMint - mintNumber) / highestMint)`
  - Lower mint numbers receive higher premiums (e.g., Mint #1 of 500 gets ~1.998× multiplier)
  - Highest mint numbers receive no premium (1.0× multiplier)
  - Falls back to cMart price when no auction history exists
  - Skips adjustment for unlimited-edition cToons or single-mint sets
- Updated `ownerValuation()` to use the new mint-adjusted calculation instead of raw average sale price

## Implementation Details
- The mint premium formula incentivizes lower mint numbers, reflecting their rarity value
- The function gracefully handles edge cases: missing data, unlimited editions, and single-mint sets
- Results are rounded to the nearest integer for display
- Maintains backward compatibility by returning '—' when no valuation data is available

https://claude.ai/code/session_01N6A8az3m3B3oB6rRKo6pni