### PR TITLE
Add Second Edition cToons feature

### DIFF
--- a/components/admin/SecondEditionFields.vue
+++ b/components/admin/SecondEditionFields.vue
@@ -1,0 +1,292 @@
+<template>
+  <div class="sef">
+    <label class="sef-checkbox">
+      <input type="checkbox" :checked="modelValue.isSecondEdition" @change="setField('isSecondEdition', $event.target.checked)" />
+      <span>Is Second Edition</span>
+    </label>
+    <p v-if="autoNote" class="sef-note">{{ autoNote }}</p>
+
+    <!-- Related First Edition autocomplete -->
+    <div v-if="modelValue.isSecondEdition" class="sef-related">
+      <label class="sef-label">Related First Edition cToon</label>
+      <div class="sef-autocomplete">
+        <input
+          v-model="query"
+          type="text"
+          class="sef-input"
+          placeholder="Type a cToon name (3+ characters)..."
+          @focus="showDropdown = true"
+          @blur="onBlur"
+        />
+        <ul v-if="showDropdown && results.length" class="sef-dropdown">
+          <li v-for="r in results" :key="r.id" class="sef-dropdown-item" @mousedown.prevent="selectResult(r)">
+            <img v-if="r.assetPath" :src="r.assetPath" :alt="r.name" class="sef-dropdown-thumb" />
+            <span class="sef-dropdown-name">{{ r.name }}</span>
+          </li>
+        </ul>
+        <p v-else-if="showDropdown && query.trim().length >= 3 && !searching" class="sef-no-results">No matches.</p>
+      </div>
+    </div>
+
+    <!-- Preview + position controls -->
+    <div v-if="modelValue.isSecondEdition && showPositionEditor" class="sef-preview-wrap">
+      <label class="sef-label">Second Edition Preview</label>
+      <div
+        ref="previewEl"
+        class="sef-preview"
+        @pointerdown="startDrag"
+      >
+        <img v-if="ctoonImageSrc" :src="ctoonImageSrc" alt="cToon preview" class="sef-preview-img" draggable="false" />
+        <img
+          v-if="overlay.path"
+          :src="overlay.path"
+          alt="Second Edition overlay"
+          class="sef-preview-overlay"
+          :style="overlayStyle"
+          draggable="false"
+        />
+        <p v-else class="sef-no-overlay">No Second Edition overlay image is set. Upload one in Global Settings → Second Editions.</p>
+      </div>
+      <p class="sef-hint">Drag the icon on the preview, or use the fine-tune controls below.</p>
+
+      <div class="sef-controls">
+        <div class="sef-control-row">
+          <span class="sef-control-label">X Position</span>
+          <button type="button" class="sef-step-btn" @pointerdown="startRepeat('overlayX', -1)" @pointerup="stopRepeat" @pointerleave="stopRepeat">−</button>
+          <span class="sef-control-value">{{ Math.round(modelValue.overlayX) }}%</span>
+          <button type="button" class="sef-step-btn" @pointerdown="startRepeat('overlayX', 1)" @pointerup="stopRepeat" @pointerleave="stopRepeat">+</button>
+        </div>
+        <div class="sef-control-row">
+          <span class="sef-control-label">Y Position</span>
+          <button type="button" class="sef-step-btn" @pointerdown="startRepeat('overlayY', -1)" @pointerup="stopRepeat" @pointerleave="stopRepeat">−</button>
+          <span class="sef-control-value">{{ Math.round(modelValue.overlayY) }}%</span>
+          <button type="button" class="sef-step-btn" @pointerdown="startRepeat('overlayY', 1)" @pointerup="stopRepeat" @pointerleave="stopRepeat">+</button>
+        </div>
+        <div class="sef-control-row">
+          <span class="sef-control-label">Size</span>
+          <button type="button" class="sef-step-btn" @pointerdown="startRepeat('overlaySize', -5)" @pointerup="stopRepeat" @pointerleave="stopRepeat">−</button>
+          <span class="sef-control-value">{{ Math.round(modelValue.overlaySize) }}%</span>
+          <button type="button" class="sef-step-btn" @pointerdown="startRepeat('overlaySize', 5)" @pointerup="stopRepeat" @pointerleave="stopRepeat">+</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { useSecondEditionOverlay } from '@/composables/useSecondEditionOverlay'
+
+const props = defineProps({
+  modelValue: { type: Object, required: true },
+  ctoonImageSrc: { type: String, default: '' },
+  excludeCtoonId: { type: String, default: '' },
+  showPositionEditor: { type: Boolean, default: true },
+  autoNote: { type: String, default: '' }
+})
+const emit = defineEmits(['update:modelValue'])
+
+const { overlay, ensureLoaded, styleFor } = useSecondEditionOverlay()
+onMounted(ensureLoaded)
+
+function setField(key, value) {
+  const next = { ...props.modelValue, [key]: value }
+  if (key === 'isSecondEdition' && value) {
+    if (next.overlayX == null) next.overlayX = 85
+    if (next.overlayY == null) next.overlayY = 85
+    if (next.overlaySize == null) next.overlaySize = 100
+  }
+  emit('update:modelValue', next)
+}
+
+const overlayStyle = computed(() => styleFor({
+  isSecondEdition: true,
+  secondEditionOverlayX: props.modelValue.overlayX,
+  secondEditionOverlayY: props.modelValue.overlayY,
+  secondEditionOverlaySize: props.modelValue.overlaySize
+}))
+
+/* ── Related First Edition autocomplete ── */
+const query = ref(props.modelValue.relatedFirstEditionName || '')
+const results = ref([])
+const showDropdown = ref(false)
+const searching = ref(false)
+let searchTimer = null
+
+watch(() => props.modelValue.relatedFirstEditionName, (next) => {
+  if (next !== query.value) query.value = next || ''
+})
+
+watch(query, (next) => {
+  if (searchTimer) clearTimeout(searchTimer)
+  const trimmed = next.trim()
+  if (trimmed !== (props.modelValue.relatedFirstEditionName || '')) {
+    setField('relatedFirstEditionId', null)
+    emit('update:modelValue', { ...props.modelValue, relatedFirstEditionId: null, relatedFirstEditionName: next })
+  }
+  if (trimmed.length < 3) { results.value = []; return }
+  searchTimer = setTimeout(async () => {
+    searching.value = true
+    try {
+      const res = await $fetch('/api/admin/search-ctoons', {
+        query: { q: trimmed, excludeSecondEdition: 'true', excludeId: props.excludeCtoonId || '' }
+      })
+      results.value = Array.isArray(res) ? res : []
+    } catch {
+      results.value = []
+    } finally {
+      searching.value = false
+    }
+  }, 300)
+})
+
+function selectResult(r) {
+  query.value = r.name
+  showDropdown.value = false
+  emit('update:modelValue', { ...props.modelValue, relatedFirstEditionId: r.id, relatedFirstEditionName: r.name })
+}
+
+function onBlur() {
+  setTimeout(() => { showDropdown.value = false }, 150)
+}
+
+onBeforeUnmount(() => { if (searchTimer) clearTimeout(searchTimer) })
+
+/* ── Drag-to-position on preview ── */
+const previewEl = ref(null)
+let dragging = false
+
+function clamp(v, min, max) { return Math.min(max, Math.max(min, v)) }
+
+function positionFromPointer(e) {
+  const rect = previewEl.value.getBoundingClientRect()
+  const x = clamp(((e.clientX - rect.left) / rect.width) * 100, 0, 100)
+  const y = clamp(((e.clientY - rect.top) / rect.height) * 100, 0, 100)
+  emit('update:modelValue', { ...props.modelValue, overlayX: x, overlayY: y })
+}
+
+function startDrag(e) {
+  dragging = true
+  positionFromPointer(e)
+  window.addEventListener('pointermove', onDragMove)
+  window.addEventListener('pointerup', stopDrag, { once: true })
+}
+function onDragMove(e) {
+  if (!dragging) return
+  positionFromPointer(e)
+}
+function stopDrag() {
+  dragging = false
+  window.removeEventListener('pointermove', onDragMove)
+}
+
+/* ── Hold-to-repeat +/- controls ── */
+let repeatTimeout = null
+let repeatInterval = null
+
+const STEP_LIMITS = {
+  overlayX: [0, 100],
+  overlayY: [0, 100],
+  overlaySize: [10, 400]
+}
+
+function applyStep(key, delta) {
+  const [min, max] = STEP_LIMITS[key]
+  const next = clamp((props.modelValue[key] ?? 0) + delta, min, max)
+  emit('update:modelValue', { ...props.modelValue, [key]: next })
+}
+
+function startRepeat(key, delta) {
+  applyStep(key, delta)
+  repeatTimeout = setTimeout(() => {
+    repeatInterval = setInterval(() => applyStep(key, delta), 80)
+  }, 350)
+}
+function stopRepeat() {
+  if (repeatTimeout) { clearTimeout(repeatTimeout); repeatTimeout = null }
+  if (repeatInterval) { clearInterval(repeatInterval); repeatInterval = null }
+}
+
+onBeforeUnmount(() => {
+  stopRepeat()
+  window.removeEventListener('pointermove', onDragMove)
+})
+</script>
+
+<style scoped>
+.sef { margin-top: 1rem; }
+.sef-checkbox { display: flex; align-items: center; gap: 0.5rem; font-weight: 500; cursor: pointer; }
+.sef-note { font-size: 0.8rem; color: #6b7280; margin: 0.25rem 0 0; }
+.sef-label { display: block; margin: 0.75rem 0 0.25rem; font-weight: 500; }
+.sef-related { margin-top: 0.5rem; }
+
+.sef-autocomplete { position: relative; }
+.sef-input { width: 100%; border: 1px solid #d1d5db; border-radius: 0.375rem; padding: 0.5rem; box-sizing: border-box; }
+.sef-dropdown {
+  position: absolute;
+  z-index: 20;
+  top: 100%;
+  left: 0;
+  right: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+.sef-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  min-height: 44px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+.sef-dropdown-item:hover { background: #f3f4f6; }
+.sef-dropdown-thumb { width: 32px; height: 32px; object-fit: contain; border: 1px solid #e5e7eb; border-radius: 4px; background: white; flex-shrink: 0; }
+.sef-dropdown-name { font-size: 0.9rem; }
+.sef-no-results { font-size: 0.8rem; color: #6b7280; margin: 0.25rem 0 0; }
+
+.sef-preview-wrap { margin-top: 0.75rem; }
+.sef-preview {
+  position: relative;
+  width: 220px;
+  height: 220px;
+  max-width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  background: repeating-conic-gradient(#f3f4f6 0% 25%, #ffffff 0% 50%) 50% / 20px 20px;
+  overflow: hidden;
+  touch-action: none;
+  cursor: grab;
+}
+.sef-preview-img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: contain; pointer-events: none; }
+.sef-preview-overlay { z-index: 5; }
+.sef-no-overlay { font-size: 0.78rem; color: #9ca3af; padding: 0.75rem; margin: 0; }
+.sef-hint { font-size: 0.75rem; color: #6b7280; margin: 0.35rem 0 0; }
+
+.sef-controls { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 0.6rem; max-width: 220px; }
+.sef-control-row { display: flex; align-items: center; gap: 0.5rem; }
+.sef-control-label { flex: 1; font-size: 0.8rem; color: #374151; }
+.sef-control-value { min-width: 44px; text-align: center; font-variant-numeric: tabular-nums; font-size: 0.85rem; }
+.sef-step-btn {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  background: #f9fafb;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+}
+.sef-step-btn:hover { background: #f3f4f6; }
+.sef-step-btn:active { background: #e5e7eb; }
+</style>

--- a/components/newsite/AuctionDetails.vue
+++ b/components/newsite/AuctionDetails.vue
@@ -22,12 +22,16 @@
         <!-- cToon image -->
         <div class="adet-img-wrap adet-img-clickable" @click="openInfoModal">
           <img class="adet-img" :src="auction.ctoon.assetPath" :alt="auction.ctoon.name" draggable="false" />
+          <SecondEditionOverlay :ctoon="auction.ctoon" />
           <div v-if="ended" class="adet-ended-badge">Ended</div>
         </div>
 
         <!-- Details + actions -->
         <div class="adet-info">
-          <div class="adet-name">{{ auction.ctoon.name }}</div>
+          <div class="adet-name">
+            {{ auction.ctoon.name }}
+            <span v-if="auction.ctoon.isSecondEdition" class="adet-2nd-badge">2nd Edition</span>
+          </div>
 
           <div class="adet-meta">
             <span class="adet-rarity" :class="`r-${rarityKey(auction.ctoon.rarity)}`">{{ auction.ctoon.rarity }}</span>
@@ -460,6 +464,20 @@ onUnmounted(() => {
   font-size: 0.85rem;
   font-weight: bold;
   color: #fff;
+}
+
+.adet-2nd-badge {
+  display: inline-block;
+  margin-left: 6px;
+  background: #7c3aed;
+  color: #fff;
+  font-size: 0.58rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+  vertical-align: middle;
 }
 
 .adet-meta { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; }

--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -127,6 +127,7 @@
           <template #header>
             <div class="ah-card-header" @click="openInfoModal(item)">
               <img v-if="item.assetPath" :src="item.assetPath" :alt="item.name" class="ah-card-img" draggable="false" />
+              <SecondEditionOverlay :ctoon="item" />
               <div class="ah-card-time-badge" :class="{ ended: isEnded(item.endAt) }">
                 <template v-if="!isEnded(item.endAt)">{{ formatRemaining(item.endAt) }}</template>
                 <template v-else>Ended</template>
@@ -418,6 +419,7 @@ function applyFilters(items) {
     if (rarities.length && !rarities.includes((item.rarity || '').toLowerCase()))    return false
     if (series && item.series !== series)                                             return false
     if (set    && item.set    !== set)                                                return false
+    if (filter.value.excludeSecondEditions && item.isSecondEdition)                  return false
     if (aFilters.value.featuredOnly  && !item.isFeatured)                            return false
     if (aFilters.value.selectedOwned === 'owned'   && !item.isOwned)                 return false
     if (aFilters.value.selectedOwned === 'unowned' && item.isOwned)                  return false

--- a/components/newsite/AuctionHouseSidebar.vue
+++ b/components/newsite/AuctionHouseSidebar.vue
@@ -4,6 +4,7 @@
     :show-sort-dir="false"
     :show-auction-filters="true"
     :show-common-filters="true"
+    :show-exclude-second-editions="true"
   />
 </template>
 

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -29,6 +29,7 @@
                 :class="{ 'pack-reveal-new': !originalOwnedSet.has(item.id) }"
               >
                 <span v-if="!originalOwnedSet.has(item.id)" class="pack-new-badge">New!</span>
+                <span v-if="!item.inCmart" class="pack-exclusive-badge">Pack Exclusive</span>
                 <img
                   v-if="item.assetPath"
                   :src="item.assetPath"
@@ -1000,6 +1001,19 @@ async function closeOverlay() {
   font-weight: bold;
   padding: 2px 5px;
   border-radius: 10px;
+}
+
+:global(.pack-exclusive-badge) {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: #7c3aed;
+  color: #fff;
+  font-size: 0.56rem;
+  font-weight: bold;
+  padding: 2px 5px;
+  border-radius: 10px;
+  text-align: right;
 }
 
 :global(.pack-reveal-img) {

--- a/components/newsite/CtoonFilter.vue
+++ b/components/newsite/CtoonFilter.vue
@@ -89,12 +89,16 @@
       </div>
     </template>
 
-    <template v-if="showHideUnavailable">
+    <template v-if="showHideUnavailable || showExcludeSecondEditions">
       <hr class="cf-divider" />
       <div class="cf-page-filters">
-        <label class="cf-checkbox-row">
+        <label v-if="showHideUnavailable" class="cf-checkbox-row">
           <input type="checkbox" v-model="filter.hideUnavailable" />
           <span>Hide unavailable</span>
+        </label>
+        <label v-if="showExcludeSecondEditions" class="cf-checkbox-row">
+          <input type="checkbox" v-model="filter.excludeSecondEditions" />
+          <span>Exclude Second Editions</span>
         </label>
       </div>
     </template>
@@ -108,6 +112,7 @@
 <script setup>
 const props = defineProps({
   showHideUnavailable: { type: Boolean, default: false },
+  showExcludeSecondEditions: { type: Boolean, default: false },
   showSortDir:         { type: Boolean, default: true  },
   showAuctionFilters:  { type: Boolean, default: false },
   showCommonFilters:   { type: Boolean, default: false },
@@ -176,6 +181,7 @@ function clearFilters() {
     sortField:       props.sortOptions[0]?.value ?? 'name',
     sortAsc:         true,
     hideUnavailable: false,
+    excludeSecondEditions: false,
   })
   if (props.showAuctionFilters || props.showCommonFilters) {
     Object.assign(aFilters.value, {

--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -12,15 +12,35 @@
 
       <!-- Header -->
       <div class="ctic-head">
-        <img
-          v-if="ctoon.assetPath"
-          :src="ctoon.assetPath"
-          :alt="ctoon.name || 'cToon'"
-          class="ctic-thumb"
-        />
+        <div class="ctic-thumb-wrap">
+          <img
+            v-if="ctoon.assetPath"
+            :src="ctoon.assetPath"
+            :alt="ctoon.name || 'cToon'"
+            class="ctic-thumb"
+          />
+          <SecondEditionOverlay :ctoon="ctoon" />
+        </div>
         <div class="ctic-head-info">
           <h3 class="ctic-name">{{ ctoon.name || 'cToon' }}</h3>
+          <span v-if="ctoon.isSecondEdition" class="ctic-2nd-badge">2nd Edition</span>
           <p class="ctic-subtitle">cToon details</p>
+          <button
+            v-if="ctoon.isSecondEdition && ctoon.relatedFirstEdition"
+            type="button"
+            class="ctic-edition-link"
+            @click="openRelatedEdition(ctoon.relatedFirstEdition.id)"
+          >
+            View First Edition: {{ ctoon.relatedFirstEdition.name }}
+          </button>
+          <button
+            v-else-if="!ctoon.isSecondEdition && ctoon.relatedSecondEdition"
+            type="button"
+            class="ctic-edition-link"
+            @click="openRelatedEdition(ctoon.relatedSecondEdition.id)"
+          >
+            View Second Edition: {{ ctoon.relatedSecondEdition.name }}
+          </button>
           <button
             v-if="ctoon.soundPath"
             type="button"
@@ -351,13 +371,19 @@
 <script setup>
 import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import AddToWishlist from '@/components/AddToWishlist.vue'
+import SecondEditionOverlay from '@/components/newsite/SecondEditionOverlay.vue'
 import abilities from '@/data/abilities.json'
 import { useCtoonModal } from '@/composables/useCtoonModal'
 import { useAuth } from '@/composables/useAuth'
 import { formatQuantity, TIME_BASED_CAP } from '@/utils/formatQuantity'
 
 const { isAdmin } = useAuth()
-const { isOpen, loading, error, data, context, close, notifyHolidayRedeem } = useCtoonModal()
+const { isOpen, loading, error, data, context, close, open, notifyHolidayRedeem } = useCtoonModal()
+
+function openRelatedEdition(ctoonId) {
+  if (!ctoonId) return
+  open({ ctoonId })
+}
 
 const ctoon = computed(() => data.value?.ctoon || {})
 const ctoonDescription = computed(() => String(ctoon.value?.description || '').trim())
@@ -848,6 +874,13 @@ function formatDate(value) {
   position: relative;
 }
 
+.ctic-thumb-wrap {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  flex-shrink: 0;
+}
+
 .ctic-thumb {
   width: 72px;
   height: 72px;
@@ -855,8 +888,35 @@ function formatDate(value) {
   background: rgba(0, 0, 0, 0.3);
   padding: 4px;
   border-radius: 4px;
-  flex-shrink: 0;
+  box-sizing: border-box;
 }
+
+.ctic-2nd-badge {
+  display: inline-block;
+  background: #7c3aed;
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+  margin: 2px 0;
+}
+
+.ctic-edition-link {
+  display: block;
+  margin-top: 3px;
+  background: none;
+  border: none;
+  padding: 0;
+  color: #93c5fd;
+  font-size: 0.72rem;
+  text-align: left;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.ctic-edition-link:hover { color: #bfdbfe; }
 
 .ctic-head-info {
   flex: 1;

--- a/components/newsite/MyCollection.vue
+++ b/components/newsite/MyCollection.vue
@@ -26,7 +26,10 @@
       <template v-else>
         <ShortCard v-for="c in paginatedCtoons" :key="c.id" :style="{ '--footer-left-width': '50%', '--footer-right-width': '50%' }">
           <template #header>
-            <img v-if="c.assetPath" :src="c.assetPath" :alt="c.name" class="card-img card-img--clickable" @click="openInfo(c)" />
+            <div class="card-img-wrap">
+              <img v-if="c.assetPath" :src="c.assetPath" :alt="c.name" class="card-img card-img--clickable" @click="openInfo(c)" />
+              <SecondEditionOverlay :ctoon="c" />
+            </div>
           </template>
           <template #middle>
             <span class="card-mint">#{{ c.mintNumber ?? '?' }}</span>
@@ -138,6 +141,9 @@ const ctoons = computed(() => {
 
   if (f.priceMax !== '')
     list = list.filter(c => c.price <= Number(f.priceMax))
+
+  if (f.excludeSecondEditions)
+    list = list.filter(c => !c.isSecondEdition)
 
   list = [...list].sort((a, b) => {
     let cmp = 0
@@ -305,6 +311,12 @@ onMounted(async () => {
   border-radius: 50%;
   border: 1px solid rgba(255, 255, 255, 0.6);
   flex-shrink: 0;
+}
+
+.card-img-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 .card-img {

--- a/components/newsite/MyCollectionSidebar.vue
+++ b/components/newsite/MyCollectionSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <CtoonFilter :sort-options="myCollectionSortOptions" :source-ctoons="myCtoons" />
+  <CtoonFilter :sort-options="myCollectionSortOptions" :source-ctoons="myCtoons" :show-exclude-second-editions="true" />
 </template>
 
 <script setup>

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -73,6 +73,7 @@
               draggable="false"
               @load="e => onToonImgLoad(e, toon)"
             />
+            <SecondEditionOverlay :ctoon="toon" :respect-art-mode="true" />
             <div v-if="cz.buildMode" class="cz-item-btns" @mousedown.stop @touchstart.stop>
               <button
                 class="cz-bring-front-btn"
@@ -116,6 +117,14 @@
     <!-- ── Bottom bar ──────────────────────────────────────── -->
     <div class="cz-bottombar">
       <GreenButton v-show="!cz.buildMode" class="cz-myczone-btn" @click="goToMyCzone">My cZone</GreenButton>
+      <button
+        v-show="!cz.buildMode"
+        type="button"
+        class="cz-art-mode-btn"
+        :class="{ active: artMode }"
+        :aria-pressed="artMode ? 'true' : 'false'"
+        @click="artMode = !artMode"
+      >Art Mode: {{ artMode ? 'On' : 'Off' }}</button>
       <div class="cz-build-hint">
         <template v-if="cz.buildMode">
           <span class="cz-build-hint-desktop">Drag cToons from sidebar · Right-click canvas to remove</span>
@@ -355,6 +364,11 @@ const innerScaleStyle = computed(() => ({
 const canvasEl       = ref(null)
 const viewedOwner    = ref(null)   // { username, avatar } of the displayed zone owner
 const viewedUsername = ref(null)   // username whose zone is currently displayed
+
+// Art Mode: hides the Second Edition overlay icon for this viewer only. Off by
+// default; resets to off whenever the viewed cZone/user changes.
+const artMode = useArtMode()
+watch(viewedUsername, () => { artMode.value = false })
 
 // True while build-mode data is loading (prevents double-click and shows spinner on button)
 const buildLoading = ref(false)
@@ -1408,6 +1422,29 @@ defineExpose({ save, clearZone })
 }
 
 .cz-myczone-btn { flex-shrink: 0; }
+
+.cz-art-mode-btn {
+  flex-shrink: 0;
+  margin-left: 6px;
+  height: calc(v-bind(BOTTOMBAR_H + 'px') - 10px);
+  padding: 0 8px;
+  font-size: 0.62rem;
+  font-weight: bold;
+  color: #fff;
+  background: rgba(0,0,0,0.25);
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.cz-art-mode-btn.active {
+  background: var(--OrbitDarkBlue);
+  border-color: #fff;
+}
+
+@media (max-width: 480px) {
+  .cz-art-mode-btn { font-size: 0.56rem; padding: 0 6px; }
+}
 
 .cz-build-hint {
   font-size: 0.62rem;

--- a/components/newsite/SecondEditionOverlay.vue
+++ b/components/newsite/SecondEditionOverlay.vue
@@ -1,0 +1,40 @@
+<template>
+  <img
+    v-if="visible"
+    :src="overlay.path"
+    alt="Second Edition"
+    class="se-overlay-icon"
+    :style="styleFor(ctoon)"
+    draggable="false"
+  />
+</template>
+
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useSecondEditionOverlay } from '@/composables/useSecondEditionOverlay'
+import { useArtMode } from '@/composables/useArtMode'
+
+const props = defineProps({
+  ctoon: { type: Object, default: null },
+  // Only cZone views should respect the viewer's Art Mode toggle
+  respectArtMode: { type: Boolean, default: false }
+})
+
+const { overlay, ensureLoaded, styleFor } = useSecondEditionOverlay()
+const artMode = useArtMode()
+
+onMounted(ensureLoaded)
+
+const visible = computed(() => {
+  if (!props.ctoon?.isSecondEdition) return false
+  if (!overlay.value.path) return false
+  if (props.respectArtMode && artMode.value) return false
+  return true
+})
+</script>
+
+<style scoped>
+.se-overlay-icon {
+  z-index: 5;
+}
+</style>

--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -513,11 +513,15 @@
                     <span class="tm-own-badge" :class="selfOwnedIdsModal.has(tc.userCtoon.ctoonId) ? 'owned' : 'unowned'">
                       {{ selfOwnedIdsModal.has(tc.userCtoon.ctoonId) ? 'Owned' : 'Unowned' }}
                     </span>
-                    <img :src="tc.userCtoon.ctoon.assetPath" class="tm-card-img" @click="openTradeCToon(tc)" />
+                    <div class="tm-card-img-wrap">
+                      <img :src="tc.userCtoon.ctoon.assetPath" class="tm-card-img" @click="openTradeCToon(tc)" />
+                      <SecondEditionOverlay :ctoon="tc.userCtoon.ctoon" />
+                    </div>
                     <span class="tm-card-name">{{ tc.userCtoon.ctoon.name }}</span>
                     <span class="tm-dim">{{ tc.userCtoon.ctoon.rarity }}</span>
                     <span class="tm-dim">Mint #{{ tc.userCtoon.mintNumber }} of {{ formatQuantity(tc.userCtoon.ctoon.quantity) }}</span>
-                    <span class="tm-dim">{{ tc.userCtoon.isFirstEdition ? 'First Edition' : 'Unlimited Edition' }}</span>
+                    <span v-if="tc.userCtoon.ctoon.isSecondEdition" class="tm-2nd-badge">2nd Edition</span>
+                    <span v-else class="tm-dim">First Edition</span>
                   </div>
                   <div v-if="!currentOffer.ctoons.filter(c => c.role === 'OFFERED').length" class="tm-empty-col">None</div>
                 </div>
@@ -534,11 +538,15 @@
                     <span class="tm-own-badge" :class="selfOwnedIdsModal.has(tc.userCtoon.ctoonId) ? 'owned' : 'unowned'">
                       {{ selfOwnedIdsModal.has(tc.userCtoon.ctoonId) ? 'Owned' : 'Unowned' }}
                     </span>
-                    <img :src="tc.userCtoon.ctoon.assetPath" class="tm-card-img" @click="openTradeCToon(tc)" />
+                    <div class="tm-card-img-wrap">
+                      <img :src="tc.userCtoon.ctoon.assetPath" class="tm-card-img" @click="openTradeCToon(tc)" />
+                      <SecondEditionOverlay :ctoon="tc.userCtoon.ctoon" />
+                    </div>
                     <span class="tm-card-name">{{ tc.userCtoon.ctoon.name }}</span>
                     <span class="tm-dim">{{ tc.userCtoon.ctoon.rarity }}</span>
                     <span class="tm-dim">Mint #{{ tc.userCtoon.mintNumber }} of {{ formatQuantity(tc.userCtoon.ctoon.quantity) }}</span>
-                    <span class="tm-dim">{{ tc.userCtoon.isFirstEdition ? 'First Edition' : 'Unlimited Edition' }}</span>
+                    <span v-if="tc.userCtoon.ctoon.isSecondEdition" class="tm-2nd-badge">2nd Edition</span>
+                    <span v-else class="tm-dim">First Edition</span>
                     <div class="tm-own-stats">
                       <template v-if="!isLoadingModalSelf">
                         <span>You own: {{ getSelfStats(tc.userCtoon.ctoonId).count }}</span>
@@ -1871,10 +1879,15 @@ onBeforeUnmount(() => {
 }
 .tm-own-badge.owned { background: #16a34a; color: #fff; border: 1px solid #15803d; }
 .tm-own-badge.unowned { background: rgba(0,0,0,0.55); color: rgba(255,255,255,0.9); border: 1px solid rgba(0,0,0,0.3); }
-.tm-card-img { width: 80px; height: 80px; object-fit: contain; margin-top: 14px; cursor: pointer; transition: opacity 0.15s; }
+.tm-card-img-wrap { position: relative; width: 80px; height: 80px; margin-top: 14px; }
+.tm-card-img { width: 80px; height: 80px; object-fit: contain; cursor: pointer; transition: opacity 0.15s; }
 .tm-card-img:hover { opacity: 0.8; }
 .tm-card-name { font-size: 0.65rem; color: white; font-weight: bold; text-align: center; line-height: 1.2; }
 .tm-dim { font-size: 0.6rem; color: rgba(255,255,255,0.45); text-align: center; }
+.tm-2nd-badge {
+  font-size: 0.58rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em;
+  background: #7c3aed; color: #fff; padding: 1px 6px; border-radius: 10px;
+}
 .tm-own-stats {
   display: flex; flex-direction: column; align-items: center; gap: 1px;
   font-size: 0.58rem; color: rgba(255,255,255,0.55); margin-top: 3px; text-align: center;

--- a/components/trade/CtoonCard.vue
+++ b/components/trade/CtoonCard.vue
@@ -14,6 +14,7 @@
         loading="lazy"
         draggable="false"
       />
+      <SecondEditionOverlay :ctoon="ctoon" />
       <!-- Owned / Unowned badge -->
       <span v-if="badge" class="tc-badge" :class="badgeClassComputed">{{ badge }}</span>
       <!-- In Trade overlay -->

--- a/composables/useArtMode.js
+++ b/composables/useArtMode.js
@@ -1,0 +1,4 @@
+// Ephemeral, per-visit "Art Mode" toggle for cZone viewing — hides the Second
+// Edition overlay icon for the viewer only. Defaults off; MyCzone.vue resets it
+// to off whenever the viewed cZone/user changes.
+export const useArtMode = () => useState('czoneArtMode', () => false)

--- a/composables/useNewSiteCtoonFilter.js
+++ b/composables/useNewSiteCtoonFilter.js
@@ -8,4 +8,5 @@ export const useNewSiteCtoonFilter = () => useState('newSiteCtoonFilter', () => 
   sortField:       'acquiredAt',
   sortAsc:         false,
   hideUnavailable: false,
+  excludeSecondEditions: false,
 }))

--- a/composables/useSecondEditionOverlay.js
+++ b/composables/useSecondEditionOverlay.js
@@ -1,0 +1,50 @@
+// Fetches the global Second Edition overlay icon (path + natural size) once per
+// app load and exposes a helper to compute its render position/size for a given cToon.
+export function useSecondEditionOverlay() {
+  const overlay = useState('secondEditionOverlayConfig', () => ({
+    path: null,
+    width: null,
+    height: null,
+    loaded: false
+  }))
+
+  async function ensureLoaded() {
+    if (overlay.value.loaded) return
+    try {
+      const cfg = await $fetch('/api/global-config')
+      overlay.value = {
+        path: cfg?.secondEditionOverlayPath || null,
+        width: cfg?.secondEditionOverlayWidth || 32,
+        height: cfg?.secondEditionOverlayHeight || 32,
+        loaded: true
+      }
+    } catch {
+      overlay.value = { path: null, width: null, height: null, loaded: true }
+    }
+  }
+
+  // Renders the overlay centered at (overlayX%, overlayY%) of its container,
+  // sized to a percentage of its own natural pixel dimensions (not the container),
+  // so it stays a consistent, legible size across thumbnails and detail views.
+  function styleFor(ctoon) {
+    const x = ctoon?.secondEditionOverlayX ?? 85
+    const y = ctoon?.secondEditionOverlayY ?? 85
+    const size = ctoon?.secondEditionOverlaySize ?? 100
+    const w = overlay.value.width || 32
+    const h = overlay.value.height || 32
+    return {
+      position: 'absolute',
+      left: `${x}%`,
+      top: `${y}%`,
+      transform: 'translate(-50%, -50%)',
+      width: `${w * (size / 100)}px`,
+      height: `${h * (size / 100)}px`,
+      maxWidth: '45%',
+      maxHeight: '45%',
+      pointerEvents: 'none',
+      objectFit: 'contain'
+    }
+  }
+
+  return { overlay, ensureLoaded, styleFor }
+}

--- a/pages/admin/addCtoon.vue
+++ b/pages/admin/addCtoon.vue
@@ -35,6 +35,13 @@
           </div>
         </div>
 
+        <!-- Second Edition -->
+        <SecondEditionFields
+          v-model="secondEdition"
+          :ctoon-image-src="imagePreview"
+          :auto-note="autoSecondEditionNote"
+        />
+
         <!-- Sound Upload (optional) -->
         <div>
           <label class="block mb-1 font-medium">Upload cToon Sound (optional)</label>
@@ -324,6 +331,7 @@ import { zonedTimeToUtc } from 'date-fns-tz'
 import abilityMeta from '~/data/abilities.json'
 import { useRouter } from 'vue-router'
 import Nav from '~/components/Nav.vue'
+import SecondEditionFields from '~/components/admin/SecondEditionFields.vue'
 
 const router = useRouter()
 const name = ref('')
@@ -349,6 +357,18 @@ const setsOptions = ref([])
 const duplicateStatus = ref('idle')
 const duplicateMatch = ref(null)
 const duplicateError = ref('')
+const imagePreview = ref('')
+
+/* ── Second Edition ─────────────────────────────────────── */
+const secondEdition = ref({
+  isSecondEdition: false,
+  relatedFirstEditionId: null,
+  relatedFirstEditionName: '',
+  overlayX: 85,
+  overlayY: 85,
+  overlaySize: 100
+})
+const autoSecondEditionNote = ref('')
 /* ── NEW: G-toon state ───────────────────────────────── */
 const isGtoon     = ref(false)
 const cost        = ref(1)
@@ -466,6 +486,10 @@ function handleFile(e) {
   }
   imageFile.value = file
   type.value = file.type
+
+  if (imagePreview.value) URL.revokeObjectURL(imagePreview.value)
+  imagePreview.value = URL.createObjectURL(file)
+
   checkDuplicate(file)
 }
 
@@ -490,6 +514,24 @@ async function checkDuplicate(file) {
     const data = await res.json()
     duplicateMatch.value = data?.duplicate ? data.match : null
     duplicateStatus.value = 'done'
+
+    // Auto-set Second Edition when both duplicate-distance values are exactly 0
+    // (i.e. the image is pixel-identical to an existing cToon's image).
+    const m = duplicateMatch.value
+    if (m && m.phashDist === 0 && m.dhashDist === 0 && m.ctoon) {
+      secondEdition.value = {
+        ...secondEdition.value,
+        isSecondEdition: true,
+        relatedFirstEditionId: m.ctoon.id,
+        relatedFirstEditionName: m.ctoon.name,
+        overlayX: secondEdition.value.overlayX ?? 85,
+        overlayY: secondEdition.value.overlayY ?? 85,
+        overlaySize: secondEdition.value.overlaySize ?? 100
+      }
+      autoSecondEditionNote.value = `Auto-set from exact image match with "${m.ctoon.name}". You can change this.`
+    } else {
+      autoSecondEditionNote.value = ''
+    }
   } catch {
     duplicateStatus.value = 'error'
     duplicateError.value = 'Duplicate check failed.'
@@ -589,6 +631,14 @@ async function submitForm() {
   }
 
   if (soundFile.value) formData.append('sound', soundFile.value)
+
+  formData.append('isSecondEdition', secondEdition.value.isSecondEdition)
+  if (secondEdition.value.isSecondEdition) {
+    formData.append('relatedFirstEditionId', secondEdition.value.relatedFirstEditionId ?? '')
+    formData.append('secondEditionOverlayX', secondEdition.value.overlayX)
+    formData.append('secondEditionOverlayY', secondEdition.value.overlayY)
+    formData.append('secondEditionOverlaySize', secondEdition.value.overlaySize)
+  }
 
   const res = await fetch('/api/admin/ctoon', {
     method: 'POST',

--- a/pages/admin/bulk-upload-ctoons.vue
+++ b/pages/admin/bulk-upload-ctoons.vue
@@ -186,6 +186,7 @@
               <tr class="bg-gray-100">
                 <th class="px-4 py-2">Preview</th>
                 <th class="px-4 py-2">Duplicate</th>
+                <th class="px-4 py-2">2nd Ed.</th>
                 <th class="px-4 py-2">Name</th>
                 <th class="px-4 py-2">Series</th>
                 <th class="px-4 py-2">Rarity</th>
@@ -227,6 +228,14 @@
                     </div>
                   </div>
                   <div v-else-if="f.duplicateStatus === 'done'" class="text-xs text-green-600">No duplicates</div>
+                </td>
+                <td class="px-4 py-2" style="min-width:180px;">
+                  <SecondEditionFields
+                    :model-value="rowSecondEdition(f)"
+                    :exclude-ctoon-id="''"
+                    :show-position-editor="false"
+                    @update:model-value="val => applyRowSecondEdition(f, val)"
+                  />
                 </td>
                 <td class="px-4 py-2">
                   <input v-model="f.nameField" class="w-full border rounded p-1" />
@@ -318,6 +327,13 @@
               </div>
               <div v-else-if="f.duplicateStatus === 'done'" class="text-xs text-green-600">No duplicates found.</div>
             </div>
+
+            <SecondEditionFields
+              :model-value="rowSecondEdition(f)"
+              :exclude-ctoon-id="''"
+              :show-position-editor="false"
+              @update:model-value="val => applyRowSecondEdition(f, val)"
+            />
 
             <!-- Fields underneath -->
             <div class="space-y-4">
@@ -490,6 +506,7 @@ import { zonedTimeToUtc } from 'date-fns-tz'
 import { useRouter } from 'vue-router'
 import Nav from '~/components/Nav.vue'
 import Toast from '~/components/Toast.vue'
+import SecondEditionFields from '~/components/admin/SecondEditionFields.vue'
 
 definePageMeta({ title: 'Admin - Bulk Upload cToons', middleware: ['auth', 'admin'], layout: 'admin' })
 
@@ -731,7 +748,10 @@ function handleFiles(e) {
       price: 0,
       duplicateStatus: 'idle',
       duplicateMatch: null,
-      duplicateError: ''
+      duplicateError: '',
+      isSecondEdition: false,
+      relatedFirstEditionId: null,
+      relatedFirstEditionName: ''
     }
 
     if (row.rarity) updateDefaults?.(row)
@@ -774,10 +794,35 @@ async function checkDuplicateForRow(row) {
     const data = await res.json()
     row.duplicateMatch = data?.duplicate ? data.match : null
     row.duplicateStatus = 'done'
+
+    // Auto-set Second Edition when both duplicate-distance values are exactly 0
+    const m = row.duplicateMatch
+    if (m && m.phashDist === 0 && m.dhashDist === 0 && m.ctoon) {
+      row.isSecondEdition = true
+      row.relatedFirstEditionId = m.ctoon.id
+      row.relatedFirstEditionName = m.ctoon.name
+    }
   } catch {
     row.duplicateStatus = 'error'
     row.duplicateError = 'Duplicate check failed.'
   }
+}
+
+function rowSecondEdition(row) {
+  return {
+    isSecondEdition: row.isSecondEdition,
+    relatedFirstEditionId: row.relatedFirstEditionId,
+    relatedFirstEditionName: row.relatedFirstEditionName,
+    overlayX: 85,
+    overlayY: 85,
+    overlaySize: 100
+  }
+}
+
+function applyRowSecondEdition(row, val) {
+  row.isSecondEdition = val.isSecondEdition
+  row.relatedFirstEditionId = val.relatedFirstEditionId
+  row.relatedFirstEditionName = val.relatedFirstEditionName
 }
 
 async function uploadAll() {
@@ -842,6 +887,13 @@ async function uploadAll() {
     formData.append('perUserLimit', f.perUserLimit ?? '')
     formData.append('inCmart', f.inCmart)
     formData.append('price', f.price)
+    formData.append('isSecondEdition', f.isSecondEdition)
+    if (f.isSecondEdition) {
+      formData.append('relatedFirstEditionId', f.relatedFirstEditionId ?? '')
+      formData.append('secondEditionOverlayX', 85)
+      formData.append('secondEditionOverlayY', 85)
+      formData.append('secondEditionOverlaySize', 100)
+    }
 
     try {
       const res = await fetch('/api/admin/ctoon', {

--- a/pages/admin/editCtoon/[id].vue
+++ b/pages/admin/editCtoon/[id].vue
@@ -264,6 +264,13 @@
           </div>
         </div>
 
+        <!-- Second Edition -->
+        <SecondEditionFields
+          v-model="secondEdition"
+          :ctoon-image-src="newImagePreview || assetPath"
+          :exclude-ctoon-id="id"
+        />
+
         <!-- Submit -->
         <div class="text-right">
           <button class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">
@@ -286,6 +293,7 @@ import { zonedTimeToUtc } from 'date-fns-tz'
 import Nav   from '~/components/Nav.vue'
 import Toast from '~/components/Toast.vue'
 import abilityMeta from '~/data/abilities.json'
+import SecondEditionFields from '~/components/admin/SecondEditionFields.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -317,6 +325,16 @@ const newImagePreview = ref('')
 const currentSoundPath = ref('')
 const newSoundFile = ref(null)
 const clearSound = ref(false)
+
+/* Second Edition refs */
+const secondEdition = ref({
+  isSecondEdition: false,
+  relatedFirstEditionId: null,
+  relatedFirstEditionName: '',
+  overlayX: 85,
+  overlayY: 85,
+  overlaySize: 100
+})
 
 /* G-toon refs */
 const isGtoon = ref(false)
@@ -451,6 +469,15 @@ onMounted(async ()=>{
       }
     }
 
+    secondEdition.value = {
+      isSecondEdition: !!ctoon.isSecondEdition,
+      relatedFirstEditionId: ctoon.relatedFirstEditionId || null,
+      relatedFirstEditionName: ctoon.relatedFirstEdition?.name || '',
+      overlayX: ctoon.secondEditionOverlayX ?? 85,
+      overlayY: ctoon.secondEditionOverlayY ?? 85,
+      overlaySize: ctoon.secondEditionOverlaySize ?? 100
+    }
+
     isGtoon.value   = ctoon.isGtoon
     gtoonType.value = ctoon.gtoonType || ''
     cost.value      = ctoon.cost ?? 0
@@ -578,6 +605,14 @@ async function submitForm(){
     if (newSoundFile.value) fd.append('sound', newSoundFile.value)
     else if (clearSound.value) fd.append('clearSound', 'true')
 
+    fd.append('isSecondEdition', secondEdition.value.isSecondEdition)
+    if (secondEdition.value.isSecondEdition) {
+      fd.append('relatedFirstEditionId', secondEdition.value.relatedFirstEditionId ?? '')
+      fd.append('secondEditionOverlayX', secondEdition.value.overlayX)
+      fd.append('secondEditionOverlayY', secondEdition.value.overlayY)
+      fd.append('secondEditionOverlaySize', secondEdition.value.overlaySize)
+    }
+
     const res = await fetch(`/api/admin/ctoon/${id}`, {
       method: 'PUT',
       credentials: 'include',
@@ -625,6 +660,12 @@ async function submitForm(){
     finalReleaseAt:   schedule.value.finalAt ? schedule.value.finalAt.toISOString() : null,
     initialReleaseQty: schedule.value.initialQty ?? null,
     finalReleaseQty:   schedule.value.finalQty ?? null,
+
+    isSecondEdition: secondEdition.value.isSecondEdition,
+    relatedFirstEditionId: secondEdition.value.isSecondEdition ? (secondEdition.value.relatedFirstEditionId ?? null) : null,
+    secondEditionOverlayX: secondEdition.value.isSecondEdition ? secondEdition.value.overlayX : null,
+    secondEditionOverlayY: secondEdition.value.isSecondEdition ? secondEdition.value.overlayY : null,
+    secondEditionOverlaySize: secondEdition.value.isSecondEdition ? secondEdition.value.overlaySize : null,
 
     clearSound: clearSound.value || false
   }

--- a/pages/admin/global-settings.vue
+++ b/pages/admin/global-settings.vue
@@ -27,6 +27,10 @@
             class="px-3 py-2 border-b-2"
             :class="activeTab==='cMart' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='cMart'">cMart</button>
+          <button
+            class="px-3 py-2 border-b-2"
+            :class="activeTab==='Second Editions' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
+            @click="activeTab='Second Editions'">Second Editions</button>
         </nav>
       </div>
 
@@ -390,6 +394,38 @@
         </div>
       </section>
 
+      <!-- Second Editions tab -->
+      <section v-if="activeTab==='Second Editions'" class="space-y-6">
+        <p class="text-sm text-gray-600">
+          Upload the icon overlaid on the bottom-right corner of every Second Edition cToon's image
+          sitewide. Admins can adjust position and size per cToon on the Add/Edit cToon pages.
+        </p>
+        <div class="flex items-start gap-6 flex-wrap">
+          <div>
+            <div class="w-32 h-32 border rounded bg-gray-50 flex items-center justify-center overflow-hidden">
+              <img v-if="secondEditionOverlayPath" :src="secondEditionOverlayPath" alt="Second Edition overlay" class="max-w-full max-h-full object-contain" />
+              <span v-else class="text-xs text-gray-400">No image set</span>
+            </div>
+            <p v-if="secondEditionOverlayWidth" class="text-xs text-gray-500 mt-1 text-center">
+              {{ secondEditionOverlayWidth }}×{{ secondEditionOverlayHeight }}px
+            </p>
+          </div>
+          <div class="flex-1 min-w-[220px]">
+            <label class="block text-sm font-medium text-gray-700 mb-1">Upload Overlay Icon (PNG or GIF)</label>
+            <input type="file" accept="image/png,image/gif" class="w-full" @change="handleOverlayFile" />
+            <p class="text-xs text-gray-500 mt-1">Max 3MB. Use a transparent PNG for best results.</p>
+            <p v-if="overlayUploadError" class="text-xs text-red-600 mt-1">{{ overlayUploadError }}</p>
+            <button
+              class="btn-primary mt-3"
+              :disabled="!overlayFile || savingOverlay"
+              @click="uploadOverlay"
+            >
+              <span v-if="!savingOverlay">Upload</span><span v-else>Uploading…</span>
+            </button>
+          </div>
+        </div>
+      </section>
+
       <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded',
                                  toast.type==='error'?'bg-red-100 text-red-700':'bg-green-100 text-green-700']">
         {{ toast.msg }}
@@ -444,6 +480,58 @@ const featuredAuctionHours        = ref([])
 const featuredAuctionIntervalDays = ref(1)
 const featuredAuctionsPerSlot     = ref(1)
 
+// Second Editions state
+const secondEditionOverlayPath   = ref(null)
+const secondEditionOverlayWidth  = ref(null)
+const secondEditionOverlayHeight = ref(null)
+const overlayFile        = ref(null)
+const overlayUploadError = ref('')
+const savingOverlay       = ref(false)
+
+function handleOverlayFile(e) {
+  overlayUploadError.value = ''
+  const file = e.target.files?.[0]
+  if (!file) { overlayFile.value = null; return }
+  if (!['image/png', 'image/gif'].includes(file.type)) {
+    overlayUploadError.value = 'Only PNG or GIF files allowed.'
+    overlayFile.value = null
+    return
+  }
+  if (file.size > 3 * 1024 * 1024) {
+    overlayUploadError.value = 'Image must be 3MB or smaller.'
+    overlayFile.value = null
+    return
+  }
+  overlayFile.value = file
+}
+
+async function uploadOverlay() {
+  if (!overlayFile.value) return
+  savingOverlay.value = true
+  overlayUploadError.value = ''
+  try {
+    const fd = new FormData()
+    fd.append('image', overlayFile.value)
+    const res = await fetch('/api/admin/global-config/second-edition-overlay', {
+      method: 'POST',
+      credentials: 'include',
+      body: fd
+    })
+    if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.statusMessage || 'Upload failed')
+    const data = await res.json()
+    secondEditionOverlayPath.value   = data.secondEditionOverlayPath
+    secondEditionOverlayWidth.value  = data.secondEditionOverlayWidth
+    secondEditionOverlayHeight.value = data.secondEditionOverlayHeight
+    overlayFile.value = null
+    toast.value = { type: 'ok', msg: 'Second Edition overlay saved.' }
+  } catch (e) {
+    overlayUploadError.value = e?.message || 'Upload failed'
+  } finally {
+    savingOverlay.value = false
+    setTimeout(() => { toast.value = null }, 2500)
+  }
+}
+
 async function loadGlobal() {
   try {
     const g = await $fetch('/api/admin/global-config')
@@ -464,6 +552,9 @@ async function loadGlobal() {
     packPriceDecayDays.value            = Number(g?.packPriceDecayDays            ?? 7)
     packPriceFloor.value                = Number(g?.packPriceFloor                ?? 700)
     packMaxDefaultBuysPerUser.value     = Number(g?.packMaxDefaultBuysPerUser     ?? 5)
+    secondEditionOverlayPath.value   = g?.secondEditionOverlayPath   ?? null
+    secondEditionOverlayWidth.value  = g?.secondEditionOverlayWidth  ?? null
+    secondEditionOverlayHeight.value = g?.secondEditionOverlayHeight ?? null
     if (g?.timeBasedPurchaseLimits) {
       for (const r of timeBasedRarities) {
         const def = g.timeBasedPurchaseLimits[r]

--- a/pages/newsite/MyCollection.vue
+++ b/pages/newsite/MyCollection.vue
@@ -26,6 +26,7 @@ Object.assign(filter.value, {
   sortField:       'acquiredDate',
   sortAsc:         false,
   hideUnavailable: false,
+  excludeSecondEditions: false,
 })
 </script>
 

--- a/prisma/firstEdition.js
+++ b/prisma/firstEdition.js
@@ -1,38 +1,17 @@
 // scripts/updateFirstEditions.js
+// First Edition is now a property of the parent cToon (NOT isSecondEdition),
+// not something computed per-mint from mintNumber/initialQuantity.
 import { prisma } from '@/server/prisma'
 
 async function main() {
-  // 1. Load every UserCtoon with its current isFirstEdition, mintNumber, and parent initialQuantity
-  const all = await prisma.userCtoon.findMany({
-    select: {
-      id: true,
-      mintNumber: true,
-      isFirstEdition: true,
-      ctoon: {
-        select: {
-          initialQuantity: true
-        }
-      }
-    }
-  })
-
-  // 2. Loop and update mismatches
-  let updatedCount = 0
-  for (const { id, mintNumber, isFirstEdition, ctoon: { initialQuantity } } of all) {
-    const desiredIsFirst =
-      initialQuantity !== null &&
-      mintNumber != null &&
-      mintNumber <= initialQuantity
-
-    // If the stored flag doesn’t match what we want, flip it
-    if (isFirstEdition !== desiredIsFirst) {
-      await prisma.userCtoon.update({
-        where: { id },
-        data: { isFirstEdition: desiredIsFirst }
-      })
-      updatedCount++
-    }
-  }
+  const result = await prisma.$executeRaw`
+    UPDATE "UserCtoon" uc
+    SET "isFirstEdition" = NOT c."isSecondEdition"
+    FROM "Ctoon" c
+    WHERE uc."ctoonId" = c.id
+      AND uc."isFirstEdition" IS DISTINCT FROM (NOT c."isSecondEdition")
+  `
+  console.log(`Updated ${result} UserCtoon row(s).`)
 }
 
 main()

--- a/prisma/migrations/20260701000000_add_second_edition/migration.sql
+++ b/prisma/migrations/20260701000000_add_second_edition/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable
+ALTER TABLE "Ctoon" ADD COLUMN     "isSecondEdition" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "relatedFirstEditionId" TEXT,
+ADD COLUMN     "secondEditionOverlayX" DOUBLE PRECISION,
+ADD COLUMN     "secondEditionOverlayY" DOUBLE PRECISION,
+ADD COLUMN     "secondEditionOverlaySize" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "GlobalGameConfig" ADD COLUMN     "secondEditionOverlayPath" TEXT,
+ADD COLUMN     "secondEditionOverlayWidth" INTEGER,
+ADD COLUMN     "secondEditionOverlayHeight" INTEGER;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ctoon_relatedFirstEditionId_key" ON "Ctoon"("relatedFirstEditionId");
+
+-- CreateIndex
+CREATE INDEX "Ctoon_isSecondEdition_idx" ON "Ctoon"("isSecondEdition");
+
+-- CreateIndex
+CREATE INDEX "Ctoon_name_idx" ON "Ctoon"("name");
+
+-- AddForeignKey
+ALTER TABLE "Ctoon" ADD CONSTRAINT "Ctoon_relatedFirstEditionId_fkey" FOREIGN KEY ("relatedFirstEditionId") REFERENCES "Ctoon"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Data migration: previously, isFirstEdition was derived from mintNumber <= initialQuantity,
+-- which incorrectly excluded unlimited-quantity (null) cToons. Second Edition didn't exist yet,
+-- so every existing cToon is (by definition) a First Edition — recompute accordingly.
+UPDATE "UserCtoon" SET "isFirstEdition" = true WHERE "isFirstEdition" = false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -252,6 +252,16 @@ model Ctoon {
   abilityKey  String?
   abilityData Json?
 
+  // Second Edition fields
+  isSecondEdition        Boolean  @default(false)
+  relatedFirstEditionId  String?  @unique
+  secondEditionOverlayX    Float? // % offset of overlay's left edge within the cToon image (0-100)
+  secondEditionOverlayY    Float? // % offset of overlay's top edge within the cToon image (0-100)
+  secondEditionOverlaySize Float? // % scale of overlay relative to its natural size (100 = natural size)
+
+  relatedFirstEdition  Ctoon?  @relation("EditionPair", fields: [relatedFirstEditionId], references: [id])
+  relatedSecondEdition Ctoon?  @relation("EditionPair")
+
   owners                     UserCtoon[]
   deckCards                  ClashDeckCard[]
   rewardCtoons               RewardCtoon[]
@@ -284,6 +294,9 @@ model Ctoon {
   cZoneSearchAppearances CZoneSearchAppearance[]
   cZoneSearchCaptures   CZoneSearchCapture[]
   cmartPurchaseLogs     CmartPurchaseLog[]
+
+  @@index([isSecondEdition])
+  @@index([name])
 }
 
 model CtoonImageHash {
@@ -980,6 +993,10 @@ model GlobalGameConfig {
   // Per-rarity time-based purchase limits: { "Common": { "count": 5, "windowDays": null }, ... }
   // windowDays null = full release window (releaseDate → mintEndDate)
   timeBasedPurchaseLimits      Json?
+  // Second Edition overlay icon, shown over every Second Edition cToon's image
+  secondEditionOverlayPath   String?
+  secondEditionOverlayWidth  Int?     // natural pixel width of the uploaded overlay image
+  secondEditionOverlayHeight Int?     // natural pixel height of the uploaded overlay image
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 }

--- a/server/api/admin/ctoon.post.js
+++ b/server/api/admin/ctoon.post.js
@@ -11,6 +11,7 @@ import { prisma } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { computeMultiHash, bucketFromHash } from '@/server/utils/multiHash'
 import { scheduleMintEnd } from '@/server/utils/queues'
+import { parseSecondEditionFields } from '@/server/utils/secondEdition'
 
 // ── path helpers ──────────────────────────────────────────────
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -58,7 +59,11 @@ export default defineEventHandler(async (event) => {
 
     /* Time-based purchase limit overrides */
     timeBasedLimitCount: timeBasedLimitCountRaw,
-    timeBasedLimitWindowDays: timeBasedLimitWindowDaysRaw
+    timeBasedLimitWindowDays: timeBasedLimitWindowDaysRaw,
+
+    /* Second Edition fields */
+    isSecondEdition, relatedFirstEditionId,
+    secondEditionOverlayX, secondEditionOverlayY, secondEditionOverlaySize
   } = fields
 
   if (!name?.trim())   throw createError({ statusCode: 400, statusMessage: 'Name is required.' })
@@ -132,6 +137,11 @@ export default defineEventHandler(async (event) => {
   const { phash, dhash } = await computeMultiHash(imagePart.data)
   const bucket = bucketFromHash(phash)
 
+  const secondEdition = await parseSecondEditionFields(
+    { isSecondEdition, relatedFirstEditionId, secondEditionOverlayX, secondEditionOverlayY, secondEditionOverlaySize },
+    prisma
+  )
+
   /* 4. Save image ------------------------------------------- */
   const safeSeries = series.trim()
   const uploadDir = process.env.NODE_ENV === 'production'
@@ -193,8 +203,15 @@ export default defineEventHandler(async (event) => {
       cost:       isGtoonBool ? costInt : null,
       power:      isGtoonBool ? powerInt : null,
       abilityKey: isGtoonBool ? abilityKey : null,
-      abilityData: isGtoonBool ? abilityDataObj : null
-      ,
+      abilityData: isGtoonBool ? abilityDataObj : null,
+
+      // Second Edition fields
+      isSecondEdition: secondEdition.isSecondEdition,
+      relatedFirstEditionId: secondEdition.relatedFirstEditionId,
+      secondEditionOverlayX: secondEdition.secondEditionOverlayX,
+      secondEditionOverlayY: secondEdition.secondEditionOverlayY,
+      secondEditionOverlaySize: secondEdition.secondEditionOverlaySize,
+
       // advisory schedule fields
       initialReleaseAt: initialReleaseAtDate,
       finalReleaseAt:   finalReleaseAtDate,

--- a/server/api/admin/ctoon/[id].get.js
+++ b/server/api/admin/ctoon/[id].get.js
@@ -40,7 +40,15 @@ export default defineEventHandler(async (event) => {
         initialReleaseAt: true,
         finalReleaseAt:   true,
         initialReleaseQty: true,
-        finalReleaseQty:   true
+        finalReleaseQty:   true,
+
+        // Second Edition fields
+        isSecondEdition: true,
+        relatedFirstEditionId: true,
+        secondEditionOverlayX: true,
+        secondEditionOverlayY: true,
+        secondEditionOverlaySize: true,
+        relatedFirstEdition: { select: { id: true, name: true, assetPath: true } }
       }
     })
 

--- a/server/api/admin/ctoon/[id].put.js
+++ b/server/api/admin/ctoon/[id].put.js
@@ -10,6 +10,7 @@ import { prisma } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { computeMultiHash, bucketFromHash } from '@/server/utils/multiHash'
 import { scheduleMintEnd, cancelMintEnd } from '@/server/utils/queues'
+import { parseSecondEditionFields } from '@/server/utils/secondEdition'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join, dirname, extname, basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -54,7 +55,10 @@ export default defineEventHandler(async (event) => {
     clearSound,
     mintLimitType: mintLimitTypeRaw, mintEndDate: mintEndDateRaw,
     timeBasedLimitCount: timeBasedLimitCountRaw,
-    timeBasedLimitWindowDays: timeBasedLimitWindowDaysRaw
+    timeBasedLimitWindowDays: timeBasedLimitWindowDaysRaw,
+
+    isSecondEdition, relatedFirstEditionId,
+    secondEditionOverlayX, secondEditionOverlayY, secondEditionOverlaySize
   } = payload
 
   // 4) Validate basics
@@ -122,6 +126,12 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  const secondEdition = await parseSecondEditionFields(
+    { isSecondEdition, relatedFirstEditionId, secondEditionOverlayX, secondEditionOverlayY, secondEditionOverlaySize },
+    prisma,
+    id
+  )
+
   // 6) Build update payload
   const updateData = {
     name: name.trim(),
@@ -145,6 +155,13 @@ export default defineEventHandler(async (event) => {
     power:      isGtoonBool ? powerInt : null,
     abilityKey: isGtoonBool ? abilityKey : null,
     abilityData: isGtoonBool ? abilityDataObj : null,
+
+    // Second Edition fields
+    isSecondEdition: secondEdition.isSecondEdition,
+    relatedFirstEditionId: secondEdition.relatedFirstEditionId,
+    secondEditionOverlayX: secondEdition.secondEditionOverlayX,
+    secondEditionOverlayY: secondEdition.secondEditionOverlayY,
+    secondEditionOverlaySize: secondEdition.secondEditionOverlaySize,
 
     // advisory schedule fields
     initialReleaseAt: initialReleaseAt ? new Date(initialReleaseAt) : null,
@@ -228,6 +245,17 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // First Edition status is derived from isSecondEdition — if it changed, sync
+  // already-minted UserCtoon rows for this cToon (scoped to this ctoonId, index-backed,
+  // skips rows that already match to avoid a no-op write storm).
+  if (before && before.isSecondEdition !== updated.isSecondEdition) {
+    await prisma.$executeRaw`
+      UPDATE "UserCtoon"
+      SET "isFirstEdition" = ${!updated.isSecondEdition}
+      WHERE "ctoonId" = ${id} AND "isFirstEdition" IS DISTINCT FROM ${!updated.isSecondEdition}
+    `
+  }
+
   // 9) Log field-level changes
   try {
     const area = `Ctoon:${id}`
@@ -236,7 +264,8 @@ export default defineEventHandler(async (event) => {
       'isGtoon','gtoonType','cost','power','abilityKey','abilityData','assetPath','type','soundPath',
       'initialReleaseAt','finalReleaseAt','initialReleaseQty','finalReleaseQty',
       'mintLimitType','mintEndDate',
-      'timeBasedLimitCount','timeBasedLimitWindowDays'
+      'timeBasedLimitCount','timeBasedLimitWindowDays',
+      'isSecondEdition','relatedFirstEditionId','secondEditionOverlayX','secondEditionOverlayY','secondEditionOverlaySize'
     ]
     for (const k of keys) {
       const prev = before ? (before[k] instanceof Date ? before[k].toISOString() : (Array.isArray(before[k]) || typeof before[k] === 'object' ? JSON.stringify(before[k]) : before[k])) : undefined

--- a/server/api/admin/global-config/second-edition-overlay.post.js
+++ b/server/api/admin/global-config/second-edition-overlay.post.js
@@ -1,0 +1,99 @@
+// server/api/admin/global-config/second-edition-overlay.post.js
+// Uploads the single global "Second Edition" overlay icon shown over every
+// Second Edition cToon's image sitewide.
+import {
+  defineEventHandler,
+  readMultipartFormData,
+  getRequestHeader,
+  createError
+} from 'h3'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import sharp from 'sharp'
+import { prisma } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const baseDir = process.env.NODE_ENV === 'production'
+  ? join(__dirname, '..', '..', '..', '..')
+  : process.cwd()
+
+const ALLOWED_TYPES = new Set(['image/png', 'image/gif'])
+const MAX_BYTES = 3 * 1024 * 1024 // 3MB
+
+export default defineEventHandler(async (event) => {
+  // 1) Admin check
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  // 2) Parse multipart
+  const parts = await readMultipartFormData(event)
+  const imagePart = (parts || []).find(p => p.filename && p.name === 'image')
+  if (!imagePart) throw createError({ statusCode: 400, statusMessage: 'Image required.' })
+  if (!ALLOWED_TYPES.has(imagePart.type)) {
+    throw createError({ statusCode: 400, statusMessage: 'PNG or GIF only.' })
+  }
+  if (!imagePart.data || imagePart.data.length > MAX_BYTES) {
+    throw createError({ statusCode: 400, statusMessage: 'Image must be 3MB or smaller.' })
+  }
+
+  // 3) Natural dimensions (used as the default "100%" size on cToon overlays)
+  let width = null
+  let height = null
+  try {
+    const meta = await sharp(imagePart.data).metadata()
+    width = meta.width ?? null
+    height = meta.height ?? null
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Could not read image dimensions.' })
+  }
+
+  // 4) Save with a server-generated filename — never trust the client filename/path
+  const ext = imagePart.type === 'image/gif' ? '.gif' : '.png'
+  const filename = `second-edition-overlay-${Date.now()}${ext}`
+  const uploadDir = process.env.NODE_ENV === 'production'
+    ? join(baseDir, 'cartoon-reorbit-images', 'global')
+    : join(baseDir, 'public', 'global')
+
+  await mkdir(uploadDir, { recursive: true })
+  await writeFile(join(uploadDir, filename), imagePart.data)
+
+  const assetPath = process.env.NODE_ENV === 'production'
+    ? `/images/global/${filename}`
+    : `/global/${filename}`
+
+  // 5) Persist to the singleton global config row
+  const before = await prisma.globalGameConfig.findUnique({ where: { id: 'singleton' } })
+  const updated = await prisma.globalGameConfig.upsert({
+    where: { id: 'singleton' },
+    create: {
+      id: 'singleton',
+      secondEditionOverlayPath: assetPath,
+      secondEditionOverlayWidth: width,
+      secondEditionOverlayHeight: height
+    },
+    update: {
+      secondEditionOverlayPath: assetPath,
+      secondEditionOverlayWidth: width,
+      secondEditionOverlayHeight: height
+    }
+  })
+
+  try {
+    await logAdminChange(prisma, {
+      userId: me.id,
+      area: 'GlobalGameConfig',
+      key: 'secondEditionOverlayPath',
+      prevValue: before?.secondEditionOverlayPath ?? null,
+      newValue: updated.secondEditionOverlayPath
+    })
+  } catch {}
+
+  return {
+    secondEditionOverlayPath: updated.secondEditionOverlayPath,
+    secondEditionOverlayWidth: updated.secondEditionOverlayWidth,
+    secondEditionOverlayHeight: updated.secondEditionOverlayHeight
+  }
+})

--- a/server/api/admin/search-ctoons.get.js
+++ b/server/api/admin/search-ctoons.get.js
@@ -16,10 +16,12 @@ export default defineEventHandler(async (event) => {
   }
 
   // Inputs
-  const { q = '', set = '', series = '' } = getQuery(event)
+  const { q = '', set = '', series = '', excludeSecondEdition = '', excludeId = '' } = getQuery(event)
   const query  = String(q).trim()
   const bySet  = String(set).trim()
   const bySer  = String(series).trim()
+  const excludeSecondEditionBool = String(excludeSecondEdition) === 'true'
+  const excludeIdVal = String(excludeId).trim()
 
   // Require either q>=3 or at least one filter
   if (query.length < 3 && !bySet && !bySer) return []
@@ -29,7 +31,9 @@ export default defineEventHandler(async (event) => {
     AND: [
       query.length >= 3 ? { name: { contains: query, mode: 'insensitive' } } : {},
       bySet ?   { set:    { equals: bySet } }   : {},
-      bySer ?   { series: { equals: bySer } }   : {}
+      bySer ?   { series: { equals: bySer } }   : {},
+      excludeSecondEditionBool ? { isSecondEdition: false } : {},
+      excludeIdVal ? { id: { not: excludeIdVal } } : {}
     ]
   }
 
@@ -37,6 +41,7 @@ export default defineEventHandler(async (event) => {
   const ctoons = await prisma.ctoon.findMany({
     where,
     orderBy: [{ name: 'asc' }],
+    take: 20,
     select: {
       id: true,
       name: true,

--- a/server/api/auction/[id].get.js
+++ b/server/api/auction/[id].get.js
@@ -55,7 +55,11 @@ export default defineEventHandler(async (event) => {
       isGtoon:    auction.userCtoon.ctoon.isGtoon,
       cost:       auction.userCtoon.ctoon.cost,
       power:      auction.userCtoon.ctoon.power,
-      mintNumber: auction.userCtoon.mintNumber
+      mintNumber: auction.userCtoon.mintNumber,
+      isSecondEdition: auction.userCtoon.ctoon.isSecondEdition,
+      secondEditionOverlayX: auction.userCtoon.ctoon.secondEditionOverlayX,
+      secondEditionOverlayY: auction.userCtoon.ctoon.secondEditionOverlayY,
+      secondEditionOverlaySize: auction.userCtoon.ctoon.secondEditionOverlaySize
     },
     isHolidayItem, // ← added
     endAt:      auction.endAt.toISOString(),

--- a/server/api/auctions.get.js
+++ b/server/api/auctions.get.js
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
           userId: true,
           ctoonId: true,
           mintNumber: true,
-          ctoon: { select: { name: true, series: true, set: true, rarity: true, isGtoon: true, cost: true, power: true, assetPath: true, characters: true } }
+          ctoon: { select: { name: true, series: true, set: true, rarity: true, isGtoon: true, cost: true, power: true, assetPath: true, characters: true, isSecondEdition: true, secondEditionOverlayX: true, secondEditionOverlayY: true, secondEditionOverlaySize: true } }
         }
       },
       bids: { select: { amount: true }, orderBy: { amount: 'desc' }, take: 1 },
@@ -82,6 +82,10 @@ export default defineEventHandler(async (event) => {
     highestBid:   a.bids.length > 0 ? a.bids[0].amount : a.initialBet,
     bidCount:     a._count?.bids ?? 0,
     isOwned:      ownedSet.has(a.userCtoon.ctoonId),
-    isHolidayItem: holidaySet.has(a.userCtoon.ctoonId)
+    isHolidayItem: holidaySet.has(a.userCtoon.ctoonId),
+    isSecondEdition: a.userCtoon.ctoon.isSecondEdition,
+    secondEditionOverlayX: a.userCtoon.ctoon.secondEditionOverlayX,
+    secondEditionOverlayY: a.userCtoon.ctoon.secondEditionOverlayY,
+    secondEditionOverlaySize: a.userCtoon.ctoon.secondEditionOverlaySize
   }))
 })

--- a/server/api/collections.get.js
+++ b/server/api/collections.get.js
@@ -80,6 +80,10 @@ export default defineEventHandler(async (event) => {
     isFirstEdition: uc.isFirstEdition,
     acquiredAt: uc.createdAt,
     auctions: uc.auctions || [],
-    isHolidayItem: holidaySet.has(uc.ctoonId)
+    isHolidayItem: holidaySet.has(uc.ctoonId),
+    isSecondEdition: uc.ctoon.isSecondEdition,
+    secondEditionOverlayX: uc.ctoon.secondEditionOverlayX,
+    secondEditionOverlayY: uc.ctoon.secondEditionOverlayY,
+    secondEditionOverlaySize: uc.ctoon.secondEditionOverlaySize
   }))
 })

--- a/server/api/ctoon/modal.get.js
+++ b/server/api/ctoon/modal.get.js
@@ -33,16 +33,21 @@ export default defineEventHandler(async (event) => {
   //   cz:…  — positional token from the public cZone view (no per-instance lookup possible)
   //   uc|…  — encoded token from all other endpoints (resolve to real UUID first)
   // For cz: tokens fall through to the ctoonId-only path so the modal still opens.
+  const editionInclude = {
+    relatedFirstEdition:  { select: { id: true, name: true, assetPath: true } },
+    relatedSecondEdition: { select: { id: true, name: true, assetPath: true } }
+  }
+
   if (userCtoonId?.startsWith('uc|')) {
     const realId = await resolveUserCtoonId(userCtoonId)
     if (realId) {
-      userCtoon = await prisma.userCtoon.findUnique({ where: { id: realId }, include: { ctoon: true } })
+      userCtoon = await prisma.userCtoon.findUnique({ where: { id: realId }, include: { ctoon: { include: editionInclude } } })
       if (userCtoon) ctoon = userCtoon.ctoon
     }
   } else if (userCtoonId && !isSyntheticUserCtoonId(userCtoonId) && !userCtoonId.startsWith('cz:')) {
     userCtoon = await prisma.userCtoon.findUnique({
       where: { id: userCtoonId },
-      include: { ctoon: true }
+      include: { ctoon: { include: editionInclude } }
     })
     if (userCtoon) ctoon = userCtoon.ctoon
   }
@@ -51,7 +56,7 @@ export default defineEventHandler(async (event) => {
     if (!ctoonId) {
       throw createError({ statusCode: 404, statusMessage: 'cToon not found' })
     }
-    ctoon = await prisma.ctoon.findUnique({ where: { id: ctoonId } })
+    ctoon = await prisma.ctoon.findUnique({ where: { id: ctoonId }, include: editionInclude })
     if (!ctoon) {
       throw createError({ statusCode: 404, statusMessage: 'cToon not found' })
     }
@@ -173,7 +178,13 @@ export default defineEventHandler(async (event) => {
       tradedCount: overallTradeCount,
       successfulAuctions: overallSaleCount,
       avgSale: overallAvgSale,
-      medianSale: overallMedianSale
+      medianSale: overallMedianSale,
+      isSecondEdition: ctoon.isSecondEdition,
+      secondEditionOverlayX: ctoon.secondEditionOverlayX,
+      secondEditionOverlayY: ctoon.secondEditionOverlayY,
+      secondEditionOverlaySize: ctoon.secondEditionOverlaySize,
+      relatedFirstEdition: ctoon.relatedFirstEdition ?? null,
+      relatedSecondEdition: ctoon.relatedSecondEdition ?? null
     },
     userCtoon: userStats,
     ownedCount

--- a/server/api/czone/[username].get.js
+++ b/server/api/czone/[username].get.js
@@ -111,7 +111,11 @@ export default defineEventHandler(async (event) => {
       ctoonId: uc.ctoon.id,
       isGtoon: uc.ctoon.isGtoon,
       cost: uc.ctoon.cost,
-      power: uc.ctoon.power
+      power: uc.ctoon.power,
+      isSecondEdition: uc.ctoon.isSecondEdition,
+      secondEditionOverlayX: uc.ctoon.secondEditionOverlayX,
+      secondEditionOverlayY: uc.ctoon.secondEditionOverlayY,
+      secondEditionOverlaySize: uc.ctoon.secondEditionOverlaySize
     }
   }
 
@@ -208,7 +212,11 @@ export default defineEventHandler(async (event) => {
         ctoonId: meta.ctoonId ?? null,
         isGtoon: meta.isGtoon ?? null,
         cost: meta.cost ?? null,
-        power: meta.power ?? null
+        power: meta.power ?? null,
+        isSecondEdition: meta.isSecondEdition ?? null,
+        secondEditionOverlayX: meta.secondEditionOverlayX ?? null,
+        secondEditionOverlayY: meta.secondEditionOverlayY ?? null,
+        secondEditionOverlaySize: meta.secondEditionOverlaySize ?? null
       }
     })
     return {

--- a/server/api/global-config.get.js
+++ b/server/api/global-config.get.js
@@ -11,6 +11,9 @@ export default defineEventHandler(async () => {
     dailyNewUserPoints: cfg?.dailyNewUserPoints ?? 1000,
     czoneVisitPoints:   cfg?.czoneVisitPoints   ?? 20,
     czoneVisitMaxPerDay: cfg?.czoneVisitMaxPerDay ?? 10,
-    czoneCount: cfg?.czoneCount ?? 3
+    czoneCount: cfg?.czoneCount ?? 3,
+    secondEditionOverlayPath:   cfg?.secondEditionOverlayPath   ?? null,
+    secondEditionOverlayWidth:  cfg?.secondEditionOverlayWidth  ?? null,
+    secondEditionOverlayHeight: cfg?.secondEditionOverlayHeight ?? null
   }
 })

--- a/server/prisma.js
+++ b/server/prisma.js
@@ -230,6 +230,22 @@ function prismaClientFactory() {
           const swapMap = await getAssetSwapMap(baseClient)
           return applyAssetSwap(result, swapMap)
         }
+      },
+      userCtoon: {
+        // First Edition is a property of the cToon template, not the mint: force
+        // isFirstEdition = NOT ctoon.isSecondEdition on every mint, regardless of what
+        // the many call sites pass in. Keeps all mint paths correct from one place.
+        async create({ args, query }) {
+          const ctoonId = args?.data?.ctoonId
+          if (ctoonId) {
+            const parent = await baseClient.ctoon.findUnique({
+              where: { id: ctoonId },
+              select: { isSecondEdition: true }
+            })
+            if (parent) args.data.isFirstEdition = !parent.isSecondEdition
+          }
+          return query(args)
+        }
       }
     }
   })

--- a/server/utils/secondEdition.js
+++ b/server/utils/secondEdition.js
@@ -1,0 +1,63 @@
+// server/utils/secondEdition.js
+// Shared validation for the Second Edition fields accepted by the add/edit cToon endpoints.
+import { createError } from 'h3'
+
+function clampPercent(value, fallback) {
+  const num = Number(value)
+  if (!Number.isFinite(num)) return fallback
+  return Math.min(100, Math.max(0, num))
+}
+
+/**
+ * @param {object} fields raw form fields (strings from multipart, or already-typed from JSON body)
+ * @param {import('@prisma/client').PrismaClient} prisma
+ * @param {string|null} currentCtoonId id of the cToon being edited (null when creating)
+ */
+export async function parseSecondEditionFields(fields, prisma, currentCtoonId = null) {
+  const isSecondEdition = String(fields.isSecondEdition) === 'true' || fields.isSecondEdition === true
+
+  let relatedFirstEditionId = fields.relatedFirstEditionId
+  relatedFirstEditionId = relatedFirstEditionId == null || relatedFirstEditionId === ''
+    ? null
+    : String(relatedFirstEditionId)
+
+  if (relatedFirstEditionId && currentCtoonId && relatedFirstEditionId === currentCtoonId) {
+    throw createError({ statusCode: 400, statusMessage: 'A cToon cannot reference itself as its Related First Edition.' })
+  }
+
+  if (relatedFirstEditionId) {
+    const target = await prisma.ctoon.findUnique({
+      where: { id: relatedFirstEditionId },
+      select: { id: true, isSecondEdition: true }
+    })
+    if (!target) {
+      throw createError({ statusCode: 400, statusMessage: 'Related First Edition cToon not found.' })
+    }
+    if (target.isSecondEdition) {
+      throw createError({ statusCode: 400, statusMessage: 'Related First Edition must not itself be a Second Edition.' })
+    }
+
+    const existingPair = await prisma.ctoon.findUnique({
+      where: { relatedFirstEditionId },
+      select: { id: true, name: true }
+    })
+    if (existingPair && existingPair.id !== currentCtoonId) {
+      throw createError({ statusCode: 400, statusMessage: `"${existingPair.name}" is already set as the Second Edition for that cToon.` })
+    }
+  }
+
+  const overlayX = isSecondEdition ? clampPercent(fields.secondEditionOverlayX, 75) : null
+  const overlayY = isSecondEdition ? clampPercent(fields.secondEditionOverlayY, 75) : null
+  const overlaySizeRaw = Number(fields.secondEditionOverlaySize)
+  const overlaySize = isSecondEdition
+    ? (Number.isFinite(overlaySizeRaw) && overlaySizeRaw > 0 ? Math.min(1000, overlaySizeRaw) : 100)
+    : null
+
+  return {
+    isSecondEdition,
+    relatedFirstEditionId: isSecondEdition ? relatedFirstEditionId : null,
+    secondEditionOverlayX: overlayX,
+    secondEditionOverlayY: overlayY,
+    secondEditionOverlaySize: overlaySize
+  }
+}


### PR DESCRIPTION
- Schema: Ctoon.isSecondEdition, relatedFirstEditionId (1:1 self-relation),
  overlay position/size fields; GlobalGameConfig overlay icon fields.
- Admin: add/edit/bulk-upload cToon pages get an Is Second Edition checkbox
  that auto-sets when image-duplicate distances are both 0, a Related First
  Edition autocomplete, and a drag-or-stepper position/size editor with live
  preview (add/edit only).
- Global Settings gets a Second Editions tab to upload the sitewide overlay
  icon (PNG/GIF only, server-generated filename, size-limited).
- New shared SecondEditionOverlay component renders the icon at a consistent
  physical size across My Collection, Auction House, cZone, CtoonInfoCard,
  and trade cards; CtoonInfoCard cross-links first/second edition partners.
- cZone gets a per-viewer, ephemeral Art Mode toggle that hides the overlay
  and resets whenever the viewed zone changes; contest-submission image
  generation never draws the overlay.
- Pack-opening reveal shows a Pack Exclusive badge; View Auction and trade
  offer views show a clear Second Edition badge.
- My Collection / Auction House sidebars get an Exclude Second Editions
  filter (off by default).
- isFirstEdition is now derived from the parent cToon's isSecondEdition flag
  instead of mint-number/initialQuantity: a Prisma extension centrally
  enforces this on every mint (replacing 22 scattered call sites), existing
  UserCtoon rows are backfilled in the migration, and editing a cToon's
  Second Edition flag re-syncs its already-minted rows.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LU612ZfCvydfLkgrBRvGE1