### PR TITLE
Add IP encryption validation and redaction for security

### DIFF
--- a/components/newsite/AdminVpnQueue.vue
+++ b/components/newsite/AdminVpnQueue.vue
@@ -117,7 +117,7 @@
               <span class="activity-user">
                 {{ entry.user?.username || entry.user?.discordTag || entry.userId?.slice(0, 8) + '…' }}
               </span>
-              <span class="activity-ip" :title="entry.ip">{{ entry.ip.slice(0, 18) }}…</span>
+              <span class="activity-ip">{{ entry.ip.slice(0, 18) }}…</span>
               <span v-if="entry.proxyType" class="activity-type">{{ entry.proxyType }}</span>
               <span v-if="entry.isp" class="activity-isp">{{ entry.isp }}</span>
               <span v-if="entry.country" class="activity-country">{{ entry.country }}</span>

--- a/server/api/admin/vpn-queue-status.get.js
+++ b/server/api/admin/vpn-queue-status.get.js
@@ -45,6 +45,14 @@ export default defineEventHandler(async (event) => {
 
   const queueStatus = getQueueStatus()
 
+  // Safety filter: never send a plaintext IP to the frontend.
+  // Encrypted IPs are lowercase hex strings; anything else (dots, colons, etc.)
+  // is a plaintext IP that should never have been stored and must be redacted.
+  const safeActivity = recentActivity.map((entry) => ({
+    ...entry,
+    ip: /^[0-9a-f]+$/i.test(entry.ip ?? '') ? entry.ip : '[redacted]',
+  }))
+
   return {
     queue: {
       pending: queueStatus.pending,
@@ -59,7 +67,7 @@ export default defineEventHandler(async (event) => {
       checkedToday,
       flaggedToday,
     },
-    recentActivity,
+    recentActivity: safeActivity,
     errors: queueStatus.errors,
   }
 })

--- a/server/middleware/login-log.js
+++ b/server/middleware/login-log.js
@@ -13,6 +13,10 @@ export default defineEventHandler(async (event) => {
   if (!ip) return
 
   const encryptedLoginIp = encryptIp(ip)
+  if (!encryptedLoginIp) {
+    console.error('[login-log] Skipping login log — IP encryption returned null for userId:', userId)
+    return
+  }
 
   // 1. LoginLog — stored encrypted, one per day per combo
   const todayStart = startOfDay(new Date())
@@ -33,6 +37,7 @@ export default defineEventHandler(async (event) => {
   // 2. VPN check — only for public IPs, deduped via UserIP table (encrypted)
   if (!isPrivateIp(ip)) {
     const encryptedIp = encryptIp(ip)
+    if (!encryptedIp) return // encryption failed, do not proceed
 
     // Check if we've seen this (userId, encryptedIp) combo before
     const existingUserIp = await prisma.userIP.findUnique({

--- a/server/utils/ip-encrypt.js
+++ b/server/utils/ip-encrypt.js
@@ -21,8 +21,8 @@ function getKeyAndIV() {
 
 /**
  * Encrypt a plaintext IP address → hex ciphertext string.
- * Returns the original value unchanged if IP_ENCRYPTION_KEY is not set
- * (development fallback — log a warning).
+ * Returns null if encryption fails (e.g. IP_ENCRYPTION_KEY not set).
+ * NEVER falls back to returning the plaintext IP.
  */
 export function encryptIp(ip) {
   if (!ip) return ip
@@ -31,8 +31,8 @@ export function encryptIp(ip) {
     const cipher = createCipheriv('aes-256-cbc', key, iv)
     return cipher.update(ip, 'utf8', 'hex') + cipher.final('hex')
   } catch (err) {
-    console.warn('[ip-encrypt] encryptIp failed:', err.message)
-    return ip
+    console.error('[ip-encrypt] encryptIp failed — IP will NOT be stored:', err.message)
+    return null // Never fall back to storing plaintext
   }
 }
 


### PR DESCRIPTION
## Summary
This PR strengthens IP address security by implementing validation and redaction mechanisms to prevent plaintext IPs from being exposed to the frontend, and ensuring encryption failures are handled safely rather than falling back to storing plaintext data.

## Key Changes

- **IP Encryption Hardening** (`server/utils/ip-encrypt.js`):
  - Changed `encryptIp()` to return `null` on encryption failure instead of falling back to plaintext IP
  - Updated error handling to use `console.error()` and clarify that plaintext IPs will NOT be stored
  - Removed the development fallback behavior that could leak plaintext IPs

- **Login Logging Safety** (`server/middleware/login-log.js`):
  - Added null checks after `encryptIp()` calls to skip logging when encryption fails
  - Prevents incomplete or invalid records from being created with missing encrypted IPs

- **Frontend IP Redaction** (`server/api/admin/vpn-queue-status.get.js`):
  - Implemented safety filter that redacts any plaintext IPs before sending to frontend
  - Uses regex validation (`/^[0-9a-f]+$/i`) to identify encrypted IPs (hex strings) vs plaintext
  - Replaces any non-encrypted IPs with `[redacted]` placeholder
  - Added explanatory comments about the encryption format

- **UI Update** (`components/newsite/AdminVpnQueue.vue`):
  - Removed `:title` attribute from IP display to prevent plaintext IP exposure in tooltips

## Notable Implementation Details

The IP redaction filter acts as a defense-in-depth measure: even if plaintext IPs somehow end up in the database (due to legacy data or bugs), they will be caught and redacted before reaching the frontend. The regex pattern specifically looks for lowercase hex strings, which is the expected format of encrypted IPs, treating anything else as suspicious.

https://claude.ai/code/session_019wYH4KNK2JVypS4Vp3AL5t