### PR TITLE
feat(analytics): revamp Collection Analytics with all-time data and failed-pack tracking

### DIFF
--- a/components/newsite/AdminCtoonCollectionAnalytics.vue
+++ b/components/newsite/AdminCtoonCollectionAnalytics.vue
@@ -5,7 +5,7 @@
         <h1 class="text-base font-semibold mb-2 text-gray-900">cToon Collection Analytics</h1>
 
         <!-- Controls row -->
-        <div class="flex flex-wrap items-center gap-3 mb-3">
+        <div class="flex flex-wrap items-center gap-3 mb-1">
           <div class="flex items-center gap-1.5">
             <label for="weekStart" class="font-medium">Week starting (Monday):</label>
             <input
@@ -55,6 +55,16 @@
             </svg>
             Refresh
           </button>
+        </div>
+
+        <!-- Filter notes -->
+        <div class="flex flex-col gap-1 mb-3">
+          <p class="text-[11px] text-blue-700 bg-blue-50 border border-blue-200 rounded px-2 py-1">
+            <strong>Note:</strong> The week selection determines <strong>which sets to analyze</strong> based on their release date. All acquisition data (points spent, trades, auctions, pack purchases) is tracked <strong>for all time</strong> — not limited to the selected week.
+          </p>
+          <p class="text-[11px] text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1">
+            <strong>Data accuracy:</strong> Failed pack tracking (packs that were opened but yielded no new set cToons) requires UserPack records that were first tracked on <strong>May 31, 2026</strong>. Data before that date may undercount pack-related costs.
+          </p>
         </div>
 
         <div v-if="loading" class="text-center py-6 text-gray-500">Loading…</div>
@@ -118,7 +128,7 @@
               <div>
                 <h2 class="text-sm font-semibold mb-1 text-gray-900">Points Distribution — ≥1 Set Completers</h2>
                 <p class="text-[11px] text-gray-600 mb-1">
-                  Distribution of total points spent to collect at least one full set.
+                  Distribution of total all-time points spent to collect at least one full set.
                 </p>
                 <div class="chart-container">
                   <canvas ref="oneSetCanvas"></canvas>
@@ -127,7 +137,7 @@
               <div>
                 <h2 class="text-sm font-semibold mb-1 text-gray-900">Points Distribution — All Sets Completers</h2>
                 <p class="text-[11px] text-gray-600 mb-1">
-                  Distribution of total points spent to collect every set released that week.
+                  Distribution of total all-time points spent to collect every set released that week.
                 </p>
                 <div class="chart-container">
                   <canvas ref="allSetsCanvas"></canvas>
@@ -136,7 +146,7 @@
             </div>
 
             <!-- Tab toggle -->
-            <div class="flex gap-1 mb-2">
+            <div class="flex gap-1 mb-3">
               <button
                 type="button"
                 :class="[
@@ -157,6 +167,63 @@
               >
                 All Sets Completers ({{ filteredAllSetsUsers.length }})
               </button>
+            </div>
+
+            <!-- Aggregate breakdown -->
+            <div v-if="activeBreakdown" class="mb-3 bg-gray-50 border rounded p-3">
+              <h3 class="text-[11px] font-semibold text-gray-800 mb-2">
+                Aggregate Acquisition Breakdown
+                <span class="font-normal text-gray-500">(across all {{ activeTab === 'one' ? '≥1 set' : 'all sets' }} completers)</span>
+              </h3>
+              <div class="overflow-x-auto">
+                <table class="text-[11px] w-full max-w-lg">
+                  <thead>
+                    <tr class="border-b bg-gray-100">
+                      <th class="px-2 py-1 text-left text-gray-800">Method</th>
+                      <th class="px-2 py-1 text-right text-gray-800">Count</th>
+                      <th class="px-2 py-1 text-right text-gray-800">Total Points</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr class="border-b">
+                      <td class="px-2 py-1 text-gray-700">cMart purchases</td>
+                      <td class="px-2 py-1 text-right tabular-nums">{{ activeBreakdown.totalCmartCount.toLocaleString() }}</td>
+                      <td class="px-2 py-1 text-right tabular-nums">{{ activeBreakdown.totalCmartPoints.toLocaleString() }}</td>
+                    </tr>
+                    <tr class="border-b">
+                      <td class="px-2 py-1 text-gray-700">
+                        Packs purchased
+                        <span v-if="activeBreakdown.totalFailedPackCount > 0" class="text-gray-400">({{ activeBreakdown.totalFailedPackCount.toLocaleString() }} failed)</span>
+                      </td>
+                      <td class="px-2 py-1 text-right tabular-nums">{{ activeBreakdown.totalPackCount.toLocaleString() }}</td>
+                      <td class="px-2 py-1 text-right tabular-nums">{{ activeBreakdown.totalPackPoints.toLocaleString() }}</td>
+                    </tr>
+                    <tr v-if="activeBreakdown.totalFailedPackCount > 0" class="border-b bg-amber-50">
+                      <td class="px-2 py-1 text-amber-700 pl-5">↳ of which failed (no new set cToons)</td>
+                      <td class="px-2 py-1 text-right tabular-nums text-amber-700">{{ activeBreakdown.totalFailedPackCount.toLocaleString() }}</td>
+                      <td class="px-2 py-1 text-right tabular-nums text-amber-700">{{ activeBreakdown.totalFailedPackPoints.toLocaleString() }}</td>
+                    </tr>
+                    <tr class="border-b">
+                      <td class="px-2 py-1 text-gray-700">Auctions won</td>
+                      <td class="px-2 py-1 text-right tabular-nums">{{ activeBreakdown.totalAuctions.toLocaleString() }}</td>
+                      <td class="px-2 py-1 text-right tabular-nums text-gray-400">—</td>
+                    </tr>
+                    <tr class="border-b">
+                      <td class="px-2 py-1 text-gray-700">Trades made</td>
+                      <td class="px-2 py-1 text-right tabular-nums">{{ activeBreakdown.totalTrades.toLocaleString() }}</td>
+                      <td class="px-2 py-1 text-right tabular-nums text-gray-400">—</td>
+                    </tr>
+                    <tr class="font-semibold bg-gray-100">
+                      <td class="px-2 py-1 text-gray-900">Total points spent</td>
+                      <td class="px-2 py-1"></td>
+                      <td class="px-2 py-1 text-right tabular-nums text-gray-900">{{ activeBreakdown.totalPoints.toLocaleString() }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <p class="text-[10px] text-gray-500 mt-1">
+                "Failed packs" are set-eligible packs opened before a user completed the set that yielded no new cToons from that set. Points for trades shown per-user above (initiator-side only). Auction point totals roll up into user totals.
+              </p>
             </div>
 
             <!-- User table -->
@@ -187,7 +254,7 @@
                   </tr>
                 </tbody>
               </table>
-              <p v-else class="text-gray-600 py-2">No users in this category for the selected week.</p>
+              <p v-else class="text-gray-600 py-2">No users in this category for the selected sets.</p>
             </div>
 
             <!-- Footnote shown when any visible user has an estimated cost -->
@@ -303,6 +370,29 @@ const filteredAllSetsUsers = computed(() => {
 const activeUsers = computed(() =>
   activeTab.value === 'one' ? filteredOneSetUsers.value : filteredAllSetsUsers.value
 )
+
+// Compute breakdown aggregate from filtered users (not from raw API breakdown,
+// since the minCtoons filter may exclude some users)
+const activeBreakdown = computed(() => {
+  const users = activeUsers.value
+  if (!users.length) return null
+  return users.reduce((acc, u) => ({
+    totalPoints: acc.totalPoints + u.pointsSpent,
+    totalTrades: acc.totalTrades + u.tradesUsed,
+    totalAuctions: acc.totalAuctions + u.auctionsWon,
+    totalCmartCount: acc.totalCmartCount + (u.cmartCount || 0),
+    totalCmartPoints: acc.totalCmartPoints + (u.cmartPoints || 0),
+    totalPackCount: acc.totalPackCount + (u.packCount || 0),
+    totalPackPoints: acc.totalPackPoints + (u.packPoints || 0),
+    totalFailedPackCount: acc.totalFailedPackCount + (u.failedPackCount || 0),
+    totalFailedPackPoints: acc.totalFailedPackPoints + (u.failedPackPoints || 0)
+  }), {
+    totalPoints: 0, totalTrades: 0, totalAuctions: 0,
+    totalCmartCount: 0, totalCmartPoints: 0,
+    totalPackCount: 0, totalPackPoints: 0,
+    totalFailedPackCount: 0, totalFailedPackPoints: 0
+  })
+})
 
 function filteredCompletedSets(u) {
   return u.completedSets.filter(s => filteredSetNames.value.has(s))

--- a/server/api/admin/ctoon-collection-analytics.get.js
+++ b/server/api/admin/ctoon-collection-analytics.get.js
@@ -63,7 +63,7 @@ export default defineEventHandler(async (event) => {
 
   // ── Cache check ───────────────────────────────────────────────────────────
   const weekKey = weekStart.toISOString().slice(0, 10)
-  const cacheKey = `admin:collection-analytics:${weekKey}`
+  const cacheKey = `admin:collection-analytics:v2:${weekKey}`
   if (!refresh) {
     try {
       const hit = await redis.get(cacheKey)
@@ -73,7 +73,8 @@ export default defineEventHandler(async (event) => {
 
   const TRACKED_RARITIES = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare']
 
-  // ── 1. Weekly cToons ─────────────────────────────────────────────────────
+  // ── 1. cToons whose set released in the selected week ────────────────────
+  // Week selection determines WHICH SETS to analyze; all acquisition data is all-time.
   const weeklyCtoons = await prisma.ctoon.findMany({
     where: {
       releaseDate: { gte: weekStart, lt: weekEnd },
@@ -88,13 +89,20 @@ export default defineEventHandler(async (event) => {
     return result
   }
 
+  const emptyBreakdown = {
+    totalPoints: 0, totalTrades: 0, totalAuctions: 0,
+    totalCmartCount: 0, totalCmartPoints: 0,
+    totalPackCount: 0, totalPackPoints: 0,
+    totalFailedPackCount: 0, totalFailedPackPoints: 0
+  }
+
   if (weeklyCtoons.length === 0) {
     return cacheAndReturn({
       weekStart: weekStart.toISOString(),
       weekEnd: weekEnd.toISOString(),
       sets: [],
-      oneSet: { count: 0, users: [] },
-      allSets: { count: 0, users: [] },
+      oneSet: { count: 0, users: [], breakdown: { ...emptyBreakdown } },
+      allSets: { count: 0, users: [], breakdown: { ...emptyBreakdown } },
       oneSetPointsDistribution: [],
       allSetsPointsDistribution: []
     })
@@ -111,7 +119,8 @@ export default defineEventHandler(async (event) => {
   const setNames = [...setMap.keys()]
   const allWeeklyCtoonIds = weeklyCtoons.map(c => c.id)
 
-  // ── 2. Who owns which weekly cToons ──────────────────────────────────────
+  // ── 2. All-time ownership of weekly cToons ───────────────────────────────
+  // Ordered by createdAt asc so the first row per (userId, ctoonId) is the earliest acquisition.
   const ownedRows = await prisma.userCtoon.findMany({
     where: {
       ctoonId: { in: allWeeklyCtoonIds },
@@ -123,11 +132,13 @@ export default defineEventHandler(async (event) => {
       ctoonId: true,
       userPackId: true,
       pricePaid: true,
+      createdAt: true,
       user: { select: { username: true } }
-    }
+    },
+    orderBy: { createdAt: 'asc' }
   })
 
-  // userId → { username, ownedCtoonIds: Set, userCtoonByCtoonId: Map<ctoonId, ucId> }
+  // userId → { username, ownedCtoonIds: Set, firstAcquisitions: Map<ctoonId, { ucId, createdAt }> }
   const userMap = new Map()
   // ucId → { userPackId, pricePaid }
   const ucDetails = new Map()
@@ -137,13 +148,14 @@ export default defineEventHandler(async (event) => {
       userMap.set(row.userId, {
         username: row.user?.username || row.userId,
         ownedCtoonIds: new Set(),
-        userCtoonByCtoonId: new Map()
+        firstAcquisitions: new Map()
       })
     }
     const u = userMap.get(row.userId)
     if (!u.ownedCtoonIds.has(row.ctoonId)) {
       u.ownedCtoonIds.add(row.ctoonId)
-      u.userCtoonByCtoonId.set(row.ctoonId, row.id) // first uc per ctoon
+      // First row encountered (earliest createdAt) is the canonical first acquisition
+      u.firstAcquisitions.set(row.ctoonId, { ucId: row.id, createdAt: row.createdAt })
     }
     ucDetails.set(row.id, { userPackId: row.userPackId, pricePaid: row.pricePaid })
   }
@@ -174,14 +186,14 @@ export default defineEventHandler(async (event) => {
       weekStart: weekStart.toISOString(),
       weekEnd: weekEnd.toISOString(),
       sets: setNames.map(n => ({ name: n, ctoonCount: setMap.get(n).length })),
-      oneSet: { count: 0, users: [] },
-      allSets: { count: 0, users: [] },
+      oneSet: { count: 0, users: [], breakdown: { ...emptyBreakdown } },
+      allSets: { count: 0, users: [], breakdown: { ...emptyBreakdown } },
       oneSetPointsDistribution: [],
       allSetsPointsDistribution: []
     })
   }
 
-  // ── 4. Collect all relevant userCtoon IDs for completers ──────────────────
+  // ── 4. Collect first-acquisition UC IDs for completers ───────────────────
   const completerUcIds = []
   const ucIdToUserCtoon = new Map() // ucId → { userId, ctoonId }
 
@@ -191,22 +203,15 @@ export default defineEventHandler(async (event) => {
     const completedCtoonIds = new Set(
       completedSets.flatMap(s => setMap.get(s).map(c => c.id))
     )
-    for (const [ctoonId, ucId] of info.userCtoonByCtoonId) {
+    for (const [ctoonId, acq] of info.firstAcquisitions) {
       if (completedCtoonIds.has(ctoonId)) {
-        completerUcIds.push(ucId)
-        ucIdToUserCtoon.set(ucId, { userId, ctoonId })
+        completerUcIds.push(acq.ucId)
+        ucIdToUserCtoon.set(acq.ucId, { userId, ctoonId })
       }
     }
   }
 
   // ── 5. Attribution: CtoonOwnerLog (detect transfers vs original acquisition) ──
-  // A CtoonOwnerLog row is written on EVERY ownership event — including the
-  // initial mint / pack-open / direct purchase — not just transfers. So the
-  // mere presence of a log row does NOT mean the cToon was received for free.
-  // The ORIGINAL owner is the userId on the earliest log row for each userCtoon.
-  // If the current owner (a completer) is not that original owner, the cToon was
-  // transferred in (trade / auction / wishlist / admin) and no purchase points
-  // are attributed to them.
   const ownerLogs = await prisma.ctoonOwnerLog.findMany({
     where: { userCtoonId: { in: completerUcIds } },
     select: { userCtoonId: true, userId: true, createdAt: true },
@@ -307,7 +312,7 @@ export default defineEventHandler(async (event) => {
     const uc = ucDetails.get(ucId)
     if (uc?.userPackId) packIdSet.add(uc.userPackId)
   }
-  const packPriceMap = new Map() // userPackId → pricePaid (Int | null)
+  const packPriceMap = new Map() // userPackId → pricePaid
   if (packIdSet.size > 0) {
     const userPacks = await prisma.userPack.findMany({
       where: { id: { in: [...packIdSet] } },
@@ -318,12 +323,48 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // ── 10. Compute per-user totals ───────────────────────────────────────────
-  // pointsSpent sources (in priority order):
-  //   auction bid (exact) > direct cmart pricePaid (exact) > pack pricePaid (exact, deduplicated)
-  //   > rarity default fallback for direct (estimated*) > 1500 fallback for pack (estimated*)
-  //   trade points offered are added separately
-  const userTotals = new Map() // userId → { points, trades, auctions, isEstimated }
+  // ── 10. Find set-eligible packs for "failed pack" tracking ───────────────
+  // A pack is "set-eligible" if it contains at least one weekly set cToon in its reward pool.
+  // Failed packs: set-eligible packs opened before the user completed all their sets
+  // that yielded no first-acquisition set cToons — these still represent acquisition costs.
+  const packCtoonLinks = await prisma.packCtoonOption.findMany({
+    where: { ctoonId: { in: allWeeklyCtoonIds } },
+    select: { packId: true }
+  })
+  const eligiblePackIds = [...new Set(packCtoonLinks.map(l => l.packId))]
+
+  // Fetch all set-eligible UserPacks opened by completers (with known open time)
+  const eligibleUserPacksRaw = eligiblePackIds.length > 0
+    ? await prisma.userPack.findMany({
+        where: {
+          userId: { in: oneSetCompleterIds },
+          packId: { in: eligiblePackIds },
+          opened: true,
+          openedAt: { not: null }
+        },
+        select: {
+          id: true,
+          userId: true,
+          packId: true,
+          openedAt: true,
+          pricePaid: true,
+          mintedCtoons: {
+            where: { ctoonId: { in: allWeeklyCtoonIds } },
+            select: { id: true, ctoonId: true }
+          }
+        }
+      })
+    : []
+
+  // Group by userId for efficient per-user lookup
+  const eligibleUserPacksByUser = new Map() // userId → UserPack[]
+  for (const up of eligibleUserPacksRaw) {
+    if (!eligibleUserPacksByUser.has(up.userId)) eligibleUserPacksByUser.set(up.userId, [])
+    eligibleUserPacksByUser.get(up.userId).push(up)
+  }
+
+  // ── 11. Compute per-user totals ───────────────────────────────────────────
+  const userTotals = new Map()
 
   for (const userId of oneSetCompleterIds) {
     const info = userMap.get(userId)
@@ -332,27 +373,44 @@ export default defineEventHandler(async (event) => {
       completedSets.flatMap(s => setMap.get(s).map(c => c.id))
     )
 
+    // Determine the cutoff time: when the user finished acquiring all their completed sets.
+    // No costs after this point should count.
+    let cutoffTime = null
+    const firstAcqUcIds = new Set()
+    for (const [ctoonId, acq] of info.firstAcquisitions) {
+      if (completedCtoonIds.has(ctoonId)) {
+        firstAcqUcIds.add(acq.ucId)
+        if (!cutoffTime || acq.createdAt > cutoffTime) cutoffTime = acq.createdAt
+      }
+    }
+
     let points = tradePointsByUser.get(userId) || 0
     let auctions = 0
     let isEstimated = false
-    // Track which packs have already been counted to avoid double-counting
-    // when multiple set cToons came from the same pack opening.
+    // Track which packs have already been counted (successful — yielded a first-acq set cToon)
     const packsAccounted = new Set()
 
-    for (const [ctoonId, ucId] of info.userCtoonByCtoonId) {
+    // Breakdown accumulators
+    let cmartCount = 0
+    let cmartPoints = 0
+    let packCount = 0
+    let packPoints = 0
+    let auctionPoints = 0
+
+    for (const [ctoonId, acq] of info.firstAcquisitions) {
       if (!completedCtoonIds.has(ctoonId)) continue
+
+      const ucId = acq.ucId
 
       const auctionInfo = auctionByUcId.get(ucId)
       if (auctionInfo && auctionInfo.winnerId === userId) {
         points += auctionInfo.bid
+        auctionPoints += auctionInfo.bid
         auctions += 1
         continue
       }
 
-      // Transferred in (trade / wishlist / admin) → 0 additional purchase
-      // points; counted in trades. Detected by the original owner (earliest
-      // log row) differing from the current owner. No log → treat as an
-      // original acquisition by the current owner.
+      // Transferred in (trade / wishlist / admin) — no purchase cost for this user
       const originalOwner = originalOwnerByUcId.get(ucId)
       const wasTransferred = originalOwner != null && originalOwner !== userId
       if (wasTransferred) continue
@@ -365,21 +423,57 @@ export default defineEventHandler(async (event) => {
           const packPricePaid = packPriceMap.get(uc.userPackId)
           if (packPricePaid != null) {
             points += packPricePaid
+            packPoints += packPricePaid
           } else {
             points += FALLBACK_PACK_PRICE
+            packPoints += FALLBACK_PACK_PRICE
             isEstimated = true
           }
+          packCount += 1
         }
       } else {
-        // Direct cmart purchase
+        // Direct cMart purchase
         if (uc?.pricePaid != null) {
           points += uc.pricePaid
+          cmartPoints += uc.pricePaid
         } else {
           // Legacy record: fall back to rarity default price
           const rarity = ctoonRarityMap.get(ctoonId)
-          points += rarityPrices[rarity] ?? 0
+          const fallback = rarityPrices[rarity] ?? 0
+          points += fallback
+          cmartPoints += fallback
           isEstimated = true
         }
+        cmartCount += 1
+      }
+    }
+
+    // Failed packs: set-eligible packs opened before set completion that yielded
+    // no first-acquisition set cToons. These represent real points spent hunting for
+    // set cToons even though they came up empty.
+    let failedPackCount = 0
+    let failedPackPoints = 0
+
+    if (cutoffTime) {
+      const userEligiblePacks = eligibleUserPacksByUser.get(userId) || []
+      for (const up of userEligiblePacks) {
+        // Only count packs opened before the user completed their sets
+        if (up.openedAt > cutoffTime) continue
+        // Skip packs already counted in the successful-pack path
+        if (packsAccounted.has(up.id)) continue
+
+        // A pack is "failed" for this set journey if none of its minted set cToons
+        // were a first acquisition for this user
+        const hasFirstAcq = up.mintedCtoons.some(mc => firstAcqUcIds.has(mc.id))
+        if (hasFirstAcq) continue
+
+        const price = up.pricePaid ?? FALLBACK_PACK_PRICE
+        if (up.pricePaid == null) isEstimated = true
+        failedPackCount += 1
+        failedPackPoints += price
+        points += price
+        packCount += 1
+        packPoints += price
       }
     }
 
@@ -387,11 +481,18 @@ export default defineEventHandler(async (event) => {
       points,
       trades: tradeCountByUser.get(userId) || 0,
       auctions,
-      isEstimated
+      isEstimated,
+      cmartCount,
+      cmartPoints,
+      packCount,
+      packPoints,
+      failedPackCount,
+      failedPackPoints,
+      auctionPoints
     })
   }
 
-  // ── 11. Build response arrays ─────────────────────────────────────────────
+  // ── 12. Build response arrays ─────────────────────────────────────────────
   function buildUserList(ids) {
     return ids.map(userId => {
       const info = userMap.get(userId)
@@ -403,9 +504,29 @@ export default defineEventHandler(async (event) => {
         pointsSpent: totals.points,
         pointsEstimated: totals.isEstimated,
         tradesUsed: totals.trades,
-        auctionsWon: totals.auctions
+        auctionsWon: totals.auctions,
+        cmartCount: totals.cmartCount,
+        cmartPoints: totals.cmartPoints,
+        packCount: totals.packCount,
+        packPoints: totals.packPoints,
+        failedPackCount: totals.failedPackCount,
+        failedPackPoints: totals.failedPackPoints
       }
     }).sort((a, b) => a.pointsSpent - b.pointsSpent)
+  }
+
+  function buildBreakdown(users) {
+    return users.reduce((acc, u) => ({
+      totalPoints: acc.totalPoints + u.pointsSpent,
+      totalTrades: acc.totalTrades + u.tradesUsed,
+      totalAuctions: acc.totalAuctions + u.auctionsWon,
+      totalCmartCount: acc.totalCmartCount + u.cmartCount,
+      totalCmartPoints: acc.totalCmartPoints + u.cmartPoints,
+      totalPackCount: acc.totalPackCount + u.packCount,
+      totalPackPoints: acc.totalPackPoints + u.packPoints,
+      totalFailedPackCount: acc.totalFailedPackCount + u.failedPackCount,
+      totalFailedPackPoints: acc.totalFailedPackPoints + u.failedPackPoints
+    }), { ...emptyBreakdown })
   }
 
   const oneSetUsers = buildUserList(oneSetCompleterIds)
@@ -419,7 +540,7 @@ export default defineEventHandler(async (event) => {
     const raw = max / 10
     const magnitude = Math.pow(10, Math.floor(Math.log10(raw)))
     const normalized = raw / magnitude
-    let nice = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10
+    const nice = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10
     return Math.max(1, nice * magnitude)
   }
 
@@ -432,11 +553,13 @@ export default defineEventHandler(async (event) => {
     sets: setNames.map(n => ({ name: n, ctoonCount: setMap.get(n).length })),
     oneSet: {
       count: oneSetUsers.length,
-      users: oneSetUsers
+      users: oneSetUsers,
+      breakdown: buildBreakdown(oneSetUsers)
     },
     allSets: {
       count: allSetsUsers.length,
-      users: allSetsUsers
+      users: allSetsUsers,
+      breakdown: buildBreakdown(allSetsUsers)
     },
     oneSetPointsDistribution: buildHistogram(oneSetPoints, chooseBucketSize(oneSetPoints)),
     allSetsPointsDistribution: buildHistogram(allSetsPoints, chooseBucketSize(allSetsPoints))

--- a/server/api/admin/ctoon-collection-analytics.get.js
+++ b/server/api/admin/ctoon-collection-analytics.get.js
@@ -324,14 +324,29 @@ export default defineEventHandler(async (event) => {
   }
 
   // ── 10. Find set-eligible packs for "failed pack" tracking ───────────────
-  // A pack is "set-eligible" if it contains at least one weekly set cToon in its reward pool.
-  // Failed packs: set-eligible packs opened before the user completed all their sets
-  // that yielded no first-acquisition set cToons — these still represent acquisition costs.
-  const packCtoonLinks = await prisma.packCtoonOption.findMany({
-    where: { ctoonId: { in: allWeeklyCtoonIds } },
-    select: { packId: true }
-  })
-  const eligiblePackIds = [...new Set(packCtoonLinks.map(l => l.packId))]
+  // A pack is "set-eligible" if it could yield cToons from the selected sets.
+  // PackCtoonOption reflects the *current* pool and can change as rarities sell out
+  // or are rotated, so we use historical evidence as the primary signal: any pack
+  // definition that has actually minted a set cToon for any user at any time is
+  // definitively eligible. We supplement with the current PackCtoonOption config
+  // to catch newly added packs that haven't minted yet.
+  const [historicallyEligiblePacks, currentOptionPacks] = await Promise.all([
+    prisma.userPack.findMany({
+      where: {
+        mintedCtoons: { some: { ctoonId: { in: allWeeklyCtoonIds } } }
+      },
+      select: { packId: true }
+    }),
+    prisma.packCtoonOption.findMany({
+      where: { ctoonId: { in: allWeeklyCtoonIds } },
+      select: { packId: true }
+    })
+  ])
+  const eligiblePackDefIds = new Set([
+    ...historicallyEligiblePacks.map(up => up.packId),
+    ...currentOptionPacks.map(o => o.packId)
+  ])
+  const eligiblePackIds = [...eligiblePackDefIds]
 
   // Fetch all set-eligible UserPacks opened by completers (with known open time)
   const eligibleUserPacksRaw = eligiblePackIds.length > 0


### PR DESCRIPTION
- Week selection now selects which sets to analyze (by releaseDate) while all acquisition data is tracked all-time
- Added two filter notes: one explaining week = set selector (not date filter), and one noting full pack accuracy starts May 31, 2026
- Failed pack tracking: set-eligible packs opened before set completion that yielded no new set cToons now count toward points spent
- Aggregate breakdown section shows totals split by cMart purchases, packs purchased (with failed pack sub-row), auctions, and trades
- Per-user data now includes cmartCount/cmartPoints, packCount/packPoints, failedPackCount/failedPackPoints for breakdown computation
- Breakdown aggregates recomputed client-side from filtered users so minCtoons filter is respected
- Cache key versioned (v2) to avoid stale data from old response shape

https://claude.ai/code/session_01SyFDwgz8pJVdvwwoei8Bxj