### PR TITLE
Add pack price decay config and max buys per user limit

### DIFF
--- a/pages/admin/global-settings.vue
+++ b/pages/admin/global-settings.vue
@@ -269,6 +269,37 @@
           </p>
         </div>
 
+        <!-- Pack Pricing Decay -->
+        <div class="border-t pt-5">
+          <h2 class="text-base font-semibold text-gray-800 mb-1">Pack Pricing Decay</h2>
+          <p class="text-sm text-gray-500 mb-4">
+            Pack prices automatically decrease over time after they go live in cMart.
+            The price drops by the decay amount every N days until it hits the floor.
+          </p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Decay Amount (pts)</label>
+              <input type="number" min="0" class="input" v-model.number="packPriceDecayAmount" />
+              <p class="text-xs text-gray-500 mt-1">Points to drop per period (e.g. 100).</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Decay Period (days)</label>
+              <input type="number" min="1" class="input" v-model.number="packPriceDecayDays" />
+              <p class="text-xs text-gray-500 mt-1">How many days between each price drop (e.g. 7).</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Price Floor (pts)</label>
+              <input type="number" min="0" class="input" v-model.number="packPriceFloor" />
+              <p class="text-xs text-gray-500 mt-1">Minimum price a pack can decay to (e.g. 700).</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Max Default Pack Buys Per User</label>
+              <input type="number" min="1" class="input" v-model.number="packMaxDefaultBuysPerUser" />
+              <p class="text-xs text-gray-500 mt-1">Total times a user can buy a new pack (applied when pack is created).</p>
+            </div>
+          </div>
+        </div>
+
         <!-- Time-Based Release Purchase Limits -->
         <div class="border-t pt-5">
           <h2 class="text-base font-semibold text-gray-800 mb-1">Time-Based Release Purchase Limits</h2>
@@ -385,6 +416,10 @@ const savingCmart = ref(false)
 const firstAdditionalCzoneCost      = ref(25000)
 const subsequentAdditionalCzoneCost = ref(50000)
 const cmartHalfPriceEnabled         = ref(false)
+const packPriceDecayAmount          = ref(100)
+const packPriceDecayDays            = ref(7)
+const packPriceFloor                = ref(700)
+const packMaxDefaultBuysPerUser     = ref(5)
 
 // Time-based purchase limits (per rarity)
 const timeBasedRarities = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare']
@@ -424,7 +459,11 @@ async function loadGlobal() {
     featuredAuctionHours.value        = Array.isArray(g?.featuredAuctionHours) ? g.featuredAuctionHours : []
     featuredAuctionIntervalDays.value = Number(g?.featuredAuctionIntervalDays ?? 1)
     featuredAuctionsPerSlot.value     = Number(g?.featuredAuctionsPerSlot ?? 1)
-    cmartHalfPriceEnabled.value = Boolean(g?.cmartHalfPriceEnabled ?? false)
+    cmartHalfPriceEnabled.value         = Boolean(g?.cmartHalfPriceEnabled ?? false)
+    packPriceDecayAmount.value          = Number(g?.packPriceDecayAmount          ?? 100)
+    packPriceDecayDays.value            = Number(g?.packPriceDecayDays            ?? 7)
+    packPriceFloor.value                = Number(g?.packPriceFloor                ?? 700)
+    packMaxDefaultBuysPerUser.value     = Number(g?.packMaxDefaultBuysPerUser     ?? 5)
     if (g?.timeBasedPurchaseLimits) {
       for (const r of timeBasedRarities) {
         const def = g.timeBasedPurchaseLimits[r]
@@ -561,7 +600,11 @@ async function saveCmart() {
       body: {
         dailyPointLimit: Number(dailyPointLimit.value),
         cmartHalfPriceEnabled: cmartHalfPriceEnabled.value,
-        timeBasedPurchaseLimits
+        timeBasedPurchaseLimits,
+        packPriceDecayAmount:      Number(packPriceDecayAmount.value),
+        packPriceDecayDays:        Number(packPriceDecayDays.value),
+        packPriceFloor:            Number(packPriceFloor.value),
+        packMaxDefaultBuysPerUser: Number(packMaxDefaultBuysPerUser.value)
       }
     })
     toast.value = { type: 'ok', msg: 'cMart settings saved.' }

--- a/pages/cmart.vue
+++ b/pages/cmart.vue
@@ -588,8 +588,8 @@
               Purchasing…
             </span>
             <span v-else>
-              Buy Pack for {{ displayPrice(pack.price) }} Pts
-              <span v-if="cmartHalfPriceEnabled" class="ml-1 line-through text-indigo-200 text-xs">{{ pack.price }}</span>
+              Buy Pack for {{ displayPrice(pack.effectivePrice ?? pack.price) }} Pts
+              <span v-if="cmartHalfPriceEnabled" class="ml-1 line-through text-indigo-200 text-xs">{{ pack.effectivePrice ?? pack.price }}</span>
             </span>
             </button>
           </div>
@@ -716,8 +716,8 @@
               class="mt-2 w-full bg-indigo-600 hover:bg-indigo-700 text-white py-2 rounded"
               @click.stop="buyPack(packDetails)"
             >
-              Buy Pack for {{ displayPrice(packDetails?.price) }} Pts
-              <span v-if="cmartHalfPriceEnabled && packDetails?.price" class="ml-1 line-through text-indigo-200 text-xs">{{ packDetails?.price }}</span>
+              Buy Pack for {{ displayPrice(packDetails?.effectivePrice ?? packDetails?.price) }} Pts
+              <span v-if="cmartHalfPriceEnabled && (packDetails?.effectivePrice ?? packDetails?.price)" class="ml-1 line-through text-indigo-200 text-xs">{{ packDetails?.effectivePrice ?? packDetails?.price }}</span>
             </button>
           </template>
 
@@ -1363,7 +1363,7 @@ async function openPackModal(pack) {
 
 // ────────── Buy Pack & Start Animation ──────────
 async function buyPack(pack) {
-  if (user.value.points < displayPrice(pack.price)) {
+  if (user.value.points < displayPrice(pack.effectivePrice ?? pack.price)) {
     return showToast("You don't have enough points")
   }
   buyingPacks.value.add(pack.id)

--- a/prisma/migrations/20260606000000_add_pack_pricing_decay_config/migration.sql
+++ b/prisma/migrations/20260606000000_add_pack_pricing_decay_config/migration.sql
@@ -1,0 +1,8 @@
+-- Add pack price decay configuration fields to GlobalGameConfig
+ALTER TABLE "GlobalGameConfig" ADD COLUMN "packPriceDecayAmount" INTEGER NOT NULL DEFAULT 100;
+ALTER TABLE "GlobalGameConfig" ADD COLUMN "packPriceDecayDays" INTEGER NOT NULL DEFAULT 7;
+ALTER TABLE "GlobalGameConfig" ADD COLUMN "packPriceFloor" INTEGER NOT NULL DEFAULT 700;
+ALTER TABLE "GlobalGameConfig" ADD COLUMN "packMaxDefaultBuysPerUser" INTEGER NOT NULL DEFAULT 5;
+
+-- Add total max buys per user to Pack
+ALTER TABLE "Pack" ADD COLUMN "maxBuysPerUser" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -721,6 +721,7 @@ model Pack {
   scheduledOffAt     DateTime?
   sellOutBehavior    PackSellOutBehavior @default(REMOVE_ON_ANY_RARITY_EMPTY)
   dailyPurchaseLimit Int?
+  maxBuysPerUser     Int?
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
@@ -968,6 +969,11 @@ model GlobalGameConfig {
   featuredAuctionsPerSlot      Int      @default(1)      // auctions created per slot
   featuredAuctionLastFiredSlot String?                   // idempotency key e.g. "2026-03-30-08"
   cmartHalfPriceEnabled        Boolean  @default(false)   // halves cToon and pack prices in cMart
+  // Pack price decay settings
+  packPriceDecayAmount         Int      @default(100)     // points to drop per decay period
+  packPriceDecayDays           Int      @default(7)       // days between each price drop
+  packPriceFloor               Int      @default(700)     // minimum price after decay
+  packMaxDefaultBuysPerUser    Int      @default(5)       // default maxBuysPerUser set on new packs
   // Per-rarity time-based purchase limits: { "Common": { "count": 5, "windowDays": null }, ... }
   // windowDays null = full release window (releaseDate → mintEndDate)
   timeBasedPurchaseLimits      Json?

--- a/server/api/admin/global-config.post.js
+++ b/server/api/admin/global-config.post.js
@@ -37,7 +37,11 @@ export default defineEventHandler(async (event) => {
     featuredAuctionIntervalDays,
     featuredAuctionsPerSlot,
     cmartHalfPriceEnabled,
-    timeBasedPurchaseLimits
+    timeBasedPurchaseLimits,
+    packPriceDecayAmount,
+    packPriceDecayDays,
+    packPriceFloor,
+    packMaxDefaultBuysPerUser
   } = body
 
   // minimally require the existing cap; other fields optional with defaults
@@ -66,7 +70,11 @@ export default defineEventHandler(async (event) => {
     cmartHalfPriceEnabled: (typeof cmartHalfPriceEnabled === 'boolean') ? cmartHalfPriceEnabled : undefined,
     timeBasedPurchaseLimits: (timeBasedPurchaseLimits !== undefined && timeBasedPurchaseLimits !== null)
       ? timeBasedPurchaseLimits
-      : undefined
+      : undefined,
+    packPriceDecayAmount:      (typeof packPriceDecayAmount      === 'number') ? Math.max(0, packPriceDecayAmount)      : undefined,
+    packPriceDecayDays:        (typeof packPriceDecayDays        === 'number') ? Math.max(1, packPriceDecayDays)        : undefined,
+    packPriceFloor:            (typeof packPriceFloor            === 'number') ? Math.max(0, packPriceFloor)            : undefined,
+    packMaxDefaultBuysPerUser: (typeof packMaxDefaultBuysPerUser === 'number') ? Math.max(1, packMaxDefaultBuysPerUser) : undefined
   }
 
   // 3) Upsert the singleton global config row
@@ -94,7 +102,11 @@ export default defineEventHandler(async (event) => {
           'Rare':       { count: 3, windowDays: null },
           'Very Rare':  { count: 2, windowDays: null },
           'Crazy Rare': { count: 1, windowDays: null }
-        }
+        },
+        packPriceDecayAmount:      payload.packPriceDecayAmount      ?? 100,
+        packPriceDecayDays:        payload.packPriceDecayDays        ?? 7,
+        packPriceFloor:            payload.packPriceFloor            ?? 700,
+        packMaxDefaultBuysPerUser: payload.packMaxDefaultBuysPerUser ?? 5
       },
       update: {
         dailyPointLimit: payload.dailyPointLimit,
@@ -110,7 +122,11 @@ export default defineEventHandler(async (event) => {
         ...(payload.featuredAuctionIntervalDays !== undefined ? { featuredAuctionIntervalDays: payload.featuredAuctionIntervalDays } : {}),
         ...(payload.featuredAuctionsPerSlot !== undefined ? { featuredAuctionsPerSlot: payload.featuredAuctionsPerSlot } : {}),
         ...(payload.cmartHalfPriceEnabled !== undefined ? { cmartHalfPriceEnabled: payload.cmartHalfPriceEnabled } : {}),
-        ...(payload.timeBasedPurchaseLimits !== undefined ? { timeBasedPurchaseLimits: payload.timeBasedPurchaseLimits } : {})
+        ...(payload.timeBasedPurchaseLimits !== undefined ? { timeBasedPurchaseLimits: payload.timeBasedPurchaseLimits } : {}),
+        ...(payload.packPriceDecayAmount      !== undefined ? { packPriceDecayAmount:      payload.packPriceDecayAmount }      : {}),
+        ...(payload.packPriceDecayDays        !== undefined ? { packPriceDecayDays:        payload.packPriceDecayDays }        : {}),
+        ...(payload.packPriceFloor            !== undefined ? { packPriceFloor:            payload.packPriceFloor }            : {}),
+        ...(payload.packMaxDefaultBuysPerUser !== undefined ? { packMaxDefaultBuysPerUser: payload.packMaxDefaultBuysPerUser } : {})
       }
     })
     clearUpgradesConfigCache()
@@ -127,7 +143,11 @@ export default defineEventHandler(async (event) => {
       'featuredAuctionHours',
       'featuredAuctionIntervalDays',
       'featuredAuctionsPerSlot',
-      'cmartHalfPriceEnabled'
+      'cmartHalfPriceEnabled',
+      'packPriceDecayAmount',
+      'packPriceDecayDays',
+      'packPriceFloor',
+      'packMaxDefaultBuysPerUser'
     ]
     for (const k of fields) {
       const prevVal = before ? before[k] : undefined

--- a/server/api/admin/packs.post.js
+++ b/server/api/admin/packs.post.js
@@ -159,6 +159,12 @@ export default defineEventHandler(async (event) => {
     : `/packs/${filename}`
 
 
+  const globalCfg = await db.globalGameConfig.findUnique({
+    where: { id: 'singleton' },
+    select: { packMaxDefaultBuysPerUser: true }
+  })
+  const defaultMaxBuys = globalCfg?.packMaxDefaultBuysPerUser ?? 5
+
   const result = await db.$transaction(async (tx) => {
     const pack = await tx.pack.create({
       data: {
@@ -169,7 +175,8 @@ export default defineEventHandler(async (event) => {
         inCmart: meta.inCmart ?? false,
         sellOutBehavior: meta.sellOutBehavior ?? 'REMOVE_ON_ANY_RARITY_EMPTY',
         scheduledAt,
-        scheduledOffAt
+        scheduledOffAt,
+        maxBuysPerUser: defaultMaxBuys
       }
     })
 

--- a/server/api/cmart/packs.get.js
+++ b/server/api/cmart/packs.get.js
@@ -1,27 +1,20 @@
 // server/api/cmart/packs.get.js
 // Public-facing endpoint: list every Pack that is flagged `inCmart = true`.
-// Returned shape:
-//
-// [
-//   {
-//     id:   "uuid",
-//     name: "Starter Pack",
-//     price: 500,
-//     imagePath: "/packs/starter.png",
-//     rarityConfigs: [ { rarity:"Common", count:3 }, … ]
-//   },
-//   ...
-// ]
-//
-// No admin check required; optionally fail if user isn’t logged-in.
+// Returns effectivePrice (decay applied, before half-price) alongside the base price.
 
 import { defineEventHandler, createError, getRequestHeader } from 'h3'
 import { prisma as db } from '@/server/prisma'
 
+function computeDecayedPrice(basePrice, sentAt, decayAmount, decayDays, priceFloor) {
+  if (!sentAt || decayAmount <= 0 || decayDays <= 0) return basePrice
+  const msPerDay = 24 * 60 * 60 * 1000
+  const daysSinceListed = Math.floor((Date.now() - new Date(sentAt).getTime()) / msPerDay)
+  const periods = Math.floor(daysSinceListed / decayDays)
+  const decayed = basePrice - periods * decayAmount
+  return Math.max(decayed, priceFloor)
+}
 
 export default defineEventHandler(async (event) => {
-  /* ── OPTIONAL auth: if your shop requires login to view ───────── */
-  // Comment this block out if guests are allowed.
   const cookie = getRequestHeader(event, 'cookie') || ''
   try {
     await $fetch('/api/auth/me', { headers: { cookie } })
@@ -29,24 +22,41 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 401, statusMessage: 'Login required' })
   }
 
-  /* ── Fetch packs that are visible in cMart ─────────────────────── */
   try {
-    const packs = await db.pack.findMany({
-      where: { inCmart: true },
-      orderBy: { createdAt: 'desc' },
-      select: {
-        id: true,
-        name: true,
-        price: true,
-        imagePath: true,
-        rarityConfigs: {
-          select: { rarity: true, count: true, probabilityPercent: true }
+    const [packs, globalCfg] = await Promise.all([
+      db.pack.findMany({
+        where: { inCmart: true },
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          name: true,
+          price: true,
+          imagePath: true,
+          sentAt: true,
+          rarityConfigs: {
+            select: { rarity: true, count: true, probabilityPercent: true }
+          }
         }
-      }
-    })
-    return packs
+      }),
+      db.globalGameConfig.findUnique({
+        where: { id: 'singleton' },
+        select: {
+          packPriceDecayAmount: true,
+          packPriceDecayDays: true,
+          packPriceFloor: true
+        }
+      })
+    ])
+
+    const decayAmount = globalCfg?.packPriceDecayAmount ?? 100
+    const decayDays   = globalCfg?.packPriceDecayDays   ?? 7
+    const priceFloor  = globalCfg?.packPriceFloor        ?? 700
+
+    return packs.map(pack => ({
+      ...pack,
+      effectivePrice: computeDecayedPrice(pack.price, pack.sentAt, decayAmount, decayDays, priceFloor)
+    }))
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error('[GET /api/cmart/packs]', err)
     throw createError({ statusCode: 500, statusMessage: 'Internal Server Error' })
   }

--- a/server/api/cmart/packs/buy.post.js
+++ b/server/api/cmart/packs/buy.post.js
@@ -95,21 +95,42 @@ export default defineEventHandler(async (event) => {
   const [pack, userPts, activeLocks, globalCfg] = await Promise.all([
     db.pack.findUnique({
       where:  { id: packId },
-      select: { id: true, price: true, inCmart: true, dailyPurchaseLimit: true }
+      select: { id: true, price: true, inCmart: true, dailyPurchaseLimit: true, maxBuysPerUser: true, sentAt: true }
     }),
     db.userPoints.findUnique({ where: { userId: me.id }, select: { points: true } }),
     db.lockedPoints.findMany({
       where:  { userId: me.id, status: 'ACTIVE' },
       select: { amount: true }
     }),
-    db.globalGameConfig.findUnique({ where: { id: 'singleton' }, select: { cmartHalfPriceEnabled: true } })
+    db.globalGameConfig.findUnique({
+      where: { id: 'singleton' },
+      select: {
+        cmartHalfPriceEnabled: true,
+        packPriceDecayAmount: true,
+        packPriceDecayDays: true,
+        packPriceFloor: true
+      }
+    })
   ])
   if (!pack || !pack.inCmart) {
     throw createError({ statusCode: 404, statusMessage: 'Pack not found' })
   }
+
+  // Apply price decay based on how long the pack has been listed
+  const decayAmount = globalCfg?.packPriceDecayAmount ?? 100
+  const decayDays   = globalCfg?.packPriceDecayDays   ?? 7
+  const priceFloor  = globalCfg?.packPriceFloor        ?? 700
+  let decayedPrice = pack.price
+  if (pack.sentAt && decayAmount > 0 && decayDays > 0) {
+    const msPerDay = 24 * 60 * 60 * 1000
+    const daysSinceListed = Math.floor((Date.now() - new Date(pack.sentAt).getTime()) / msPerDay)
+    const periods = Math.floor(daysSinceListed / decayDays)
+    decayedPrice = Math.max(pack.price - periods * decayAmount, priceFloor)
+  }
+
   const effectivePackPrice = globalCfg?.cmartHalfPriceEnabled === true
-    ? Math.floor(pack.price / 2)
-    : pack.price
+    ? Math.floor(decayedPrice / 2)
+    : decayedPrice
   const totalPoints    = userPts?.points || 0
   const lockedSum      = activeLocks.reduce((acc, lock) => acc + (lock.amount || 0), 0)
   const availablePoints = totalPoints - lockedSum
@@ -132,7 +153,20 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  /* 5.  daily purchase limit check --------------------------------------- */
+  /* 5a. total purchase limit check -------------------------------------- */
+  if (pack.maxBuysPerUser != null) {
+    const totalPurchased = await db.userPack.count({
+      where: { userId: me.id, packId: pack.id }
+    })
+    if (totalPurchased >= pack.maxBuysPerUser) {
+      throw createError({
+        statusCode: 429,
+        statusMessage: `Purchase limit reached — you can only buy this pack ${pack.maxBuysPerUser} time${pack.maxBuysPerUser === 1 ? '' : 's'}`
+      })
+    }
+  }
+
+  /* 5b. daily purchase limit check -------------------------------------- */
   if (pack.dailyPurchaseLimit != null) {
     const windowStart = getDailyWindowStart()
     const purchasedToday = await db.userPack.count({


### PR DESCRIPTION
- New GlobalGameConfig fields: packPriceDecayAmount (100pts), packPriceDecayDays (7),
  packPriceFloor (700pts), packMaxDefaultBuysPerUser (5)
- New Pack field: maxBuysPerUser (total lifetime limit per user)
- packs.get.js: computes effectivePrice with decay applied for display
- buy.post.js: enforces decayed price at purchase time and maxBuysPerUser total limit
- packs.post.js: sets maxBuysPerUser from global config on new pack creation
- global-config.post.js: handles save/load of the 4 new settings
- global-settings.vue: new "Pack Pricing Decay" section in cMart tab
- cmart.vue: uses effectivePrice for display and buy checks

https://claude.ai/code/session_01UwyCSfQY4bgGLNX5nAJGaP