### PR TITLE
Add cToon Collection Analytics admin page

### DIFF
--- a/components/newsite/AdminCtoonCollectionAnalytics.vue
+++ b/components/newsite/AdminCtoonCollectionAnalytics.vue
@@ -1,0 +1,347 @@
+<template>
+  <div class="admin-collection-analytics bg-gray-50 text-xs">
+    <div class="p-2">
+      <div class="bg-white rounded-lg shadow p-3">
+        <h1 class="text-base font-semibold mb-2">cToon Collection Analytics</h1>
+
+        <!-- Week picker -->
+        <div class="flex flex-wrap items-center gap-3 mb-3">
+          <div class="flex items-center gap-1.5">
+            <label for="weekStart" class="font-medium">Week starting (Monday):</label>
+            <input
+              id="weekStart"
+              v-model="weekStartInput"
+              type="date"
+              class="border rounded px-1.5 py-0.5 text-xs"
+              @change="load"
+            />
+          </div>
+          <button
+            type="button"
+            class="border rounded px-2 py-0.5 text-xs bg-blue-50 hover:bg-blue-100"
+            @click="loadPrevWeek"
+          >
+            Previous week
+          </button>
+          <button
+            type="button"
+            class="border rounded px-2 py-0.5 text-xs bg-blue-50 hover:bg-blue-100"
+            @click="loadNextWeek"
+          >
+            Next week
+          </button>
+          <span v-if="weekEnd" class="text-gray-500">
+            {{ formatDate(weekStartInput) }} – {{ formatDate(weekEnd) }}
+          </span>
+        </div>
+
+        <div v-if="loading" class="text-center py-6 text-gray-500">Loading…</div>
+        <div v-else-if="error" class="text-red-600 py-4">{{ error }}</div>
+        <template v-else>
+
+          <!-- No sets found -->
+          <div v-if="!data || data.sets.length === 0" class="py-4 text-gray-500">
+            No cToon sets with a release date in this week.
+          </div>
+
+          <template v-else>
+            <!-- Sets released this week -->
+            <div class="mb-3">
+              <h2 class="text-sm font-semibold mb-1">Sets Released This Week</h2>
+              <div class="flex flex-wrap gap-2">
+                <span
+                  v-for="s in data.sets"
+                  :key="s.name"
+                  class="inline-block bg-blue-100 text-blue-800 rounded-full px-2 py-0.5 text-[11px]"
+                >
+                  {{ s.name }} ({{ s.ctoonCount }} cToons)
+                </span>
+              </div>
+            </div>
+
+            <!-- Summary stats -->
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+              <div class="bg-green-50 rounded p-2 text-center">
+                <div class="text-lg font-bold text-green-700">{{ data.oneSet.count }}</div>
+                <div class="text-[11px] text-green-600">Completed ≥1 Set</div>
+              </div>
+              <div class="bg-purple-50 rounded p-2 text-center">
+                <div class="text-lg font-bold text-purple-700">{{ data.allSets.count }}</div>
+                <div class="text-[11px] text-purple-600">Completed All Sets</div>
+              </div>
+              <div class="bg-gray-50 rounded p-2 text-center">
+                <div class="text-lg font-bold text-gray-700">{{ avgPoints(data.oneSet.users) }}</div>
+                <div class="text-[11px] text-gray-500">Avg pts (1 set)</div>
+              </div>
+              <div class="bg-gray-50 rounded p-2 text-center">
+                <div class="text-lg font-bold text-gray-700">{{ avgPoints(data.allSets.users) }}</div>
+                <div class="text-[11px] text-gray-500">Avg pts (all sets)</div>
+              </div>
+            </div>
+
+            <!-- Tab toggle -->
+            <div class="flex gap-1 mb-2">
+              <button
+                type="button"
+                :class="[
+                  'px-2 py-1 rounded text-[11px] border',
+                  activeTab === 'one' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-gray-700 hover:bg-gray-50'
+                ]"
+                @click="activeTab = 'one'"
+              >
+                ≥1 Set Completers ({{ data.oneSet.count }})
+              </button>
+              <button
+                type="button"
+                :class="[
+                  'px-2 py-1 rounded text-[11px] border',
+                  activeTab === 'all' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 hover:bg-gray-50'
+                ]"
+                @click="activeTab = 'all'"
+              >
+                All Sets Completers ({{ data.allSets.count }})
+              </button>
+            </div>
+
+            <!-- User table -->
+            <div class="overflow-x-auto mb-4">
+              <table v-if="activeUsers.length" class="min-w-full table-auto border-collapse text-[11px]">
+                <thead>
+                  <tr class="bg-gray-100">
+                    <th class="px-1.5 py-1 text-left">User</th>
+                    <th class="px-1.5 py-1 text-left">Completed Sets</th>
+                    <th class="px-1.5 py-1 text-right">Points Spent</th>
+                    <th class="px-1.5 py-1 text-right">Trades Used</th>
+                    <th class="px-1.5 py-1 text-right">Auctions Won</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="u in activeUsers"
+                    :key="u.userId"
+                    class="border-b hover:bg-gray-50"
+                  >
+                    <td class="px-1.5 py-1 font-medium">{{ u.username }}</td>
+                    <td class="px-1.5 py-1 text-gray-600">{{ u.completedSets.join(', ') }}</td>
+                    <td class="px-1.5 py-1 text-right tabular-nums">{{ u.pointsSpent.toLocaleString() }}</td>
+                    <td class="px-1.5 py-1 text-right tabular-nums">{{ u.tradesUsed }}</td>
+                    <td class="px-1.5 py-1 text-right tabular-nums">{{ u.auctionsWon }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p v-else class="text-gray-500 py-2">No users in this category for the selected week.</p>
+            </div>
+
+            <!-- Charts -->
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <div>
+                <h2 class="text-sm font-semibold mb-1">Points Distribution — ≥1 Set Completers</h2>
+                <p class="text-[11px] text-gray-500 mb-1">
+                  Distribution of total points spent to collect at least one full set.
+                </p>
+                <div class="chart-container">
+                  <canvas ref="oneSetCanvas"></canvas>
+                </div>
+              </div>
+              <div>
+                <h2 class="text-sm font-semibold mb-1">Points Distribution — All Sets Completers</h2>
+                <p class="text-[11px] text-gray-500 mb-1">
+                  Distribution of total points spent to collect every set released that week.
+                </p>
+                <div class="chart-container">
+                  <canvas ref="allSetsCanvas"></canvas>
+                </div>
+              </div>
+            </div>
+
+          </template>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import {
+  Chart,
+  BarController, BarElement,
+  CategoryScale, LinearScale,
+  Title, Tooltip, Legend
+} from 'chart.js'
+
+Chart.register(BarController, BarElement, CategoryScale, LinearScale, Title, Tooltip, Legend)
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function prevMonday(from = new Date()) {
+  const d = new Date(from)
+  d.setHours(0, 0, 0, 0)
+  const day = d.getDay() // 0=Sun..6=Sat
+  // Go to last week's Monday
+  const daysBack = day === 0 ? 13 : day + 6
+  d.setDate(d.getDate() - daysBack)
+  return d
+}
+
+function toYMD(d) {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function formatDate(ymd) {
+  if (!ymd) return ''
+  const d = new Date(`${ymd}T00:00:00`)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function addDays(ymd, n) {
+  const d = new Date(`${ymd}T00:00:00`)
+  d.setDate(d.getDate() + n)
+  return toYMD(d)
+}
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+const weekStartInput = ref(toYMD(prevMonday()))
+const weekEnd = computed(() => addDays(weekStartInput.value, 6))
+
+const loading = ref(false)
+const error = ref(null)
+const data = ref(null)
+const activeTab = ref('one')
+
+const activeUsers = computed(() =>
+  activeTab.value === 'one' ? (data.value?.oneSet.users ?? []) : (data.value?.allSets.users ?? [])
+)
+
+function avgPoints(users) {
+  if (!users.length) return 0
+  return Math.round(users.reduce((s, u) => s + u.pointsSpent, 0) / users.length).toLocaleString()
+}
+
+// ── Chart refs ────────────────────────────────────────────────────────────────
+
+const oneSetCanvas = ref(null)
+const allSetsCanvas = ref(null)
+let oneSetChart = null
+let allSetsChart = null
+
+function destroyCharts() {
+  oneSetChart?.destroy()
+  allSetsChart?.destroy()
+  oneSetChart = null
+  allSetsChart = null
+}
+
+function buildBarChart(canvas, distribution, color, label) {
+  if (!canvas) return null
+  const labels = distribution.map(b => b.label)
+  const counts = distribution.map(b => b.count)
+  return new Chart(canvas, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{
+        label,
+        data: counts,
+        backgroundColor: color,
+        borderRadius: 3
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: true,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title: ctx => `Points: ${ctx[0].label}`,
+            label: ctx => `${ctx.raw} user${ctx.raw === 1 ? '' : 's'}`
+          }
+        }
+      },
+      scales: {
+        x: {
+          title: { display: true, text: 'Points Spent', font: { size: 10 } },
+          ticks: { font: { size: 10 } }
+        },
+        y: {
+          title: { display: true, text: 'Users', font: { size: 10 } },
+          ticks: { precision: 0, font: { size: 10 } },
+          beginAtZero: true
+        }
+      }
+    }
+  })
+}
+
+function renderCharts() {
+  destroyCharts()
+  if (!data.value) return
+  nextTick(() => {
+    const oneDist = data.value.oneSetPointsDistribution
+    const allDist = data.value.allSetsPointsDistribution
+
+    if (oneSetCanvas.value) {
+      oneSetChart = buildBarChart(
+        oneSetCanvas.value,
+        oneDist,
+        'rgba(34, 197, 94, 0.7)',
+        '≥1 Set Completers'
+      )
+    }
+    if (allSetsCanvas.value) {
+      allSetsChart = buildBarChart(
+        allSetsCanvas.value,
+        allDist,
+        'rgba(147, 51, 234, 0.7)',
+        'All Sets Completers'
+      )
+    }
+  })
+}
+
+// ── Data fetch ────────────────────────────────────────────────────────────────
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    data.value = await $fetch('/api/admin/ctoon-collection-analytics', {
+      params: { weekStart: weekStartInput.value }
+    })
+    renderCharts()
+  } catch (err) {
+    error.value = err?.data?.statusMessage || err?.message || 'Failed to load analytics'
+  } finally {
+    loading.value = false
+  }
+}
+
+function loadPrevWeek() {
+  weekStartInput.value = addDays(weekStartInput.value, -7)
+  load()
+}
+
+function loadNextWeek() {
+  weekStartInput.value = addDays(weekStartInput.value, 7)
+  load()
+}
+
+onMounted(load)
+onBeforeUnmount(destroyCharts)
+
+watch(data, () => {
+  nextTick(renderCharts)
+})
+</script>
+
+<style scoped>
+.chart-container {
+  position: relative;
+  height: 220px;
+}
+</style>

--- a/components/newsite/AdminNav.vue
+++ b/components/newsite/AdminNav.vue
@@ -76,7 +76,8 @@ const menus = [
       { id: 'monsterBattleLogs',  label: 'Monster Battle Logs', to: '/newsite/admin/monsterBattleLogs' },
       { id: 'lottoLogs',          label: 'Lotto Logs',         to: '/newsite/admin/lottoLogs' },
       { id: 'winWheelLogs',       label: 'Win Wheel Logs',     to: '/newsite/admin/winWheelLogs' },
-      { id: 'scavengerLogs',      label: 'Scavenger Logs',     to: '/newsite/admin/scavengerLogs' }
+      { id: 'scavengerLogs',      label: 'Scavenger Logs',     to: '/newsite/admin/scavengerLogs' },
+      { id: 'collectionAnalytics', label: 'Collection Analytics', to: '/newsite/admin/collectionAnalytics' }
     ]
   }
 ]

--- a/pages/newsite/admin/[[section]].vue
+++ b/pages/newsite/admin/[[section]].vue
@@ -21,6 +21,7 @@
       <AdminWinWheelLogs v-else-if="section === 'winWheelLogs'" />
       <AdminScavengerLogs v-else-if="section === 'scavengerLogs'" />
       <AdminVpnQueue v-else-if="section === 'vpn-queue'" />
+      <AdminCtoonCollectionAnalytics v-else-if="section === 'collectionAnalytics'" />
       <div v-else class="newsite-admin-placeholder">
         <h1 class="newsite-admin-title">Unknown section</h1>
       </div>

--- a/server/api/admin/ctoon-collection-analytics.get.js
+++ b/server/api/admin/ctoon-collection-analytics.get.js
@@ -1,0 +1,339 @@
+import { defineEventHandler, getQuery, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+function lastMonday(from = new Date()) {
+  const d = new Date(from)
+  d.setUTCHours(0, 0, 0, 0)
+  const day = d.getUTCDay() // 0=Sun ... 6=Sat
+  const daysBack = day === 0 ? 13 : day + 6 // go back to the Monday before last
+  d.setUTCDate(d.getUTCDate() - daysBack)
+  return d
+}
+
+function buildHistogram(values, bucketSize) {
+  if (!values.length) return []
+  const max = Math.max(...values)
+  const buckets = []
+  for (let lo = 0; lo <= max; lo += bucketSize) {
+    const hi = lo + bucketSize
+    const label = `${lo}–${hi - 1}`
+    const count = values.filter(v => v >= lo && v < hi).length
+    buckets.push({ label, count })
+  }
+  // trim trailing zero buckets
+  while (buckets.length > 1 && buckets[buckets.length - 1].count === 0) buckets.pop()
+  return buckets
+}
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const { weekStart: weekStartParam } = getQuery(event)
+
+  let weekStart
+  if (weekStartParam) {
+    weekStart = new Date(`${weekStartParam}T00:00:00.000Z`)
+    if (isNaN(weekStart.getTime())) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid weekStart date' })
+    }
+  } else {
+    weekStart = lastMonday()
+  }
+
+  const weekEnd = new Date(weekStart)
+  weekEnd.setUTCDate(weekEnd.getUTCDate() + 7)
+
+  // ── 1. Weekly cToons ─────────────────────────────────────────────────────
+  const weeklyCtoons = await prisma.ctoon.findMany({
+    where: {
+      releaseDate: { gte: weekStart, lt: weekEnd },
+      set: { not: null }
+    },
+    select: { id: true, set: true, name: true, price: true }
+  })
+
+  if (weeklyCtoons.length === 0) {
+    return {
+      weekStart: weekStart.toISOString(),
+      weekEnd: weekEnd.toISOString(),
+      sets: [],
+      oneSet: { count: 0, users: [] },
+      allSets: { count: 0, users: [] },
+      oneSetPointsDistribution: [],
+      allSetsPointsDistribution: []
+    }
+  }
+
+  // Group by set name
+  const setMap = new Map() // setName → [{ id, name, price }]
+  const ctoonPriceMap = new Map() // ctoonId → price
+  for (const c of weeklyCtoons) {
+    if (!setMap.has(c.set)) setMap.set(c.set, [])
+    setMap.get(c.set).push(c)
+    ctoonPriceMap.set(c.id, c.price)
+  }
+  const setNames = [...setMap.keys()]
+  const allWeeklyCtoonIds = weeklyCtoons.map(c => c.id)
+
+  // ── 2. Who owns which weekly cToons ──────────────────────────────────────
+  const ownedRows = await prisma.userCtoon.findMany({
+    where: {
+      ctoonId: { in: allWeeklyCtoonIds },
+      burnedAt: null
+    },
+    select: {
+      id: true,
+      userId: true,
+      ctoonId: true,
+      user: { select: { username: true } }
+    }
+  })
+
+  // userId → { username, ownedCtoonIds: Set, userCtoonByCtoonId: Map<ctoonId, ucId> }
+  const userMap = new Map()
+  for (const row of ownedRows) {
+    if (!userMap.has(row.userId)) {
+      userMap.set(row.userId, {
+        username: row.user?.username || row.userId,
+        ownedCtoonIds: new Set(),
+        userCtoonByCtoonId: new Map()
+      })
+    }
+    const u = userMap.get(row.userId)
+    if (!u.ownedCtoonIds.has(row.ctoonId)) {
+      u.ownedCtoonIds.add(row.ctoonId)
+      u.userCtoonByCtoonId.set(row.ctoonId, row.id) // first uc per ctoon
+    }
+  }
+
+  // ── 3. Determine completers ───────────────────────────────────────────────
+  // oneSetCompleters: completed at least 1 of the weekly sets
+  // allSetsCompleters: completed every set released that week
+  const oneSetCompleterIds = []
+  const allSetsCompleterIds = []
+  const userCompletedSetsMap = new Map() // userId → string[]
+
+  for (const [userId, info] of userMap) {
+    const completed = []
+    for (const [setName, ctoons] of setMap) {
+      if (ctoons.every(c => info.ownedCtoonIds.has(c.id))) {
+        completed.push(setName)
+      }
+    }
+    if (completed.length > 0) {
+      oneSetCompleterIds.push(userId)
+      userCompletedSetsMap.set(userId, completed)
+    }
+    if (completed.length === setNames.length) {
+      allSetsCompleterIds.push(userId)
+    }
+  }
+
+  if (oneSetCompleterIds.length === 0) {
+    return {
+      weekStart: weekStart.toISOString(),
+      weekEnd: weekEnd.toISOString(),
+      sets: setNames.map(n => ({ name: n, ctoonCount: setMap.get(n).length })),
+      oneSet: { count: 0, users: [] },
+      allSets: { count: 0, users: [] },
+      oneSetPointsDistribution: [],
+      allSetsPointsDistribution: []
+    }
+  }
+
+  // ── 4. Collect all relevant userCtoon IDs for completers ──────────────────
+  // Only the ONE userCtoon per ctoon per user (first acquired) that is part of a completed set
+  const completerUcIds = []
+  const ucIdToUserCtoon = new Map() // ucId → { userId, ctoonId }
+
+  for (const userId of oneSetCompleterIds) {
+    const info = userMap.get(userId)
+    const completedSets = userCompletedSetsMap.get(userId)
+    const completedCtoonIds = new Set(
+      completedSets.flatMap(s => setMap.get(s).map(c => c.id))
+    )
+    for (const [ctoonId, ucId] of info.userCtoonByCtoonId) {
+      if (completedCtoonIds.has(ctoonId)) {
+        completerUcIds.push(ucId)
+        ucIdToUserCtoon.set(ucId, { userId, ctoonId })
+      }
+    }
+  }
+
+  // ── 5. Attribution: CtoonOwnerLog (detect transfers vs direct mint) ───────
+  const ownerLogs = await prisma.ctoonOwnerLog.findMany({
+    where: { userCtoonId: { in: completerUcIds } },
+    select: { userCtoonId: true, userId: true }
+  })
+  // ucId → userId who this was transferred TO (if it was transferred)
+  const transferredUcIds = new Set(ownerLogs.map(l => l.userCtoonId))
+
+  // ── 6. Attribution: Auction wins ──────────────────────────────────────────
+  const auctionWins = await prisma.auction.findMany({
+    where: {
+      winnerId: { in: oneSetCompleterIds },
+      status: 'CLOSED',
+      userCtoonId: { in: completerUcIds }
+    },
+    select: {
+      winnerId: true,
+      userCtoonId: true,
+      highestBid: true
+    }
+  })
+  // ucId → highestBid
+  const auctionByUcId = new Map()
+  for (const a of auctionWins) {
+    auctionByUcId.set(a.userCtoonId, { bid: a.highestBid, winnerId: a.winnerId })
+  }
+
+  // ── 7. Attribution: Accepted trades ──────────────────────────────────────
+  // Find trades where a completer received a set cToon
+  const acceptedTrades = await prisma.tradeOffer.findMany({
+    where: {
+      status: 'ACCEPTED',
+      OR: [
+        { recipientId: { in: oneSetCompleterIds } },
+        { initiatorId: { in: oneSetCompleterIds } }
+      ]
+    },
+    select: {
+      id: true,
+      initiatorId: true,
+      recipientId: true,
+      pointsOffered: true,
+      ctoons: {
+        select: {
+          role: true,
+          userCtoonId: true,
+          userCtoon: { select: { ctoonId: true } }
+        }
+      }
+    }
+  })
+
+  // For each trade, determine if a set cToon was received by a completer
+  // tradeCount: userId → count of trades where they received a set cToon
+  // tradePoints: userId → points they paid as initiator with points+set cToon received
+  const tradeCountByUser = new Map()
+  const tradePointsByUser = new Map()
+
+  for (const offer of acceptedTrades) {
+    const offeredSetCtoons = offer.ctoons.filter(
+      tc => tc.role === 'OFFERED' && allWeeklyCtoonIds.includes(tc.userCtoon?.ctoonId)
+    )
+    const requestedSetCtoons = offer.ctoons.filter(
+      tc => tc.role === 'REQUESTED' && allWeeklyCtoonIds.includes(tc.userCtoon?.ctoonId)
+    )
+
+    // Recipient got OFFERED set cToons
+    if (offeredSetCtoons.length > 0 && oneSetCompleterIds.includes(offer.recipientId)) {
+      tradeCountByUser.set(offer.recipientId, (tradeCountByUser.get(offer.recipientId) || 0) + 1)
+    }
+
+    // Initiator got REQUESTED set cToons (and may have paid points)
+    if (requestedSetCtoons.length > 0 && oneSetCompleterIds.includes(offer.initiatorId)) {
+      tradeCountByUser.set(offer.initiatorId, (tradeCountByUser.get(offer.initiatorId) || 0) + 1)
+      if (offer.pointsOffered > 0) {
+        tradePointsByUser.set(
+          offer.initiatorId,
+          (tradePointsByUser.get(offer.initiatorId) || 0) + offer.pointsOffered
+        )
+      }
+    }
+  }
+
+  // ── 8. Compute per-user totals ────────────────────────────────────────────
+  // pointsSpent: cmart (Ctoon.price) + auction wins (highestBid) + trade points offered
+  const userTotals = new Map() // userId → { points, trades, auctions }
+
+  for (const userId of oneSetCompleterIds) {
+    const info = userMap.get(userId)
+    const completedSets = userCompletedSetsMap.get(userId)
+    const completedCtoonIds = new Set(
+      completedSets.flatMap(s => setMap.get(s).map(c => c.id))
+    )
+
+    let points = tradePointsByUser.get(userId) || 0
+    let auctions = 0
+
+    for (const [ctoonId, ucId] of info.userCtoonByCtoonId) {
+      if (!completedCtoonIds.has(ctoonId)) continue
+
+      const auctionInfo = auctionByUcId.get(ucId)
+      if (auctionInfo && auctionInfo.winnerId === userId) {
+        points += auctionInfo.bid
+        auctions += 1
+      } else if (!transferredUcIds.has(ucId)) {
+        // Direct mint (cmart / pack / code) — use published price as proxy
+        points += ctoonPriceMap.get(ctoonId) || 0
+      }
+      // transferred without auction → trade (0 additional points, counted in trades)
+    }
+
+    userTotals.set(userId, {
+      points,
+      trades: tradeCountByUser.get(userId) || 0,
+      auctions
+    })
+  }
+
+  // ── 9. Build response arrays ──────────────────────────────────────────────
+  function buildUserList(ids) {
+    return ids.map(userId => {
+      const info = userMap.get(userId)
+      const totals = userTotals.get(userId)
+      return {
+        userId,
+        username: info.username,
+        completedSets: userCompletedSetsMap.get(userId),
+        pointsSpent: totals.points,
+        tradesUsed: totals.trades,
+        auctionsWon: totals.auctions
+      }
+    }).sort((a, b) => a.pointsSpent - b.pointsSpent)
+  }
+
+  const oneSetUsers = buildUserList(oneSetCompleterIds)
+  const allSetsUsers = buildUserList(allSetsCompleterIds)
+
+  // Histogram bucket size: auto-scale to ~10 meaningful buckets
+  function chooseBucketSize(values) {
+    if (!values.length) return 100
+    const max = Math.max(...values)
+    if (max === 0) return 100
+    const raw = max / 10
+    const magnitude = Math.pow(10, Math.floor(Math.log10(raw)))
+    const normalized = raw / magnitude
+    let nice = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10
+    return Math.max(1, nice * magnitude)
+  }
+
+  const oneSetPoints = oneSetUsers.map(u => u.pointsSpent)
+  const allSetsPoints = allSetsUsers.map(u => u.pointsSpent)
+
+  return {
+    weekStart: weekStart.toISOString(),
+    weekEnd: weekEnd.toISOString(),
+    sets: setNames.map(n => ({ name: n, ctoonCount: setMap.get(n).length })),
+    oneSet: {
+      count: oneSetUsers.length,
+      users: oneSetUsers
+    },
+    allSets: {
+      count: allSetsUsers.length,
+      users: allSetsUsers
+    },
+    oneSetPointsDistribution: buildHistogram(oneSetPoints, chooseBucketSize(oneSetPoints)),
+    allSetsPointsDistribution: buildHistogram(allSetsPoints, chooseBucketSize(allSetsPoints))
+  }
+})

--- a/server/api/admin/ctoon-collection-analytics.get.js
+++ b/server/api/admin/ctoon-collection-analytics.get.js
@@ -1,5 +1,8 @@
 import { defineEventHandler, getQuery, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+
+const CACHE_TTL_SECONDS = 86400 // 24 hours
 
 function lastMonday(from = new Date()) {
   const d = new Date(from)
@@ -52,6 +55,14 @@ export default defineEventHandler(async (event) => {
   const weekEnd = new Date(weekStart)
   weekEnd.setUTCDate(weekEnd.getUTCDate() + 7)
 
+  // ── Cache check ───────────────────────────────────────────────────────────
+  const weekKey = weekStart.toISOString().slice(0, 10)
+  const cacheKey = `admin:collection-analytics:${weekKey}`
+  try {
+    const hit = await redis.get(cacheKey)
+    if (hit) return JSON.parse(hit)
+  } catch {}
+
   // ── 1. Weekly cToons ─────────────────────────────────────────────────────
   const weeklyCtoons = await prisma.ctoon.findMany({
     where: {
@@ -61,8 +72,13 @@ export default defineEventHandler(async (event) => {
     select: { id: true, set: true, name: true, price: true }
   })
 
+  async function cacheAndReturn(result) {
+    try { await redis.set(cacheKey, JSON.stringify(result), 'EX', CACHE_TTL_SECONDS) } catch {}
+    return result
+  }
+
   if (weeklyCtoons.length === 0) {
-    return {
+    return cacheAndReturn({
       weekStart: weekStart.toISOString(),
       weekEnd: weekEnd.toISOString(),
       sets: [],
@@ -70,7 +86,7 @@ export default defineEventHandler(async (event) => {
       allSets: { count: 0, users: [] },
       oneSetPointsDistribution: [],
       allSetsPointsDistribution: []
-    }
+    })
   }
 
   // Group by set name
@@ -139,7 +155,7 @@ export default defineEventHandler(async (event) => {
   }
 
   if (oneSetCompleterIds.length === 0) {
-    return {
+    return cacheAndReturn({
       weekStart: weekStart.toISOString(),
       weekEnd: weekEnd.toISOString(),
       sets: setNames.map(n => ({ name: n, ctoonCount: setMap.get(n).length })),
@@ -147,7 +163,7 @@ export default defineEventHandler(async (event) => {
       allSets: { count: 0, users: [] },
       oneSetPointsDistribution: [],
       allSetsPointsDistribution: []
-    }
+    })
   }
 
   // ── 4. Collect all relevant userCtoon IDs for completers ──────────────────
@@ -321,7 +337,7 @@ export default defineEventHandler(async (event) => {
   const oneSetPoints = oneSetUsers.map(u => u.pointsSpent)
   const allSetsPoints = allSetsUsers.map(u => u.pointsSpent)
 
-  return {
+  return cacheAndReturn({
     weekStart: weekStart.toISOString(),
     weekEnd: weekEnd.toISOString(),
     sets: setNames.map(n => ({ name: n, ctoonCount: setMap.get(n).length })),
@@ -335,5 +351,5 @@ export default defineEventHandler(async (event) => {
     },
     oneSetPointsDistribution: buildHistogram(oneSetPoints, chooseBucketSize(oneSetPoints)),
     allSetsPointsDistribution: buildHistogram(allSetsPoints, chooseBucketSize(allSetsPoints))
-  }
+  })
 })

--- a/server/api/admin/purchases.get.js
+++ b/server/api/admin/purchases.get.js
@@ -1,6 +1,9 @@
 // server/api/admin/purchases.get.js
 import { defineEventHandler, getQuery, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+
+const CACHE_TTL_SECONDS = 86400 // 24 hours
 
 export default defineEventHandler(async (event) => {
   // 1) Admin check
@@ -21,6 +24,13 @@ export default defineEventHandler(async (event) => {
     ? rawGroupBy
     : 'daily'
 
+  // 3) Cache check
+  const cacheKey = `admin:purchases:${timeframe}:${method}:${groupBy}`
+  try {
+    const hit = await redis.get(cacheKey)
+    if (hit) return JSON.parse(hit)
+  } catch {}
+
   const now = new Date()
   const startDate = new Date(now)
   switch (timeframe) {
@@ -31,7 +41,7 @@ export default defineEventHandler(async (event) => {
     default:   startDate.setMonth(startDate.getMonth() - 3)
   }
 
-  // 3) Helper to run the appropriate aggregation
+  // 4) Helper to run the appropriate aggregation
   async function fetchPurchases(kind /* 'ctoon' | 'pack' */) {
     const like = kind === 'pack' ? '%Bought Pack%' : '%Bought cToon%'
     if (groupBy === 'weekly') {
@@ -71,19 +81,21 @@ export default defineEventHandler(async (event) => {
     `
   }
 
-  // 4) Return per requested method
+  async function cacheAndReturn(result) {
+    try { await redis.set(cacheKey, JSON.stringify(result), 'EX', CACHE_TTL_SECONDS) } catch {}
+    return result
+  }
+
+  // 5) Return per requested method
   if (method === 'ctoon') {
-    const ctoonPurchases = await fetchPurchases('ctoon')
-    return ctoonPurchases
+    return cacheAndReturn(await fetchPurchases('ctoon'))
   } else if (method === 'pack') {
-    const packPurchases = await fetchPurchases('pack')
-    return packPurchases
+    return cacheAndReturn(await fetchPurchases('pack'))
   } else {
-    // fallback—if someone omits/changes method, return both
     const [ctoonPurchases, packPurchases] = await Promise.all([
       fetchPurchases('ctoon'),
       fetchPurchases('pack')
     ])
-    return { ctoonPurchases, packPurchases }
+    return cacheAndReturn({ ctoonPurchases, packPurchases })
   }
 })


### PR DESCRIPTION
Tracks weekly set completion: how many users collected at least one full
set (or all sets) from a selected week's releases, plus attribution of
points spent, trades used, and auctions won per user. Includes two
histogram charts showing the points-spent distribution for each group.

- server/api/admin/ctoon-collection-analytics.get.js — new API endpoint
- components/newsite/AdminCtoonCollectionAnalytics.vue — new admin page component
- AdminNav.vue — added "Collection Analytics" link under Admin Logs
- [[section]].vue — wired in the new component via collectionAnalytics route