### PR TITLE
Add VPN Queue admin page and remove page metadata

### DIFF
--- a/components/newsite/AdminNav.vue
+++ b/components/newsite/AdminNav.vue
@@ -49,7 +49,7 @@ const menus = [
     items: [
       { id: 'analytics',     label: 'Analytics',    to: '/newsite/admin' },
       { id: 'manageUsers',   label: 'Manage Users', to: '/newsite/admin/manageUsers' },
-      { id: 'core-placeholder-1', label: 'Placeholder', to: null },
+      { id: 'vpnQueue', label: 'VPN Queue', to: '/newsite/admin/vpn-queue' },
       { id: 'core-placeholder-2', label: 'Placeholder', to: null },
       { id: 'core-placeholder-3', label: 'Placeholder', to: null },
       { id: 'core-placeholder-4', label: 'Placeholder', to: null },

--- a/components/newsite/AdminVpnQueue.vue
+++ b/components/newsite/AdminVpnQueue.vue
@@ -134,17 +134,6 @@
 </template>
 
 <script setup>
-definePageMeta({
-  layout: 'newsite-template',
-  middleware: ['auth', 'admin'],
-  showAdbar: false,
-  showNav: true,
-  showSidebar: false,
-  showFooter: false,
-})
-
-useHead({ title: 'VPN Queue Monitor — Admin' })
-
 const data = ref(null)
 const loading = ref(false)
 const error = ref(null)

--- a/pages/newsite/admin/[[section]].vue
+++ b/pages/newsite/admin/[[section]].vue
@@ -20,6 +20,7 @@
       <AdminLottoLogs v-else-if="section === 'lottoLogs'" />
       <AdminWinWheelLogs v-else-if="section === 'winWheelLogs'" />
       <AdminScavengerLogs v-else-if="section === 'scavengerLogs'" />
+      <AdminVpnQueue v-else-if="section === 'vpn-queue'" />
       <div v-else class="newsite-admin-placeholder">
         <h1 class="newsite-admin-title">Unknown section</h1>
       </div>


### PR DESCRIPTION
## Summary
This PR integrates the VPN Queue Monitor into the admin dashboard by creating a dedicated route and navigation menu item, while removing redundant page metadata from the component.

## Key Changes
- **Removed page metadata** from `AdminVpnQueue.vue`: Deleted `definePageMeta()` and `useHead()` calls that were defining layout, middleware, and page title configuration
- **Added VPN Queue route**: Updated `pages/newsite/admin/[[section]].vue` to render the `AdminVpnQueue` component when the `vpn-queue` section is accessed
- **Updated admin navigation**: Replaced placeholder menu item in `AdminNav.vue` with a functional "VPN Queue" link pointing to `/newsite/admin/vpn-queue`

## Implementation Details
The page metadata removal suggests these configurations are now being handled at a higher level (likely in the parent admin page component or through a layout wrapper), reducing duplication and centralizing admin page configuration. The component itself retains all its functional logic for displaying VPN queue data.

https://claude.ai/code/session_01GLsFQ1MCvtDdenHEP9jqCT