### PR TITLE
Fix sets/series dropdowns empty in My Collection sidebar

### DIFF
--- a/components/newsite/CtoonFilter.vue
+++ b/components/newsite/CtoonFilter.vue
@@ -119,11 +119,13 @@ const props = defineProps({
       { value: 'rarity', label: 'Rarity' },
     ],
   },
+  sourceCtoons: { type: Array, default: null },
 })
 
 const filter   = useNewSiteCtoonFilter()
 const aFilters = useAuctionHouseFilters()
-const ctoons   = useState('cmartCtoons', () => [])
+const fallbackCtoons = useState('cmartCtoons', () => [])
+const ctoons = computed(() => props.sourceCtoons !== null ? props.sourceCtoons : fallbackCtoons.value)
 
 const RARITIES = [
   { value: 'common',       label: 'C',  cls: 'cf-rb-common'        },

--- a/components/newsite/MyCollectionSidebar.vue
+++ b/components/newsite/MyCollectionSidebar.vue
@@ -1,8 +1,10 @@
 <template>
-  <CtoonFilter :sort-options="myCollectionSortOptions" />
+  <CtoonFilter :sort-options="myCollectionSortOptions" :source-ctoons="myCtoons" />
 </template>
 
 <script setup>
+const myCtoons = useState('myCollectionCtoons', () => [])
+
 const myCollectionSortOptions = [
   { value: 'acquiredDate', label: 'Acquired Date' },
   { value: 'mintNumber',   label: 'Mint #'        },


### PR DESCRIPTION
CtoonFilter was hardcoded to read from the cmartCtoons shared state,
which is only populated by the cMart and AuctionHouse pages.
MyCollection.vue stores its ctoons under myCollectionCtoons, so the
Series and Set dropdowns in MyCollectionSidebar were always empty (or
showing stale cMart data from a previous visit).

Added a sourceCtoons prop to CtoonFilter so callers can supply their
own ctoon list; when omitted it falls back to cmartCtoons as before.
MyCollectionSidebar now passes the myCollectionCtoons state as
sourceCtoons, giving the dropdowns the correct data once the collection
loads.

https://claude.ai/code/session_01ELpJ8Nuqm7QqEbr4thJtrE