### PR TITLE
Add missing fields to ctoon admin API response

### DIFF
--- a/server/api/admin/ctoon/[id].get.js
+++ b/server/api/admin/ctoon/[id].get.js
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
         rarity: true, assetPath: true, releaseDate: true,
         price: true, inCmart: true, codeOnly: true,
         quantity: true, initialQuantity: true, perUserLimit: true,
-        characters: true,
+        characters: true, description: true, soundPath: true,
 
         // NEW G-toon fields
         isGtoon:    true,
@@ -33,6 +33,8 @@ export default defineEventHandler(async (event) => {
         // mint limit fields
         mintLimitType: true,
         mintEndDate: true,
+        timeBasedLimitCount: true,
+        timeBasedLimitWindowDays: true,
 
         // advisory schedule fields
         initialReleaseAt: true,


### PR DESCRIPTION
## Summary
Extended the ctoon admin API endpoint to include additional fields in the response payload that were previously missing.

## Key Changes
- Added `description` and `soundPath` fields to the base ctoon properties
- Added `timeBasedLimitCount` and `timeBasedLimitWindowDays` fields to the mint limit configuration section

## Details
These fields are now included in the Prisma select statement for the GET `/api/admin/ctoon/[id]` endpoint, making them available in the API response. This allows admin clients to retrieve complete ctoon metadata including descriptions, sound assets, and time-based minting limit configurations.

https://claude.ai/code/session_01WHKDTgeJqxujd32Pacpovo