### PR TITLE
Add pack analytics admin page at /admin/packanalytics

### DIFF
--- a/components/Nav.vue
+++ b/components/Nav.vue
@@ -356,6 +356,7 @@ const adminGroups = [
       { label: 'Monster Battle Logs', to: '/admin/manage-monster-battles' },
       { label: 'Lotto Logs', to: '/admin/lotto-logs' },
       { label: 'Win Wheel Logs', to: '/admin/winwheellogs' },
+      { label: 'Pack Analytics', to: '/admin/packanalytics' },
       { label: 'Scavenger Logs', to: '/admin/scavenger-logs' }
     ]
   }

--- a/components/newsite/CzoneEdit.vue
+++ b/components/newsite/CzoneEdit.vue
@@ -36,13 +36,11 @@
           <div
             v-for="c in filteredCollection" :key="c.id"
             class="czew-toon-wrap"
-            :class="{ 'in-zone': currentZoneToonIds.has(c.id) }"
-            @mousedown.prevent="!currentZoneToonIds.has(c.id) && startDrag(c, $event)"
-            @touchstart="!currentZoneToonIds.has(c.id) && onToonTouchStart(c, $event)"
-            @touchend="!currentZoneToonIds.has(c.id) && onToonTouchEnd(c, $event)"
+            @mousedown.prevent="startDrag(c, $event)"
+            @touchstart="onToonTouchStart(c, $event)"
+            @touchend="onToonTouchEnd(c, $event)"
           >
             <img :src="c.assetPath" :alt="c.name" :title="c.name" draggable="false" class="czew-toon" />
-            <div v-if="currentZoneToonIds.has(c.id)" class="czew-toon-overlay" />
           </div>
           <div v-if="!filteredCollection.length" class="czew-empty" style="grid-column:1/-1">No cToons found.</div>
         </template>
@@ -106,9 +104,23 @@ const selectedSeries  = ref('')
 
 const currentZoneBg = computed(() => cz.value.zones[cz.value.activeZone]?.background ?? '')
 
-const currentZoneToonIds = computed(() =>
-  new Set((cz.value.zones[cz.value.activeZone]?.toons ?? []).map(t => t.id))
-)
+// Stable identity for a cToon shared between the collection payload and the
+// saved zone payload. The per-item `id` differs between the two (the
+// collection uses a synthetic `uc|…` token while saved zones store the real
+// UserCtoon UUID), so we key on ctoonId + mintNumber, which both carry.
+function toonKey(item) {
+  return `${item.ctoonId ?? 'x'}|${item.mintNumber ?? 'x'}`
+}
+
+// Keys of cToons already placed in ANY zone — hidden from the sidebar so they
+// can't be dragged into a zone a second time (e.g. after a page refresh).
+const placedToonKeys = computed(() => {
+  const keys = new Set()
+  for (const zone of cz.value.zones ?? []) {
+    for (const t of zone?.toons ?? []) keys.add(toonKey(t))
+  }
+  return keys
+})
 
 const seriesList = computed(() =>
   [...new Set(cz.value.collection.map(c => c.series).filter(Boolean))].sort()
@@ -118,7 +130,9 @@ const filteredCollection = computed(() => {
   const q = search.value.toLowerCase()
   const rs = activeRarities.value
   const s  = selectedSeries.value
+  const placed = placedToonKeys.value
   return cz.value.collection.filter(c => {
+    if (placed.has(toonKey(c)))                               return false
     if (q  && !(c.name   || '').toLowerCase().includes(q))    return false
     if (rs.length && !rs.includes((c.rarity || '').toLowerCase())) return false
     if (s  && c.series !== s)                                  return false
@@ -181,6 +195,8 @@ function addToonToTopLeft(c) {
   img.onload = () => {
     zone.toons.push({
       id: c.id,
+      ctoonId: c.ctoonId,
+      mintNumber: c.mintNumber,
       assetPath: c.assetPath,
       name: c.name,
       x: 0,
@@ -312,8 +328,7 @@ function selectBg(bg) {
   cursor: grab;
   user-select: none;
 }
-.czew-toon-wrap.in-zone { cursor: default; }
-.czew-toon-wrap:not(.in-zone):hover .czew-toon { background: rgba(0,0,0,0.4); }
+.czew-toon-wrap:hover .czew-toon { background: rgba(0,0,0,0.4); }
 
 .czew-toon {
   display: block;
@@ -325,14 +340,6 @@ function selectBg(bg) {
   padding: 3px;
   image-rendering: pixelated;
   box-sizing: border-box;
-}
-
-.czew-toon-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(90, 90, 90, 0.6);
-  border-radius: 4px;
-  pointer-events: none;
 }
 
 /* ── Background grid ── */

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -763,7 +763,8 @@ function onGlobalUp(e) {
         const w = img.naturalWidth
         const h = img.naturalHeight
         currentZone.value.toons.push({
-          id: c.id, assetPath: c.assetPath, name: c.name,
+          id: c.id, ctoonId: c.ctoonId, mintNumber: c.mintNumber,
+          assetPath: c.assetPath, name: c.name,
           x: clamp(x - w / 2, 0, canvasW() - w),
           y: clamp(y - h / 2, 0, canvasH() - h),
           width: w, height: h,

--- a/pages/admin/packanalytics.vue
+++ b/pages/admin/packanalytics.vue
@@ -1,0 +1,218 @@
+<template>
+  <div class="min-h-screen bg-gray-50">
+    <Nav />
+    <div class="mt-8">&nbsp;</div>
+    <div class="px-6 mt-16 md:mt-20">
+      <h1 class="text-2xl font-bold mb-4">Pack Analytics</h1>
+
+      <!-- Filters -->
+      <form class="bg-white border rounded p-4 flex flex-wrap items-end gap-4 mb-6" @submit.prevent="applyFilters">
+        <div>
+          <label class="block text-sm font-medium mb-1">From</label>
+          <input type="date" v-model="from" class="border rounded px-2 py-1" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium mb-1">To</label>
+          <input type="date" v-model="to" class="border rounded px-2 py-1" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium mb-1">Set</label>
+          <select v-model="selectedSet" class="border rounded px-2 py-1">
+            <option value="">All sets</option>
+            <option v-for="s in sets" :key="s" :value="s">{{ s }}</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm font-medium mb-1">Pack</label>
+          <select v-model="selectedPack" class="border rounded px-2 py-1">
+            <option value="">All packs</option>
+            <option v-for="p in packs" :key="p.id" :value="p.id">{{ p.name }}</option>
+          </select>
+        </div>
+        <button class="bg-indigo-600 text-white rounded px-4 py-2">Apply</button>
+        <button type="button" class="text-sm text-gray-600 underline" @click="setLastNDays(30)">Last 30 days</button>
+      </form>
+
+      <!-- Summary stat -->
+      <div class="bg-white rounded shadow p-4 mb-6 inline-flex flex-col">
+        <p class="text-sm text-gray-500 mb-1">Packs Opened</p>
+        <p class="text-3xl font-bold">{{ loading ? '—' : packsOpened }}</p>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <!-- Stacked bar chart -->
+        <div class="bg-white rounded shadow p-4">
+          <h2 class="text-xl font-semibold mb-2">Rarity Distribution</h2>
+          <div class="chart-container"><canvas ref="barCanvas"></canvas></div>
+        </div>
+
+        <!-- Breakdown table -->
+        <div class="bg-white rounded shadow p-4">
+          <h2 class="text-xl font-semibold mb-2">Breakdown</h2>
+          <div v-if="loading" class="text-gray-500">Loading…</div>
+          <div v-else-if="!hasData" class="text-gray-500">No data in this range.</div>
+          <table v-else class="w-full text-sm">
+            <thead>
+              <tr class="text-left border-b">
+                <th class="py-2">Rarity</th>
+                <th class="py-2 text-right">Total</th>
+                <th class="py-2 text-right">Shop</th>
+                <th class="py-2 text-right">PE</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="r in rarityBreakdown" :key="r.rarity" class="border-b">
+                <td class="py-1">
+                  <span class="inline-block w-3 h-3 rounded-sm mr-2" :style="{ backgroundColor: colorFor(r.rarity) }"></span>
+                  {{ capitalize(r.rarity) }}
+                </td>
+                <td class="py-1 text-right">{{ r.total.toLocaleString() }}</td>
+                <td class="py-1 text-right">{{ r.shop.toLocaleString() }}</td>
+                <td class="py-1 text-right">{{ r.pe.toLocaleString() }}</td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr class="border-t-2 font-semibold">
+                <td class="pt-2">Totals</td>
+                <td class="pt-2 text-right">{{ totalCtoons.toLocaleString() }}</td>
+                <td class="pt-2 text-right">{{ totalShop.toLocaleString() }}</td>
+                <td class="pt-2 text-right">{{ totalPE.toLocaleString() }}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import Nav from '@/components/Nav.vue'
+import { Chart, BarController, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js'
+
+Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip, Legend)
+
+definePageMeta({ title: 'Admin - Pack Analytics', middleware: ['auth', 'admin'], layout: 'admin' })
+
+const from = ref('')
+const to = ref('')
+const selectedSet = ref('')
+const selectedPack = ref('')
+
+const sets = ref([])
+const packs = ref([])
+const packsOpened = ref(0)
+const rarityBreakdown = ref([])
+const loading = ref(false)
+
+const hasData = computed(() => rarityBreakdown.value.some(r => r.total > 0))
+const totalCtoons = computed(() => rarityBreakdown.value.reduce((s, r) => s + r.total, 0))
+const totalShop = computed(() => rarityBreakdown.value.reduce((s, r) => s + r.shop, 0))
+const totalPE = computed(() => rarityBreakdown.value.reduce((s, r) => s + r.pe, 0))
+
+const RARITY_COLORS = {
+  common: '#9CA3AF',
+  uncommon: '#3B82F6',
+  rare: '#8B5CF6',
+  'very rare': '#F59E0B'
+}
+const colorFor = r => RARITY_COLORS[r] || '#10B981'
+const capitalize = s => s.replace(/\b\w/g, c => c.toUpperCase())
+
+function toYMD(d) {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const da = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${da}`
+}
+
+function setLastNDays(n) {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(end.getDate() - (n - 1))
+  from.value = toYMD(start)
+  to.value = toYMD(end)
+}
+
+const barCanvas = ref(null)
+let barChart
+
+async function fetchData() {
+  if (!from.value || !to.value) return
+  loading.value = true
+  try {
+    const params = new URLSearchParams({ start: from.value, end: to.value })
+    if (selectedSet.value) params.set('set', selectedSet.value)
+    if (selectedPack.value) params.set('packId', selectedPack.value)
+
+    const data = await $fetch(`/api/admin/pack-analytics?${params.toString()}`, { credentials: 'include' })
+
+    packsOpened.value = data.packsOpened ?? 0
+    rarityBreakdown.value = data.rarityBreakdown ?? []
+    sets.value = data.sets ?? []
+    packs.value = data.packs ?? []
+
+    barChart.data.labels = rarityBreakdown.value.map(r => capitalize(r.rarity))
+    barChart.data.datasets = [
+      {
+        label: 'Shop',
+        data: rarityBreakdown.value.map(r => r.shop),
+        backgroundColor: '#3B82F6'
+      },
+      {
+        label: 'PE',
+        data: rarityBreakdown.value.map(r => r.pe),
+        backgroundColor: '#8B5CF6'
+      }
+    ]
+    barChart.update()
+  } catch (e) {
+    console.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function applyFilters() {
+  if (!from.value || !to.value) return
+  if (new Date(from.value) > new Date(to.value)) {
+    const t = from.value
+    from.value = to.value
+    to.value = t
+  }
+  fetchData()
+}
+
+onMounted(() => {
+  setLastNDays(30)
+
+  barChart = new Chart(barCanvas.value.getContext('2d'), {
+    type: 'bar',
+    data: { labels: [], datasets: [] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: { stacked: true, ticks: { color: '#000' } },
+        y: { stacked: true, beginAtZero: true, ticks: { color: '#000' } }
+      },
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: { color: '#000' }
+        }
+      }
+    }
+  })
+
+  fetchData()
+})
+</script>
+
+<style scoped>
+.chart-container {
+  height: 360px;
+  position: relative;
+}
+</style>

--- a/prisma/migrations/20260530000000_add_userpack_fk_to_userctoon/migration.sql
+++ b/prisma/migrations/20260530000000_add_userpack_fk_to_userctoon/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "UserCtoon" ADD COLUMN "userPackId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "UserCtoon" ADD CONSTRAINT "UserCtoon_userPackId_fkey" FOREIGN KEY ("userPackId") REFERENCES "UserPack"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -313,9 +313,11 @@ model UserCtoon {
   userPurchased  Boolean   @default(true)
   createdAt      DateTime  @default(now())
   burnedAt       DateTime?
+  userPackId     String?
 
-  user  User  @relation(fields: [userId], references: [id])
-  ctoon Ctoon @relation(fields: [ctoonId], references: [id])
+  user     User      @relation(fields: [userId], references: [id])
+  ctoon    Ctoon     @relation(fields: [ctoonId], references: [id])
+  userPack UserPack? @relation(fields: [userPackId], references: [id])
 
   tradeCtoons               TradeCtoon[]
   tradeOfferCtoons          TradeOfferCtoon[]
@@ -756,8 +758,9 @@ model UserPack {
   openedAt  DateTime?
   createdAt DateTime  @default(now())
 
-  user User @relation(fields: [userId], references: [id])
-  pack Pack @relation(fields: [packId], references: [id])
+  user         User       @relation(fields: [userId], references: [id])
+  pack         Pack       @relation(fields: [packId], references: [id])
+  mintedCtoons UserCtoon[]
 }
 
 model LoginLog {

--- a/server/api/admin/pack-analytics.get.js
+++ b/server/api/admin/pack-analytics.get.js
@@ -1,0 +1,116 @@
+import { defineEventHandler, getQuery, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+function parseStartYMD(ymd) {
+  if (typeof ymd !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(ymd)) return null
+  const d = new Date(`${ymd}T00:00:00.000Z`)
+  return isNaN(d.getTime()) ? null : d
+}
+
+function parseEndYMD(ymd) {
+  if (typeof ymd !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(ymd)) return null
+  const d = new Date(`${ymd}T23:59:59.999Z`)
+  return isNaN(d.getTime()) ? null : d
+}
+
+const RARITIES = ['common', 'uncommon', 'rare', 'very rare']
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const { start, end, packId, set } = getQuery(event)
+
+  let endDate = (typeof end === 'string' && parseEndYMD(end)) || new Date()
+  let startDate = (typeof start === 'string' && parseStartYMD(start)) || null
+
+  if (!startDate) {
+    const s = new Date(endDate)
+    s.setDate(s.getDate() - 29)
+    startDate = new Date(Date.UTC(s.getUTCFullYear(), s.getUTCMonth(), s.getUTCDate(), 0, 0, 0, 0))
+  }
+
+  if (startDate > endDate) {
+    const tmp = startDate
+    startDate = endDate
+    endDate = tmp
+  }
+
+  // If filtering by pack, resolve the ctoon IDs for that pack
+  let ctoonIdFilter = undefined
+  if (packId && typeof packId === 'string') {
+    const opts = await prisma.packCtoonOption.findMany({
+      where: { packId },
+      select: { ctoonId: true }
+    })
+    ctoonIdFilter = { in: opts.map(o => o.ctoonId) }
+  }
+
+  // Packs opened in the date range
+  const packsOpened = await prisma.userPack.count({
+    where: {
+      opened: true,
+      openedAt: { gte: startDate, lte: endDate },
+      ...(packId && typeof packId === 'string' ? { packId } : {})
+    }
+  })
+
+  // Ctoon counts grouped by rarity × inCmart (shop vs PE) for each rarity
+  const rarityBreakdown = await Promise.all(
+    RARITIES.map(async (rarity) => {
+      const ctoonWhere = {
+        rarity,
+        ...(ctoonIdFilter ? { id: ctoonIdFilter } : {}),
+        ...(set && typeof set === 'string' ? { set } : {})
+      }
+
+      const [shop, pe] = await Promise.all([
+        prisma.userCtoon.count({
+          where: {
+            createdAt: { gte: startDate, lte: endDate },
+            ctoon: { ...ctoonWhere, inCmart: true }
+          }
+        }),
+        prisma.userCtoon.count({
+          where: {
+            createdAt: { gte: startDate, lte: endDate },
+            ctoon: { ...ctoonWhere, inCmart: false }
+          }
+        })
+      ])
+
+      return { rarity, shop, pe, total: shop + pe }
+    })
+  )
+
+  // Filter options for dropdowns — sets from ctoons that appear in at least one pack
+  const [setsRaw, packs] = await Promise.all([
+    prisma.ctoon.findMany({
+      where: { set: { not: null }, packOptions: { some: {} } },
+      select: { set: true },
+      distinct: ['set'],
+      orderBy: { set: 'asc' }
+    }),
+    prisma.pack.findMany({
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' }
+    })
+  ])
+
+  return {
+    start: startDate.toISOString(),
+    end: endDate.toISOString(),
+    packsOpened,
+    rarityBreakdown,
+    sets: setsRaw.map(s => s.set).filter(Boolean),
+    packs
+  }
+})

--- a/server/api/admin/users/[id]/vpn-details.get.js
+++ b/server/api/admin/users/[id]/vpn-details.get.js
@@ -1,6 +1,7 @@
 // server/api/admin/users/[id]/vpn-details.get.js
 import { defineEventHandler, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { decryptIp } from '@/server/utils/ip-encrypt'
 
 export default defineEventHandler(async (event) => {
   // 1) Auth: must be admin
@@ -23,5 +24,5 @@ export default defineEventHandler(async (event) => {
     orderBy: { detectedAt: 'desc' },
   })
 
-  return logs
+  return logs.map(log => ({ ...log, ip: decryptIp(log.ip) }))
 })

--- a/server/api/cmart/open-pack.get.js
+++ b/server/api/cmart/open-pack.get.js
@@ -177,7 +177,7 @@ export default defineEventHandler(async (event) => {
 
   /* ── 3. queue mints & build response ───────────────────── */
   for (const c of chosen)
-    await mintQueue.add('mintCtoon', { userId, ctoonId: c.id, isSpecial: true })
+    await mintQueue.add('mintCtoon', { userId, ctoonId: c.id, isSpecial: true, userPackId })
 
   const mintNumbers  = {}
   const inCmartFlags = {}

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -9,7 +9,7 @@ const connection = {
 
 // Create a BullMQ worker to process mint jobs
 const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
-    const { userId, ctoonId, isSpecial = false, effectivePrice } = job.data
+    const { userId, ctoonId, isSpecial = false, effectivePrice, userPackId = null } = job.data
 
     const TIME_BASED_CAP = 999999999
 
@@ -243,7 +243,7 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
 
       // 3) Create the UserCtoon with the atomic mintNumber
       const uc = await tx.userCtoon.create({
-        data: { userId, ctoonId, mintNumber, isFirstEdition },
+        data: { userId, ctoonId, mintNumber, isFirstEdition, ...(userPackId ? { userPackId } : {}) },
         select: { id: true, mintNumber: true }
       })
 


### PR DESCRIPTION
Shows packs opened, and cToon mints broken down by rarity (C/UC/R/VR)
with Shop (inCmart=true) vs PE (inCmart=false) split. Supports date
range filtering and optional set/pack dropdown filters. Includes a
stacked bar chart and a breakdown table with totals row.

https://claude.ai/code/session_012dFp8BgfsPy6QrVyiku2BF