### PR TITLE
Add SecondEditionOverlay to trade confirmation cards

### DIFF
--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -400,7 +400,10 @@
               <div v-if="!selectedTargetCtoons.length" class="tr-suggest-dim tr-confirm-empty">No cToons selected.</div>
               <div v-else class="tr-confirm-cards">
                 <div v-for="c in selectedTargetCtoons" :key="c.id" class="tr-confirm-card">
-                  <img :src="c.assetPath" :alt="c.name" class="tr-confirm-img" />
+                  <div class="tr-confirm-img-wrap">
+                    <img :src="c.assetPath" :alt="c.name" class="tr-confirm-img" />
+                    <SecondEditionOverlay :ctoon="c" />
+                  </div>
                   <span class="tr-confirm-name">{{ c.name }}</span>
                   <span class="tr-suggest-dim">{{ c.rarity }}</span>
                 </div>
@@ -412,7 +415,10 @@
               <div v-if="!selectedInitiatorCtoons.length" class="tr-suggest-dim tr-confirm-empty">No cToons offered.</div>
               <div v-else class="tr-confirm-cards">
                 <div v-for="c in selectedInitiatorCtoons" :key="c.id" class="tr-confirm-card">
-                  <img :src="c.assetPath" :alt="c.name" class="tr-confirm-img" />
+                  <div class="tr-confirm-img-wrap">
+                    <img :src="c.assetPath" :alt="c.name" class="tr-confirm-img" />
+                    <SecondEditionOverlay :ctoon="c" />
+                  </div>
                   <span class="tr-confirm-name">{{ c.name }}</span>
                   <span class="tr-suggest-dim">{{ c.rarity }}</span>
                 </div>
@@ -1712,6 +1718,7 @@ onBeforeUnmount(() => {
   display: flex; flex-direction: column; align-items: center; gap: 2px;
   background: rgba(255,255,255,0.08); border-radius: 4px; padding: 6px 4px; overflow: hidden;
 }
+.tr-confirm-img-wrap { position: relative; width: 100%; }
 .tr-confirm-img { width: 100%; max-height: 64px; object-fit: contain; }
 .tr-confirm-name { font-size: 0.6rem; color: white; text-align: center; line-height: 1.2; width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tr-confirm-rarity { font-size: 0.55rem; color: rgba(255,255,255,0.45); }


### PR DESCRIPTION
## Summary
Added the `SecondEditionOverlay` component to the trade confirmation cards in the Trade.vue component to display edition information on selected cToons.

## Key Changes
- Wrapped the confirmation card images in a new `tr-confirm-img-wrap` container div for proper positioning context
- Added `SecondEditionOverlay` component to both the target cToons and initiator cToons confirmation sections
- Added CSS styling for the new wrapper div with `position: relative` to enable absolute positioning of the overlay

## Implementation Details
- The overlay is positioned relative to the image wrapper, allowing it to display on top of the cToon images
- Both confirmation card sections (target and initiator) now display the edition overlay consistently
- The wrapper maintains 100% width to preserve the card layout while enabling the overlay functionality

https://claude.ai/code/session_01Uqd8Sxd1dknq58CUorszVs