### PR TITLE
Add time-based purchase limits with rarity-based defaults

### DIFF
--- a/server/api/admin/global-config.get.js
+++ b/server/api/admin/global-config.get.js
@@ -6,6 +6,14 @@ import {
 } from 'h3'
 import { prisma as db } from '@/server/prisma'
 
+const DEFAULT_TIME_BASED_PURCHASE_LIMITS = {
+  'Common':     { count: 5, windowDays: null },
+  'Uncommon':   { count: 4, windowDays: null },
+  'Rare':       { count: 3, windowDays: null },
+  'Very Rare':  { count: 2, windowDays: null },
+  'Crazy Rare': { count: 1, windowDays: null }
+}
+
 export default defineEventHandler(async (event) => {
   // 1) Authenticate & authorize
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -24,13 +32,12 @@ export default defineEventHandler(async (event) => {
     where: { id: 'singleton' }
   })
 
-  // 3) If not found, create with a default cap (e.g. 100)
+  // 3) If not found, create with defaults
   if (!config) {
     config = await db.globalGameConfig.create({
       data: {
         id: 'singleton',
         dailyPointLimit: 250,
-        // new fields defaults
         dailyLoginPoints: 500,
         dailyNewUserPoints: 1000,
         czoneVisitPoints: 20,
@@ -40,8 +47,16 @@ export default defineEventHandler(async (event) => {
         dhashDuplicateThreshold: 16,
         featuredAuctionHours: [],
         featuredAuctionIntervalDays: 1,
-        featuredAuctionsPerSlot: 1
+        featuredAuctionsPerSlot: 1,
+        timeBasedPurchaseLimits: DEFAULT_TIME_BASED_PURCHASE_LIMITS
       }
+    })
+  } else if (!config.timeBasedPurchaseLimits) {
+    // Backfill defaults for existing singletons created before this field was added.
+    // This ensures the purchase-limit enforcement in the mint worker has data to work with.
+    config = await db.globalGameConfig.update({
+      where: { id: 'singleton' },
+      data: { timeBasedPurchaseLimits: DEFAULT_TIME_BASED_PURCHASE_LIMITS }
     })
   }
 

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -92,7 +92,16 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
     if (!isSpecial) {
       if (ctoon.mintLimitType === 'timeBased') {
         // ── Time-based release purchase limits (replaces 48h perUserLimit for this type) ──
-        // Resolve limit: per-cToon override first, then rarity defaults from global config.
+        // Resolve limit: per-cToon override first, then rarity defaults from global config,
+        // then hardcoded defaults as a final safety net.
+        const HARDCODED_TIME_BASED_LIMITS = {
+          'Common':     { count: 5, windowDays: null },
+          'Uncommon':   { count: 4, windowDays: null },
+          'Rare':       { count: 3, windowDays: null },
+          'Very Rare':  { count: 2, windowDays: null },
+          'Crazy Rare': { count: 1, windowDays: null }
+        }
+
         let limitCount    = ctoon.timeBasedLimitCount    ?? null
         let windowDays    = ctoon.timeBasedLimitWindowDays ?? null
 
@@ -106,6 +115,15 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
               if (windowDays === null && def.windowDays != null) windowDays = Number(def.windowDays)
             }
           } catch {}
+
+          // Fallback to hardcoded defaults if the global config is missing or lacks this rarity.
+          // This ensures limits are always enforced for time-based cToons even when the DB is
+          // not yet seeded with timeBasedPurchaseLimits.
+          if (limitCount === null && HARDCODED_TIME_BASED_LIMITS[ctoon.rarity]) {
+            const def = HARDCODED_TIME_BASED_LIMITS[ctoon.rarity]
+            if (def.count != null) limitCount = Number(def.count)
+            if (windowDays === null && def.windowDays != null) windowDays = Number(def.windowDays)
+          }
         }
 
         if (limitCount !== null && limitCount > 0) {


### PR DESCRIPTION
## Summary
This PR introduces a time-based purchase limit system for collectible toons (cToons) with rarity-based defaults. The system allows enforcing purchase limits per rarity tier over configurable time windows, with support for per-cToon overrides and fallback defaults.

## Key Changes
- **Global Config Defaults**: Added `DEFAULT_TIME_BASED_PURCHASE_LIMITS` constant to `global-config.get.js` defining purchase limits by rarity (Common: 5, Uncommon: 4, Rare: 3, Very Rare: 2, Crazy Rare: 1)
- **Config Initialization**: Updated global config creation to include `timeBasedPurchaseLimits` field with default values
- **Backfill Migration**: Added logic to backfill the `timeBasedPurchaseLimits` field for existing singleton configs that were created before this field was added
- **Mint Worker Enforcement**: Enhanced the mint worker to resolve purchase limits using a three-tier fallback strategy:
  1. Per-cToon override values (`timeBasedLimitCount`, `timeBasedLimitWindowDays`)
  2. Rarity-based defaults from global config
  3. Hardcoded defaults as a final safety net
- **Hardcoded Fallback**: Added `HARDCODED_TIME_BASED_LIMITS` in the mint worker to ensure limits are always enforced even if the database hasn't been seeded with the new field

## Notable Implementation Details
- The three-tier resolution strategy ensures backward compatibility and graceful degradation
- Hardcoded defaults serve as a safety net to prevent unintended unlimited purchases during database migrations
- The `windowDays: null` value indicates no time window constraint (unlimited within the count)
- Backfill logic only updates configs missing the field, preserving any existing custom configurations

https://claude.ai/code/session_01WxEbLgr7SXeoFQmumFWJuV