### PR TITLE
Skip DB-heavy server middleware for non-API requests

### DIFF
--- a/server/middleware/daily-points.js
+++ b/server/middleware/daily-points.js
@@ -8,6 +8,14 @@ let cachedGlobalConfigTime = 0
 const GLOBAL_CONFIG_TTL_MS = 5 * 60 * 1000  // 5 minutes
 
 export default defineEventHandler(async (event) => {
+  // Only run for API requests. Static asset requests (cToon images, JS
+  // chunks) also pass through this middleware, and each one was costing an
+  // upsert + interactive transaction on the same UserPoints row — enough
+  // concurrent image requests exhausted the connection pool and 500'd the
+  // page. Every page load calls /api/auth/me, so the daily award still
+  // triggers reliably.
+  if (!event.path.startsWith('/api')) return
+
   const userId = event.context.userId
   if (!userId) return
 

--- a/server/middleware/guild-check.js
+++ b/server/middleware/guild-check.js
@@ -2,6 +2,11 @@ import { refreshDiscordTokenAndRoles } from '../utils/refreshDiscordTokenAndRole
 import { prisma } from '@/server/prisma'
 
 export default defineEventHandler(async (event) => {
+  // Only API routes need user context. Without this gate the middleware runs
+  // for every static asset too (cToon images, backgrounds, JS chunks), and a
+  // cZone full of cToons turns one page load into dozens of DB lookups.
+  if (!event.path.startsWith('/api')) return
+
   const userId = event.context.userId
   if (!userId) return
 


### PR DESCRIPTION
guild-check and daily-points ran for every request through Nitro,
including static assets. A cZone with many cToons fires dozens of
simultaneous image requests, each triggering a user lookup plus a
UserPoints upsert and interactive transaction on the same row. The
resulting connection-pool exhaustion (Prisma P2024) made the document
request 500 on refresh.

Gate both middlewares to /api paths. The daily login award still
triggers on every page load via the /api/auth/me call.

https://claude.ai/code/session_01R2UinKft4pgKVzDeraNHPd