### PR TITLE
Fix memory leaks from uncleared timers and undestroyed charts

### DIFF
--- a/components/newsite/AdminAnalytics.vue
+++ b/components/newsite/AdminAnalytics.vue
@@ -445,6 +445,9 @@ let cumChart, pctChart, uniqueChart,
     codesChart, ctoonChart, packChart, ptsHistChart, clashChart, tradesChart,
     netChart, ratioChart, turnoverChart, monsterScansChart, socketMetricsChart
 let socketMetricsTimer
+// Set true once the component starts tearing down so async fetches that resolve
+// after unmount don't touch charts we've already destroyed (see onBeforeUnmount).
+let isUnmounted = false
 
 // --- color palette ---
 const colors = {
@@ -756,7 +759,9 @@ function resetPointsZoom () {
 }
 
 async function fetchPointsDistribution () {
+  if (isUnmounted || !ptsHistChart) return
   const res = await fetch(`/api/admin/points-distribution?bucketSize=${pointsBucketSize.value}`, { credentials: 'include' })
+  if (isUnmounted || !ptsHistChart) return
   const hd = await res.json()
   const labels = hd.map(b => b.label)
   const counts = hd.map(b => b.count)
@@ -811,8 +816,9 @@ function computeLeakRisk(samples, intervalMs) {
 }
 
 async function fetchSocketMetrics() {
-  if (!socketMetricsChart) return
+  if (isUnmounted || !socketMetricsChart) return
   const res = await fetch('/api/admin/socket-metrics?limit=1440', { credentials: 'include' })
+  if (isUnmounted || !socketMetricsChart) return
   if (!res.ok) return
   const payload = await res.json()
   const samples = Array.isArray(payload.samples) ? payload.samples : []
@@ -836,9 +842,11 @@ async function fetchSocketMetrics() {
 }
 
 async function fetchData() {
+  if (isUnmounted || !cumChart) return
   const groupParam = `&groupBy=${groupBy.value}`
 
   let res = await fetch(`/api/admin/cumulative-users?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted || !cumChart) return
   let data = await res.json()
   cumChart.data.labels   = data.map(d => dateOf(d))
   cumChart.data.datasets = [{
@@ -851,6 +859,7 @@ async function fetchData() {
   cumChart.update()
 
   res = await fetch(`/api/admin/trades-requested?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   const tr = await res.json()
   tradesChart.data.labels   = tr.map(d => dateOf(d))
   tradesChart.data.datasets = [{
@@ -862,6 +871,7 @@ async function fetchData() {
   tradesChart.update()
 
   res = await fetch(`/api/admin/net-points-issues?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   const np = await res.json()
   const tfByGroup = {
     daily: TF_DAYS,
@@ -918,6 +928,7 @@ async function fetchData() {
   }
 
   res = await fetch(`/api/admin/percentage-first-purchase?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   data = await res.json()
   pctChart.data.labels   = data.map(d => dateOf(d))
   pctChart.data.datasets = [{
@@ -930,6 +941,7 @@ async function fetchData() {
   pctChart.update()
 
   res = await fetch(`/api/admin/unique-logins?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   data = await res.json()
   uniqueChart.data.labels   = data.map(d => dateOf(d))
   uniqueChart.data.datasets = [{
@@ -942,6 +954,7 @@ async function fetchData() {
   uniqueChart.update()
 
   res = await fetch('/api/admin/active-discord', { credentials: 'include' })
+  if (isUnmounted) return
   const ad = await res.json()
   activeDiscord.value = {
     percentage: Math.round((ad.active / ad.total) * 100),
@@ -950,6 +963,7 @@ async function fetchData() {
   }
 
   res = await fetch(`/api/admin/clash-stats?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   const cs = await res.json()
   const total    = cs.reduce((s, d) => s + (d.count || 0), 0)
   const finished = cs.reduce((s, d) => s + (d.finishedCount || 0), 0)
@@ -986,6 +1000,7 @@ async function fetchData() {
   clashChart.update()
 
   res = await fetch(`/api/admin/monster-scans?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   const ms = await res.json()
   monsterScansChart.data.labels = ms.map(d => dateOf(d))
   monsterScansChart.data.datasets = [
@@ -1017,6 +1032,7 @@ async function fetchData() {
   monsterScansChart.update()
 
   res = await fetch(`/api/admin/spend-earn-ratio?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   const sr = await res.json()
   ratioWindowCount.value = (tfByGroup[groupBy.value] || TF_DAYS)[selectedTimeframe.value]
 
@@ -1069,6 +1085,7 @@ async function fetchData() {
   }
 
   res = await fetch(`/api/admin/codes-redeemed?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   let cr = await res.json()
   codesChart.data.labels   = cr.map(d => dateOf(d))
   codesChart.data.datasets = [{
@@ -1080,6 +1097,7 @@ async function fetchData() {
   codesChart.update()
 
   res = await fetch(`/api/admin/purchases?method=ctoon&timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   let pd = await res.json()
   if (pd.ctoonPurchases) pd = pd.ctoonPurchases
   ctoonChart.data.labels   = pd.map(d => dateOf(d))
@@ -1092,6 +1110,7 @@ async function fetchData() {
   ctoonChart.update()
 
   res = await fetch(`/api/admin/purchases?method=pack&timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   let pp = await res.json()
   if (pp.packPurchases) pp = pp.packPurchases
   packChart.data.labels   = pp.map(d => dateOf(d))
@@ -1106,6 +1125,7 @@ async function fetchData() {
   await fetchPointsDistribution()
 
   res = await fetch(`/api/admin/rarity-turnover-rate?timeframe=${selectedTimeframe.value}${groupParam}`, { credentials: 'include' })
+  if (isUnmounted) return
   const turnrate = await res.json()
   const turnoverCounts = {
     daily: turnrate.days,
@@ -1250,11 +1270,29 @@ onMounted(async () => {
   await nextTick()
   await fetchData()
   await fetchSocketMetrics()
-  socketMetricsTimer = setInterval(fetchSocketMetrics, socketMetricsIntervalMs.value)
+  // Skip arming the poller if we already unmounted during the awaits above —
+  // onBeforeUnmount would have run before this timer existed and couldn't clear it.
+  if (!isUnmounted) socketMetricsTimer = setInterval(fetchSocketMetrics, socketMetricsIntervalMs.value)
 })
 
 onBeforeUnmount(() => {
-  if (socketMetricsTimer) clearInterval(socketMetricsTimer)
+  // Mark unmounted first so any in-flight fetch bails before touching charts,
+  // then stop the poller before destroying so it can't fire mid-teardown.
+  isUnmounted = true
+  if (socketMetricsTimer) { clearInterval(socketMetricsTimer); socketMetricsTimer = null }
+
+  // Destroy every Chart.js instance so its canvas, resize listeners and
+  // animation frames are released instead of leaking on each unmount (this
+  // component re-mounts every time the newsite admin section switches).
+  ;[
+    cumChart, pctChart, uniqueChart, codesChart, ctoonChart, packChart,
+    ptsHistChart, clashChart, tradesChart, netChart, ratioChart,
+    turnoverChart, monsterScansChart, socketMetricsChart
+  ].forEach(ch => { try { ch?.destroy() } catch {} })
+
+  cumChart = pctChart = uniqueChart = codesChart = ctoonChart = packChart =
+    ptsHistChart = clashChart = tradesChart = netChart = ratioChart =
+    turnoverChart = monsterScansChart = socketMetricsChart = null
 })
 
 watch([selectedTimeframe, groupBy], async () => {

--- a/components/newsite/AdminAuctionLogs.vue
+++ b/components/newsite/AdminAuctionLogs.vue
@@ -180,7 +180,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 
 const pageSize = 100
 const page = ref(1)
@@ -245,6 +245,11 @@ function scheduleFilterFetch() {
 
 // Winner autocomplete
 let winnerSuggestDebounceId = null
+
+onBeforeUnmount(() => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  if (winnerSuggestDebounceId) clearTimeout(winnerSuggestDebounceId)
+})
 watch(winnerQuery, (val) => {
   if (winnerSuggestDebounceId) clearTimeout(winnerSuggestDebounceId)
   const trimmed = val.trim()

--- a/components/newsite/AdminAuthLogs.vue
+++ b/components/newsite/AdminAuthLogs.vue
@@ -184,7 +184,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 
 const logs             = ref([])
 const logsTotal        = ref(0)
@@ -348,6 +348,10 @@ onMounted(() => {
 })
 
 let searchDebounceId = null
+
+onBeforeUnmount(() => {
+  if (searchDebounceId) clearTimeout(searchDebounceId)
+})
 watch(searchTerm, () => {
   if (searchDebounceId) clearTimeout(searchDebounceId)
   searchDebounceId = setTimeout(() => {

--- a/components/newsite/AdminCheatFinder.vue
+++ b/components/newsite/AdminCheatFinder.vue
@@ -337,7 +337,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 
 const tabs = [
   { id: 'duplicateIps', label: 'Duplicate IPs' },
@@ -509,6 +509,11 @@ watch(searchTerm, () => {
 })
 
 let vpnSearchDebounceId = null
+
+onBeforeUnmount(() => {
+  if (searchDebounceId) clearTimeout(searchDebounceId)
+  if (vpnSearchDebounceId) clearTimeout(vpnSearchDebounceId)
+})
 watch(vpnSearchTerm, (val) => {
   if (vpnSearchDebounceId) clearTimeout(vpnSearchDebounceId)
   // Only trigger a fetch when 0 chars (cleared) or 3+ chars

--- a/components/newsite/AdminCtoonOwnerLogs.vue
+++ b/components/newsite/AdminCtoonOwnerLogs.vue
@@ -198,7 +198,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 
 const logs = ref([])
 const total = ref(0)
@@ -326,6 +326,12 @@ watch(userQuery, () => {
 })
 
 let ctoonSuggestDebounceId = null
+
+onBeforeUnmount(() => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  if (userSuggestDebounceId) clearTimeout(userSuggestDebounceId)
+  if (ctoonSuggestDebounceId) clearTimeout(ctoonSuggestDebounceId)
+})
 watch(ctoonQuery, () => {
   if (ctoonSuggestDebounceId) clearTimeout(ctoonSuggestDebounceId)
   ctoonSuggestDebounceId = setTimeout(fetchCtoonSuggestions, 250)

--- a/components/newsite/AdminCzoneContest.vue
+++ b/components/newsite/AdminCzoneContest.vue
@@ -332,6 +332,11 @@ const contests        = ref([])
 const loadingContests = ref(false)
 const showAll         = ref(false)
 const toast           = ref(null)
+let toastTimer = null
+
+onBeforeUnmount(() => {
+  if (toastTimer) clearTimeout(toastTimer)
+})
 const ctoonOptions    = ref([])
 const bgOptions       = ref([])
 
@@ -383,7 +388,8 @@ const autoForm = ref({ ...automation.value })
 // ── Helpers ──────────────────────────────────────────────────────────────────
 function showToast(msg, type = 'success') {
   toast.value = { msg, type }
-  setTimeout(() => { toast.value = null }, 3500)
+  if (toastTimer) clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => { toast.value = null; toastTimer = null }, 3500)
 }
 
 function fmtDate(dt) {

--- a/components/newsite/AdminDeviceFingerprintLogs.vue
+++ b/components/newsite/AdminDeviceFingerprintLogs.vue
@@ -214,7 +214,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 
 const items = ref([])
 const total = ref(0)
@@ -316,6 +316,10 @@ function clearFilters() {
 }
 
 let filterDebounceId = null
+
+onBeforeUnmount(() => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+})
 watch([usernameQuery, visitorIdQuery, ipQuery, duplicatesOnly], () => {
   if (filterDebounceId) clearTimeout(filterDebounceId)
   filterDebounceId = setTimeout(() => {

--- a/components/newsite/AdminGtoonsClashLogs.vue
+++ b/components/newsite/AdminGtoonsClashLogs.vue
@@ -102,7 +102,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 
 const games = ref([])
 const total = ref(0)
@@ -225,6 +225,10 @@ function prevPage() {
 }
 
 let filterDebounceId = null
+
+onBeforeUnmount(() => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+})
 watch([fromDate, toDate], () => {
   if (filterDebounceId) clearTimeout(filterDebounceId)
   filterDebounceId = setTimeout(() => {

--- a/components/newsite/AdminLottoLogs.vue
+++ b/components/newsite/AdminLottoLogs.vue
@@ -150,7 +150,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 
 const from = ref('')
 const to = ref('')
@@ -260,6 +260,10 @@ async function fetchSummary() {
 }
 
 let userSuggestTimer = null
+
+onBeforeUnmount(() => {
+  if (userSuggestTimer) clearTimeout(userSuggestTimer)
+})
 async function fetchUserSuggestions() {
   const term = userQuery.value.trim()
   if (term.length < 3) {

--- a/components/newsite/AdminManageUsers.vue
+++ b/components/newsite/AdminManageUsers.vue
@@ -591,7 +591,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 
 const users    = ref([])
 const official = ref(null)
@@ -1109,6 +1109,12 @@ const dissolveStep = ref('')
 const dissolveSummary = ref(null)
 const dissolveCategoryCounts = ref(null)
 let dissolvePoller = null
+
+// Stop the dissolve status poller if this view is switched away from while a
+// dissolve is still running (the modal-close handler only fires on modal close).
+onBeforeUnmount(() => {
+  if (dissolvePoller) { clearInterval(dissolvePoller); dissolvePoller = null }
+})
 
 function defaultStartLocal() {
   const now = new Date()

--- a/components/newsite/AdminMonsterBattleLogs.vue
+++ b/components/newsite/AdminMonsterBattleLogs.vue
@@ -109,7 +109,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 
 const battles = ref([])
 const total = ref(0)
@@ -242,6 +242,10 @@ async function prevPage() {
 }
 
 let filterDebounceId = null
+
+onBeforeUnmount(() => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+})
 watch([searchTerm, fromDate, toDate], () => {
   if (filterDebounceId) clearTimeout(filterDebounceId)
   filterDebounceId = setTimeout(() => {

--- a/components/newsite/AdminPointLogs.vue
+++ b/components/newsite/AdminPointLogs.vue
@@ -109,7 +109,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 
 const logs = ref([])
 const total = ref(0)
@@ -175,6 +175,10 @@ function prevPage() {
 }
 
 let filterDebounceId = null
+
+onBeforeUnmount(() => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+})
 watch([searchTerm, fromDate, toDate], () => {
   if (filterDebounceId) clearTimeout(filterDebounceId)
   filterDebounceId = setTimeout(() => {

--- a/components/newsite/AdminTradeLogs.vue
+++ b/components/newsite/AdminTradeLogs.vue
@@ -218,7 +218,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 
 const rarityValues = { Common: 100, Uncommon: 200, Rare: 400, 'Very Rare': 750, 'Crazy Rare': 1250 }
 
@@ -337,6 +337,11 @@ watch([userQuery, selectedStatus, fromDate, toDate], () => {
 })
 
 let suggestionDebounceId = null
+
+onBeforeUnmount(() => {
+  if (filterDebounceId) clearTimeout(filterDebounceId)
+  if (suggestionDebounceId) clearTimeout(suggestionDebounceId)
+})
 watch(userQuery, () => {
   if (suggestionDebounceId) clearTimeout(suggestionDebounceId)
   suggestionDebounceId = setTimeout(fetchUserSuggestions, 200)

--- a/pages/admin/addHolidayEvent.vue
+++ b/pages/admin/addHolidayEvent.vue
@@ -230,7 +230,7 @@
 
 <script setup>
 definePageMeta({ title: 'Admin - Add Holiday Event', middleware: ['auth','admin'], layout: 'admin' })
-import { ref, computed, onMounted, nextTick } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useRouter } from '#app'
 
 const router = useRouter()
@@ -429,15 +429,17 @@ const invalidTooltip = computed(() => {
 })
 
 // Close dropdowns on outside click
-if (process.client) {
-  window.addEventListener('click', e => {
-    if (!e.target.closest('.cto-autocomplete')) {
-      itemsOpen.value = false
-      poolOpen.value = false
-      setsOpen.value = false
-    }
-  })
+function handleOutsideClick(e) {
+  if (!e.target.closest('.cto-autocomplete')) {
+    itemsOpen.value = false
+    poolOpen.value = false
+    setsOpen.value = false
+  }
 }
+if (process.client) window.addEventListener('click', handleOutsideClick)
+onBeforeUnmount(() => {
+  if (process.client) window.removeEventListener('click', handleOutsideClick)
+})
 
 /* ---------- Submit (send UTC ISO derived from Chicago time) ---------- */
 async function submit() {

--- a/pages/admin/codes.vue
+++ b/pages/admin/codes.vue
@@ -253,7 +253,7 @@
 
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import Nav from '~/components/Nav.vue'
 
 definePageMeta({
@@ -459,6 +459,12 @@ watch(activeTab, (tab) => {
 
 onMounted(() => {
   fetchCreatedCodes()
+})
+
+onBeforeUnmount(() => {
+  if (claimedFilterDebounceId) clearTimeout(claimedFilterDebounceId)
+  if (createdFilterDebounceId) clearTimeout(createdFilterDebounceId)
+  if (claimedSuggestDebounceId) clearTimeout(claimedSuggestDebounceId)
 })
 </script>
 

--- a/pages/admin/ctoons.vue
+++ b/pages/admin/ctoons.vue
@@ -273,7 +273,7 @@
 <script setup>
 definePageMeta({ title: 'Admin - cToons', middleware: ['auth','admin'], layout: 'admin' })
 
-import { ref, onMounted, computed, watch, nextTick } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, watch, nextTick } from 'vue'
 import Nav from '~/components/Nav.vue'
 import BulkEditCtoonModal from '~/components/BulkEditCtoonModal.vue'
 import { formatQuantity, TIME_BASED_CAP } from '~/utils/formatQuantity'
@@ -441,6 +441,10 @@ onMounted(() => {
   if (set) selectedSet.value = set
   if (series) selectedSeries.value = series
   loadPage(1)
+})
+
+onBeforeUnmount(() => {
+  clearTimeout(searchTimer)
 })
 </script>
 

--- a/pages/admin/edit-holidayevent/[id].vue
+++ b/pages/admin/edit-holidayevent/[id].vue
@@ -174,7 +174,7 @@
 
 <script setup>
 definePageMeta({ title: 'Admin - Edit Holiday Event', middleware: ['auth','admin'], layout: 'admin' })
-import { ref, computed, onMounted, nextTick } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useRoute, useRouter } from '#app'
 
 const route = useRoute()
@@ -347,14 +347,16 @@ const invalidTooltip = computed(() => {
 })
 
 // Outside click
-if (process.client) {
-  window.addEventListener('click', e => {
-    if (!e.target.closest('.cto-autocomplete')) {
-      itemsOpen.value = false
-      poolOpen.value = false
-    }
-  })
+function handleOutsideClick(e) {
+  if (!e.target.closest('.cto-autocomplete')) {
+    itemsOpen.value = false
+    poolOpen.value = false
+  }
 }
+if (process.client) window.addEventListener('click', handleOutsideClick)
+onBeforeUnmount(() => {
+  if (process.client) window.removeEventListener('click', handleOutsideClick)
+})
 
 // Submit (send UTC ISO derived from Chicago time)
 async function submit() {

--- a/pages/admin/edit-pack/[id].vue
+++ b/pages/admin/edit-pack/[id].vue
@@ -279,7 +279,7 @@
 definePageMeta({ title: 'Admin - Edit Pack', middleware:['auth','admin'], layout:'admin' })
 
 /* ---------------- imports ---------------- */
-import { ref, reactive, computed, onMounted, watch } from 'vue'
+import { ref, reactive, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter, useRoute, useFetch } from '#app'
 
 /* ---------------- route & pack fetch ---------------- */
@@ -485,12 +485,14 @@ function onManualWeight (rarity,id) {
   // rebalanceIfNeeded(rarity,id)
 }
 
-if (process.client) {
-  window.addEventListener('click', e => {
-    if (!e.target.closest('.cto-autocomplete'))
-      suggestionsOpen.value = false
-  })
+function handleOutsideClick(e) {
+  if (!e.target.closest('.cto-autocomplete'))
+    suggestionsOpen.value = false
 }
+if (process.client) window.addEventListener('click', handleOutsideClick)
+onBeforeUnmount(() => {
+  if (process.client) window.removeEventListener('click', handleOutsideClick)
+})
 
 /* ------------- load cToons & hydrate ------------ */
 const router = useRouter()

--- a/pages/admin/new-pack.vue
+++ b/pages/admin/new-pack.vue
@@ -428,7 +428,7 @@
 <script setup>
 // Meta & imports
 definePageMeta({ title: 'Admin - New Pack', middleware: ['auth','admin'], layout: 'admin' })
-import { ref, reactive, computed, onMounted, watch } from 'vue'
+import { ref, reactive, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from '#app'
 
 // 1️⃣ Basic pack fields
@@ -672,12 +672,14 @@ function addSetToSelection() {
 
 
 // Close dropdowns on outside click
-if (process.client) {
-  window.addEventListener('click', e => {
-    if (!e.target.closest('.cto-autocomplete')) suggestionsOpen.value = false
-    if (!e.target.closest('.set-autocomplete')) setSuggestionsOpen.value = false
-  })
+function handleOutsideClick(e) {
+  if (!e.target.closest('.cto-autocomplete')) suggestionsOpen.value = false
+  if (!e.target.closest('.set-autocomplete')) setSuggestionsOpen.value = false
 }
+if (process.client) window.addEventListener('click', handleOutsideClick)
+onBeforeUnmount(() => {
+  if (process.client) window.removeEventListener('click', handleOutsideClick)
+})
 
 // 7️⃣ Validation
 const countsValid = computed(() =>

--- a/pages/admin/userctoons.vue
+++ b/pages/admin/userctoons.vue
@@ -180,7 +180,7 @@
 
 <script setup>
 definePageMeta({ title: 'Admin - User cToons', middleware: ['auth', 'admin'], layout: 'admin' })
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
 import Nav from '~/components/Nav.vue'
 import { formatQuantity, TIME_BASED_CAP } from '~/utils/formatQuantity'
 
@@ -257,15 +257,21 @@ function applyFilters() {
   loadNext()
 }
 
+let observer = null
+
 onMounted(() => {
   applyFilters()
-  const obs = new IntersectionObserver(
+  observer = new IntersectionObserver(
     entries => {
       if (entries[0].isIntersecting) loadNext()
     },
     { rootMargin: '200px' }
   )
-  if (sentinel.value) obs.observe(sentinel.value)
+  if (sentinel.value) observer.observe(sentinel.value)
+})
+
+onBeforeUnmount(() => {
+  if (observer) { observer.disconnect(); observer = null }
 })
 </script>
 

--- a/pages/admin/users.vue
+++ b/pages/admin/users.vue
@@ -596,7 +596,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import { useAsyncData, useRequestHeaders } from '#app'
 import Nav from '~/components/Nav.vue'
 
@@ -1071,6 +1071,12 @@ const dissolveStep = ref('')
 const dissolveSummary = ref(null)
 const dissolveCategoryCounts = ref(null)
 let dissolvePoller = null
+
+// Stop the dissolve status poller if the page is left while a dissolve is
+// still running (the modal-close handler only fires when the modal is closed).
+onBeforeUnmount(() => {
+  if (dissolvePoller) { clearInterval(dissolvePoller); dissolvePoller = null }
+})
 
 function defaultStartLocal() {
   // Compute tomorrow's date in CST (UTC-6) and default to 10:00 AM


### PR DESCRIPTION
This PR fixes multiple memory leaks across admin components and pages by properly cleaning up timers, event listeners, and Chart.js instances when components unmount.

## Summary
Components were leaving behind active timers, event listeners, and Chart.js instances after unmounting, causing memory to accumulate—especially problematic for the AdminAnalytics component which re-mounts frequently when switching admin sections.

## Key Changes

**AdminAnalytics.vue (most critical):**
- Added `isUnmounted` flag to prevent in-flight async fetches from updating destroyed charts
- Added early-return checks after each `await fetch()` call in `fetchData()`, `fetchPointsDistribution()`, and `fetchSocketMetrics()`
- Properly destroy all Chart.js instances in `onBeforeUnmount()` to release canvas, resize listeners, and animation frames
- Clear the socket metrics polling interval before unmount
- Guard timer initialization in `onMounted()` to handle race conditions

**Event listener cleanup:**
- `addHolidayEvent.vue`, `edit-holidayevent/[id].vue`, `edit-pack/[id].vue`, `new-pack.vue`: Extracted inline click handlers into named functions and added `onBeforeUnmount()` to remove listeners
- `userctoons.vue`: Disconnect IntersectionObserver on unmount

**Debounce/timeout cleanup:**
- `AdminCtoonOwnerLogs.vue`, `AdminCzoneContest.vue`, `AdminManageUsers.vue`, `codes.vue`, `users.vue`, `AdminAuctionLogs.vue`, `AdminCheatFinder.vue`, `AdminTradeLogs.vue`, `AdminAuthLogs.vue`, `AdminDeviceFingerprintLogs.vue`, `AdminGtoonsClashLogs.vue`, `AdminLottoLogs.vue`, `AdminMonsterBattleLogs.vue`, `AdminPointLogs.vue`, `ctoons.vue`: Added `onBeforeUnmount()` hooks to clear pending debounce/suggestion timers and polling intervals

## Implementation Details
- All cleanup is defensive with null checks and try-catch where appropriate
- The `isUnmounted` pattern in AdminAnalytics ensures async operations bail gracefully rather than causing errors
- Chart.js destruction happens before setting references to null to ensure proper cleanup order

https://claude.ai/code/session_019pswJkTe4cD8A9UuT2A7EF