### PR TITLE
Fix cToon sizing bug on page refresh

### DIFF
--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -761,6 +761,8 @@ onUnmounted(() => {
   cancelLongPress()
   cz.value.activeDrag = null
   cz.value.buildMode  = false
+  // cancel any pending dimension auto-save
+  clearTimeout(_dimSaveTimer)
   // stop any active glitch effect
   stopGlitchEffect()
 })
@@ -780,6 +782,7 @@ async function loadZone(username) {
     cz.value.activeZone  = firstActive >= 0 ? firstActive : 0
     viewedOwner.value    = { username: data.ownerName, avatar: data.avatar, lastActivity: data.lastActivity ?? null }
     loadCzoneSearchItems()
+    eagerLoadMissingDimensions()
 
     if (user.value && data.ownerId && data.ownerId !== user.value.id) {
       $fetch('/api/points/visit', { method: 'POST', body: { zoneOwnerId: data.ownerId } }).catch(() => {})
@@ -1030,6 +1033,40 @@ function cycleToonSize(idx) {
 function onToonImgLoad(e, toon) {
   if (!toon.width)  toon.width  = e.target.naturalWidth
   if (!toon.height) toon.height = e.target.naturalHeight
+}
+
+// ── Eagerly resolve missing toon dimensions on the client ─────
+// The Vue template @load handler can miss cached images during SSR
+// hydration (the event fires before Vue attaches the listener).
+// We create throwaway Image objects so the load always completes,
+// then reactively update any toons that lacked stored dimensions.
+// If the viewer owns the zone we also schedule a background save
+// so the dimensions are persisted and the flash never recurs.
+let _dimSaveTimer = null
+function eagerLoadMissingDimensions() {
+  if (typeof window === 'undefined') return
+  const zones = cz.value.zones
+  let outstanding = 0
+  let anyNew = false
+
+  for (const zone of zones) {
+    for (const toon of zone.toons) {
+      if (toon.width && toon.height) continue
+      outstanding++
+      const img = new Image()
+      img.onload = () => {
+        if (!toon.width)  { toon.width  = img.naturalWidth;  anyNew = true }
+        if (!toon.height) { toon.height = img.naturalHeight; anyNew = true }
+        outstanding--
+        if (outstanding === 0 && anyNew && isOwnZone.value && !cz.value.buildMode) {
+          clearTimeout(_dimSaveTimer)
+          _dimSaveTimer = setTimeout(() => save(), 1500)
+        }
+      }
+      img.onerror = () => { outstanding-- }
+      img.src = toon.assetPath
+    }
+  }
 }
 
 // ── cZone Search helpers ──────────────────────────────────────


### PR DESCRIPTION
When a toon's natural dimensions (width/height) aren't stored in the
database the container falls back to 80 × sizeScale pixels, which makes
toons appear small or incorrectly sized.  The Vue template @load handler
is supposed to correct this, but it is silently missed during SSR
hydration when images are already cached: the browser fires the load
event before Vue attaches the listener, so the handler never runs and
the wrong fallback size persists for the entire session.

Fix: after loadZone populates cz.value.zones, call
eagerLoadMissingDimensions() which creates throwaway Image objects for
every toon that lacks stored dimensions.  These objects always fire their
onload (for cached images this is near-instant), reactively update
toon.width / toon.height, and, when the viewer owns the zone, schedule a
1.5 s debounced background save so the dimensions are persisted to the
database.  On subsequent loads the stored values are used immediately and
the fallback path is never taken.

https://claude.ai/code/session_01G9nwDteDufLxi6P4QHVC6o