### PR TITLE
Fix special mints blocked by holiday/time-based guards and unhandled mint errors

### DIFF
--- a/components/newsite/AuctionModal.vue
+++ b/components/newsite/AuctionModal.vue
@@ -159,7 +159,7 @@ async function sendToAuction() {
     emit('created', props.ctoon.id)
     setTimeout(() => emit('close'), 1200)
   } catch (e) {
-    showToast(e.data?.message || 'Failed to create auction.', 'error')
+    showToast(e.data?.statusMessage || e.data?.message || 'Failed to create auction.', 'error')
   } finally {
     sending.value = false
   }
@@ -177,7 +177,7 @@ async function instaBid() {
     emit('created', props.ctoon.id)
     setTimeout(() => emit('close'), 1200)
   } catch (e) {
-    showToast(e.data?.message || 'Failed to create auction.', 'error')
+    showToast(e.data?.statusMessage || e.data?.message || 'Failed to create auction.', 'error')
   } finally {
     sending.value = false
   }

--- a/pages/newsite/lottery.vue
+++ b/pages/newsite/lottery.vue
@@ -148,7 +148,7 @@ async function buy() {
   } catch (e) {
     console.error('Buy failed', e)
     modalTitle.value = 'Error'
-    modalMessage.value = e?.statusMessage || 'Purchase failed'
+    modalMessage.value = e?.data?.statusMessage || e?.statusMessage || 'Purchase failed'
     showModal.value = true
   } finally {
     await fetchSelf({ force: true })

--- a/pages/newsite/redeem.vue
+++ b/pages/newsite/redeem.vue
@@ -28,8 +28,6 @@
             <button type="submit" class="rd-btn">Redeem</button>
           </form>
 
-          <p v-if="error" class="rd-error">{{ error }}</p>
-
           <!-- Success -->
           <div v-if="success" class="rd-success-wrap">
             <p class="rd-success-heading">🎉 Success! You've been awarded:</p>
@@ -78,6 +76,14 @@
           </ClientOnly>
         </div>
       </div>
+
+      <Teleport to="body">
+        <transition name="rd-toast-fade">
+          <div v-if="toast.visible" class="rd-toast" :class="toast.type">
+            {{ toast.message }}
+          </div>
+        </transition>
+      </Teleport>
 </template>
 
 <script setup>
@@ -89,30 +95,31 @@ clearSidebarMiddle()
 const rawHTML = '<!-- My special production comment for this page -->'
 
 const code = ref('')
-const error = ref('')
 const success = ref(false)
 const rewards = ref({ points: 0, ctoons: [], backgrounds: [] })
+
+const toast = reactive({ visible: false, message: '', type: 'error' })
+let toastTimer = null
+function showToast(message, type = 'error') {
+  if (toastTimer) clearTimeout(toastTimer)
+  toast.message = message
+  toast.type = type
+  toast.visible = true
+  toastTimer = setTimeout(() => { toast.visible = false }, 3500)
+}
 
 const showBalloons = ref(false)
 const balloons = ref([])
 
 async function submit() {
-  error.value = ''
   success.value = false
   rewards.value = { points: 0, ctoons: [], backgrounds: [] }
 
   try {
-    const res = await fetch('/api/redeem', {
+    const payload = await $fetch('/api/redeem', {
       method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code: code.value.trim() })
+      body: { code: code.value.trim() }
     })
-    const payload = await res.json()
-    if (!res.ok) {
-      error.value = payload.message || 'Invalid or expired code.'
-      return
-    }
 
     rewards.value.points = payload.points ?? 0
     rewards.value.ctoons = payload.ctoons ?? []
@@ -127,9 +134,9 @@ async function submit() {
     }))
     showBalloons.value = true
     setTimeout(() => { showBalloons.value = false }, 5000)
-  } catch (e) {
-    console.error(e)
-    error.value = e.message || 'An unexpected error occurred.'
+  } catch (err) {
+    const msg = err?.data?.statusMessage || err?.message || 'An unexpected error occurred.'
+    showToast(msg, 'error')
   }
 }
 </script>
@@ -227,12 +234,6 @@ body {
 
 .rd-btn:hover {
   background: var(--OrbitLightBlue, #3399cc);
-}
-
-.rd-error {
-  margin-top: 8px;
-  font-size: 0.8125rem;
-  color: #f87171;
 }
 
 .rd-success-wrap {
@@ -356,6 +357,30 @@ body {
   font-size: 0.75rem;
   color: rgba(255, 255, 255, 0.4);
 }
+
+.rd-toast {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  z-index: 9999;
+  pointer-events: none;
+  white-space: pre-wrap;
+  max-width: 420px;
+  text-align: center;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+}
+.rd-toast.error   { background: #dc2626; color: #fff; }
+.rd-toast.success { background: #16a34a; color: #fff; }
+
+.rd-toast-fade-enter-active,
+.rd-toast-fade-leave-active { transition: opacity 0.2s, transform 0.2s; }
+.rd-toast-fade-enter-from,
+.rd-toast-fade-leave-to { opacity: 0; transform: translateX(-50%) translateY(-8px); }
 
 .rd-balloons {
   position: absolute;

--- a/pages/newsite/winwheel.vue
+++ b/pages/newsite/winwheel.vue
@@ -155,6 +155,14 @@
           </div>
         </div>
       </transition>
+
+      <Teleport to="body">
+        <transition name="ww-toast-fade">
+          <div v-if="toast.visible" class="ww-toast" :class="toast.type">
+            {{ toast.message }}
+          </div>
+        </transition>
+      </Teleport>
 </template>
 
 <script setup>
@@ -168,6 +176,16 @@ definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: t
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()
+
+const toast = reactive({ visible: false, message: '', type: 'error' })
+let toastTimer = null
+function showToast(message, type = 'error') {
+  if (toastTimer) clearTimeout(toastTimer)
+  toast.message = message
+  toast.type = type
+  toast.visible = true
+  toastTimer = setTimeout(() => { toast.visible = false }, 3500)
+}
 
 const sliceCount     = 6
 const sliceAngle     = 360 / sliceCount
@@ -305,7 +323,7 @@ async function spinWheel() {
     }, spinDurationMs)
   } catch (err) {
     console.error(err)
-    alert(err.statusMessage || 'Spin failed — please try again.')
+    showToast(err?.data?.statusMessage || err?.statusMessage || 'Spin failed — please try again.', 'error')
     user.value.points += spinCost.value
     spinsLeft.value++
     isSpinning.value = false
@@ -774,6 +792,31 @@ body {
 .fade-leave-to {
   opacity: 0;
 }
+
+/* Spin error toast */
+.ww-toast {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  z-index: 9999;
+  pointer-events: none;
+  white-space: pre-wrap;
+  max-width: 420px;
+  text-align: center;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+}
+.ww-toast.error   { background: #dc2626; color: #fff; }
+.ww-toast.success { background: #16a34a; color: #fff; }
+
+.ww-toast-fade-enter-active,
+.ww-toast-fade-leave-active { transition: opacity 0.2s, transform 0.2s; }
+.ww-toast-fade-enter-from,
+.ww-toast-fade-leave-to { opacity: 0; transform: translateX(-50%) translateY(-8px); }
 
 @media (max-width: 768px) {
   .wheel-img {

--- a/server/api/czone/searches/capture.post.js
+++ b/server/api/czone/searches/capture.post.js
@@ -124,13 +124,18 @@ export default defineEventHandler(async (event) => {
   // reflects the newly captured cToon (set counts, owns counts, etc.)
   try { await redis.del(`czone:ucond:${userId}`) } catch {}
 
-  const job = await mintQueue.add('mintCtoon', { userId, ctoonId: appearance.ctoonId, isSpecial: true })
-  const qe = new QueueEvents(mintQueue.name, { connection: redisConnection })
-  await qe.waitUntilReady()
+  let qe
   try {
+    const job = await mintQueue.add('mintCtoon', { userId, ctoonId: appearance.ctoonId, isSpecial: true })
+    qe = new QueueEvents(mintQueue.name, { connection: redisConnection })
+    await qe.waitUntilReady()
     await job.waitUntilFinished(qe)
+  } catch (mintErr) {
+    // Mint failed — remove the capture record so the user can retry
+    await db.cZoneSearchCapture.delete({ where: { appearanceId } }).catch(() => {})
+    throw createError({ statusCode: 500, statusMessage: mintErr?.message || 'Failed to mint cToon. Please try again.' })
   } finally {
-    await qe.close()
+    await qe?.close()
   }
 
   const minted = await db.userCtoon.findFirst({

--- a/server/api/redeem.post.js
+++ b/server/api/redeem.post.js
@@ -144,6 +144,26 @@ export default defineEventHandler(async (event) => {
         })
       }
     }
+  } catch (mintErr) {
+    // Mint failed — best-effort rollback of the claim so the user can retry
+    try {
+      await prisma.$transaction(async (tx) => {
+        await tx.claim.delete({ where: { userId_codeId: { userId, codeId: claimCode.id } } })
+        if (pointsToAward > 0) {
+          const updated = await tx.userPoints.update({
+            where: { userId },
+            data: { points: { decrement: pointsToAward } }
+          })
+          await tx.pointsLog.create({
+            data: { userId, points: pointsToAward, total: updated.points, method: 'Redeem Code Reversal', direction: 'decrease' }
+          })
+        }
+        if (backgroundRewards.length) {
+          await tx.userBackground.deleteMany({ where: { userId, sourceCodeId: claimCode.id } })
+        }
+      })
+    } catch {}
+    throw createError({ statusCode: 500, statusMessage: mintErr?.message || 'Failed to mint cToon. Please try again.' })
   } finally {
     await qe?.close()
   }

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -18,7 +18,9 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
     if (!ctoon) throw new Error('Invalid or not-for-sale cToon')
 
     // ───────────────────── Time-based mint window guard ─────────────────────
-    if (ctoon.mintLimitType === 'timeBased' && ctoon.mintEndDate) {
+    // Special mints (code redemption, cZone capture) bypass this guard so
+    // admins can award time-based cToons regardless of the mint window.
+    if (!isSpecial && ctoon.mintLimitType === 'timeBased' && ctoon.mintEndDate) {
       if (new Date(ctoon.mintEndDate) <= new Date()) {
         // After the minting window closes the mint-end job finalizes the quantity
         // (changes it away from TIME_BASED_CAP).  Only hard-block while the sentinel
@@ -34,27 +36,31 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
     // ───────────────────────── Holiday window guard ─────────────────────────
     // If this cToon is a Holiday Item in ANY event, only allow mint while an
     // associated event is active (isActive && startsAt <= now < endsAt).
-    const now = new Date()
+    // Special mints (code redemption, cZone capture) bypass this guard so
+    // holiday cToons can be awarded outside their event window.
+    if (!isSpecial) {
+      const now = new Date()
 
-    // Is this cToon used as a Holiday Item anywhere?
-    const holidayLinkCount = await prisma.holidayEventItem.count({
-      where: { ctoonId }
-    })
-
-    if (holidayLinkCount > 0) {
-      // Is there an active event (right now) that includes this cToon?
-      const activeEvent = await prisma.holidayEvent.findFirst({
-        where: {
-          isActive: true,
-          startsAt: { lte: now },
-          endsAt:   { gt:  now },
-          items: { some: { ctoonId } }
-        },
-        select: { id: true }
+      // Is this cToon used as a Holiday Item anywhere?
+      const holidayLinkCount = await prisma.holidayEventItem.count({
+        where: { ctoonId }
       })
 
-      if (!activeEvent) {
-        throw new Error('This Holiday Item can only be minted while its event is active.')
+      if (holidayLinkCount > 0) {
+        // Is there an active event (right now) that includes this cToon?
+        const activeEvent = await prisma.holidayEvent.findFirst({
+          where: {
+            isActive: true,
+            startsAt: { lte: now },
+            endsAt:   { gt:  now },
+            items: { some: { ctoonId } }
+          },
+          select: { id: true }
+        })
+
+        if (!activeEvent) {
+          throw new Error('This Holiday Item can only be minted while its event is active.')
+        }
       }
     }
 


### PR DESCRIPTION
Three bugs were causing server errors on code redemption and cZone capture:

1. mint.worker.js: holiday window guard and time-based mint window guard both
   fired unconditionally, including for isSpecial=true mints (code redemption,
   cZone capture). Any cToon linked to a holiday event would silently fail to
   mint outside that event window. Both guards are now skipped when isSpecial=true.

2. capture.post.js: job.waitUntilFinished() had no catch block, so any mint
   failure propagated as an opaque 500. Worse, the capture record was already
   committed — users couldn't retry. Now catches the error, deletes the capture
   record so the user can retry, and surfaces the real error message.

3. redeem.post.js: same missing catch block. Now performs a best-effort rollback
   of the claim (claim record, points, backgrounds) so the user can retry the code.

https://claude.ai/code/session_01WVX7Eb4awYmqLSFq2y2PJk