### PR TITLE
Add My Wishlist button and view to MycWorld page

### DIFF
--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -803,7 +803,7 @@ function formatDate(value) {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1100;
+  z-index: 10000;
   padding: 12px;
   box-sizing: border-box;
 }

--- a/components/newsite/MyCollection.vue
+++ b/components/newsite/MyCollection.vue
@@ -274,6 +274,17 @@ onMounted(async () => {
 @media (max-width: 768px) {
   .mc-grid {
     grid-template-columns: repeat(2, 1fr);
+    --footer-height: 52px;
+    --footer-left-width: 100%;
+    --footer-right-width: 100%;
+  }
+
+  :deep(.sc-footer) {
+    flex-direction: column;
+  }
+
+  :deep(.sc-footer-right) {
+    justify-content: flex-start;
   }
 }
 

--- a/components/newsite/MyCworld.vue
+++ b/components/newsite/MyCworld.vue
@@ -5,9 +5,11 @@
       <GreenButton @click="$router.push('/newsite/MyCollection')">My Collection</GreenButton>
       <GreenButton @click="$router.push('/newsite/allCtoons')">All cToons</GreenButton>
       <GreenButton @click="$router.push('/newsite/myachievements')">Achievements</GreenButton>
+      <GreenButton @click="openWishlist">My Wishlist</GreenButton>
     </div>
     <div class="mcw-content">
-      <CzoneContest />
+      <MyWishlist v-if="showWishlist" />
+      <CzoneContest v-else />
     </div>
   </div>
 </template>
@@ -15,11 +17,21 @@
 <script setup>
 const { user } = useAuth()
 const router = useRouter()
+const { setSidebarMiddle, clearSidebarMiddle } = useNewsiteLayout()
+
+const showWishlist = ref(false)
 
 function goToCzone() {
+  showWishlist.value = false
+  clearSidebarMiddle()
   if (user.value?.username) {
     router.push(`/newsite/czone/${user.value.username}`)
   }
+}
+
+function openWishlist() {
+  showWishlist.value = true
+  setSidebarMiddle('MyWishlistSidebar')
 }
 </script>
 
@@ -43,6 +55,12 @@ function goToCzone() {
   gap: 6px;
   height: var(--mcw-nav-height);
   flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.mcw-nav::-webkit-scrollbar {
+  display: none;
 }
 
 .mcw-content {

--- a/components/newsite/MyWishlist.vue
+++ b/components/newsite/MyWishlist.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="my-wishlist">
+
+    <div class="mwl-header">My Wishlist</div>
+
+    <div class="mwl-scroll">
+      <div v-if="loading" class="mwl-status">Loading…</div>
+      <div v-else-if="!filteredItems.length && !allItems.length" class="mwl-status">Your wishlist is empty.</div>
+      <div v-else-if="!filteredItems.length" class="mwl-status">No cToons match your filters.</div>
+
+      <div v-else class="mwl-grid">
+        <ShortCard
+          v-for="c in filteredItems"
+          :key="c.id"
+          :style="{ '--footer-left-width': '100%', '--footer-right-width': '0%' }"
+        >
+          <template #header>
+            <div class="card-header-wrap" @click="openInfo(c)">
+              <img v-if="c.assetPath" :src="c.assetPath" :alt="c.name" class="card-img" />
+              <span
+                class="owned-badge"
+                :class="c.isOwned ? 'owned-badge--owned' : 'owned-badge--unowned'"
+              >{{ c.isOwned ? 'Owned' : 'Unowned' }}</span>
+            </div>
+          </template>
+          <template #middle>
+            <span class="card-name">{{ c.name }}</span>
+            <span class="rarity-dot" :style="{ background: rarityColor(c.rarity) }" :title="c.rarity" />
+          </template>
+          <template #footer-left>
+            <button
+              class="remove-btn"
+              :disabled="processing.has(c.id)"
+              @click.stop="removeItem(c)"
+            >Remove from Wishlist</button>
+          </template>
+        </ShortCard>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script setup>
+const { open: openCtoonModal } = useCtoonModal()
+const filter = useMyWishlistFilter()
+const { remove: wishlistRemove } = useWishlist()
+
+function openInfo(c) {
+  openCtoonModal({ ctoonId: c.id, assetPath: c.assetPath, name: c.name })
+}
+
+const RARITY_COLORS = {
+  'common':       '#aaaaaa',
+  'uncommon':     '#33cc33',
+  'rare':         '#3399ff',
+  'very rare':    '#aa44ff',
+  'crazy rare':   '#ffaa00',
+  'prize only':   '#ff3366',
+  'code only':    '#00cccc',
+  'auction only': '#ff6600',
+}
+
+function rarityColor(rarity) {
+  return RARITY_COLORS[(rarity || '').toLowerCase()] || '#aaaaaa'
+}
+
+const RARITY_ORDER = {
+  'common': 0, 'uncommon': 1, 'rare': 2, 'very rare': 3,
+  'crazy rare': 4, 'prize only': 5, 'code only': 6, 'auction only': 7,
+}
+
+const allItems  = ref([])
+const loading   = ref(true)
+const processing = ref(new Set())
+
+const filteredItems = computed(() => {
+  const f = filter.value
+  let list = allItems.value.filter(c => {
+    const nm = !f.name || c.name.toLowerCase().includes(f.name.toLowerCase())
+    const r  = !f.rarities.length || f.rarities.includes((c.rarity || '').toLowerCase())
+    return nm && r
+  })
+
+  return list.slice().sort((a, b) => {
+    let cmp = 0
+    if (f.sortField === 'rarity') {
+      const ar = RARITY_ORDER[(a.rarity || '').toLowerCase()] ?? 99
+      const br = RARITY_ORDER[(b.rarity || '').toLowerCase()] ?? 99
+      cmp = ar - br
+    } else if (f.sortField === 'releaseDate') {
+      const at = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
+      const bt = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
+      cmp = at - bt
+    } else {
+      cmp = (a.name || '').localeCompare(b.name || '')
+    }
+    return f.sortAsc ? cmp : -cmp
+  })
+})
+
+async function removeItem(c) {
+  if (processing.value.has(c.id)) return
+  processing.value = new Set([...processing.value, c.id])
+  try {
+    await wishlistRemove(c.id)
+    allItems.value = allItems.value.filter(item => item.id !== c.id)
+  } finally {
+    const next = new Set(processing.value)
+    next.delete(c.id)
+    processing.value = next
+  }
+}
+
+onMounted(async () => {
+  try {
+    allItems.value = await $fetch('/api/wishlist')
+  } catch (err) {
+    console.error('MyWishlist: failed to load', err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+.my-wishlist {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: white;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.mwl-header {
+  flex-shrink: 0;
+  width: 100%;
+  height: 23px;
+  line-height: 21px;
+  padding-bottom: 2px;
+  overflow: hidden;
+  text-align: center;
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: #fff;
+  background: var(--OrbitLightBlue);
+  box-sizing: border-box;
+}
+
+.mwl-scroll {
+  flex: 1;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--OrbitLightBlue) transparent;
+  padding: 6px;
+  box-sizing: border-box;
+}
+
+.mwl-status {
+  text-align: center;
+  color: #336699;
+  font-size: 2rem;
+  padding: 20px;
+}
+
+/* ── Grid ── */
+.mwl-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  grid-auto-rows: var(--shortcard-height);
+  gap: 4px;
+  --shortcard-width: 100%;
+}
+
+@media (max-width: 768px) {
+  .mwl-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ── Card contents ── */
+.card-header-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.card-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transform: scale(0.7);
+}
+
+.card-header-wrap:hover .card-img { filter: brightness(1.12); }
+
+.owned-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  font-size: 0.5rem;
+  font-weight: bold;
+  padding: 1px 4px;
+  border-radius: 3px;
+  line-height: 1.4;
+  pointer-events: none;
+}
+
+.owned-badge--owned   { background: #16a34a;            color: #fff; }
+.owned-badge--unowned { background: rgba(0, 0, 0, 0.55); color: rgba(255, 255, 255, 0.75); }
+
+.card-name {
+  font-size: 0.6rem;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  text-align: center;
+}
+
+.rarity-dot {
+  width: 8px;
+  height: 8px;
+  min-width: 8px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  flex-shrink: 0;
+}
+
+/* ── Remove button ── */
+.remove-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  font-size: 0.65rem;
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border: none;
+  background: #f47b00;
+  color: #fff;
+  cursor: pointer;
+  user-select: none;
+}
+
+.remove-btn:disabled { opacity: 0.5; cursor: default; }
+.remove-btn:not(:disabled):hover { filter: brightness(1.1); }
+</style>

--- a/components/newsite/MyWishlist.vue
+++ b/components/newsite/MyWishlist.vue
@@ -79,7 +79,8 @@ const filteredItems = computed(() => {
   let list = allItems.value.filter(c => {
     const nm = !f.name || c.name.toLowerCase().includes(f.name.toLowerCase())
     const r  = !f.rarities.length || f.rarities.includes((c.rarity || '').toLowerCase())
-    return nm && r
+    const tr = !f.tradable || c.hasTradableOwner
+    return nm && r && tr
   })
 
   return list.slice().sort((a, b) => {

--- a/components/newsite/MyWishlistSidebar.vue
+++ b/components/newsite/MyWishlistSidebar.vue
@@ -1,0 +1,212 @@
+<template>
+  <div class="mws">
+
+    <!-- Search -->
+    <div class="mws-search">
+      <span class="mws-search-icon">&#9906;</span>
+      <input type="text" v-model="filter.name" placeholder="Search name..." />
+    </div>
+
+    <hr class="mws-divider" />
+
+    <!-- Rarity -->
+    <div>
+      <div class="mws-label">Rarity</div>
+      <div class="mws-rarity-grid">
+        <button
+          v-for="r in RARITIES"
+          :key="r.value"
+          class="mws-rarity-btn"
+          :class="[r.cls, { active: filter.rarities.includes(r.value) }]"
+          @click="toggleRarity(r.value)"
+        >{{ r.label }}</button>
+      </div>
+    </div>
+
+    <hr class="mws-divider" />
+
+    <!-- Sort -->
+    <div>
+      <div class="mws-label">Sort By</div>
+      <div class="mws-sort-row">
+        <select class="mws-select" v-model="filter.sortField">
+          <option value="name">Name (A→Z)</option>
+          <option value="rarity">Rarity</option>
+          <option value="releaseDate">Release Date</option>
+        </select>
+        <button class="mws-sort-dir" @click="filter.sortAsc = !filter.sortAsc">
+          {{ filter.sortAsc ? '▲' : '▼' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Clear -->
+    <button class="mws-clear" @click="clearFilters">Clear Filters</button>
+
+  </div>
+</template>
+
+<script setup>
+const filter = useMyWishlistFilter()
+
+const RARITIES = [
+  { value: 'common',       label: 'C',  cls: 'mws-rb-common'        },
+  { value: 'uncommon',     label: 'U',  cls: 'mws-rb-uncommon'      },
+  { value: 'rare',         label: 'R',  cls: 'mws-rb-rare'          },
+  { value: 'very rare',    label: 'VR', cls: 'mws-rb-very-rare'     },
+  { value: 'crazy rare',   label: 'CR', cls: 'mws-rb-crazy-rare'    },
+  { value: 'prize only',   label: 'PO', cls: 'mws-rb-prize-only'    },
+  { value: 'code only',    label: 'CO', cls: 'mws-rb-code-only'     },
+  { value: 'auction only', label: 'AO', cls: 'mws-rb-auction-only'  },
+]
+
+function toggleRarity(val) {
+  const idx = filter.value.rarities.indexOf(val)
+  if (idx === -1) filter.value.rarities = [...filter.value.rarities, val]
+  else            filter.value.rarities = filter.value.rarities.filter(r => r !== val)
+}
+
+function clearFilters() {
+  Object.assign(filter.value, {
+    name:      '',
+    rarities:  [],
+    sortField: 'name',
+    sortAsc:   true,
+  })
+}
+</script>
+
+<style scoped>
+.mws {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  overflow-y: auto;
+  padding: 6px 4px;
+  box-sizing: border-box;
+  scrollbar-width: thin;
+  scrollbar-color: var(--OrbitDarkBlue) transparent;
+}
+
+/* ── Label ── */
+.mws-label {
+  font-size: 0.6rem;
+  font-weight: bold;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 2px;
+}
+
+/* ── Search ── */
+.mws-search {
+  display: flex;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 20px;
+  padding: 3px 8px;
+  gap: 4px;
+}
+
+.mws-search-icon { font-size: 0.7rem; color: rgba(255, 255, 255, 0.4); }
+
+.mws-search input {
+  background: none;
+  border: none;
+  outline: none;
+  color: #fff;
+  font-size: 0.75rem;
+  width: 100%;
+  padding: 0;
+}
+
+.mws-search input::placeholder { color: rgba(255, 255, 255, 0.35); }
+
+/* ── Rarity ── */
+.mws-rarity-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.mws-rarity-btn {
+  border: none;
+  border-radius: 4px;
+  padding: 2px 5px;
+  font-size: 0.6rem;
+  font-weight: bold;
+  cursor: pointer;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+
+.mws-rarity-btn.active { opacity: 1; }
+.mws-rarity-btn:hover  { opacity: 0.85; }
+
+.mws-rb-common       { background: #6b7280; color: #fff; }
+.mws-rb-uncommon     { background: #e5e7eb; color: #111; }
+.mws-rb-rare         { background: #16a34a; color: #fff; }
+.mws-rb-very-rare    { background: #2563eb; color: #fff; }
+.mws-rb-crazy-rare   { background: #7c3aed; color: #fff; }
+.mws-rb-prize-only   { background: #111;    color: #e5e7eb; }
+.mws-rb-code-only    { background: #ea580c; color: #fff; }
+.mws-rb-auction-only { background: #eab308; color: #111; }
+
+/* ── Sort ── */
+.mws-sort-row {
+  display: flex;
+  gap: 4px;
+}
+
+.mws-select {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.72rem;
+  padding: 3px 6px;
+  outline: none;
+  cursor: pointer;
+}
+
+.mws-select option { background: #1a3a58; }
+
+.mws-sort-dir {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.8rem;
+  padding: 2px 7px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+/* ── Clear ── */
+.mws-clear {
+  width: 100%;
+  padding: 4px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.2);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  margin-top: auto;
+  font-family: inherit;
+}
+
+.mws-clear:hover { background: rgba(255, 255, 255, 0.1); color: #fff; }
+
+/* ── Divider ── */
+.mws-divider {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 0;
+}
+</style>

--- a/components/newsite/MyWishlistSidebar.vue
+++ b/components/newsite/MyWishlistSidebar.vue
@@ -9,6 +9,15 @@
 
     <hr class="mws-divider" />
 
+    <!-- Tradable owners filter -->
+    <label class="mws-checkbox-row">
+      <input type="checkbox" v-model="filter.tradable" class="mws-checkbox" />
+      <span class="mws-checkbox-label">Has Tradable Owner</span>
+    </label>
+    <p class="mws-hint">Only show cToons where at least one player who owns it has marked it as tradable.</p>
+
+    <hr class="mws-divider" />
+
     <!-- Rarity -->
     <div>
       <div class="mws-label">Rarity</div>
@@ -70,6 +79,7 @@ function clearFilters() {
   Object.assign(filter.value, {
     name:      '',
     rarities:  [],
+    tradable:  false,
     sortField: 'name',
     sortAsc:   true,
   })
@@ -184,6 +194,38 @@ function clearFilters() {
   padding: 2px 7px;
   cursor: pointer;
   flex-shrink: 0;
+}
+
+/* ── Tradable checkbox ── */
+.mws-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.mws-checkbox {
+  accent-color: var(--OrbitLightBlue);
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.mws-checkbox-label {
+  font-size: 0.72rem;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.mws-checkbox-row:hover .mws-checkbox-label { color: #fff; }
+
+.mws-hint {
+  font-size: 0.6rem;
+  color: rgba(255, 255, 255, 0.4);
+  margin: 0;
+  line-height: 1.4;
 }
 
 /* ── Clear ── */

--- a/composables/useMyWishlistFilter.js
+++ b/composables/useMyWishlistFilter.js
@@ -1,6 +1,7 @@
 export const useMyWishlistFilter = () => useState('myWishlistFilter', () => ({
   name:      '',
   rarities:  [],
+  tradable:  false,
   sortField: 'name',
   sortAsc:   true,
 }))

--- a/composables/useMyWishlistFilter.js
+++ b/composables/useMyWishlistFilter.js
@@ -1,0 +1,6 @@
+export const useMyWishlistFilter = () => useState('myWishlistFilter', () => ({
+  name:      '',
+  rarities:  [],
+  sortField: 'name',
+  sortAsc:   true,
+}))

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -255,6 +255,7 @@ html.newsite-active body {
           <AuctionHouseSidebar v-show="sidebarMiddleComponent === 'AuctionHouseSidebar'" />
           <MyCollectionSidebar v-show="sidebarMiddleComponent === 'MyCollectionSidebar'" />
           <AllCtoonsSidebar    v-show="sidebarMiddleComponent === 'AllCtoonsSidebar'" />
+          <MyWishlistSidebar   v-show="sidebarMiddleComponent === 'MyWishlistSidebar'" />
           <TradeSidebarWrapper v-show="sidebarMiddleComponent === 'TradeSidebarWrapper'" />
           <CzoneSidebarMiddle  v-show="sidebarMiddleComponent === 'CzoneSidebarMiddle'" />
         </div>

--- a/server/api/wishlist.get.js
+++ b/server/api/wishlist.get.js
@@ -25,16 +25,33 @@ export default defineEventHandler(async (event) => {
     include: { ctoon: true }
   })
 
-  // 3. Fetch the IDs of all cToons this user owns
-  const ownedRecords = await prisma.userCtoon.findMany({
-    where: { userId },
-    select: { ctoonId: true }
-  })
-  const ownedIds = new Set(ownedRecords.map(r => r.ctoonId))
+  const wishlistCtoonIds = wishlistItems.map(item => item.ctoonId)
 
-  // 4. Map to plain ctoon objects with isOwned flag
+  // 3. Fetch the IDs of all cToons this user owns
+  // 4. Find which wishlisted cToons have at least one tradable owner (any user)
+  const [ownedRecords, tradableRecords] = await Promise.all([
+    prisma.userCtoon.findMany({
+      where: { userId },
+      select: { ctoonId: true }
+    }),
+    prisma.userTradeListItem.findMany({
+      where: {
+        userCtoon: {
+          ctoonId: { in: wishlistCtoonIds },
+          burnedAt: null
+        }
+      },
+      select: { userCtoon: { select: { ctoonId: true } } }
+    })
+  ])
+
+  const ownedIds         = new Set(ownedRecords.map(r => r.ctoonId))
+  const tradableCtoonIds = new Set(tradableRecords.map(r => r.userCtoon.ctoonId))
+
+  // 5. Map to plain ctoon objects with isOwned and hasTradableOwner flags
   return wishlistItems.map(({ ctoon }) => ({
     ...ctoon,
-    isOwned: ownedIds.has(ctoon.id)
+    isOwned:          ownedIds.has(ctoon.id),
+    hasTradableOwner: tradableCtoonIds.has(ctoon.id)
   }))
 })


### PR DESCRIPTION
- Add "My Wishlist" GreenButton to MyCworld nav row
- Clicking it shows a new MyWishlist component (inline, no navigation) and activates MyWishlistSidebar
- MyWishlist fetches full ctoon data from /api/wishlist with owned badge, rarity dot, and Remove button per card; layout matches AllCtoons (6-col grid, OrbitLightBlue header)
- MyWishlistSidebar provides name search, rarity filter, and sort controls via useMyWishlistFilter composable
- Nav row gets overflow-x: auto + scrollbar-width: none so buttons wrap-scroll on mobile without a visible scrollbar
- Register MyWishlistSidebar in newsite-template layout sidebar switcher

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vt8AwY1ys7GbFq58osv9Ff