### PR TITLE
Fix overlay positioning in scaled transform contexts

### DIFF
--- a/components/newsite/SecondEditionOverlay.vue
+++ b/components/newsite/SecondEditionOverlay.vue
@@ -62,6 +62,21 @@ function measure() {
   const boxAspect = box.width / box.height
   const imgAspect = img.naturalWidth / img.naturalHeight
 
+  // When the container's aspect ratio matches the image's, the image fills the
+  // box with no object-fit letterboxing — so the pixel-measured content rect is
+  // identical to the simpler percentage-based styleFor(), and we defer to it.
+  // This matters because getBoundingClientRect() above returns *transform-scaled*
+  // pixels: inside a scaled ancestor (e.g. the cZone canvas's
+  // `transform: scale()`), those px would be mis-applied in the un-scaled layout
+  // space of the absolutely-positioned overlay, shrinking the icon and pulling
+  // it toward the top-left by the scale factor. Percentages, by contrast, are
+  // invariant to ancestor transforms, so styleFor() keeps the icon locked to the
+  // artwork at every canvas scale. The pixel path is only needed where the image
+  // is genuinely letterboxed (aspect mismatch), and those call sites are never
+  // inside a transform.
+  const ASPECT_EPSILON = 0.01
+  if (Math.abs(boxAspect - imgAspect) < ASPECT_EPSILON) { contentRect.value = null; return }
+
   let width, height
   if (imgAspect > boxAspect) {
     // Image is relatively wider than the box: full width, letterboxed top/bottom.


### PR DESCRIPTION
## Summary
Fixed an issue where the SecondEditionOverlay icon would shrink and misalign when positioned inside a scaled ancestor element (like the cZone canvas). The fix detects when the container and image aspect ratios match, and uses percentage-based positioning instead of pixel measurements in those cases.

## Key Changes
- Added aspect ratio comparison logic to detect when image fills container without letterboxing
- When aspect ratios match (within 0.01 epsilon), defer to percentage-based `styleFor()` positioning instead of pixel-measured `getBoundingClientRect()` values
- This prevents transform-scaled pixel values from being incorrectly applied in the unscaled layout space of the absolutely-positioned overlay

## Implementation Details
The issue occurred because `getBoundingClientRect()` returns transform-scaled pixel coordinates. When the overlay is absolutely-positioned in an unscaled layout space but its parent is scaled via CSS `transform: scale()`, applying those pixel measurements directly would shrink the icon and pull it toward the top-left by the scale factor.

Percentage-based positioning from `styleFor()` is invariant to ancestor transforms, keeping the icon locked to the artwork at every canvas scale. The pixel measurement path is only needed for genuinely letterboxed images (aspect ratio mismatch), which never occur inside transform contexts in the current codebase.

https://claude.ai/code/session_01LhbZQ2cScY3kDvZg3MWDcG