### PR TITLE
Add 'own X cToons from pool' prerequisite option to claim codes

### DIFF
--- a/pages/admin/create-code.vue
+++ b/pages/admin/create-code.vue
@@ -103,6 +103,26 @@
             + Add prerequisite cToon
           </button>
           <p class="text-sm text-gray-500">Leave empty for no prerequisites.</p>
+
+          <div class="mt-3 space-y-2">
+            <label class="inline-flex items-center gap-2">
+              <input type="checkbox" v-model="prereqPoolEnabled" />
+              <span class="font-medium">Only require owning some cToons from this pool</span>
+            </label>
+            <div v-if="prereqPoolEnabled" class="flex items-center gap-2">
+              <span class="text-sm">Must own at least</span>
+              <input
+                v-model.number="prereqMinOwned"
+                type="number"
+                min="1"
+                class="w-24 border rounded p-2"
+              />
+              <span class="text-sm">of the selected cToons</span>
+            </div>
+            <p v-if="prereqPoolEnabled" class="text-sm text-gray-500">
+              Unchecked, users must own ALL prerequisite cToons. Checked, owning any {{ prereqMinOwned || 'X' }} from the pool is enough.
+            </p>
+          </div>
         </div>
 
         <!-- Points Reward -->
@@ -308,6 +328,8 @@ function removePoolItem(i) { poolItems.value.splice(i, 1) }
 
 // at the top, alongside your other refs
 const prereqCtoons = ref([{ ctoonName: '' }])
+const prereqPoolEnabled = ref(false)
+const prereqMinOwned = ref(1)
 
 function addPrereqCtoon() {
   prereqCtoons.value.push({ ctoonName: '' })
@@ -462,6 +484,21 @@ async function submitForm() {
     validPrereqs.push({ ctoonId: resolved.id })
   }
 
+  if (prereqPoolEnabled.value) {
+    if (validPrereqs.length === 0) {
+      error.value = 'Add at least one prerequisite cToon to use the ownership pool option.'
+      return
+    }
+    if (!Number.isInteger(prereqMinOwned.value) || prereqMinOwned.value < 1) {
+      error.value = 'Number of cToons to own must be at least 1.'
+      return
+    }
+    if (prereqMinOwned.value > validPrereqs.length) {
+      error.value = 'Number of cToons to own cannot exceed the number of prerequisite cToons.'
+      return
+    }
+  }
+
   // build payload
   // build either fixed cToons or pooled
   let rewardBlock = { points: points.value, backgrounds: backgroundsPayload }
@@ -509,6 +546,7 @@ async function submitForm() {
     code: code.value.trim(),
     maxClaims: maxClaims.value,
     prerequisites: validPrereqs,
+    prereqMinOwned: prereqPoolEnabled.value ? prereqMinOwned.value : null,
     startsAt: startsIso,
     expiresAt: expiresIso,
     rewards: [rewardBlock]

--- a/pages/admin/edit-code.vue
+++ b/pages/admin/edit-code.vue
@@ -211,6 +211,26 @@
               + Add prerequisite cToon
             </button>
             <p class="text-sm text-gray-500">Leave empty for no prerequisites.</p>
+
+            <div class="mt-3 space-y-2">
+              <label class="inline-flex items-center gap-2">
+                <input type="checkbox" v-model="prereqPoolEnabled" />
+                <span class="font-medium">Only require owning some cToons from this pool</span>
+              </label>
+              <div v-if="prereqPoolEnabled" class="flex items-center gap-2">
+                <span class="text-sm">Must own at least</span>
+                <input
+                  v-model.number="prereqMinOwned"
+                  type="number"
+                  min="1"
+                  class="w-24 border rounded p-2"
+                />
+                <span class="text-sm">of the selected cToons</span>
+              </div>
+              <p v-if="prereqPoolEnabled" class="text-sm text-gray-500">
+                Unchecked, users must own ALL prerequisite cToons. Checked, owning any {{ prereqMinOwned || 'X' }} from the pool is enough.
+              </p>
+            </div>
           </div>
 
           <!-- Background Rewards -->
@@ -279,6 +299,8 @@ const expiresAt     = ref('')
 const points        = ref(0)
 const ctoonRewards  = ref([])
 const prereqCtoons  = ref([{ ctoonName: '' }])
+const prereqPoolEnabled = ref(false)
+const prereqMinOwned    = ref(1)
 const error         = ref('')
 
 // options
@@ -391,6 +413,10 @@ onMounted(async () => {
         return { ctoonName: found?.name||'' }
       })
     }
+    if (entry.prereqMinOwned != null) {
+      prereqPoolEnabled.value = true
+      prereqMinOwned.value    = entry.prereqMinOwned
+    }
   } catch (e) {
     fetchError.value = e
   } finally {
@@ -443,6 +469,21 @@ async function submitForm() {
     validPrereqs.push({ ctoonId: found.id })
   }
 
+  if (prereqPoolEnabled.value) {
+    if (validPrereqs.length === 0) {
+      error.value = 'Add at least one prerequisite cToon to use the ownership pool option.'
+      return
+    }
+    if (!Number.isInteger(prereqMinOwned.value) || prereqMinOwned.value < 1) {
+      error.value = 'Number of cToons to own must be at least 1.'
+      return
+    }
+    if (prereqMinOwned.value > validPrereqs.length) {
+      error.value = 'Number of cToons to own cannot exceed the number of prerequisite cToons.'
+      return
+    }
+  }
+
   // Build backgrounds payload *now* so it reflects current selections
   const backgroundsPayload = bgRewards.value
     .map(r => {
@@ -486,6 +527,7 @@ async function submitForm() {
     code: code.value.trim(),
     maxClaims: maxClaims.value,
     prerequisites: validPrereqs,
+    prereqMinOwned: prereqPoolEnabled.value ? prereqMinOwned.value : null,
     startsAt: startsIso,
     expiresAt: expiresIso,
     rewards: [rewardBlock]

--- a/prisma/migrations/20260611000000_add_prereq_min_owned_to_claim_code/migration.sql
+++ b/prisma/migrations/20260611000000_add_prereq_min_owned_to_claim_code/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ClaimCode" ADD COLUMN "prereqMinOwned" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -589,6 +589,9 @@ model ClaimCode {
   createdAt      DateTime  @default(now())
   startsAt       DateTime?
   expiresAt      DateTime?
+  // When set, users must own at least this many distinct cToons from the
+  // prerequisites pool. When null, users must own ALL prerequisite cToons.
+  prereqMinOwned Int?
 
   claims                Claim[]
   rewards               ClaimCodeReward[]

--- a/server/api/admin/codes.get.js
+++ b/server/api/admin/codes.get.js
@@ -75,6 +75,7 @@ export default defineEventHandler(async (event) => {
         maxClaims: true,
         startsAt: true,
         expiresAt: true,
+        prereqMinOwned: true,
         prerequisites: {
           select: {
             ctoonId: true,

--- a/server/api/admin/codes.post.js
+++ b/server/api/admin/codes.post.js
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
   if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
 
   const body = await readBody(event)
-  const { code, maxClaims, startsAt, expiresAt, rewards, prerequisites, backgrounds: topLevelBackgrounds, backgroundIds: topLevelBackgroundIds } = body || {}
+  const { code, maxClaims, startsAt, expiresAt, rewards, prerequisites, prereqMinOwned, backgrounds: topLevelBackgrounds, backgroundIds: topLevelBackgroundIds } = body || {}
 
   if (!code || typeof code !== 'string') throw createError({ statusCode: 400, statusMessage: 'Code is required.' })
   if (typeof maxClaims !== 'number' || maxClaims < 1) throw createError({ statusCode: 400, statusMessage: 'maxClaims must be a positive integer.' })
@@ -33,6 +33,14 @@ export default defineEventHandler(async (event) => {
     if (!p?.ctoonId || typeof p.ctoonId !== 'string') throw createError({ statusCode: 400, statusMessage: `Invalid ctoonId in prerequisites[${i}].` })
     return { ctoonId: p.ctoonId }
   })
+
+  let prereqMin = null
+  if (prereqMinOwned != null) {
+    if (!Number.isInteger(prereqMinOwned) || prereqMinOwned < 1) throw createError({ statusCode: 400, statusMessage: 'prereqMinOwned must be a positive integer.' })
+    if (prereqCreates.length === 0) throw createError({ statusCode: 400, statusMessage: 'prereqMinOwned requires at least one prerequisite cToon.' })
+    if (prereqMinOwned > prereqCreates.length) throw createError({ statusCode: 400, statusMessage: 'prereqMinOwned cannot exceed the number of prerequisite cToons.' })
+    prereqMin = prereqMinOwned
+  }
 
   function normalizeBackgroundIds(arr, where = 'rewards[].backgrounds') {
     if (!Array.isArray(arr)) return []
@@ -105,6 +113,7 @@ export default defineEventHandler(async (event) => {
         maxClaims,
         startsAt: startsDate,
         expiresAt: expiresDate,
+        prereqMinOwned: prereqMin,
         rewards: { create: rewardCreates },
         prerequisites: { create: prereqCreates }
       }

--- a/server/api/admin/codes.put.js
+++ b/server/api/admin/codes.put.js
@@ -9,7 +9,7 @@ export default defineEventHandler(async (event) => {
   try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
   if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
 
-  const { code, maxClaims, startsAt, expiresAt, rewards, prerequisites } = await readBody(event)
+  const { code, maxClaims, startsAt, expiresAt, rewards, prerequisites, prereqMinOwned } = await readBody(event)
 
   if (!code || typeof code !== 'string') throw createError({ statusCode: 400, statusMessage: 'Code is required.' })
   if (typeof maxClaims !== 'number' || maxClaims < 1) throw createError({ statusCode: 400, statusMessage: 'maxClaims must be >= 1.' })
@@ -98,6 +98,14 @@ export default defineEventHandler(async (event) => {
     return { ctoonId: p.ctoonId }
   })
 
+  let prereqMin = null
+  if (prereqMinOwned != null) {
+    if (!Number.isInteger(prereqMinOwned) || prereqMinOwned < 1) throw createError({ statusCode: 400, statusMessage: 'prereqMinOwned must be a positive integer.' })
+    if (prereqCreates.length === 0) throw createError({ statusCode: 400, statusMessage: 'prereqMinOwned requires at least one prerequisite cToon.' })
+    if (prereqMinOwned > prereqCreates.length) throw createError({ statusCode: 400, statusMessage: 'prereqMinOwned cannot exceed the number of prerequisite cToons.' })
+    prereqMin = prereqMinOwned
+  }
+
   const results = await prisma.$transaction([
     prisma.rewardCtoon.deleteMany({ where: { reward: { codeId } } }),
     prisma.rewardCtoonPool.deleteMany({ where: { reward: { codeId } } }), // NEW
@@ -106,7 +114,7 @@ export default defineEventHandler(async (event) => {
     prisma.claimCodePrerequisite.deleteMany({ where: { codeId } }),
     prisma.claimCode.update({
       where: { code },
-      data: { maxClaims, startsAt: startsDate, expiresAt: expiresDate, rewards: { create: rewardCreates }, prerequisites: { create: prereqCreates } }
+      data: { maxClaims, startsAt: startsDate, expiresAt: expiresDate, prereqMinOwned: prereqMin, rewards: { create: rewardCreates }, prerequisites: { create: prereqCreates } }
     })
   ])
   const updated = await prisma.claimCode.findUnique({
@@ -148,6 +156,9 @@ export default defineEventHandler(async (event) => {
     const nextExp = expiresDate ? new Date(expiresDate).toISOString() : null
     if (prevExp !== nextExp) {
       await logAdminChange(prisma, { userId: me.id, area, key: 'expiresAt', prevValue: existing.expiresAt, newValue: expiresDate })
+    }
+    if ((existing.prereqMinOwned ?? null) !== prereqMin) {
+      await logAdminChange(prisma, { userId: me.id, area, key: 'prereqMinOwned', prevValue: existing.prereqMinOwned ?? null, newValue: prereqMin })
     }
     // structural diffs
     const prevStruct = simplify(existing)

--- a/server/api/redeem.post.js
+++ b/server/api/redeem.post.js
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
   const { code } = await readBody(event)
   if (!code || typeof code !== 'string') throw createError({ statusCode: 400, statusMessage: 'Code is required' })
 
-  const claimCode = await prisma.claimCode.findUnique({ where: { code }, select: { id: true, maxClaims: true, startsAt: true, expiresAt: true } })
+  const claimCode = await prisma.claimCode.findUnique({ where: { code }, select: { id: true, maxClaims: true, startsAt: true, expiresAt: true, prereqMinOwned: true } })
   if (!claimCode) throw createError({ statusCode: 404, statusMessage: 'Invalid code' })
   if (claimCode.startsAt && claimCode.startsAt > new Date()) throw createError({ statusCode: 400, statusMessage: 'This code is not yet available' })
   if (claimCode.expiresAt && claimCode.expiresAt < new Date()) throw createError({ statusCode: 400, statusMessage: 'Code expired' })
@@ -32,8 +32,18 @@ export default defineEventHandler(async (event) => {
   if (prereqs.length > 0) {
     const owned = await prisma.userCtoon.findMany({ where: { userId, ctoonId: { in: prereqs.map(p => p.ctoonId) } }, select: { ctoonId: true } })
     const ownedIds = new Set(owned.map(o => o.ctoonId))
-    const missing = prereqs.filter(p => !ownedIds.has(p.ctoonId)).map(p => p.ctoon.name)
-    if (missing.length) throw createError({ statusCode: 400, statusMessage: `You must own the following cToons to redeem this code: ${missing.join(', ')}` })
+    if (claimCode.prereqMinOwned != null) {
+      // Pool mode: user must own at least X distinct cToons from the prerequisite pool
+      const required = Math.min(claimCode.prereqMinOwned, prereqs.length)
+      const ownedCount = prereqs.filter(p => ownedIds.has(p.ctoonId)).length
+      if (ownedCount < required) {
+        const poolNames = prereqs.map(p => p.ctoon.name)
+        throw createError({ statusCode: 400, statusMessage: `You must own at least ${required} of the following cToons to redeem this code (you own ${ownedCount}): ${poolNames.join(', ')}` })
+      }
+    } else {
+      const missing = prereqs.filter(p => !ownedIds.has(p.ctoonId)).map(p => p.ctoon.name)
+      if (missing.length) throw createError({ statusCode: 400, statusMessage: `You must own the following cToons to redeem this code: ${missing.join(', ')}` })
+    }
   }
 
   const totalClaims = await prisma.claim.count({ where: { codeId: claimCode.id } })


### PR DESCRIPTION
Admins can now mark a code's prerequisite cToons as a pool and set how
many of them a user must own (instead of requiring all of them). The
redeem API enforces the threshold by counting distinct owned cToons
from the pool, so both /redeem and /newsite/redeem adhere to it.

- Add nullable ClaimCode.prereqMinOwned column (null = must own all)
- Accept/validate prereqMinOwned in admin codes POST/PUT, return it in GET
- Add pool toggle + threshold input on create-code and edit-code pages
- Log prereqMinOwned changes in the admin change log

https://claude.ai/code/session_01Jryp6BvuGaQdfAB1LwQcXX