### PR TITLE
Fix Second Edition overlay position on cZone canvas (letterboxed toons)

### DIFF
--- a/components/newsite/SecondEditionOverlay.vue
+++ b/components/newsite/SecondEditionOverlay.vue
@@ -56,41 +56,40 @@ function measure() {
   const parent = img?.parentElement
   if (!img || !parent || !img.naturalWidth || !img.naturalHeight) { contentRect.value = null; return }
 
-  const box = parent.getBoundingClientRect()
-  if (!box.width || !box.height) { contentRect.value = null; return }
+  // Measure the container in LAYOUT pixels (offsetWidth/offsetHeight) rather than
+  // getBoundingClientRect(). getBoundingClientRect() returns pixels already
+  // multiplied by any ancestor CSS transform — e.g. the cZone canvas wraps its
+  // items in `.cz-canvas-inner { transform: scale() }` to fit an 800×600 design
+  // space to the viewport. But the overlay's absolute left/top/width below are
+  // applied in the *un-scaled* layout coordinate space of its positioned parent,
+  // so mixing in transform-scaled measurements shrank the icon and pulled it
+  // toward the top-left by the scale factor. Layout metrics ignore ancestor
+  // transforms, keeping measurement and placement in the same frame so the icon
+  // stays locked to the artwork at every canvas scale (the ancestor transform
+  // then scales the overlay and image together, uniformly). In non-transformed
+  // call sites offsetWidth === getBoundingClientRect().width, so their behaviour
+  // is unchanged.
+  const boxW = parent.offsetWidth
+  const boxH = parent.offsetHeight
+  if (!boxW || !boxH) { contentRect.value = null; return }
 
-  const boxAspect = box.width / box.height
+  const boxAspect = boxW / boxH
   const imgAspect = img.naturalWidth / img.naturalHeight
-
-  // When the container's aspect ratio matches the image's, the image fills the
-  // box with no object-fit letterboxing — so the pixel-measured content rect is
-  // identical to the simpler percentage-based styleFor(), and we defer to it.
-  // This matters because getBoundingClientRect() above returns *transform-scaled*
-  // pixels: inside a scaled ancestor (e.g. the cZone canvas's
-  // `transform: scale()`), those px would be mis-applied in the un-scaled layout
-  // space of the absolutely-positioned overlay, shrinking the icon and pulling
-  // it toward the top-left by the scale factor. Percentages, by contrast, are
-  // invariant to ancestor transforms, so styleFor() keeps the icon locked to the
-  // artwork at every canvas scale. The pixel path is only needed where the image
-  // is genuinely letterboxed (aspect mismatch), and those call sites are never
-  // inside a transform.
-  const ASPECT_EPSILON = 0.01
-  if (Math.abs(boxAspect - imgAspect) < ASPECT_EPSILON) { contentRect.value = null; return }
 
   let width, height
   if (imgAspect > boxAspect) {
     // Image is relatively wider than the box: full width, letterboxed top/bottom.
-    width = box.width
-    height = box.width / imgAspect
+    width = boxW
+    height = boxW / imgAspect
   } else {
     // Image is relatively taller than the box: full height, letterboxed left/right.
-    height = box.height
-    width = box.height * imgAspect
+    height = boxH
+    width = boxH * imgAspect
   }
 
   contentRect.value = {
-    left: (box.width - width) / 2,
-    top: (box.height - height) / 2,
+    left: (boxW - width) / 2,
+    top: (boxH - height) / 2,
     width,
     height
   }


### PR DESCRIPTION
## Summary
Follow-up to #726. That PR fixed cZone toons whose stored `width`/`height` matched their image's natural aspect ratio (the aspect-match short-circuit to the percentage path). But when a toon's stored dimensions differ from the image's natural aspect, the image **letterboxes** inside `.cz-item`, so the component falls back to the pixel-measurement path — which was still reading `getBoundingClientRect()` and left the icon offset toward the top-left on the scaled cZone canvas.

## Change
`measure()` now measures the container in **layout pixels** (`offsetWidth`/`offsetHeight`) instead of `getBoundingClientRect()`.

- `getBoundingClientRect()` returns pixels already multiplied by any ancestor CSS transform — the cZone canvas wraps items in `.cz-canvas-inner { transform: scale() }` to fit an 800×600 design space to the viewport. Those scaled px were then applied in the *un-scaled* layout coordinate space of the absolutely-positioned overlay, shrinking the icon and pulling it toward the top-left by the scale factor.
- Layout metrics (`offsetWidth`/`offsetHeight`) ignore ancestor transforms, so measurement and placement share one coordinate frame; the ancestor transform then scales the overlay and the artwork together, uniformly.
- Correct at every canvas scale, **whether or not the image letterboxes** — so it no longer depends on the toon's stored dimensions matching the image aspect.
- This supersedes the aspect-match short-circuit from #726, which is removed.

## Compatibility
In every non-transformed call site (infocard modal, admin cToon list, admin Second Edition preview, trade cards, collection cards, etc.) `offsetWidth === getBoundingClientRect().width`, so their rendering is unchanged. The exposed `contentRect` stays border-box/scale-1 in those contexts, so `SecondEditionFields.vue`'s drag-to-position preview is unaffected.

## Testing
- [ ] Verify the Second Edition icon sits at the saved X/Y/size on `newsite/czone/[username]` at full desktop width and at narrow/mobile widths (canvas scale well below 1), including the 0.5×/2× per-toon size cycle.
- [ ] Confirm no regression in the infocard modal, admin cToon list, and admin Second Edition preview/drag editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhbZQ2cScY3kDvZg3MWDcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhbZQ2cScY3kDvZg3MWDcG)_