### PR TITLE
Add SEO titles, descriptions, and Open Graph tags to newsite pages

### DIFF
--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -273,6 +273,26 @@ const route = useRoute()
 const { isOpen: ctoonModalIsOpen } = useCtoonModal()
 const { sidebarMiddleComponent, mobileSidebarCollapsed } = useNewsiteLayout()
 const czoneState = useState('newSiteCzoneState', () => ({ buildMode: false }))
+
+const siteName = 'Cartoon ReOrbit'
+const defaultDescription = "Cartoon ReOrbit is a fan-made revival of Cartoon Network's Cartoon Orbit. Collect cToons, build your cZone, trade with other players, and play games."
+const resolveMeta = value =>
+  typeof value === 'function' ? value(route) : typeof value === 'string' ? value : ''
+const pageTitle = computed(() => resolveMeta(route.meta.title))
+const fullTitle = computed(() => (pageTitle.value ? `${pageTitle.value} | ${siteName}` : siteName))
+const pageDescription = computed(() => resolveMeta(route.meta.description) || defaultDescription)
+
+useHead({ title: fullTitle })
+useSeoMeta({
+  description: pageDescription,
+  ogTitle: fullTitle,
+  ogDescription: pageDescription,
+  ogSiteName: siteName,
+  ogType: 'website',
+  twitterCard: 'summary',
+  robots: computed(() => route.meta.robots || null)
+})
+
 useHead({
   htmlAttrs: { class: 'newsite-active' },
   bodyAttrs: { class: computed(() => {

--- a/pages/newsite/AuctionHouse.vue
+++ b/pages/newsite/AuctionHouse.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Auction House',
+  description: 'Bid on rare and exclusive cToons in the Cartoon ReOrbit Auction House, or put your own cToons up for auction.'
+})
 
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('AuctionHouseSidebar')

--- a/pages/newsite/Games.vue
+++ b/pages/newsite/Games.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Games',
+  description: 'Play Cartoon ReOrbit games like gToons Clash, Winball, and the Win Wheel to earn points and exclusive cToons.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/MyCollection.vue
+++ b/pages/newsite/MyCollection.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'My Collection',
+  description: 'View and manage your cToon collection on Cartoon ReOrbit.'
+})
 
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('MyCollectionSidebar')

--- a/pages/newsite/MycWorld.vue
+++ b/pages/newsite/MycWorld.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'My cWorld',
+  description: 'Manage your cWorld on Cartoon ReOrbit and organize the cZones where you show off your cToons.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/admin/[[section]].vue
+++ b/pages/newsite/admin/[[section]].vue
@@ -37,6 +37,9 @@ definePageMeta({
   showAdbar: true,
   showNav: true,
   showSidebar: false,
+  title: 'Admin',
+  description: 'Cartoon ReOrbit administration tools.',
+  robots: 'noindex, nofollow'
 })
 useHead({ htmlAttrs: { class: 'newsite-admin-page' } })
 

--- a/pages/newsite/allCtoons.vue
+++ b/pages/newsite/allCtoons.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'All cToons',
+  description: 'Browse every cToon on Cartoon ReOrbit. Filter by series, set, and rarity to find your favorites.'
+})
 
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('AllCtoonsSidebar')

--- a/pages/newsite/cmart.vue
+++ b/pages/newsite/cmart.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'cMart',
+  description: 'Shop the cMart on Cartoon ReOrbit and spend your points on the newest cToon releases and packs.'
+})
 
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('CmartSidebar')

--- a/pages/newsite/czone/[username].vue
+++ b/pages/newsite/czone/[username].vue
@@ -3,7 +3,24 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: route => {
+    const raw = route.params.username
+    const name = typeof raw === 'string' ? raw : (Array.isArray(raw) ? raw[0] : '')
+    return name ? `${name}'s cZone` : 'cZone'
+  },
+  description: route => {
+    const raw = route.params.username
+    const name = typeof raw === 'string' ? raw : (Array.isArray(raw) ? raw[0] : '')
+    return name
+      ? `Visit ${name}'s cZone on Cartoon ReOrbit and check out their cToon collection.`
+      : 'Visit a player cZone on Cartoon ReOrbit and check out their cToon collection.'
+  }
+})
 
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('CzoneSidebarMiddle')

--- a/pages/newsite/czonesearch/[id].vue
+++ b/pages/newsite/czonesearch/[id].vue
@@ -234,7 +234,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'cZone Search',
+  description: 'Join the cZone Search contest on Cartoon ReOrbit — hunt through player cZones to find cToons and win prizes.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/earnpoints.vue
+++ b/pages/newsite/earnpoints.vue
@@ -8,7 +8,14 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Earn Points',
+  description: 'Discover all the ways to earn points on Cartoon ReOrbit, from daily visits to games and contests, and grow your cToon collection.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/gtoons/[id].vue
+++ b/pages/newsite/gtoons/[id].vue
@@ -240,6 +240,8 @@ definePageMeta({
   showSidebar: false,
   showFooter: false,
   mainContentBorder: false,
+  title: 'gToons Clash Match',
+  description: 'Live gToons Clash card battle match on Cartoon ReOrbit.'
 })
 
 const { clearSidebarMiddle } = useNewsiteLayout()

--- a/pages/newsite/gtoons/index.vue
+++ b/pages/newsite/gtoons/index.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'gToons Clash',
+  description: 'Play gToons Clash, the head-to-head card battle game on Cartoon ReOrbit. Build decks from your cToons and battle other players.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/gtoons/play.vue
+++ b/pages/newsite/gtoons/play.vue
@@ -178,6 +178,8 @@ definePageMeta({
   showSidebar: false,
   showFooter: false,
   mainContentBorder: false,
+  title: 'gToons Clash Play',
+  description: 'Jump into a gToons Clash card battle on Cartoon ReOrbit.'
 })
 
 const { clearSidebarMiddle } = useNewsiteLayout()

--- a/pages/newsite/home.vue
+++ b/pages/newsite/home.vue
@@ -16,7 +16,14 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Home',
+  description: "Welcome to Cartoon ReOrbit, a fan-made revival of Cartoon Network's Cartoon Orbit. Collect cToons, build your cZone, trade with friends, and play games."
+})
 useHead({ htmlAttrs: { class: 'newsite-home' } })
 
 const { clearSidebarMiddle } = useNewsiteLayout()

--- a/pages/newsite/lottery.vue
+++ b/pages/newsite/lottery.vue
@@ -86,7 +86,14 @@ import { ref, onMounted } from 'vue'
 import CtoonAsset from '@/components/CtoonAsset.vue'
 import { useAuth } from '~/composables/useAuth'
 
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Lottery',
+  description: 'Enter the Cartoon ReOrbit lottery for a chance to win points and exclusive cToon prizes.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -79,6 +79,17 @@ import { useRuntimeConfig } from '#imports'
 
 definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
 
+// This page opts out of the newsite layout, so it sets its own SEO tags.
+useSeoMeta({
+  title: 'Marble Race | Cartoon ReOrbit',
+  description: 'Join the live multiplayer marble race on Cartoon ReOrbit and cheer your marble to the finish line.',
+  ogTitle: 'Marble Race | Cartoon ReOrbit',
+  ogDescription: 'Join the live multiplayer marble race on Cartoon ReOrbit and cheer your marble to the finish line.',
+  ogSiteName: 'Cartoon ReOrbit',
+  ogType: 'website',
+  twitterCard: 'summary'
+})
+
 const { user, fetchSelf, isAdmin } = useAuth()
 const runtime = useRuntimeConfig()
 

--- a/pages/newsite/myachievements.vue
+++ b/pages/newsite/myachievements.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'My Achievements',
+  description: 'Track your Cartoon ReOrbit achievements and the rewards you have unlocked.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/myczone.vue
+++ b/pages/newsite/myczone.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'My cZone',
+  description: 'Build and decorate your personal cZone on Cartoon ReOrbit with cToons from your collection.'
+})
 
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('CzoneSidebarMiddle')

--- a/pages/newsite/newcmart.vue
+++ b/pages/newsite/newcmart.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'cMart',
+  description: 'Shop the cMart on Cartoon ReOrbit and spend your points on the newest cToon releases and packs.'
+})
 
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('NewcmartSidebar')

--- a/pages/newsite/news.vue
+++ b/pages/newsite/news.vue
@@ -8,7 +8,14 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'News',
+  description: 'The latest Cartoon ReOrbit news and announcements: new cToon releases, events, contests, and site updates.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/redeem.vue
+++ b/pages/newsite/redeem.vue
@@ -87,7 +87,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Redeem Code',
+  description: 'Redeem a code on Cartoon ReOrbit to claim cToons, points, and other rewards.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/settings.vue
+++ b/pages/newsite/settings.vue
@@ -102,7 +102,15 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Settings',
+  description: 'Manage your Cartoon ReOrbit account settings, avatar, and notification preferences.',
+  robots: 'noindex, nofollow'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/spinthewheel.vue
+++ b/pages/newsite/spinthewheel.vue
@@ -73,7 +73,14 @@ import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { io } from 'socket.io-client'
 import { useRuntimeConfig } from '#imports'
 
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Spin the Wheel',
+  description: 'Spin the wheel on Cartoon ReOrbit for a chance to win points and prizes.'
+})
 
 const { user, fetchSelf, isAdmin } = useAuth()
 const runtime = useRuntimeConfig()

--- a/pages/newsite/survey.vue
+++ b/pages/newsite/survey.vue
@@ -115,13 +115,13 @@ import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { navigateTo } from '#app'
 
 definePageMeta({
-  layout:     'newsite-template',
-  middleware: 'newsite',
-  showAdbar:  true,
-  showNav:    true,
+  layout:      'newsite-template',
+  middleware:  'newsite',
+  showAdbar:   true,
+  showNav:     true,
+  title:       'Community Survey — Earn 3,000 Points',
+  description: 'Share your feedback in the Cartoon ReOrbit community survey and earn 3,000 points.'
 })
-
-useHead({ title: 'Community Survey — Earn 3,000 Points' })
 
 const MIN_CHARS = 250
 

--- a/pages/newsite/tournaments/[id].vue
+++ b/pages/newsite/tournaments/[id].vue
@@ -171,7 +171,14 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAuth } from '@/composables/useAuth'
 
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'gToons Clash Tournament',
+  description: 'Follow gToons Clash tournament brackets, standings, and matches on Cartoon ReOrbit.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/trade.vue
+++ b/pages/newsite/trade.vue
@@ -3,7 +3,14 @@
 </template>
 
 <script setup>
-definePageMeta({ layout: 'newsite-template', middleware: ['auth', 'newsite'], showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: ['auth', 'newsite'],
+  showAdbar: true,
+  showNav: true,
+  title: 'Trade',
+  description: 'Trade cToons with other Cartoon ReOrbit players in live trade rooms.'
+})
 
 const { setSidebarMiddle } = useNewsiteLayout()
 setSidebarMiddle('TradeSidebarWrapper')

--- a/pages/newsite/winball.vue
+++ b/pages/newsite/winball.vue
@@ -26,7 +26,14 @@
 <script setup>
 import { useHead } from '#imports'
 
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Winball',
+  description: 'Play Winball, the pinball-style game on Cartoon ReOrbit, for a chance to win points and exclusive cToons.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()

--- a/pages/newsite/winwheel.vue
+++ b/pages/newsite/winwheel.vue
@@ -172,7 +172,14 @@ import { useAuth } from '@/composables/useAuth'
 import ScavengerHuntModal from '@/components/ScavengerHuntModal.vue'
 import { useScavengerHunt } from '@/composables/useScavengerHunt'
 
-definePageMeta({ layout: 'newsite-template', middleware: 'newsite', showAdbar: true, showNav: true })
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Win Wheel',
+  description: 'Spin the Win Wheel on Cartoon ReOrbit for a chance at points and exclusive cToons.'
+})
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()


### PR DESCRIPTION
The newsite-template layout now sets the document title from
route.meta.title (with the 'Cartoon ReOrbit' site-name suffix, matching
the default layout), a meta description from route.meta.description with
a sensible site-wide fallback, plus Open Graph and Twitter card tags and
optional robots directives.

Every page under pages/newsite declares a title and description via
definePageMeta. The cZone page builds its title/description from the
username route param. Settings and admin pages are marked
noindex/nofollow. The marbles page opts out of the layout, so it sets
its own tags with useSeoMeta.

https://claude.ai/code/session_01HpHs7oNwh5pc3rGcpvvKPq