### PR TITLE
Fix czone page crash from partial newSiteCzoneState init in layout

### DIFF
--- a/components/newsite/CzoneEdit.vue
+++ b/components/newsite/CzoneEdit.vue
@@ -102,7 +102,7 @@ const search          = ref('')
 const activeRarities  = ref([])
 const selectedSeries  = ref('')
 
-const currentZoneBg = computed(() => cz.value.zones[cz.value.activeZone]?.background ?? '')
+const currentZoneBg = computed(() => cz.value.zones?.[cz.value.activeZone]?.background ?? '')
 
 // Stable identity for a cToon shared between the collection payload and the
 // saved zone payload. The per-item `id` differs between the two (the
@@ -189,7 +189,7 @@ function onToonTouchEnd(c, e) {
 }
 
 function addToonToTopLeft(c) {
-  const zone = cz.value.zones[cz.value.activeZone]
+  const zone = cz.value.zones?.[cz.value.activeZone]
   if (!zone || zone.toons.some(t => t.id === c.id)) return
   const img = new Image()
   img.onload = () => {
@@ -209,7 +209,8 @@ function addToonToTopLeft(c) {
 }
 
 function selectBg(bg) {
-  cz.value.zones[cz.value.activeZone].background = bg.imagePath
+  const zone = cz.value.zones?.[cz.value.activeZone]
+  if (zone) zone.background = bg.imagePath
 }
 </script>
 

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -696,7 +696,7 @@ function goToTradeWithCtoon(item) {
   router.push(`/newsite/trade?username=${encodeURIComponent(viewedUsername.value)}&userCtoonId=${encodeURIComponent(item.userCtoonId)}`)
 }
 
-const currentZone = computed(() => cz.value.zones[cz.value.activeZone] ?? { background: '', toons: [] })
+const currentZone = computed(() => cz.value.zones?.[cz.value.activeZone] ?? { background: '', toons: [] })
 const isOwnZone   = computed(() => !!user.value && viewedUsername.value === user.value.username)
 
 const lastOnlineText = computed(() => {

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -272,7 +272,7 @@ html.newsite-active body {
 const route = useRoute()
 const { isOpen: ctoonModalIsOpen } = useCtoonModal()
 const { sidebarMiddleComponent, mobileSidebarCollapsed } = useNewsiteLayout()
-const czoneState = useState('newSiteCzoneState', () => ({ buildMode: false }))
+const czoneState = useNewSiteCzoneState()
 
 const siteName = 'Cartoon ReOrbit'
 const defaultDescription = "Cartoon ReOrbit is a fan-made revival of Cartoon Network's Cartoon Orbit. Collect cToons, build your cZone, trade with other players, and play games."


### PR DESCRIPTION
The newsite layout initialized useState('newSiteCzoneState') with just
{ buildMode: false }. Because the layout's setup runs before any page or
sidebar component, its init won the race over the full default in
useNewSiteCzoneState(), leaving cz.zones/activeZone undefined. Rendering
/newsite/czone/[username] then threw 'undefined is not an object
(evaluating cz.value.zones[cz.value.activeZone])' and showed the error
page on load/refresh.

Use the shared composable in the layout so the state always has its full
shape, and guard the zones[activeZone] reads in MyCzone and CzoneEdit so
a partially-shaped state can never crash the render.

https://claude.ai/code/session_011WDxYdWuVXTMBKwgLbLNdm