### PR TITLE
Add mint number sorting to collection view

### DIFF
--- a/components/newsite/MyCollection.vue
+++ b/components/newsite/MyCollection.vue
@@ -153,6 +153,19 @@ const ctoons = computed(() => {
       const at = a.acquiredAt ? new Date(a.acquiredAt).getTime() : 0
       const bt = b.acquiredAt ? new Date(b.acquiredAt).getTime() : 0
       cmp = at - bt
+    } else if (f.sortField === 'mintNumber') {
+      // Primary: mint number (direction controlled by sortAsc)
+      const am = a.mintNumber ?? Infinity
+      const bm = b.mintNumber ?? Infinity
+      const primaryCmp = f.sortAsc ? (am - bm) : (bm - am)
+      if (primaryCmp !== 0) return primaryCmp
+      // Secondary: acquisition date descending (fixed)
+      const at = a.acquiredAt ? new Date(a.acquiredAt).getTime() : 0
+      const bt = b.acquiredAt ? new Date(b.acquiredAt).getTime() : 0
+      const secondaryCmp = bt - at
+      if (secondaryCmp !== 0) return secondaryCmp
+      // Tertiary: name ascending (fixed)
+      return a.name.localeCompare(b.name)
     } else {
       cmp = a.name.localeCompare(b.name)
     }

--- a/components/newsite/MyCollectionSidebar.vue
+++ b/components/newsite/MyCollectionSidebar.vue
@@ -5,8 +5,18 @@
 <script setup>
 const myCollectionSortOptions = [
   { value: 'acquiredDate', label: 'Acquired Date' },
+  { value: 'mintNumber',   label: 'Mint #'        },
   { value: 'name',         label: 'Name'          },
   { value: 'price',        label: 'Price'         },
   { value: 'rarity',       label: 'Rarity'        },
 ]
+
+const filter = useNewSiteCtoonFilter()
+
+// When switching to mint number sort, default to ascending
+watch(() => filter.value.sortField, (newField) => {
+  if (newField === 'mintNumber') {
+    filter.value.sortAsc = true
+  }
+})
 </script>


### PR DESCRIPTION
## Summary
Added support for sorting the collection by mint number with intelligent secondary and tertiary sort criteria.

## Key Changes
- **MyCollection.vue**: Implemented mint number sort logic with multi-level sorting:
  - Primary: mint number (respects ascending/descending toggle)
  - Secondary: acquisition date (fixed descending order)
  - Tertiary: name (fixed ascending order)
  - Items without a mint number are sorted to the end (treated as Infinity)

- **MyCollectionSidebar.vue**: 
  - Added "Mint #" option to the sort dropdown menu
  - Added watcher to automatically set ascending order when mint number sort is selected

## Implementation Details
- The mint number sort uses a multi-level comparison approach to provide consistent ordering when mint numbers are equal
- Missing mint numbers are handled gracefully by treating them as Infinity, placing them at the end of the list
- The sort direction toggle is respected for the primary sort field (mint number), while secondary and tertiary sorts use fixed directions for consistency

https://claude.ai/code/session_01HMmZJL3ZPFAvhmZNYrAYPW