### PR TITLE
Fix layout scaling to account for browser zoom levels

### DIFF
--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -309,10 +309,15 @@ const scale = ref(1)
 const isMobile = ref(false)
 
 const computeLayout = () => {
-  isMobile.value = window.innerWidth < MOBILE_BREAKPOINT
+  // outerWidth is not affected by browser zoom, so zooming doesn't trigger
+  // mobile layout or recalculate the CSS scale transform
+  isMobile.value = window.outerWidth < MOBILE_BREAKPOINT
   if (!isMobile.value) {
-    const scaleX = (window.innerWidth - SITE_PADDING) / SITE_WIDTH
-    const scaleY = (window.innerHeight - SITE_PADDING) / SITE_HEIGHT
+    const scaleX = (window.outerWidth - SITE_PADDING) / SITE_WIDTH
+    // Infer zoom factor from outerWidth/innerWidth to get the unzoomed height
+    const zoomFactor = window.innerWidth > 0 ? window.outerWidth / window.innerWidth : 1
+    const unzoomedHeight = window.innerHeight * zoomFactor
+    const scaleY = (unzoomedHeight - SITE_PADDING) / SITE_HEIGHT
     scale.value = Math.min(scaleX, scaleY, 1)
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,7 +2,7 @@ export default defineNuxtConfig({
   app: {
     head: {
       meta: [
-        { name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' }
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' }
       ]
     }
   },


### PR DESCRIPTION
## Summary
Updated the layout computation logic to properly handle browser zoom by using `window.outerWidth` instead of `window.innerWidth` and inferring the actual zoom factor to calculate unzoomed dimensions. Also removed viewport scaling restrictions to allow users to zoom.

## Key Changes
- **Layout breakpoint detection**: Changed from `window.innerWidth` to `window.outerWidth` to prevent mobile layout from being triggered by browser zoom
- **Scale calculation**: Updated scaleX calculation to use `window.outerWidth` for consistency
- **Zoom-aware height calculation**: Added zoom factor inference (`window.outerWidth / window.innerWidth`) to compute the unzoomed viewport height, ensuring the Y-axis scale is calculated correctly regardless of zoom level
- **Viewport meta tag**: Removed `maximum-scale=1` and `user-scalable=no` restrictions to allow users to zoom the page

## Implementation Details
The key insight is that `window.outerWidth` represents the browser window width unaffected by zoom, while `window.innerWidth` is affected by zoom. By calculating the zoom factor from their ratio, we can determine the true unzoomed height and compute the appropriate CSS scale transform without being affected by user zoom actions.

https://claude.ai/code/session_01DfmMuvwUhoBHnniHyhsjYe