### PR TITLE
Track exact purchase price on UserCtoon and UserPack for analytics

### DIFF
--- a/components/newsite/AdminCtoonCollectionAnalytics.vue
+++ b/components/newsite/AdminCtoonCollectionAnalytics.vue
@@ -70,11 +70,15 @@
                 <div class="text-[11px] text-purple-600">Completed All Sets</div>
               </div>
               <div class="bg-gray-50 rounded p-2 text-center">
-                <div class="text-lg font-bold text-gray-700">{{ avgPoints(data.oneSet.users) }}</div>
+                <div class="text-lg font-bold text-gray-700">
+                  {{ avgPoints(data.oneSet.users) }}<span v-if="data.oneSet.users.some(u => u.pointsEstimated)" class="text-amber-500" title="Includes estimated costs">*</span>
+                </div>
                 <div class="text-[11px] text-gray-500">Avg pts (1 set)</div>
               </div>
               <div class="bg-gray-50 rounded p-2 text-center">
-                <div class="text-lg font-bold text-gray-700">{{ avgPoints(data.allSets.users) }}</div>
+                <div class="text-lg font-bold text-gray-700">
+                  {{ avgPoints(data.allSets.users) }}<span v-if="data.allSets.users.some(u => u.pointsEstimated)" class="text-amber-500" title="Includes estimated costs">*</span>
+                </div>
                 <div class="text-[11px] text-gray-500">Avg pts (all sets)</div>
               </div>
             </div>
@@ -145,7 +149,9 @@
                   >
                     <td class="px-1.5 py-1 font-medium text-gray-900">{{ u.username }}</td>
                     <td class="px-1.5 py-1 text-gray-700">{{ u.completedSets.join(', ') }}</td>
-                    <td class="px-1.5 py-1 text-right tabular-nums text-gray-900">{{ u.pointsSpent.toLocaleString() }}</td>
+                    <td class="px-1.5 py-1 text-right tabular-nums text-gray-900">
+                      {{ u.pointsSpent.toLocaleString() }}<span v-if="u.pointsEstimated" class="text-amber-500" title="Some costs estimated">*</span>
+                    </td>
                     <td class="px-1.5 py-1 text-right tabular-nums text-gray-900">{{ u.tradesUsed }}</td>
                     <td class="px-1.5 py-1 text-right tabular-nums text-gray-900">{{ u.auctionsWon }}</td>
                   </tr>
@@ -153,6 +159,12 @@
               </table>
               <p v-else class="text-gray-600 py-2">No users in this category for the selected week.</p>
             </div>
+
+            <!-- Footnote shown when any visible user has an estimated cost -->
+            <p v-if="activeUsers.some(u => u.pointsEstimated)" class="mt-1 text-[10px] text-amber-600">
+              * Points marked with an asterisk include estimated costs: rarity default prices for legacy direct purchases,
+              or {{ FALLBACK_PACK_PRICE.toLocaleString() }} pts per pack for purchases made before pack price tracking was added.
+            </p>
 
           </template>
         </template>
@@ -171,6 +183,8 @@ import {
 } from 'chart.js'
 
 Chart.register(BarController, BarElement, CategoryScale, LinearScale, Title, Tooltip, Legend)
+
+const FALLBACK_PACK_PRICE = 1500
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/components/newsite/AdminCtoonCollectionAnalytics.vue
+++ b/components/newsite/AdminCtoonCollectionAnalytics.vue
@@ -44,6 +44,17 @@
               class="border rounded px-1.5 py-0.5 text-xs w-16"
             />
           </div>
+          <button
+            type="button"
+            :disabled="loading"
+            class="flex items-center gap-1 border rounded px-2 py-0.5 text-xs bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="loadFresh"
+          >
+            <svg :class="['w-3 h-3', loading ? 'animate-spin' : '']" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Refresh
+          </button>
         </div>
 
         <div v-if="loading" class="text-center py-6 text-gray-500">Loading…</div>
@@ -383,19 +394,23 @@ function renderCharts() {
 
 // ── Data fetch ────────────────────────────────────────────────────────────────
 
-async function load() {
+async function load(refresh = false) {
   loading.value = true
   error.value = null
   try {
-    data.value = await $fetch('/api/admin/ctoon-collection-analytics', {
-      params: { weekStart: weekStartInput.value }
-    })
+    const params = { weekStart: weekStartInput.value }
+    if (refresh) params.refresh = '1'
+    data.value = await $fetch('/api/admin/ctoon-collection-analytics', { params })
     renderCharts()
   } catch (err) {
     error.value = err?.data?.statusMessage || err?.message || 'Failed to load analytics'
   } finally {
     loading.value = false
   }
+}
+
+function loadFresh() {
+  load(true)
 }
 
 function loadPrevWeek() {

--- a/components/newsite/AdminCtoonCollectionAnalytics.vue
+++ b/components/newsite/AdminCtoonCollectionAnalytics.vue
@@ -4,7 +4,7 @@
       <div class="bg-white rounded-lg shadow p-3">
         <h1 class="text-base font-semibold mb-2 text-gray-900">cToon Collection Analytics</h1>
 
-        <!-- Week picker -->
+        <!-- Controls row -->
         <div class="flex flex-wrap items-center gap-3 mb-3">
           <div class="flex items-center gap-1.5">
             <label for="weekStart" class="font-medium">Week starting (Monday):</label>
@@ -33,6 +33,17 @@
           <span v-if="weekEnd" class="text-gray-500">
             {{ formatDate(weekStartInput) }} – {{ formatDate(weekEnd) }}
           </span>
+
+          <div class="flex items-center gap-1.5 ml-auto">
+            <label for="minCtoons" class="font-medium whitespace-nowrap">Min cToons per set:</label>
+            <input
+              id="minCtoons"
+              v-model.number="minCtoons"
+              type="number"
+              min="1"
+              class="border rounded px-1.5 py-0.5 text-xs w-16"
+            />
+          </div>
         </div>
 
         <div v-if="loading" class="text-center py-6 text-gray-500">Loading…</div>
@@ -45,39 +56,47 @@
           </div>
 
           <template v-else>
-            <!-- Sets released this week -->
+            <!-- Sets released this week (filtered) -->
             <div class="mb-3">
-              <h2 class="text-sm font-semibold mb-1">Sets Released This Week</h2>
-              <div class="flex flex-wrap gap-2">
+              <h2 class="text-sm font-semibold mb-1">
+                Sets Released This Week
+                <span v-if="filteredSets.length < data.sets.length" class="text-[11px] font-normal text-gray-500">
+                  (showing {{ filteredSets.length }} of {{ data.sets.length }} with ≥{{ minCtoons }} cToons)
+                </span>
+              </h2>
+              <div v-if="filteredSets.length" class="flex flex-wrap gap-2">
                 <span
-                  v-for="s in data.sets"
+                  v-for="s in filteredSets"
                   :key="s.name"
                   class="inline-block bg-blue-100 text-blue-800 rounded-full px-2 py-0.5 text-[11px]"
                 >
                   {{ s.name }} ({{ s.ctoonCount }} cToons)
                 </span>
               </div>
+              <p v-else class="text-gray-500 text-[11px]">
+                No sets have {{ minCtoons }}+ cToons this week.
+              </p>
             </div>
 
             <!-- Summary stats -->
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
               <div class="bg-green-50 rounded p-2 text-center">
-                <div class="text-lg font-bold text-green-700">{{ data.oneSet.count }}</div>
+                <div class="text-lg font-bold text-green-700">{{ filteredOneSetUsers.length }}</div>
                 <div class="text-[11px] text-green-600">Completed ≥1 Set</div>
               </div>
               <div class="bg-purple-50 rounded p-2 text-center">
-                <div class="text-lg font-bold text-purple-700">{{ data.allSets.count }}</div>
+                <div class="text-lg font-bold text-purple-700">{{ filteredAllSetsUsers.length }}</div>
                 <div class="text-[11px] text-purple-600">Completed All Sets</div>
               </div>
               <div class="bg-gray-50 rounded p-2 text-center">
                 <div class="text-lg font-bold text-gray-700">
-                  {{ avgPoints(data.oneSet.users) }}<span v-if="data.oneSet.users.some(u => u.pointsEstimated)" class="text-amber-500" title="Includes estimated costs">*</span>
+                  {{ avgPoints(filteredOneSetUsers) }}<span v-if="filteredOneSetUsers.some(u => u.pointsEstimated)" class="text-amber-500" title="Includes estimated costs">*</span>
                 </div>
                 <div class="text-[11px] text-gray-500">Avg pts (1 set)</div>
               </div>
               <div class="bg-gray-50 rounded p-2 text-center">
                 <div class="text-lg font-bold text-gray-700">
-                  {{ avgPoints(data.allSets.users) }}<span v-if="data.allSets.users.some(u => u.pointsEstimated)" class="text-amber-500" title="Includes estimated costs">*</span>
+                  {{ avgPoints(filteredAllSetsUsers) }}<span v-if="filteredAllSetsUsers.some(u => u.pointsEstimated)" class="text-amber-500" title="Includes estimated costs">*</span>
                 </div>
                 <div class="text-[11px] text-gray-500">Avg pts (all sets)</div>
               </div>
@@ -115,7 +134,7 @@
                 ]"
                 @click="activeTab = 'one'"
               >
-                ≥1 Set Completers ({{ data.oneSet.count }})
+                ≥1 Set Completers ({{ filteredOneSetUsers.length }})
               </button>
               <button
                 type="button"
@@ -125,7 +144,7 @@
                 ]"
                 @click="activeTab = 'all'"
               >
-                All Sets Completers ({{ data.allSets.count }})
+                All Sets Completers ({{ filteredAllSetsUsers.length }})
               </button>
             </div>
 
@@ -148,7 +167,7 @@
                     class="border-b hover:bg-gray-50"
                   >
                     <td class="px-1.5 py-1 font-medium text-gray-900">{{ u.username }}</td>
-                    <td class="px-1.5 py-1 text-gray-700">{{ u.completedSets.join(', ') }}</td>
+                    <td class="px-1.5 py-1 text-gray-700">{{ filteredCompletedSets(u).join(', ') }}</td>
                     <td class="px-1.5 py-1 text-right tabular-nums text-gray-900">
                       {{ u.pointsSpent.toLocaleString() }}<span v-if="u.pointsEstimated" class="text-amber-500" title="Some costs estimated">*</span>
                     </td>
@@ -217,19 +236,66 @@ function addDays(ymd, n) {
   return toYMD(d)
 }
 
+function buildHistogram(users) {
+  const values = users.map(u => u.pointsSpent)
+  if (!values.length) return []
+  const max = Math.max(...values)
+  if (max === 0) return [{ label: '0–0', count: values.length }]
+  const raw = max / 10
+  const magnitude = Math.pow(10, Math.floor(Math.log10(raw)))
+  const normalized = raw / magnitude
+  const nice = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10
+  const bucketSize = Math.max(1, nice * magnitude)
+  const buckets = []
+  for (let lo = 0; lo <= max; lo += bucketSize) {
+    const hi = lo + bucketSize
+    buckets.push({ label: `${lo}–${hi - 1}`, count: values.filter(v => v >= lo && v < hi).length })
+  }
+  while (buckets.length > 1 && buckets[buckets.length - 1].count === 0) buckets.pop()
+  return buckets
+}
+
 // ── State ────────────────────────────────────────────────────────────────────
 
 const weekStartInput = ref(toYMD(prevMonday()))
 const weekEnd = computed(() => addDays(weekStartInput.value, 6))
+const minCtoons = ref(19)
 
 const loading = ref(false)
 const error = ref(null)
 const data = ref(null)
 const activeTab = ref('one')
 
+// ── Filtered computed ─────────────────────────────────────────────────────────
+
+const filteredSets = computed(() => {
+  if (!data.value) return []
+  return data.value.sets.filter(s => s.ctoonCount >= minCtoons.value)
+})
+
+const filteredSetNames = computed(() => new Set(filteredSets.value.map(s => s.name)))
+
+const filteredOneSetUsers = computed(() => {
+  if (!data.value) return []
+  return data.value.oneSet.users.filter(u =>
+    u.completedSets.some(s => filteredSetNames.value.has(s))
+  )
+})
+
+const filteredAllSetsUsers = computed(() => {
+  if (!data.value) return []
+  return data.value.allSets.users.filter(u =>
+    u.completedSets.some(s => filteredSetNames.value.has(s))
+  )
+})
+
 const activeUsers = computed(() =>
-  activeTab.value === 'one' ? (data.value?.oneSet.users ?? []) : (data.value?.allSets.users ?? [])
+  activeTab.value === 'one' ? filteredOneSetUsers.value : filteredAllSetsUsers.value
 )
+
+function filteredCompletedSets(u) {
+  return u.completedSets.filter(s => filteredSetNames.value.has(s))
+}
 
 function avgPoints(users) {
   if (!users.length) return 0
@@ -296,13 +362,10 @@ function renderCharts() {
   destroyCharts()
   if (!data.value) return
   nextTick(() => {
-    const oneDist = data.value.oneSetPointsDistribution
-    const allDist = data.value.allSetsPointsDistribution
-
     if (oneSetCanvas.value) {
       oneSetChart = buildBarChart(
         oneSetCanvas.value,
-        oneDist,
+        buildHistogram(filteredOneSetUsers.value),
         'rgba(34, 197, 94, 0.7)',
         '≥1 Set Completers'
       )
@@ -310,7 +373,7 @@ function renderCharts() {
     if (allSetsCanvas.value) {
       allSetsChart = buildBarChart(
         allSetsCanvas.value,
-        allDist,
+        buildHistogram(filteredAllSetsUsers.value),
         'rgba(147, 51, 234, 0.7)',
         'All Sets Completers'
       )
@@ -349,6 +412,10 @@ onMounted(load)
 onBeforeUnmount(destroyCharts)
 
 watch(data, () => {
+  nextTick(renderCharts)
+})
+
+watch(minCtoons, () => {
   nextTick(renderCharts)
 })
 </script>

--- a/components/newsite/AdminPackAnalytics.vue
+++ b/components/newsite/AdminPackAnalytics.vue
@@ -34,7 +34,7 @@
             type="button"
             :disabled="loading"
             class="flex items-center gap-1 border rounded px-2 py-1 text-xs bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed"
-            @click="fetchData"
+            @click="fetchData(true)"
           >
             <svg :class="['w-3 h-3', loading ? 'animate-spin' : '']" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -154,7 +154,7 @@ function setLastNDays(n) {
 const barCanvas = ref(null)
 let barChart = null
 
-async function fetchData() {
+async function fetchData(refresh = false) {
   if (!from.value || !to.value) return
   loading.value = true
   error.value = null
@@ -162,6 +162,7 @@ async function fetchData() {
     const params = new URLSearchParams({ start: from.value, end: to.value })
     if (selectedSet.value) params.set('set', selectedSet.value)
     if (selectedPack.value) params.set('packId', selectedPack.value)
+    if (refresh) params.set('refresh', '1')
 
     const data = await $fetch(`/api/admin/pack-analytics?${params.toString()}`)
 

--- a/components/newsite/AdminPackAnalytics.vue
+++ b/components/newsite/AdminPackAnalytics.vue
@@ -30,6 +30,17 @@
           </div>
           <button type="submit" class="border rounded px-2 py-1 text-xs bg-blue-600 text-white hover:bg-blue-700">Apply</button>
           <button type="button" class="text-xs text-blue-600 underline" @click="setLastNDays(30)">Last 30 days</button>
+          <button
+            type="button"
+            :disabled="loading"
+            class="flex items-center gap-1 border rounded px-2 py-1 text-xs bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="fetchData"
+          >
+            <svg :class="['w-3 h-3', loading ? 'animate-spin' : '']" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Refresh
+          </button>
         </form>
 
         <div v-if="loading" class="text-center py-6 text-gray-500">Loading…</div>

--- a/prisma/migrations/20260531000000_add_price_paid_to_userctoon_and_userpack/migration.sql
+++ b/prisma/migrations/20260531000000_add_price_paid_to_userctoon_and_userpack/migration.sql
@@ -1,0 +1,7 @@
+-- Add pricePaid to UserCtoon: records exact points charged for direct cmart purchases.
+-- NULL for pack-acquired, trade-received, lottery-won, etc.
+ALTER TABLE "UserCtoon" ADD COLUMN "pricePaid" INTEGER;
+
+-- Add pricePaid to UserPack: records effective pack price at time of purchase.
+-- NULL for legacy records purchased before this tracking was added.
+ALTER TABLE "UserPack" ADD COLUMN "pricePaid" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -314,6 +314,7 @@ model UserCtoon {
   createdAt      DateTime  @default(now())
   burnedAt       DateTime?
   userPackId     String?
+  pricePaid      Int?      // Points charged at purchase time; null for pack-origin, trade, reward, etc.
 
   user     User      @relation(fields: [userId], references: [id])
   ctoon    Ctoon     @relation(fields: [ctoonId], references: [id])
@@ -760,6 +761,7 @@ model UserPack {
   opened    Boolean   @default(false)
   openedAt  DateTime?
   createdAt DateTime  @default(now())
+  pricePaid Int?      // Effective points charged at purchase time; null for legacy records
 
   user         User       @relation(fields: [userId], references: [id])
   pack         Pack       @relation(fields: [packId], references: [id])

--- a/server/api/admin/ctoon-collection-analytics.get.js
+++ b/server/api/admin/ctoon-collection-analytics.get.js
@@ -46,7 +46,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
   }
 
-  const { weekStart: weekStartParam } = getQuery(event)
+  const { weekStart: weekStartParam, refresh } = getQuery(event)
 
   let weekStart
   if (weekStartParam) {
@@ -64,10 +64,12 @@ export default defineEventHandler(async (event) => {
   // ── Cache check ───────────────────────────────────────────────────────────
   const weekKey = weekStart.toISOString().slice(0, 10)
   const cacheKey = `admin:collection-analytics:${weekKey}`
-  try {
-    const hit = await redis.get(cacheKey)
-    if (hit) return JSON.parse(hit)
-  } catch {}
+  if (!refresh) {
+    try {
+      const hit = await redis.get(cacheKey)
+      if (hit) return JSON.parse(hit)
+    } catch {}
+  }
 
   const TRACKED_RARITIES = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare']
 

--- a/server/api/admin/ctoon-collection-analytics.get.js
+++ b/server/api/admin/ctoon-collection-analytics.get.js
@@ -4,6 +4,12 @@ import { redis } from '@/server/utils/redis'
 
 const CACHE_TTL_SECONDS = 86400 // 24 hours
 
+const FALLBACK_PACK_PRICE = 1500
+
+const HARDCODED_RARITY_PRICES = {
+  'Common': 100, 'Uncommon': 200, 'Rare': 400, 'Very Rare': 750, 'Crazy Rare': 1250
+}
+
 function lastMonday(from = new Date()) {
   const d = new Date(from)
   d.setUTCHours(0, 0, 0, 0)
@@ -92,13 +98,13 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Group by set name
-  const setMap = new Map() // setName → [{ id, name, price }]
-  const ctoonPriceMap = new Map() // ctoonId → price
+  // Group by set name; build rarity lookup for fallback pricing
+  const setMap = new Map() // setName → [{ id, name, price, rarity }]
+  const ctoonRarityMap = new Map() // ctoonId → rarity
   for (const c of weeklyCtoons) {
     if (!setMap.has(c.set)) setMap.set(c.set, [])
     setMap.get(c.set).push(c)
-    ctoonPriceMap.set(c.id, c.price)
+    ctoonRarityMap.set(c.id, c.rarity)
   }
   const setNames = [...setMap.keys()]
   const allWeeklyCtoonIds = weeklyCtoons.map(c => c.id)
@@ -113,12 +119,17 @@ export default defineEventHandler(async (event) => {
       id: true,
       userId: true,
       ctoonId: true,
+      userPackId: true,
+      pricePaid: true,
       user: { select: { username: true } }
     }
   })
 
   // userId → { username, ownedCtoonIds: Set, userCtoonByCtoonId: Map<ctoonId, ucId> }
   const userMap = new Map()
+  // ucId → { userPackId, pricePaid }
+  const ucDetails = new Map()
+
   for (const row of ownedRows) {
     if (!userMap.has(row.userId)) {
       userMap.set(row.userId, {
@@ -132,11 +143,10 @@ export default defineEventHandler(async (event) => {
       u.ownedCtoonIds.add(row.ctoonId)
       u.userCtoonByCtoonId.set(row.ctoonId, row.id) // first uc per ctoon
     }
+    ucDetails.set(row.id, { userPackId: row.userPackId, pricePaid: row.pricePaid })
   }
 
   // ── 3. Determine completers ───────────────────────────────────────────────
-  // oneSetCompleters: completed at least 1 of the weekly sets
-  // allSetsCompleters: completed every set released that week
   const oneSetCompleterIds = []
   const allSetsCompleterIds = []
   const userCompletedSetsMap = new Map() // userId → string[]
@@ -170,7 +180,6 @@ export default defineEventHandler(async (event) => {
   }
 
   // ── 4. Collect all relevant userCtoon IDs for completers ──────────────────
-  // Only the ONE userCtoon per ctoon per user (first acquired) that is part of a completed set
   const completerUcIds = []
   const ucIdToUserCtoon = new Map() // ucId → { userId, ctoonId }
 
@@ -193,7 +202,6 @@ export default defineEventHandler(async (event) => {
     where: { userCtoonId: { in: completerUcIds } },
     select: { userCtoonId: true, userId: true }
   })
-  // ucId → userId who this was transferred TO (if it was transferred)
   const transferredUcIds = new Set(ownerLogs.map(l => l.userCtoonId))
 
   // ── 6. Attribution: Auction wins ──────────────────────────────────────────
@@ -209,14 +217,12 @@ export default defineEventHandler(async (event) => {
       highestBid: true
     }
   })
-  // ucId → highestBid
   const auctionByUcId = new Map()
   for (const a of auctionWins) {
     auctionByUcId.set(a.userCtoonId, { bid: a.highestBid, winnerId: a.winnerId })
   }
 
   // ── 7. Attribution: Accepted trades ──────────────────────────────────────
-  // Find trades where a completer received a set cToon
   const acceptedTrades = await prisma.tradeOffer.findMany({
     where: {
       status: 'ACCEPTED',
@@ -240,9 +246,6 @@ export default defineEventHandler(async (event) => {
     }
   })
 
-  // For each trade, determine if a set cToon was received by a completer
-  // tradeCount: userId → count of trades where they received a set cToon
-  // tradePoints: userId → points they paid as initiator with points+set cToon received
   const tradeCountByUser = new Map()
   const tradePointsByUser = new Map()
 
@@ -254,12 +257,10 @@ export default defineEventHandler(async (event) => {
       tc => tc.role === 'REQUESTED' && allWeeklyCtoonIds.includes(tc.userCtoon?.ctoonId)
     )
 
-    // Recipient got OFFERED set cToons
     if (offeredSetCtoons.length > 0 && oneSetCompleterIds.includes(offer.recipientId)) {
       tradeCountByUser.set(offer.recipientId, (tradeCountByUser.get(offer.recipientId) || 0) + 1)
     }
 
-    // Initiator got REQUESTED set cToons (and may have paid points)
     if (requestedSetCtoons.length > 0 && oneSetCompleterIds.includes(offer.initiatorId)) {
       tradeCountByUser.set(offer.initiatorId, (tradeCountByUser.get(offer.initiatorId) || 0) + 1)
       if (offer.pointsOffered > 0) {
@@ -271,9 +272,43 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // ── 8. Compute per-user totals ────────────────────────────────────────────
-  // pointsSpent: cmart (Ctoon.price) + auction wins (highestBid) + trade points offered
-  const userTotals = new Map() // userId → { points, trades, auctions }
+  // ── 8. Fetch rarity fallback prices from GlobalGameConfig ─────────────────
+  let rarityPrices = { ...HARDCODED_RARITY_PRICES }
+  try {
+    const cfg = await prisma.globalGameConfig.findUnique({
+      where: { id: 'singleton' },
+      select: { rarityDefaults: true }
+    })
+    if (cfg?.rarityDefaults) {
+      for (const [rarity, vals] of Object.entries(cfg.rarityDefaults)) {
+        if (vals?.price != null) rarityPrices[rarity] = vals.price
+      }
+    }
+  } catch {}
+
+  // ── 9. Fetch UserPack prices for pack-acquired set cToons ─────────────────
+  const packIdSet = new Set()
+  for (const ucId of completerUcIds) {
+    const uc = ucDetails.get(ucId)
+    if (uc?.userPackId) packIdSet.add(uc.userPackId)
+  }
+  const packPriceMap = new Map() // userPackId → pricePaid (Int | null)
+  if (packIdSet.size > 0) {
+    const userPacks = await prisma.userPack.findMany({
+      where: { id: { in: [...packIdSet] } },
+      select: { id: true, pricePaid: true }
+    })
+    for (const up of userPacks) {
+      packPriceMap.set(up.id, up.pricePaid)
+    }
+  }
+
+  // ── 10. Compute per-user totals ───────────────────────────────────────────
+  // pointsSpent sources (in priority order):
+  //   auction bid (exact) > direct cmart pricePaid (exact) > pack pricePaid (exact, deduplicated)
+  //   > rarity default fallback for direct (estimated*) > 1500 fallback for pack (estimated*)
+  //   trade points offered are added separately
+  const userTotals = new Map() // userId → { points, trades, auctions, isEstimated }
 
   for (const userId of oneSetCompleterIds) {
     const info = userMap.get(userId)
@@ -284,6 +319,10 @@ export default defineEventHandler(async (event) => {
 
     let points = tradePointsByUser.get(userId) || 0
     let auctions = 0
+    let isEstimated = false
+    // Track which packs have already been counted to avoid double-counting
+    // when multiple set cToons came from the same pack opening.
+    const packsAccounted = new Set()
 
     for (const [ctoonId, ucId] of info.userCtoonByCtoonId) {
       if (!completedCtoonIds.has(ctoonId)) continue
@@ -293,20 +332,43 @@ export default defineEventHandler(async (event) => {
         points += auctionInfo.bid
         auctions += 1
       } else if (!transferredUcIds.has(ucId)) {
-        // Direct mint (cmart / pack / code) — use published price as proxy
-        points += ctoonPriceMap.get(ctoonId) || 0
+        const uc = ucDetails.get(ucId)
+        if (uc?.userPackId) {
+          // Pack-acquired — count each pack's cost once even if it yielded multiple set cToons
+          if (!packsAccounted.has(uc.userPackId)) {
+            packsAccounted.add(uc.userPackId)
+            const packPricePaid = packPriceMap.get(uc.userPackId)
+            if (packPricePaid != null) {
+              points += packPricePaid
+            } else {
+              points += FALLBACK_PACK_PRICE
+              isEstimated = true
+            }
+          }
+        } else {
+          // Direct cmart purchase
+          if (uc?.pricePaid != null) {
+            points += uc.pricePaid
+          } else {
+            // Legacy record: fall back to rarity default price
+            const rarity = ctoonRarityMap.get(ctoonId)
+            points += rarityPrices[rarity] ?? 0
+            isEstimated = true
+          }
+        }
       }
-      // transferred without auction → trade (0 additional points, counted in trades)
+      // transferred (trade / wishlist / lottery) → 0 additional points, counted in trades
     }
 
     userTotals.set(userId, {
       points,
       trades: tradeCountByUser.get(userId) || 0,
-      auctions
+      auctions,
+      isEstimated
     })
   }
 
-  // ── 9. Build response arrays ──────────────────────────────────────────────
+  // ── 11. Build response arrays ─────────────────────────────────────────────
   function buildUserList(ids) {
     return ids.map(userId => {
       const info = userMap.get(userId)
@@ -316,6 +378,7 @@ export default defineEventHandler(async (event) => {
         username: info.username,
         completedSets: userCompletedSetsMap.get(userId),
         pointsSpent: totals.points,
+        pointsEstimated: totals.isEstimated,
         tradesUsed: totals.trades,
         auctionsWon: totals.auctions
       }

--- a/server/api/admin/pack-analytics.get.js
+++ b/server/api/admin/pack-analytics.get.js
@@ -1,5 +1,8 @@
 import { defineEventHandler, getQuery, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+
+const CACHE_TTL_SECONDS = 3600 // 1 hour
 
 function parseStartYMD(ymd) {
   if (typeof ymd !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(ymd)) return null
@@ -13,7 +16,7 @@ function parseEndYMD(ymd) {
   return isNaN(d.getTime()) ? null : d
 }
 
-const RARITIES = ['common', 'uncommon', 'rare', 'very rare']
+const RARITIES = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare']
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -27,7 +30,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
   }
 
-  const { start, end, packId, set } = getQuery(event)
+  const { start, end, packId, set, refresh } = getQuery(event)
 
   let endDate = (typeof end === 'string' && parseEndYMD(end)) || new Date()
   let startDate = (typeof start === 'string' && parseStartYMD(start)) || null
@@ -42,6 +45,17 @@ export default defineEventHandler(async (event) => {
     const tmp = startDate
     startDate = endDate
     endDate = tmp
+  }
+
+  const startKey = startDate.toISOString().slice(0, 10)
+  const endKey = endDate.toISOString().slice(0, 10)
+  const cacheKey = `admin:pack-analytics:${startKey}:${endKey}:${packId || 'all'}:${set || 'all'}`
+
+  if (!refresh) {
+    try {
+      const hit = await redis.get(cacheKey)
+      if (hit) return JSON.parse(hit)
+    } catch {}
   }
 
   // If filtering by pack, resolve the ctoon IDs for that pack
@@ -63,7 +77,7 @@ export default defineEventHandler(async (event) => {
     }
   })
 
-  // Ctoon counts grouped by rarity × inCmart (shop vs PE) for each rarity
+  // Ctoon counts grouped by rarity × inCmart (shop vs pack-exclusive)
   const rarityBreakdown = await Promise.all(
     RARITIES.map(async (rarity) => {
       const ctoonWhere = {
@@ -105,7 +119,7 @@ export default defineEventHandler(async (event) => {
     })
   ])
 
-  return {
+  const result = {
     start: startDate.toISOString(),
     end: endDate.toISOString(),
     packsOpened,
@@ -113,4 +127,8 @@ export default defineEventHandler(async (event) => {
     sets: setsRaw.map(s => s.set).filter(Boolean),
     packs
   }
+
+  try { await redis.set(cacheKey, JSON.stringify(result), 'EX', CACHE_TTL_SECONDS) } catch {}
+
+  return result
 })

--- a/server/api/cmart/packs/buy.post.js
+++ b/server/api/cmart/packs/buy.post.js
@@ -162,12 +162,13 @@ export default defineEventHandler(async (event) => {
       data: { userId: me.id, points: effectivePackPrice, total: updated.points, method: "Bought Pack", direction: 'decrease' }
     })
 
-    // 6-b  create UserPack (sealed)
+    // 6-b  create UserPack (sealed) — record effective price paid at this moment
     const userPack = await tx.userPack.create({
       data: {
         userId: me.id,
         packId: pack.id,
-        opened: false
+        opened: false,
+        pricePaid: effectivePackPrice
       }
     })
 

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -243,7 +243,11 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
 
       // 3) Create the UserCtoon with the atomic mintNumber
       const uc = await tx.userCtoon.create({
-        data: { userId, ctoonId, mintNumber, isFirstEdition, ...(userPackId ? { userPackId } : {}) },
+        data: {
+          userId, ctoonId, mintNumber, isFirstEdition,
+          ...(userPackId ? { userPackId } : {}),
+          pricePaid: isSpecial ? null : chargePrice
+        },
         select: { id: true, mintNumber: true }
       })
 


### PR DESCRIPTION
Adds pricePaid fields to capture the effective points charged at the
moment of purchase (respecting half-price events, etc.) so collection
analytics can report accurate spend instead of relying on the current
Ctoon.price field which may have changed.

- UserCtoon.pricePaid (Int?): set to chargePrice for direct cmart buys;
  null for pack-acquired, traded, or rewarded cToons
- UserPack.pricePaid (Int?): set to effectivePackPrice at buy time;
  null for legacy records
- Mint worker writes pricePaid on every non-special UserCtoon
- Pack buy endpoint writes pricePaid on every new UserPack
- Analytics API prefers exact pricePaid, falls back to rarity defaults
  (direct) or 1500 pts (packs) for legacy records; flags these as
  estimated via pointsEstimated boolean
- Analytics component shows amber * on estimated values with footnote
  explaining the fallbacks used

https://claude.ai/code/session_016LtDY4vu4yJMSmg5eBknNE