### PR TITLE
Fix Make Tradable button state in MyCollection not reflecting trade list correctly

### DIFF
--- a/composables/useTradeList.js
+++ b/composables/useTradeList.js
@@ -10,7 +10,7 @@ export function useTradeList() {
     loading.value = true
     $fetch('/api/trade-list')
       .then(data => {
-        tradeList.value = (data || []).map(item => item.userCtoonId)
+        tradeList.value = (data || []).map(item => item.id || item.userCtoonId)
       })
       .catch(err => { console.error('Failed to load trade list:', err) })
       .finally(() => { loading.value = false })

--- a/server/api/trade-list.get.js
+++ b/server/api/trade-list.get.js
@@ -25,9 +25,10 @@ export default defineEventHandler(async (event) => {
 
   const items = await prisma.userTradeListItem.findMany({
     where: { userId, userCtoon: { userId, burnedAt: null } },
-    select: { userCtoon: { select: { userId: true, ctoonId: true, mintNumber: true } } }
+    select: { userCtoon: { select: { id: true, userId: true, ctoonId: true, mintNumber: true } } }
   })
   return items.map(item => ({
+    id: item.userCtoon.id,
     userCtoonId: encodeUserCtoonId(item.userCtoon.userId, item.userCtoon.ctoonId, item.userCtoon.mintNumber)
   }))
 })


### PR DESCRIPTION
GET /api/trade-list now returns the raw UUID id alongside the encoded userCtoonId.
useTradeList stores raw UUIDs so they match c.id from /api/collections, fixing the
initial button label always showing "Make Tradable" regardless of actual trade list state.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AMPzoSqU78AXCXcDRXto3C