### PR TITLE
Add Second Edition overlay support to pack reveal cards

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -30,12 +30,15 @@
               >
                 <span v-if="!originalOwnedSet.has(item.id)" class="pack-new-badge">New!</span>
                 <span v-if="!item.inCmart" class="pack-exclusive-badge">Pack Exclusive</span>
-                <img
-                  v-if="item.assetPath"
-                  :src="item.assetPath"
-                  :alt="item.name"
-                  class="pack-reveal-img"
-                />
+                <div class="pack-reveal-img-wrap">
+                  <img
+                    v-if="item.assetPath"
+                    :src="item.assetPath"
+                    :alt="item.name"
+                    class="pack-reveal-img"
+                  />
+                  <SecondEditionOverlay :ctoon="item" />
+                </div>
                 <p class="pack-reveal-name">{{ item.name }}</p>
                 <p class="pack-reveal-rarity">{{ item.rarity }}</p>
                 <p class="pack-reveal-mint">Mint #{{ item.mintNumber }}</p>
@@ -1017,11 +1020,17 @@ async function closeOverlay() {
   text-align: right;
 }
 
+:global(.pack-reveal-img-wrap) {
+  position: relative;
+  display: inline-block;
+  margin-top: 16px;
+}
+
 :global(.pack-reveal-img) {
   width: 80px;
   height: 80px;
   object-fit: contain;
-  margin-top: 16px;
+  display: block;
 }
 
 :global(.pack-reveal-name) {

--- a/server/api/cmart/open-pack.get.js
+++ b/server/api/cmart/open-pack.get.js
@@ -189,14 +189,18 @@ export default defineEventHandler(async (event) => {
   }
 
   return chosen.map(c => ({
-    id:         c.id,
-    name:       c.name,
-    assetPath:  c.assetPath,
-    rarity:     c.rarity,
-    isGtoon:    c.isGtoon,
-    cost:       c.cost,
-    power:      c.power,
-    mintNumber: mintNumbers[c.id],
-    inCmart:    inCmartFlags[c.id]
+    id:                      c.id,
+    name:                    c.name,
+    assetPath:               c.assetPath,
+    rarity:                  c.rarity,
+    isGtoon:                 c.isGtoon,
+    cost:                    c.cost,
+    power:                   c.power,
+    mintNumber:              mintNumbers[c.id],
+    inCmart:                 inCmartFlags[c.id],
+    isSecondEdition:         c.isSecondEdition,
+    secondEditionOverlayX:   c.secondEditionOverlayX,
+    secondEditionOverlayY:   c.secondEditionOverlayY,
+    secondEditionOverlaySize: c.secondEditionOverlaySize,
   }))
 })


### PR DESCRIPTION
## Summary
This PR adds support for displaying Second Edition overlays on pack reveal cards in the Cmart component. The changes include UI updates to accommodate the overlay and API response enhancements to provide the necessary positioning and sizing data.

## Key Changes
- **UI Enhancement**: Wrapped the pack reveal image in a new `pack-reveal-img-wrap` container to enable overlay positioning
- **Component Integration**: Added `SecondEditionOverlay` component to display on top of pack reveal images
- **Styling Updates**: 
  - Created new `.pack-reveal-img-wrap` styles with `position: relative` and `display: inline-block` to serve as a positioning context
  - Moved `margin-top` from the image to the wrapper and added `display: block` to the image for proper layout
- **API Response**: Extended the pack opening endpoint to include Second Edition metadata:
  - `isSecondEdition`: Boolean flag indicating if the card is a Second Edition variant
  - `secondEditionOverlayX`: X-coordinate for overlay positioning
  - `secondEditionOverlayY`: Y-coordinate for overlay positioning
  - `secondEditionOverlaySize`: Size parameter for the overlay
- **Code Formatting**: Aligned object property assignments in the API response for improved readability

## Implementation Details
The overlay is positioned absolutely within the wrapper container, allowing it to be layered on top of the card image without affecting the layout flow. The positioning and sizing data is now provided by the backend, enabling flexible overlay placement per card.

https://claude.ai/code/session_01RrkxaEDEMACBFPgR5RJxkM