### PR TITLE
Add mintLimitType support for Time-Based vs Defined cToon limits

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -332,8 +332,27 @@ const nowTs = ref(Date.now())
 let _tick = null
 let _refreshTimer = null
 
+// Only Defined Number Limit cToons have a 2-phase cap guard.
+// Returns the currently-active cap: initialCap before finalReleaseAt, full
+// quantity after.  Time-Based Limit cToons simply return their raw quantity
+// (or Infinity when unlimited) so they are never artificially capped.
+function currentAllowedCap(c) {
+  if (c.quantity == null) return Infinity
+  if (c.mintLimitType !== 'defined') return Number(c.quantity)
+  const finalAt = c.finalReleaseAt ? new Date(c.finalReleaseAt).getTime() : null
+  const beforeFinal = finalAt ? nowTs.value < finalAt : false
+  const initCap = Number(c.initialCap ?? 0)
+  return beforeFinal ? (initCap || 0) : Number(c.quantity)
+}
+
 function isSoldOut(c) {
-  return c.quantity != null && c.totalMinted >= c.quantity
+  if (c.quantity == null) return false
+  if (c.mintLimitType === 'defined') {
+    // Defined Number Limit: respect the 2-phase cap guard
+    return c.totalMinted >= currentAllowedCap(c)
+  }
+  // Time-Based Limit: no phase cap — check raw quantity only
+  return c.totalMinted >= c.quantity
 }
 
 function hasCountdown(c) {

--- a/pages/cmart.vue
+++ b/pages/cmart.vue
@@ -452,10 +452,10 @@
                 <button
                   v-else
                   @click="buyCtoon(ctoon)"
-                  :disabled="(ctoon.quantity !== null && ctoon.quantity !== TIME_BASED_CAP && ctoon.minted >= currentAllowedCap(ctoon)) || buyingCtoons.has(ctoon.id)"
+                  :disabled="(ctoon.mintLimitType === 'defined' && ctoon.quantity !== null && ctoon.minted >= currentAllowedCap(ctoon)) || buyingCtoons.has(ctoon.id)"
                   class="flex-1 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded disabled:opacity-50 text-xs"
                 >
-                  <span v-if="ctoon.quantity !== null && ctoon.quantity !== TIME_BASED_CAP && ctoon.minted >= currentAllowedCap(ctoon)">Sold Out</span>
+                  <span v-if="ctoon.mintLimitType === 'defined' && ctoon.quantity !== null && ctoon.minted >= currentAllowedCap(ctoon)">Sold Out</span>
                   <span v-else-if="buyingCtoons.has(ctoon.id)">Purchasing…</span>
                   <span v-else>
                     Buy for {{ displayPrice(ctoon.price) }} Pts
@@ -858,6 +858,8 @@ function getFinalReleaseAt(ctoon) {
 }
 
 function shouldShowFinalCountdown(ctoon) {
+  // The 2-phase countdown only applies to Defined Number Limit cToons
+  if (ctoon.mintLimitType !== 'defined') return false
   if (ctoon.quantity === null) return false
   if (!ctoon.releaseDate) return false
   const finalAt = getFinalReleaseAt(ctoon)
@@ -873,6 +875,9 @@ function shouldShowFinalCountdown(ctoon) {
 
 function currentAllowedCap(ctoon) {
   if (ctoon.quantity === null) return Infinity
+  // Only apply the 2-phase timer cap guard to Defined Number Limit cToons;
+  // Time-Based Limit cToons mint freely during their window.
+  if (ctoon.mintLimitType !== 'defined') return Number(ctoon.quantity)
   const finalAt = ctoon.finalReleaseAt ? new Date(ctoon.finalReleaseAt).getTime() : null
   const beforeFinal = finalAt ? nowTs.value < finalAt : false
   const initCap = Number(ctoon.initialCap ?? 0)
@@ -1260,7 +1265,8 @@ onMounted(async () => {
       owners:      c.owners,
       characters:  c.characters,
       minted:      c.totalMinted ?? 0,
-      // staged release helpers
+      mintLimitType: c.mintLimitType ?? null,
+      // staged release helpers (Defined Number Limit only)
       initialCap:  c.initialCap ?? null,
       finalReleaseAt: c.finalReleaseAt ?? null,
       nextReleaseAt:  c.nextReleaseAt ?? null,

--- a/server/api/cmart.get.js
+++ b/server/api/cmart.get.js
@@ -45,6 +45,7 @@ export default defineEventHandler(async () => {
       cost: true,
       power: true,
       characters: true,
+      mintLimitType: true,
       // advisory fields (optional)
       initialReleaseAt: true,
       finalReleaseAt: true,
@@ -53,20 +54,32 @@ export default defineEventHandler(async () => {
     }
   })
 
-  // Compute nextReleaseAt and initialCap for UI convenience
+  // Compute nextReleaseAt and initialCap for UI convenience.
+  // The 2-phase cap guard (initialCap / finalReleaseAt) only applies to
+  // Defined Number Limit cToons.  Time-Based Limit cToons mint freely
+  // during their window and must not receive phase logic.
   return ctoons.map(c => {
     const qty = c.quantity
-    const finalAt = c.finalReleaseAt
-      ? new Date(c.finalReleaseAt)
-      : c.releaseDate
-        ? new Date(new Date(c.releaseDate).getTime() + delayHours * 60 * 60 * 1000)
-        : null
-    const initialCap = qty != null ? computeInitialCap(qty, initialPercent, c.initialReleaseQty) : null
+    const isDefinedLimit = c.mintLimitType === 'defined'
+
+    // Only compute phase fields for Defined Number Limit cToons
+    const finalAt = isDefinedLimit
+      ? (c.finalReleaseAt
+          ? new Date(c.finalReleaseAt)
+          : c.releaseDate
+            ? new Date(new Date(c.releaseDate).getTime() + delayHours * 60 * 60 * 1000)
+            : null)
+      : null
+    const initialCap = isDefinedLimit && qty != null
+      ? computeInitialCap(qty, initialPercent, c.initialReleaseQty)
+      : null
     let nextReleaseAt = null
     if (c.releaseDate && new Date(c.releaseDate) > now) {
       nextReleaseAt = c.releaseDate
     } else if (
-      qty != null && c.releaseDate && finalAt && now < finalAt && c.totalMinted >= (initialCap ?? 0) && c.totalMinted < qty
+      isDefinedLimit &&
+      qty != null && c.releaseDate && finalAt && now < finalAt &&
+      c.totalMinted >= (initialCap ?? 0) && c.totalMinted < qty
     ) {
       nextReleaseAt = finalAt.toISOString()
     }


### PR DESCRIPTION
## Summary
This PR adds support for distinguishing between two types of minting limits for cToons: "Defined Number Limit" (fixed quantity with 2-phase cap guard) and "Time-Based Limit" (freely mintable during a time window). The logic now correctly applies phase-based caps and countdowns only to Defined Number Limit cToons, while Time-Based Limit cToons bypass these restrictions.

## Key Changes

- **Backend (cmart.get.js)**:
  - Added `mintLimitType` to the Prisma query selection
  - Updated cap computation logic to only apply 2-phase guards (`initialCap` / `finalReleaseAt`) when `mintLimitType === 'defined'`
  - Time-Based Limit cToons now return `null` for phase-related fields to prevent incorrect cap logic

- **Frontend (Cmart.vue & cmart.vue)**:
  - Added `currentAllowedCap()` function that respects `mintLimitType`:
    - Defined Number Limit: applies 2-phase cap guard (initial cap before finalReleaseAt, full quantity after)
    - Time-Based Limit: returns raw quantity without phase restrictions
  - Updated `isSoldOut()` logic to check `mintLimitType` before applying phase caps
  - Updated `shouldShowFinalCountdown()` to only show countdown for Defined Number Limit cToons
  - Updated buy button disabled state to only restrict sales based on phase caps for Defined Number Limit cToons
  - Added `mintLimitType` to the cToon data mapping on mount

## Implementation Details

- Time-Based Limit cToons with `quantity == null` (unlimited) return `Infinity` as their cap
- The 2-phase cap guard (initial phase with reduced cap, final phase with full quantity) only applies to Defined Number Limit cToons
- Comments added throughout to clarify which logic applies to which limit type
- Removed dependency on `TIME_BASED_CAP` constant in favor of explicit `mintLimitType` checks

https://claude.ai/code/session_01BPbp1XuStYqfiUkwTFbCU3