### PR TITLE
Add featured item visual indicator to auction cards

### DIFF
--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -131,6 +131,7 @@
                 <template v-if="!isEnded(item.endAt)">{{ formatRemaining(item.endAt) }}</template>
                 <template v-else>Ended</template>
               </div>
+              <span v-if="item.isFeatured" class="ah-card-featured-tag">Featured</span>
               <span
                 v-if="activeTab === 'current'"
                 class="ah-own-badge ah-card-own-badge"
@@ -840,6 +841,22 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
   pointer-events: none;
 }
 .ah-card-time-badge.ended { color: rgba(255,255,255,0.45); }
+
+.ah-card-featured-tag {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  font-size: 0.48rem;
+  font-weight: bold;
+  background: #fbbf24;
+  color: #000;
+  padding: 1px 5px;
+  border-radius: 10px;
+  pointer-events: none;
+  z-index: 2;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
 
 .ah-card-middle {
   position: relative;

--- a/server/api/auctions.get.js
+++ b/server/api/auctions.get.js
@@ -38,8 +38,7 @@ export default defineEventHandler(async (event) => {
       _count: { select: { bids: true } }
     },
     orderBy: [
-      { isFeatured: 'desc' }, // featured first
-      { endAt: 'asc' }        // then soonest-ending
+      { endAt: 'asc' }
     ]
   })
 
@@ -62,15 +61,8 @@ export default defineEventHandler(async (event) => {
   const ownedSet = new Set(owned.map(u => u.ctoonId))
   const holidaySet = new Set(holidayItems.map(h => h.ctoonId))
 
-  // 4) Ensure featured items are first (defensive in case DB ordering changes)
-  const ordered = auctions.slice().sort((a, b) => {
-    const fb = (b.isFeatured ? 1 : 0) - (a.isFeatured ? 1 : 0)
-    if (fb !== 0) return fb
-    return new Date(a.endAt) - new Date(b.endAt)
-  })
-
-  // 5) Shape for client
-  return ordered.map(a => ({
+  // 4) Shape for client
+  return auctions.map(a => ({
     id:           a.id,
     isFeatured:   a.isFeatured,
     userCtoonId:  encodeUserCtoonId(a.userCtoon.userId, a.userCtoon.ctoonId, a.userCtoon.mintNumber),


### PR DESCRIPTION
## Summary
This PR adds a visual "Featured" tag to auction items that have the `isFeatured` flag set, while simplifying the backend sorting logic to rely solely on end time ordering.

## Key Changes
- **Frontend (AuctionHouse.vue)**
  - Added a "Featured" badge/tag that displays in the top-right corner of featured auction cards
  - Styled with amber background (#fbbf24), bold uppercase text, and appropriate positioning/z-index

- **Backend (auctions.get.js)**
  - Removed `isFeatured` from the database `orderBy` clause, now sorting only by `endAt` (ascending)
  - Removed the defensive client-side sorting logic that re-ordered results to ensure featured items appeared first
  - The `isFeatured` field is still returned to the client for display purposes

## Implementation Details
- The featured tag uses absolute positioning to overlay on the card without affecting layout
- Styling includes `pointer-events: none` to prevent interaction interference
- The tag is conditionally rendered only when `item.isFeatured` is true
- Backend now trusts the database query ordering without additional client-side manipulation

https://claude.ai/code/session_01A2NspmL4w6me9hyLkA4FDC