### PR TITLE
Hide cToons already placed in any cZone from build sidebar

### DIFF
--- a/components/newsite/CzoneEdit.vue
+++ b/components/newsite/CzoneEdit.vue
@@ -36,13 +36,11 @@
           <div
             v-for="c in filteredCollection" :key="c.id"
             class="czew-toon-wrap"
-            :class="{ 'in-zone': currentZoneToonIds.has(c.id) }"
-            @mousedown.prevent="!currentZoneToonIds.has(c.id) && startDrag(c, $event)"
-            @touchstart="!currentZoneToonIds.has(c.id) && onToonTouchStart(c, $event)"
-            @touchend="!currentZoneToonIds.has(c.id) && onToonTouchEnd(c, $event)"
+            @mousedown.prevent="startDrag(c, $event)"
+            @touchstart="onToonTouchStart(c, $event)"
+            @touchend="onToonTouchEnd(c, $event)"
           >
             <img :src="c.assetPath" :alt="c.name" :title="c.name" draggable="false" class="czew-toon" />
-            <div v-if="currentZoneToonIds.has(c.id)" class="czew-toon-overlay" />
           </div>
           <div v-if="!filteredCollection.length" class="czew-empty" style="grid-column:1/-1">No cToons found.</div>
         </template>
@@ -106,9 +104,15 @@ const selectedSeries  = ref('')
 
 const currentZoneBg = computed(() => cz.value.zones[cz.value.activeZone]?.background ?? '')
 
-const currentZoneToonIds = computed(() =>
-  new Set((cz.value.zones[cz.value.activeZone]?.toons ?? []).map(t => t.id))
-)
+// cToon ids already placed in ANY zone — these are hidden from the sidebar so
+// they can't be dragged into a zone a second time (e.g. after a page refresh).
+const placedToonIds = computed(() => {
+  const ids = new Set()
+  for (const zone of cz.value.zones ?? []) {
+    for (const t of zone?.toons ?? []) ids.add(t.id)
+  }
+  return ids
+})
 
 const seriesList = computed(() =>
   [...new Set(cz.value.collection.map(c => c.series).filter(Boolean))].sort()
@@ -118,7 +122,9 @@ const filteredCollection = computed(() => {
   const q = search.value.toLowerCase()
   const rs = activeRarities.value
   const s  = selectedSeries.value
+  const placed = placedToonIds.value
   return cz.value.collection.filter(c => {
+    if (placed.has(c.id))                                     return false
     if (q  && !(c.name   || '').toLowerCase().includes(q))    return false
     if (rs.length && !rs.includes((c.rarity || '').toLowerCase())) return false
     if (s  && c.series !== s)                                  return false
@@ -312,8 +318,7 @@ function selectBg(bg) {
   cursor: grab;
   user-select: none;
 }
-.czew-toon-wrap.in-zone { cursor: default; }
-.czew-toon-wrap:not(.in-zone):hover .czew-toon { background: rgba(0,0,0,0.4); }
+.czew-toon-wrap:hover .czew-toon { background: rgba(0,0,0,0.4); }
 
 .czew-toon {
   display: block;
@@ -325,14 +330,6 @@ function selectBg(bg) {
   padding: 3px;
   image-rendering: pixelated;
   box-sizing: border-box;
-}
-
-.czew-toon-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(90, 90, 90, 0.6);
-  border-radius: 4px;
-  pointer-events: none;
 }
 
 /* ── Background grid ── */


### PR DESCRIPTION
Previously the build-mode sidebar only checked the active zone, so cToons
placed in other zones (or shown after a page refresh) still appeared and
could be dragged into a zone again. Now toons placed in any zone are
filtered out of the sidebar entirely.