### PR TITLE
Add PostgreSQL backup/restore scripts with Google Drive integration

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,21 +1,19 @@
 #!/usr/bin/env bash
 # =============================================================================
-# backup-db.sh — PostgreSQL → S3 backup (low resource, no temp files on disk)
+# backup-db.sh — PostgreSQL → Google Drive backup (low resource, no disk writes)
 # =============================================================================
-# Pipes pg_dump directly through gzip into S3 so nothing is written locally.
-# Schedule via system cron (not PM2) so it uses zero memory when idle.
+# Pipes pg_dump directly through gzip into Google Drive via rclone rcat.
+# Nothing is written to the server's disk. Schedule via system cron (not PM2)
+# so it uses zero memory when idle.
 #
 # Required env vars (or set them in /etc/cartoon-reorbit-backup.env):
-#   DATABASE_URL          postgresql://user:pass@host:port/dbname
-#   BACKUP_S3_BUCKET      my-backups-bucket
-#   AWS_ACCESS_KEY_ID     (IAM backup user key)
-#   AWS_SECRET_ACCESS_KEY (IAM backup user secret)
-#   AWS_DEFAULT_REGION    us-east-1   (or wherever your bucket lives)
+#   DATABASE_URL           postgresql://user:pass@host:port/dbname
+#   BACKUP_DRIVE_REMOTE    gdrive          (name of your rclone remote)
+#   BACKUP_DRIVE_FOLDER    cartoon-reorbit-backups  (Google Drive folder path)
 #
 # Optional env vars:
-#   BACKUP_S3_PREFIX      backups/cartoon-reorbit  (default shown)
-#   BACKUP_RETAIN_DAYS    30                        (days of local log retention)
-#   BACKUP_LOG_FILE       /var/log/cartoon-reorbit-backup.log
+#   BACKUP_LOG_FILE        /var/log/cartoon-reorbit-backup.log
+#   RCLONE_CONFIG          /root/.config/rclone/rclone.conf  (default location)
 # =============================================================================
 
 set -euo pipefail
@@ -33,21 +31,16 @@ fi
 # Validate required variables
 # ---------------------------------------------------------------------------
 : "${DATABASE_URL:?DATABASE_URL is not set}"
-: "${BACKUP_S3_BUCKET:?BACKUP_S3_BUCKET is not set}"
-: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is not set}"
-: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is not set}"
-: "${AWS_DEFAULT_REGION:?AWS_DEFAULT_REGION is not set}"
+: "${BACKUP_DRIVE_REMOTE:?BACKUP_DRIVE_REMOTE is not set (e.g. gdrive)}"
+: "${BACKUP_DRIVE_FOLDER:?BACKUP_DRIVE_FOLDER is not set (e.g. cartoon-reorbit-backups)}"
 
 # ---------------------------------------------------------------------------
 # Config with sensible defaults
 # ---------------------------------------------------------------------------
-S3_PREFIX="${BACKUP_S3_PREFIX:-backups/cartoon-reorbit}"
 LOG_FILE="${BACKUP_LOG_FILE:-/var/log/cartoon-reorbit-backup.log}"
-RETAIN_DAYS="${BACKUP_RETAIN_DAYS:-30}"
-
 TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
-S3_KEY="${S3_PREFIX}/db-${TIMESTAMP}.sql.gz"
-S3_URI="s3://${BACKUP_S3_BUCKET}/${S3_KEY}"
+DEST_FILE="db-${TIMESTAMP}.sql.gz"
+DEST_PATH="${BACKUP_DRIVE_REMOTE}:${BACKUP_DRIVE_FOLDER}/${DEST_FILE}"
 
 # ---------------------------------------------------------------------------
 # Logging helper
@@ -57,16 +50,13 @@ log() {
 }
 
 log "=== Backup started ==="
-log "Target: ${S3_URI}"
+log "Target: ${DEST_PATH}"
 
 # ---------------------------------------------------------------------------
 # Parse DATABASE_URL → pg_dump friendly args
 # e.g. postgresql://orbit_user:pass@localhost:5432/orbitdb
 # ---------------------------------------------------------------------------
-DB_URL="${DATABASE_URL}"
-DB_PROTO="$(echo "$DB_URL" | grep -oP '^[^:]+(?=://)')"
-DB_URL_NOSCHEME="${DB_URL#*://}"
-
+DB_URL_NOSCHEME="${DATABASE_URL#*://}"
 DB_USER="$(echo "$DB_URL_NOSCHEME" | grep -oP '^[^:@]+(?=[:@])')"
 DB_PASS="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=:)[^@]+(?=@)' || echo '')"
 DB_HOST_PORT="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=@)[^/]+')"
@@ -78,6 +68,7 @@ log "Database: ${DB_HOST}:${DB_PORT}/${DB_NAME} (user: ${DB_USER})"
 
 # ---------------------------------------------------------------------------
 # Dump → compress → upload in a single pipe (no disk write)
+# rclone rcat reads from stdin and streams directly to Google Drive
 # ---------------------------------------------------------------------------
 PGPASSWORD="$DB_PASS" pg_dump \
   --host="$DB_HOST" \
@@ -89,11 +80,11 @@ PGPASSWORD="$DB_PASS" pg_dump \
   --no-owner \
   --no-acl \
   | gzip --best \
-  | aws s3 cp - "$S3_URI" \
-      --storage-class STANDARD_IA \
-      --no-progress
+  | rclone rcat "${DEST_PATH}" \
+      --drive-chunk-size 32M \
+      --no-check-certificate
 
-log "Upload complete: ${S3_URI}"
+log "Upload complete: ${DEST_PATH}"
 
 # ---------------------------------------------------------------------------
 # Trim old log file so it doesn't grow forever (keep last ~1000 lines)

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# =============================================================================
+# backup-db.sh — PostgreSQL → S3 backup (low resource, no temp files on disk)
+# =============================================================================
+# Pipes pg_dump directly through gzip into S3 so nothing is written locally.
+# Schedule via system cron (not PM2) so it uses zero memory when idle.
+#
+# Required env vars (or set them in /etc/cartoon-reorbit-backup.env):
+#   DATABASE_URL          postgresql://user:pass@host:port/dbname
+#   BACKUP_S3_BUCKET      my-backups-bucket
+#   AWS_ACCESS_KEY_ID     (IAM backup user key)
+#   AWS_SECRET_ACCESS_KEY (IAM backup user secret)
+#   AWS_DEFAULT_REGION    us-east-1   (or wherever your bucket lives)
+#
+# Optional env vars:
+#   BACKUP_S3_PREFIX      backups/cartoon-reorbit  (default shown)
+#   BACKUP_RETAIN_DAYS    30                        (days of local log retention)
+#   BACKUP_LOG_FILE       /var/log/cartoon-reorbit-backup.log
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Load a secrets file if present (keeps creds out of the crontab line)
+# ---------------------------------------------------------------------------
+SECRETS_FILE="${SECRETS_FILE:-/etc/cartoon-reorbit-backup.env}"
+if [[ -f "$SECRETS_FILE" ]]; then
+  # shellcheck disable=SC1090
+  set -a; source "$SECRETS_FILE"; set +a
+fi
+
+# ---------------------------------------------------------------------------
+# Validate required variables
+# ---------------------------------------------------------------------------
+: "${DATABASE_URL:?DATABASE_URL is not set}"
+: "${BACKUP_S3_BUCKET:?BACKUP_S3_BUCKET is not set}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is not set}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is not set}"
+: "${AWS_DEFAULT_REGION:?AWS_DEFAULT_REGION is not set}"
+
+# ---------------------------------------------------------------------------
+# Config with sensible defaults
+# ---------------------------------------------------------------------------
+S3_PREFIX="${BACKUP_S3_PREFIX:-backups/cartoon-reorbit}"
+LOG_FILE="${BACKUP_LOG_FILE:-/var/log/cartoon-reorbit-backup.log}"
+RETAIN_DAYS="${BACKUP_RETAIN_DAYS:-30}"
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+S3_KEY="${S3_PREFIX}/db-${TIMESTAMP}.sql.gz"
+S3_URI="s3://${BACKUP_S3_BUCKET}/${S3_KEY}"
+
+# ---------------------------------------------------------------------------
+# Logging helper
+# ---------------------------------------------------------------------------
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$LOG_FILE"
+}
+
+log "=== Backup started ==="
+log "Target: ${S3_URI}"
+
+# ---------------------------------------------------------------------------
+# Parse DATABASE_URL → pg_dump friendly args
+# e.g. postgresql://orbit_user:pass@localhost:5432/orbitdb
+# ---------------------------------------------------------------------------
+DB_URL="${DATABASE_URL}"
+DB_PROTO="$(echo "$DB_URL" | grep -oP '^[^:]+(?=://)')"
+DB_URL_NOSCHEME="${DB_URL#*://}"
+
+DB_USER="$(echo "$DB_URL_NOSCHEME" | grep -oP '^[^:@]+(?=[:@])')"
+DB_PASS="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=:)[^@]+(?=@)' || echo '')"
+DB_HOST_PORT="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=@)[^/]+')"
+DB_HOST="$(echo "$DB_HOST_PORT" | cut -d: -f1)"
+DB_PORT="$(echo "$DB_HOST_PORT" | grep -oP '(?<=:)\d+' || echo '5432')"
+DB_NAME="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=/)[^?]+')"
+
+log "Database: ${DB_HOST}:${DB_PORT}/${DB_NAME} (user: ${DB_USER})"
+
+# ---------------------------------------------------------------------------
+# Dump → compress → upload in a single pipe (no disk write)
+# ---------------------------------------------------------------------------
+PGPASSWORD="$DB_PASS" pg_dump \
+  --host="$DB_HOST" \
+  --port="$DB_PORT" \
+  --username="$DB_USER" \
+  --dbname="$DB_NAME" \
+  --no-password \
+  --format=plain \
+  --no-owner \
+  --no-acl \
+  | gzip --best \
+  | aws s3 cp - "$S3_URI" \
+      --storage-class STANDARD_IA \
+      --no-progress
+
+log "Upload complete: ${S3_URI}"
+
+# ---------------------------------------------------------------------------
+# Trim old log file so it doesn't grow forever (keep last ~1000 lines)
+# ---------------------------------------------------------------------------
+if [[ -f "$LOG_FILE" ]]; then
+  tail -n 1000 "$LOG_FILE" > "${LOG_FILE}.tmp" && mv "${LOG_FILE}.tmp" "$LOG_FILE"
+fi
+
+log "=== Backup finished ==="

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# =============================================================================
+# restore-db.sh — Restore a PostgreSQL backup from S3
+# =============================================================================
+# Usage:
+#   ./scripts/restore-db.sh                        # list available backups
+#   ./scripts/restore-db.sh <s3-key-or-timestamp>  # restore a specific backup
+#
+# The script will prompt for confirmation before dropping/recreating the DB.
+# =============================================================================
+
+set -euo pipefail
+
+SECRETS_FILE="${SECRETS_FILE:-/etc/cartoon-reorbit-backup.env}"
+if [[ -f "$SECRETS_FILE" ]]; then
+  set -a; source "$SECRETS_FILE"; set +a
+fi
+
+: "${DATABASE_URL:?DATABASE_URL is not set}"
+: "${BACKUP_S3_BUCKET:?BACKUP_S3_BUCKET is not set}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is not set}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is not set}"
+: "${AWS_DEFAULT_REGION:?AWS_DEFAULT_REGION is not set}"
+
+S3_PREFIX="${BACKUP_S3_PREFIX:-backups/cartoon-reorbit}"
+
+# Parse DATABASE_URL
+DB_URL_NOSCHEME="${DATABASE_URL#*://}"
+DB_USER="$(echo "$DB_URL_NOSCHEME" | grep -oP '^[^:@]+(?=[:@])')"
+DB_PASS="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=:)[^@]+(?=@)' || echo '')"
+DB_HOST_PORT="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=@)[^/]+')"
+DB_HOST="$(echo "$DB_HOST_PORT" | cut -d: -f1)"
+DB_PORT="$(echo "$DB_HOST_PORT" | grep -oP '(?<=:)\d+' || echo '5432')"
+DB_NAME="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=/)[^?]+')"
+
+# ---------------------------------------------------------------------------
+# List mode: no argument provided
+# ---------------------------------------------------------------------------
+if [[ $# -eq 0 ]]; then
+  echo "Available backups in s3://${BACKUP_S3_BUCKET}/${S3_PREFIX}/"
+  echo ""
+  aws s3 ls "s3://${BACKUP_S3_BUCKET}/${S3_PREFIX}/" \
+    | sort -r \
+    | head -20 \
+    | awk '{print NR". "$NF}'
+  echo ""
+  echo "Usage: $0 <filename-from-list-above>"
+  echo "  e.g. $0 db-2025-05-25T02-00-00Z.sql.gz"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Restore mode
+# ---------------------------------------------------------------------------
+TARGET="$1"
+
+# Allow passing just the timestamp portion or the full filename
+if [[ "$TARGET" != *".sql.gz" ]]; then
+  TARGET="db-${TARGET}.sql.gz"
+fi
+S3_KEY="${S3_PREFIX}/${TARGET}"
+S3_URI="s3://${BACKUP_S3_BUCKET}/${S3_KEY}"
+
+echo ""
+echo "⚠️  WARNING: This will DROP and RECREATE the database '${DB_NAME}' on ${DB_HOST}."
+echo "Source: ${S3_URI}"
+echo ""
+read -r -p "Type the database name to confirm: " CONFIRM
+if [[ "$CONFIRM" != "$DB_NAME" ]]; then
+  echo "Aborted — name did not match."
+  exit 1
+fi
+
+echo "Downloading and restoring..."
+PGPASSWORD="$DB_PASS" aws s3 cp "$S3_URI" - \
+  | gunzip \
+  | PGPASSWORD="$DB_PASS" psql \
+      --host="$DB_HOST" \
+      --port="$DB_PORT" \
+      --username="$DB_USER" \
+      --dbname="$DB_NAME" \
+      --no-password
+
+echo ""
+echo "✅ Restore complete from ${S3_URI}"

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,28 +1,25 @@
 #!/usr/bin/env bash
 # =============================================================================
-# restore-db.sh — Restore a PostgreSQL backup from S3
+# restore-db.sh — Restore a PostgreSQL backup from Google Drive
 # =============================================================================
 # Usage:
 #   ./scripts/restore-db.sh                        # list available backups
-#   ./scripts/restore-db.sh <s3-key-or-timestamp>  # restore a specific backup
+#   ./scripts/restore-db.sh <filename-or-timestamp> # restore a specific backup
 #
-# The script will prompt for confirmation before dropping/recreating the DB.
+# The script will prompt for confirmation before touching the database.
 # =============================================================================
 
 set -euo pipefail
 
 SECRETS_FILE="${SECRETS_FILE:-/etc/cartoon-reorbit-backup.env}"
 if [[ -f "$SECRETS_FILE" ]]; then
+  # shellcheck disable=SC1090
   set -a; source "$SECRETS_FILE"; set +a
 fi
 
 : "${DATABASE_URL:?DATABASE_URL is not set}"
-: "${BACKUP_S3_BUCKET:?BACKUP_S3_BUCKET is not set}"
-: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is not set}"
-: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is not set}"
-: "${AWS_DEFAULT_REGION:?AWS_DEFAULT_REGION is not set}"
-
-S3_PREFIX="${BACKUP_S3_PREFIX:-backups/cartoon-reorbit}"
+: "${BACKUP_DRIVE_REMOTE:?BACKUP_DRIVE_REMOTE is not set (e.g. gdrive)}"
+: "${BACKUP_DRIVE_FOLDER:?BACKUP_DRIVE_FOLDER is not set (e.g. cartoon-reorbit-backups)}"
 
 # Parse DATABASE_URL
 DB_URL_NOSCHEME="${DATABASE_URL#*://}"
@@ -33,13 +30,15 @@ DB_HOST="$(echo "$DB_HOST_PORT" | cut -d: -f1)"
 DB_PORT="$(echo "$DB_HOST_PORT" | grep -oP '(?<=:)\d+' || echo '5432')"
 DB_NAME="$(echo "$DB_URL_NOSCHEME" | grep -oP '(?<=/)[^?]+')"
 
+REMOTE_PATH="${BACKUP_DRIVE_REMOTE}:${BACKUP_DRIVE_FOLDER}"
+
 # ---------------------------------------------------------------------------
 # List mode: no argument provided
 # ---------------------------------------------------------------------------
 if [[ $# -eq 0 ]]; then
-  echo "Available backups in s3://${BACKUP_S3_BUCKET}/${S3_PREFIX}/"
+  echo "Available backups in ${REMOTE_PATH}/"
   echo ""
-  aws s3 ls "s3://${BACKUP_S3_BUCKET}/${S3_PREFIX}/" \
+  rclone ls "${REMOTE_PATH}/" \
     | sort -r \
     | head -20 \
     | awk '{print NR". "$NF}'
@@ -58,12 +57,11 @@ TARGET="$1"
 if [[ "$TARGET" != *".sql.gz" ]]; then
   TARGET="db-${TARGET}.sql.gz"
 fi
-S3_KEY="${S3_PREFIX}/${TARGET}"
-S3_URI="s3://${BACKUP_S3_BUCKET}/${S3_KEY}"
+SOURCE="${REMOTE_PATH}/${TARGET}"
 
 echo ""
-echo "⚠️  WARNING: This will DROP and RECREATE the database '${DB_NAME}' on ${DB_HOST}."
-echo "Source: ${S3_URI}"
+echo "⚠️  WARNING: This will overwrite the database '${DB_NAME}' on ${DB_HOST}."
+echo "Source: ${SOURCE}"
 echo ""
 read -r -p "Type the database name to confirm: " CONFIRM
 if [[ "$CONFIRM" != "$DB_NAME" ]]; then
@@ -72,7 +70,7 @@ if [[ "$CONFIRM" != "$DB_NAME" ]]; then
 fi
 
 echo "Downloading and restoring..."
-PGPASSWORD="$DB_PASS" aws s3 cp "$S3_URI" - \
+rclone cat "${SOURCE}" \
   | gunzip \
   | PGPASSWORD="$DB_PASS" psql \
       --host="$DB_HOST" \
@@ -82,4 +80,4 @@ PGPASSWORD="$DB_PASS" aws s3 cp "$S3_URI" - \
       --no-password
 
 echo ""
-echo "✅ Restore complete from ${S3_URI}"
+echo "✅ Restore complete from ${SOURCE}"

--- a/scripts/setup-backup.md
+++ b/scripts/setup-backup.md
@@ -1,0 +1,224 @@
+# Database Backup Setup — PostgreSQL → AWS S3
+
+Lightweight, low-resource setup: one bash script, one system cron job.  
+Zero extra Node.js processes. Zero disk usage (pipes directly to S3).
+
+---
+
+## How it works
+
+```
+pg_dump → gzip → aws s3 cp stdin → s3://your-bucket/backups/cartoon-reorbit/db-<timestamp>.sql.gz
+```
+
+The dump is piped in one shot — nothing is written to the server's disk.  
+S3 Lifecycle rules automatically delete backups older than N days.
+
+---
+
+## 1. Create an AWS IAM user (write-only, least privilege)
+
+In the AWS Console → IAM → Users → Create user: `cartoon-reorbit-backup`
+
+Attach an **inline policy** (not a managed policy — keeps it minimal):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BackupUpload",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::YOUR-BUCKET-NAME",
+        "arn:aws:s3:::YOUR-BUCKET-NAME/backups/cartoon-reorbit/*"
+      ]
+    }
+  ]
+}
+```
+
+> `GetObject` and `ListBucket` are only needed for the restore script.  
+> If you want write-only, remove them — restores will need a different user.
+
+Generate an **Access Key** for this user and save the key + secret.
+
+---
+
+## 2. Create the S3 bucket
+
+```bash
+aws s3 mb s3://YOUR-BUCKET-NAME --region us-east-1
+```
+
+**Block all public access** (enabled by default on new buckets — leave it on).
+
+**Enable versioning** (optional but recommended — S3 versioning protects against accidental overwrites):
+```bash
+aws s3api put-bucket-versioning \
+  --bucket YOUR-BUCKET-NAME \
+  --versioning-configuration Status=Enabled
+```
+
+**Set a Lifecycle rule** to auto-delete old backups (saves cost):
+
+In AWS Console → S3 → Your bucket → Management → Lifecycle rules → Create rule:
+- Rule name: `expire-old-backups`
+- Prefix: `backups/cartoon-reorbit/`
+- Expiration: **30 days** (adjust to taste)
+
+Or via CLI:
+```bash
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket YOUR-BUCKET-NAME \
+  --lifecycle-configuration '{
+    "Rules": [{
+      "ID": "expire-old-backups",
+      "Filter": {"Prefix": "backups/cartoon-reorbit/"},
+      "Status": "Enabled",
+      "Expiration": {"Days": 30}
+    }]
+  }'
+```
+
+---
+
+## 3. Install AWS CLI on the server
+
+```bash
+# Check if already installed
+aws --version
+
+# If not, install (Ubuntu/Debian)
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip /tmp/awscliv2.zip -d /tmp/
+sudo /tmp/aws/install
+aws --version
+```
+
+---
+
+## 4. Create the secrets file on the server
+
+Store credentials in a root-only file — **not** in the .env that the app reads:
+
+```bash
+sudo nano /etc/cartoon-reorbit-backup.env
+```
+
+Paste:
+```bash
+DATABASE_URL=postgresql://orbit_user:YOUR_PASSWORD@localhost:5432/orbitdb
+BACKUP_S3_BUCKET=YOUR-BUCKET-NAME
+AWS_ACCESS_KEY_ID=AKIAxxxxxxxxxxxxxxxxx
+AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+AWS_DEFAULT_REGION=us-east-1
+
+# Optional overrides:
+# BACKUP_S3_PREFIX=backups/cartoon-reorbit
+# BACKUP_RETAIN_DAYS=30
+# BACKUP_LOG_FILE=/var/log/cartoon-reorbit-backup.log
+```
+
+Lock it down:
+```bash
+sudo chmod 600 /etc/cartoon-reorbit-backup.env
+sudo chown root:root /etc/cartoon-reorbit-backup.env
+```
+
+---
+
+## 5. Deploy the scripts to the server
+
+The scripts live in `scripts/` in this repo and deploy automatically with each deploy.  
+After deploy, make them executable on the server:
+
+```bash
+chmod +x /var/www/cartoon-reorbit/scripts/backup-db.sh
+chmod +x /var/www/cartoon-reorbit/scripts/restore-db.sh
+```
+
+---
+
+## 6. Test it manually first
+
+```bash
+sudo /var/www/cartoon-reorbit/scripts/backup-db.sh
+```
+
+Check S3 to confirm the file appeared:
+```bash
+aws s3 ls s3://YOUR-BUCKET-NAME/backups/cartoon-reorbit/ \
+  --profile default  # or remove --profile if using env vars
+```
+
+---
+
+## 7. Schedule with cron
+
+Edit root's crontab (runs as root so it can read `/etc/cartoon-reorbit-backup.env`):
+
+```bash
+sudo crontab -e
+```
+
+Add one line — this runs at **2:00 AM UTC** every day:
+
+```cron
+0 2 * * * /var/www/cartoon-reorbit/scripts/backup-db.sh >> /var/log/cartoon-reorbit-backup.log 2>&1
+```
+
+The script itself also appends to that log file with timestamps.  
+Check the log anytime with:
+```bash
+tail -f /var/log/cartoon-reorbit-backup.log
+```
+
+---
+
+## 8. Restore from a backup
+
+List available backups:
+```bash
+/var/www/cartoon-reorbit/scripts/restore-db.sh
+```
+
+Restore a specific one:
+```bash
+/var/www/cartoon-reorbit/scripts/restore-db.sh db-2025-05-25T02-00-00Z.sql.gz
+```
+
+The restore script will ask you to type the database name before doing anything destructive.
+
+---
+
+## Resource usage summary
+
+| Resource | Impact |
+|----------|--------|
+| CPU | Low — `pg_dump` is gentle; runs 2 AM when traffic is lowest |
+| RAM | Negligible — bash + pipe, no Node process |
+| Disk | Zero — piped directly to S3 |
+| Network | One outbound upload per day (~varies by DB size) |
+| Cost (S3) | ~$0.023/GB/month (STANDARD_IA class) + tiny PUT cost |
+
+---
+
+## Troubleshooting
+
+**`pg_dump: error: connection to server failed`**  
+→ Check `DATABASE_URL` in `/etc/cartoon-reorbit-backup.env` — password or host may be wrong.
+
+**`aws: command not found`**  
+→ AWS CLI not installed — see step 3. Or use full path: `/usr/local/bin/aws`
+
+**`An error occurred (AccessDenied)`**  
+→ IAM policy is missing the `s3:PutObject` permission on the bucket/prefix.
+
+**Cron job not running**  
+→ Check `/var/log/syslog` for cron entries: `grep CRON /var/log/syslog`

--- a/scripts/setup-backup.md
+++ b/scripts/setup-backup.md
@@ -1,111 +1,108 @@
-# Database Backup Setup — PostgreSQL → AWS S3
+# Database Backup Setup — PostgreSQL → Google Drive
 
 Lightweight, low-resource setup: one bash script, one system cron job.  
-Zero extra Node.js processes. Zero disk usage (pipes directly to S3).
+Zero extra Node.js processes. Zero disk usage (pipes directly to Google Drive via rclone).
 
 ---
 
 ## How it works
 
 ```
-pg_dump → gzip → aws s3 cp stdin → s3://your-bucket/backups/cartoon-reorbit/db-<timestamp>.sql.gz
+pg_dump → gzip → rclone rcat → Google Drive folder
 ```
 
-The dump is piped in one shot — nothing is written to the server's disk.  
-S3 Lifecycle rules automatically delete backups older than N days.
+`rclone rcat` reads from stdin and streams directly to Google Drive — nothing  
+is written to the server's disk. The backup folder in Drive shows up in your  
+normal Google Drive just like any other file.
 
 ---
 
-## 1. Create an AWS IAM user (write-only, least privilege)
+## 1. Create a Google Service Account (best for servers — no browser needed)
 
-In the AWS Console → IAM → Users → Create user: `cartoon-reorbit-backup`
+A **Service Account** authenticates automatically without OAuth popups.
 
-Attach an **inline policy** (not a managed policy — keeps it minimal):
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "BackupUpload",
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject",
-        "s3:GetObject",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::YOUR-BUCKET-NAME",
-        "arn:aws:s3:::YOUR-BUCKET-NAME/backups/cartoon-reorbit/*"
-      ]
-    }
-  ]
-}
-```
-
-> `GetObject` and `ListBucket` are only needed for the restore script.  
-> If you want write-only, remove them — restores will need a different user.
-
-Generate an **Access Key** for this user and save the key + secret.
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project (or use an existing one), e.g. `cartoon-reorbit`
+3. Enable the **Google Drive API**:  
+   APIs & Services → Enable APIs → search "Google Drive API" → Enable
+4. Create a Service Account:  
+   APIs & Services → Credentials → Create Credentials → Service Account  
+   - Name: `cartoon-reorbit-backup`
+   - Role: leave blank (Drive access is granted via folder sharing, not IAM)
+5. Open the service account → Keys tab → Add Key → JSON  
+   Download the JSON key file — you'll copy its contents to the server.
 
 ---
 
-## 2. Create the S3 bucket
+## 2. Create a Google Drive backup folder and share it
+
+1. In your personal Google Drive, create a folder called `cartoon-reorbit-backups`
+2. Right-click the folder → Share
+3. Paste the **service account email** (looks like `cartoon-reorbit-backup@your-project.iam.gserviceaccount.com`)
+4. Set role to **Editor** → Share
+
+The service account can now write to that folder. Files still show up in your  
+personal Drive under that folder — you can see and download them normally.
+
+---
+
+## 3. Install rclone on the server
 
 ```bash
-aws s3 mb s3://YOUR-BUCKET-NAME --region us-east-1
-```
+# Quick install (downloads a single static binary — no dependencies)
+curl https://rclone.org/install.sh | sudo bash
 
-**Block all public access** (enabled by default on new buckets — leave it on).
-
-**Enable versioning** (optional but recommended — S3 versioning protects against accidental overwrites):
-```bash
-aws s3api put-bucket-versioning \
-  --bucket YOUR-BUCKET-NAME \
-  --versioning-configuration Status=Enabled
-```
-
-**Set a Lifecycle rule** to auto-delete old backups (saves cost):
-
-In AWS Console → S3 → Your bucket → Management → Lifecycle rules → Create rule:
-- Rule name: `expire-old-backups`
-- Prefix: `backups/cartoon-reorbit/`
-- Expiration: **30 days** (adjust to taste)
-
-Or via CLI:
-```bash
-aws s3api put-bucket-lifecycle-configuration \
-  --bucket YOUR-BUCKET-NAME \
-  --lifecycle-configuration '{
-    "Rules": [{
-      "ID": "expire-old-backups",
-      "Filter": {"Prefix": "backups/cartoon-reorbit/"},
-      "Status": "Enabled",
-      "Expiration": {"Days": 30}
-    }]
-  }'
+# Verify
+rclone --version
 ```
 
 ---
 
-## 3. Install AWS CLI on the server
+## 4. Configure rclone with the Service Account
+
+Copy the JSON key file to the server (scp or paste its contents):
 
 ```bash
-# Check if already installed
-aws --version
+# Create a directory for the key
+sudo mkdir -p /etc/rclone
+sudo nano /etc/rclone/gdrive-service-account.json
+# Paste the full contents of the downloaded JSON key file, save and exit
 
-# If not, install (Ubuntu/Debian)
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-unzip /tmp/awscliv2.zip -d /tmp/
-sudo /tmp/aws/install
-aws --version
+sudo chmod 600 /etc/rclone/gdrive-service-account.json
+```
+
+Configure rclone (this writes to `/root/.config/rclone/rclone.conf`):
+
+```bash
+sudo rclone config
+```
+
+Walk through the prompts:
+```
+n) New remote
+name> gdrive
+Storage> drive                         # Google Drive
+client_id>                             # leave blank
+client_secret>                         # leave blank
+scope> drive                           # full access
+root_folder_id>                        # leave blank
+service_account_file> /etc/rclone/gdrive-service-account.json
+Edit advanced config? n
+Use web browser to authenticate? n     # IMPORTANT: say no for service account
+```
+
+Test it:
+```bash
+# Should list your Google Drive root
+sudo rclone ls gdrive:
+
+# Should show the backup folder you shared
+sudo rclone ls gdrive:cartoon-reorbit-backups
 ```
 
 ---
 
-## 4. Create the secrets file on the server
-
-Store credentials in a root-only file — **not** in the .env that the app reads:
+## 5. Create the secrets file on the server
 
 ```bash
 sudo nano /etc/cartoon-reorbit-backup.env
@@ -114,15 +111,8 @@ sudo nano /etc/cartoon-reorbit-backup.env
 Paste:
 ```bash
 DATABASE_URL=postgresql://orbit_user:YOUR_PASSWORD@localhost:5432/orbitdb
-BACKUP_S3_BUCKET=YOUR-BUCKET-NAME
-AWS_ACCESS_KEY_ID=AKIAxxxxxxxxxxxxxxxxx
-AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-AWS_DEFAULT_REGION=us-east-1
-
-# Optional overrides:
-# BACKUP_S3_PREFIX=backups/cartoon-reorbit
-# BACKUP_RETAIN_DAYS=30
-# BACKUP_LOG_FILE=/var/log/cartoon-reorbit-backup.log
+BACKUP_DRIVE_REMOTE=gdrive
+BACKUP_DRIVE_FOLDER=cartoon-reorbit-backups
 ```
 
 Lock it down:
@@ -133,9 +123,9 @@ sudo chown root:root /etc/cartoon-reorbit-backup.env
 
 ---
 
-## 5. Deploy the scripts to the server
+## 6. Deploy the scripts to the server
 
-The scripts live in `scripts/` in this repo and deploy automatically with each deploy.  
+The scripts are in `scripts/` in the repo and deploy automatically with each deploy.  
 After deploy, make them executable on the server:
 
 ```bash
@@ -145,21 +135,18 @@ chmod +x /var/www/cartoon-reorbit/scripts/restore-db.sh
 
 ---
 
-## 6. Test it manually first
+## 7. Test it manually first
 
 ```bash
 sudo /var/www/cartoon-reorbit/scripts/backup-db.sh
 ```
 
-Check S3 to confirm the file appeared:
-```bash
-aws s3 ls s3://YOUR-BUCKET-NAME/backups/cartoon-reorbit/ \
-  --profile default  # or remove --profile if using env vars
-```
+Then check your Google Drive — you should see a file like  
+`db-2025-05-25T02-00-00Z.sql.gz` in the `cartoon-reorbit-backups` folder.
 
 ---
 
-## 7. Schedule with cron
+## 8. Schedule with cron
 
 Edit root's crontab (runs as root so it can read `/etc/cartoon-reorbit-backup.env`):
 
@@ -173,27 +160,43 @@ Add one line — this runs at **2:00 AM UTC** every day:
 0 2 * * * /var/www/cartoon-reorbit/scripts/backup-db.sh >> /var/log/cartoon-reorbit-backup.log 2>&1
 ```
 
-The script itself also appends to that log file with timestamps.  
-Check the log anytime with:
+Check the log anytime:
 ```bash
 tail -f /var/log/cartoon-reorbit-backup.log
 ```
 
 ---
 
-## 8. Restore from a backup
+## 9. Auto-delete old backups (keep Drive tidy)
+
+rclone has a built-in delete-before-age command. Add a second cron line to  
+delete backups older than 30 days right after the upload:
+
+```cron
+0 2 * * * /var/www/cartoon-reorbit/scripts/backup-db.sh >> /var/log/cartoon-reorbit-backup.log 2>&1
+5 2 * * * rclone delete gdrive:cartoon-reorbit-backups --min-age 30d >> /var/log/cartoon-reorbit-backup.log 2>&1
+```
+
+Or set Google Drive's own "trash items older than N days" setting in  
+Drive Settings → General → Manage storage.
+
+---
+
+## 10. Restore from a backup
 
 List available backups:
 ```bash
-/var/www/cartoon-reorbit/scripts/restore-db.sh
+sudo /var/www/cartoon-reorbit/scripts/restore-db.sh
 ```
 
 Restore a specific one:
 ```bash
-/var/www/cartoon-reorbit/scripts/restore-db.sh db-2025-05-25T02-00-00Z.sql.gz
+sudo /var/www/cartoon-reorbit/scripts/restore-db.sh db-2025-05-25T02-00-00Z.sql.gz
 ```
 
-The restore script will ask you to type the database name before doing anything destructive.
+The restore script downloads the file by streaming it from Drive — again, no  
+temp files on disk — and will ask you to type the database name before  
+doing anything destructive.
 
 ---
 
@@ -201,24 +204,33 @@ The restore script will ask you to type the database name before doing anything 
 
 | Resource | Impact |
 |----------|--------|
-| CPU | Low — `pg_dump` is gentle; runs 2 AM when traffic is lowest |
-| RAM | Negligible — bash + pipe, no Node process |
-| Disk | Zero — piped directly to S3 |
+| CPU | Low — `pg_dump` is gentle; runs at 2 AM when traffic is lowest |
+| RAM | Negligible — bash + pipe, rclone uses ~10 MB while running |
+| Disk | Zero — piped directly to Google Drive |
 | Network | One outbound upload per day (~varies by DB size) |
-| Cost (S3) | ~$0.023/GB/month (STANDARD_IA class) + tiny PUT cost |
+| Cost | Free — Google Drive 15 GB free; Google Workspace if you need more |
 
 ---
 
 ## Troubleshooting
 
 **`pg_dump: error: connection to server failed`**  
-→ Check `DATABASE_URL` in `/etc/cartoon-reorbit-backup.env` — password or host may be wrong.
+→ Check `DATABASE_URL` in `/etc/cartoon-reorbit-backup.env`.
 
-**`aws: command not found`**  
-→ AWS CLI not installed — see step 3. Or use full path: `/usr/local/bin/aws`
+**`rclone: command not found`**  
+→ rclone not installed. Run the install script in step 3. Or use full path: `/usr/bin/rclone`.
 
-**`An error occurred (AccessDenied)`**  
-→ IAM policy is missing the `s3:PutObject` permission on the bucket/prefix.
+**`Error: directory not found`**  
+→ The Google Drive folder name in `BACKUP_DRIVE_FOLDER` doesn't match exactly, or  
+the service account hasn't been shared on it yet (step 2).
+
+**`Failed to copy: googleapi: Error 403: The caller does not have permission`**  
+→ The service account email wasn't given Editor access on the Drive folder. Re-check step 2.
 
 **Cron job not running**  
-→ Check `/var/log/syslog` for cron entries: `grep CRON /var/log/syslog`
+→ Check syslog for cron entries: `grep CRON /var/log/syslog`  
+→ Make sure the script is executable: `chmod +x /var/www/cartoon-reorbit/scripts/backup-db.sh`
+
+**Service account config during `rclone config`**  
+→ If you accidentally chose browser auth, just run `sudo rclone config` again,  
+delete the remote, and recreate it. The config file is at `/root/.config/rclone/rclone.conf`.


### PR DESCRIPTION
## Summary
Add a lightweight, zero-disk-usage backup system for PostgreSQL that streams directly to Google Drive via rclone. Includes setup documentation, automated backup script, and restore utility.

## Changes
- **scripts/setup-backup.md** — Comprehensive setup guide covering:
  - Google Service Account creation for headless authentication
  - rclone installation and configuration
  - Secrets file setup
  - Manual testing and cron scheduling
  - Troubleshooting guide

- **scripts/backup-db.sh** — Automated backup script that:
  - Parses `DATABASE_URL` to extract connection parameters
  - Pipes `pg_dump` → `gzip` → `rclone rcat` directly to Google Drive (no temp files)
  - Logs all operations with timestamps
  - Trims log file to prevent unbounded growth
  - Designed to run via system cron (zero memory when idle, unlike PM2)

- **scripts/restore-db.sh** — Interactive restore utility that:
  - Lists available backups from Google Drive when called without arguments
  - Restores a specific backup by filename or timestamp
  - Requires explicit database name confirmation before overwriting
  - Streams from Drive through gunzip to psql (no disk writes)

## Implementation Details
- Uses bash parameter expansion to parse PostgreSQL connection strings
- Leverages `rclone rcat` for streaming uploads and `rclone cat` for streaming downloads
- Secrets stored in `/etc/cartoon-reorbit-backup.env` (mode 600) to keep credentials out of crontab
- Designed for minimal resource footprint: runs at off-peak hours, uses pipes instead of temp files, no persistent processes

https://claude.ai/code/session_012At5YyCUvfCCLi2gpNiAoN