### PR TITLE
Rename device fingerprints to browser fingerprints

### DIFF
--- a/components/newsite/AdminDeviceFingerprintLogs.vue
+++ b/components/newsite/AdminDeviceFingerprintLogs.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="admin-device-fingerprint-logs bg-gray-50">
     <div class="p-2 text-xs">
-      <h1 class="text-base font-bold mb-2">Device Fingerprint Logs</h1>
+      <h1 class="text-base font-bold mb-2">Browser Fingerprint Logs</h1>
 
       <!-- Filters -->
       <div class="mb-2 flex flex-wrap items-end gap-2">
@@ -61,7 +61,7 @@
       </div>
 
       <div v-if="loading" class="text-gray-500">Loading…</div>
-      <div v-else-if="items.length === 0" class="text-gray-500">No fingerprint logs found.</div>
+      <div v-else-if="items.length === 0" class="text-gray-500">No browser fingerprint logs found.</div>
       <div v-else>
         <!-- Desktop table -->
         <div class="hidden md:block overflow-x-auto">
@@ -112,7 +112,7 @@
                     <td class="px-1.5 py-1">
                       <button
                         class="px-2 py-0.5 text-[11px] border rounded hover:bg-gray-100"
-                        title="Filter to all rows sharing this fingerprint"
+                        title="Filter to all rows sharing this browser fingerprint"
                         @click="filterByVisitor(row.visitorId)"
                       >Match</button>
                     </td>

--- a/components/newsite/AdminNav.vue
+++ b/components/newsite/AdminNav.vue
@@ -64,7 +64,7 @@ const menus = [
     label: 'Admin Logs',
     items: [
       { id: 'cheatFinder',        label: 'Cheat Finder',       to: '/newsite/admin/cheatFinder' },
-      { id: 'deviceFingerprints', label: 'Device Fingerprints', to: '/newsite/admin/deviceFingerprints' },
+      { id: 'deviceFingerprints', label: 'Browser Fingerprints', to: '/newsite/admin/deviceFingerprints' },
       { id: 'authLogs',           label: 'Auth Logs',          to: '/newsite/admin/authLogs' },
       { id: 'tradeLogs',          label: 'Trade Logs',         to: '/newsite/admin/tradeLogs' },
       { id: 'auctionLogs',        label: 'Auction Logs',       to: '/newsite/admin/auctionLogs' },


### PR DESCRIPTION
## Summary
Updated terminology throughout the admin interface to use "Browser Fingerprints" instead of "Device Fingerprints" for improved clarity and accuracy.

## Key Changes
- Updated the main heading in `AdminDeviceFingerprintLogs.vue` from "Device Fingerprint Logs" to "Browser Fingerprint Logs"
- Updated the empty state message to "No browser fingerprint logs found."
- Updated the tooltip text for the Match button to reference "browser fingerprint" instead of just "fingerprint"
- Updated the navigation menu label in `AdminNav.vue` from "Device Fingerprints" to "Browser Fingerprints"

## Notes
- The component and route IDs remain unchanged (`deviceFingerprints`) to maintain backward compatibility
- These are purely UI/label changes with no functional modifications

https://claude.ai/code/session_01B71CHf16wnusyWZy85HsML