### PR TITLE
Add Set and Series filter dropdowns with URL query param persistence to allCtoons page

### DIFF
--- a/components/newsite/AllCtoons.vue
+++ b/components/newsite/AllCtoons.vue
@@ -78,6 +78,7 @@
 const { open: openCtoonModal } = useCtoonModal()
 const activeTab = useAllCtoonsTab()
 const filter    = useAllCtoonsFilter()
+const meta      = useAllCtoonsMeta()
 
 function openInfo(c) {
   openCtoonModal({ ctoonId: c.id, assetPath: c.assetPath, name: c.name })
@@ -155,7 +156,9 @@ const filteredCtoons = computed(() => {
       ? true
       : f.owned === 'owned' ? c.isOwned : !c.isOwned
     const w  = !f.wishlist || wishlist.value.includes(c.id)
-    return nm && r && o && w
+    const st = !f.set    || c.set    === f.set
+    const sr = !f.series || c.series === f.series
+    return nm && r && o && w && st && sr
   })
 })
 
@@ -221,6 +224,9 @@ onMounted(async () => {
         sortAsc:   String(filter.value.sortAsc),
       }
     })
+    const sets   = [...new Set(allCtoons.value.map(c => c.set).filter(Boolean))].sort()
+    const series = [...new Set(allCtoons.value.map(c => c.series).filter(Boolean))].sort()
+    meta.value = { sets, series }
   } catch (err) {
     console.error('AllCtoons: failed to load', err)
   } finally {

--- a/components/newsite/AllCtoonsSidebar.vue
+++ b/components/newsite/AllCtoonsSidebar.vue
@@ -17,6 +17,28 @@
 
     <hr class="acs-divider" />
 
+    <!-- Set filter -->
+    <div>
+      <div class="acs-label">Set</div>
+      <select class="acs-select acs-select-full" v-model="filter.set">
+        <option value="">All Sets</option>
+        <option v-for="s in meta.sets" :key="s" :value="s">{{ s }}</option>
+      </select>
+    </div>
+
+    <hr class="acs-divider" />
+
+    <!-- Series filter -->
+    <div>
+      <div class="acs-label">Series</div>
+      <select class="acs-select acs-select-full" v-model="filter.series">
+        <option value="">All Series</option>
+        <option v-for="s in meta.series" :key="s" :value="s">{{ s }}</option>
+      </select>
+    </div>
+
+    <hr class="acs-divider" />
+
     <!-- Search -->
     <div class="acs-search">
       <span class="acs-search-icon">&#9906;</span>
@@ -85,6 +107,7 @@
 <script setup>
 const activeTab = useAllCtoonsTab()
 const filter    = useAllCtoonsFilter()
+const meta      = useAllCtoonsMeta()
 
 const RARITIES = [
   { value: 'common',       label: 'C',  cls: 'acs-rb-common'        },
@@ -111,6 +134,8 @@ function clearFilters() {
     wishlist:  false,
     sortField: 'name',
     sortAsc:   true,
+    set:       '',
+    series:    '',
   })
 }
 </script>
@@ -270,6 +295,8 @@ function clearFilters() {
 }
 
 .acs-select option { background: #1a3a58; }
+
+.acs-select-full { width: 100%; }
 
 .acs-sort-dir {
   background: rgba(0, 0, 0, 0.25);

--- a/composables/useAllCtoonsFilter.js
+++ b/composables/useAllCtoonsFilter.js
@@ -5,4 +5,6 @@ export const useAllCtoonsFilter = () => useState('allCtoonsFilter', () => ({
   wishlist:  false,
   sortField: 'name',
   sortAsc:   true,
+  set:       '',
+  series:    '',
 }))

--- a/composables/useAllCtoonsMeta.js
+++ b/composables/useAllCtoonsMeta.js
@@ -1,0 +1,4 @@
+export const useAllCtoonsMeta = () => useState('allCtoonsMeta', () => ({
+  sets: [],
+  series: [],
+}))

--- a/pages/newsite/allCtoons.vue
+++ b/pages/newsite/allCtoons.vue
@@ -8,18 +8,38 @@ definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: t
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('AllCtoonsSidebar')
 
-const filter = useAllCtoonsFilter()
-Object.assign(filter.value, {
-  name:      '',
-  rarities:  [],
-  owned:     'all',
-  wishlist:  false,
-  sortField: 'name',
-  sortAsc:   true,
-})
-
+const route     = useRoute()
+const router    = useRouter()
+const filter    = useAllCtoonsFilter()
 const activeTab = useAllCtoonsTab()
-activeTab.value = 'AllSets'
+
+const q = route.query
+Object.assign(filter.value, {
+  name:      q.name      || '',
+  rarities:  q.rarities  ? q.rarities.split(',') : [],
+  owned:     q.owned     || 'all',
+  wishlist:  q.wishlist  === 'true',
+  sortField: q.sortField || 'name',
+  sortAsc:   q.sortAsc   !== 'false',
+  set:       q.set       || '',
+  series:    q.series    || '',
+})
+activeTab.value = q.tab === 'AllSeries' ? 'AllSeries' : 'AllSets'
+
+watch([filter, activeTab], () => {
+  const f = filter.value
+  const query = {}
+  if (f.name)                   query.name      = f.name
+  if (f.rarities.length)        query.rarities  = f.rarities.join(',')
+  if (f.owned !== 'all')        query.owned     = f.owned
+  if (f.wishlist)               query.wishlist  = 'true'
+  if (f.sortField !== 'name')   query.sortField = f.sortField
+  if (!f.sortAsc)               query.sortAsc   = 'false'
+  if (f.set)                    query.set       = f.set
+  if (f.series)                 query.series    = f.series
+  if (activeTab.value !== 'AllSets') query.tab  = activeTab.value
+  router.replace({ query })
+}, { deep: true })
 </script>
 
 <style>


### PR DESCRIPTION
- Added useAllCtoonsMeta composable to share available sets/series lists
- Added `set` and `series` fields to useAllCtoonsFilter
- AllCtoons.vue populates meta with unique sorted sets/series after data fetch and applies new filters
- AllCtoonsSidebar.vue shows Set and Series dropdowns (blank by default = no filter)
- allCtoons.vue page reads all filter state from URL query params on load and watches for changes to keep URL in sync, so refreshing preserves filter state

https://claude.ai/code/session_01V4msZdRrYGq3hCxquqiHtb