### PR TITLE
Add leaderboards page and enhance ReOrbit Match gameplay

### DIFF
--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -124,10 +124,9 @@ const tiles = computed(() => tileData.value ?? {})
 
 @media (max-width: 768px) {
   .gameshome {
-    height: max(200px, calc(100dvh - 276px));
-    grid-template-rows: repeat(4, 1fr);
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(6, minmax(70px, 1fr));
+    height: max(300px, calc(100dvh - 276px));
   }
-  .quadrant--tko,
-  .quadrant--reorbit { grid-column: 1 / -1; }
 }
 </style>

--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -1,34 +1,42 @@
 <template>
-  <div class="gameshome">
-    <NuxtLink to="/newsite/newwinball" class="quadrant quadrant--shop">
-      <img v-if="tiles.winball" :src="tiles.winball" alt="Winball" class="tile-img" />
-      <span v-else>Winball</span>
-    </NuxtLink>
-    <NuxtLink to="/newsite/lottery" class="quadrant quadrant--collection">
-      <img v-if="tiles.lotto" :src="tiles.lotto" alt="Lotto" class="tile-img" />
-      <span v-else>Lotto</span>
-    </NuxtLink>
-    <NuxtLink to="/newsite/winwheel" class="quadrant quadrant--games">
-      <img v-if="tiles.winwheel" :src="tiles.winwheel" alt="Win Wheel" class="tile-img" />
-      <span v-else>Win Wheel</span>
-    </NuxtLink>
-    <NuxtLink to="/newsite/gtoons" class="quadrant quadrant--profile">
-      <img v-if="tiles.clash" :src="tiles.clash" alt="gToons Clash" class="tile-img" />
-      <span v-else>gToons Clash</span>
-    </NuxtLink>
-    <a
-      href="https://playtko.win"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="quadrant quadrant--tko"
-    >
-      <img v-if="tiles.tko" :src="tiles.tko" alt="TKO" class="tile-img" />
-      <span v-else>TKO</span>
-    </a>
-    <NuxtLink to="/newsite/reorbitmatch" class="quadrant quadrant--reorbit">
-      <img v-if="tiles.reorbitmatch" :src="tiles.reorbitmatch" alt="ReOrbit Match" class="tile-img" />
-      <span v-else>ReOrbit Match</span>
-    </NuxtLink>
+  <div class="gameshome-wrap">
+    <div class="gh-nav">
+      <GreenButton :active="true">Games</GreenButton>
+      <NuxtLink to="/newsite/leaderboards" class="gh-nav-link">
+        <GreenButton>Leaderboards</GreenButton>
+      </NuxtLink>
+    </div>
+    <div class="gameshome">
+      <NuxtLink to="/newsite/newwinball" class="quadrant quadrant--shop">
+        <img v-if="tiles.winball" :src="tiles.winball" alt="Winball" class="tile-img" />
+        <span v-else>Winball</span>
+      </NuxtLink>
+      <NuxtLink to="/newsite/lottery" class="quadrant quadrant--collection">
+        <img v-if="tiles.lotto" :src="tiles.lotto" alt="Lotto" class="tile-img" />
+        <span v-else>Lotto</span>
+      </NuxtLink>
+      <NuxtLink to="/newsite/winwheel" class="quadrant quadrant--games">
+        <img v-if="tiles.winwheel" :src="tiles.winwheel" alt="Win Wheel" class="tile-img" />
+        <span v-else>Win Wheel</span>
+      </NuxtLink>
+      <NuxtLink to="/newsite/gtoons" class="quadrant quadrant--profile">
+        <img v-if="tiles.clash" :src="tiles.clash" alt="gToons Clash" class="tile-img" />
+        <span v-else>gToons Clash</span>
+      </NuxtLink>
+      <a
+        href="https://playtko.win"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="quadrant quadrant--tko"
+      >
+        <img v-if="tiles.tko" :src="tiles.tko" alt="TKO" class="tile-img" />
+        <span v-else>TKO</span>
+      </a>
+      <NuxtLink to="/newsite/reorbitmatch" class="quadrant quadrant--reorbit">
+        <img v-if="tiles.reorbitmatch" :src="tiles.reorbitmatch" alt="ReOrbit Match" class="tile-img" />
+        <span v-else>ReOrbit Match</span>
+      </NuxtLink>
+    </div>
   </div>
 </template>
 
@@ -38,12 +46,34 @@ const tiles = computed(() => tileData.value ?? {})
 </script>
 
 <style scoped>
+.gameshome-wrap {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.gh-nav {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  padding: 6px 6px 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  flex-shrink: 0;
+}
+.gh-nav::-webkit-scrollbar { display: none; }
+
+.gh-nav-link {
+  text-decoration: none;
+}
+
 .gameshome {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: repeat(3, 1fr);
   width: 100%;
-  height: 100%;
+  flex: 1;
   gap: 6px;
   padding: 6px;
   box-sizing: border-box;
@@ -94,7 +124,7 @@ const tiles = computed(() => tileData.value ?? {})
 
 @media (max-width: 768px) {
   .gameshome {
-    height: max(200px, calc(100dvh - 240px));
+    height: max(200px, calc(100dvh - 276px));
     grid-template-rows: repeat(4, 1fr);
   }
   .quadrant--tko,

--- a/components/newsite/GreenButton.vue
+++ b/components/newsite/GreenButton.vue
@@ -1,8 +1,14 @@
 <template>
-  <button class="green-button">
+  <button class="green-button" :class="{ 'green-button--active': active }">
     <slot />
   </button>
 </template>
+
+<script setup>
+defineProps({
+  active: { type: Boolean, default: false }
+})
+</script>
 
 <style scoped>
 .green-button {
@@ -30,11 +36,13 @@
   background: var(--OrbitGreen);
 }
 
-.green-button:active {
-  background: var(--OrbitGreen);
+.green-button:active,
+.green-button--active {
+  background: #2a6a00;
   box-shadow:
-    inset 0 1px 0 rgba(0, 0, 0, 0.2),
-    0 1px 2px rgba(0, 0, 0, 0.3);
+    inset 0 2px 4px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(0, 0, 0, 0.2);
+  border-color: #1a4a00;
 }
 
 .green-button:disabled {

--- a/components/newsite/Leaderboards.vue
+++ b/components/newsite/Leaderboards.vue
@@ -1,0 +1,296 @@
+<template>
+  <div class="leaderboards">
+    <div class="lb-nav">
+      <GreenButton :active="activeTab === 'users'" @click="activeTab = 'users'">Users</GreenButton>
+      <GreenButton :active="activeTab === 'games'" @click="activeTab = 'games'">Games</GreenButton>
+      <NuxtLink to="/newsite/games" class="lb-nav-link">
+        <GreenButton>Games Home</GreenButton>
+      </NuxtLink>
+    </div>
+
+    <!-- Users Tab -->
+    <div v-if="activeTab === 'users'" class="lb-content">
+      <div class="lb-grid">
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--points">Top Points</div>
+          <div v-if="pointsPending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in pointsData" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">{{ row.points.toLocaleString() }}</span>
+            </li>
+            <li v-if="!pointsData?.length" class="lb-empty">No data yet</li>
+          </ul>
+        </div>
+
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--earners">Top Earners (7d)</div>
+          <div v-if="earnersPending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in earnersData" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">+{{ Number(row.points).toLocaleString() }}</span>
+            </li>
+            <li v-if="!earnersData?.length" class="lb-empty">No data yet</li>
+          </ul>
+        </div>
+
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--spenders">Top Spenders (7d)</div>
+          <div v-if="spendersPending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in spendersData" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">{{ Number(row.points).toLocaleString() }}</span>
+            </li>
+            <li v-if="!spendersData?.length" class="lb-empty">No data yet</li>
+          </ul>
+        </div>
+
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--acquirers">cToon Acquirers (7d)</div>
+          <div v-if="acquirersPending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in acquirersData" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">{{ Number(row.count).toLocaleString() }}</span>
+            </li>
+            <li v-if="!acquirersData?.length" class="lb-empty">No data yet</li>
+          </ul>
+        </div>
+
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--unique">Unique cToons</div>
+          <div v-if="uniquePending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in uniqueData" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">{{ Number(row.count).toLocaleString() }}</span>
+            </li>
+            <li v-if="!uniqueData?.length" class="lb-empty">No data yet</li>
+          </ul>
+        </div>
+
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--total">Total cToons</div>
+          <div v-if="totalPending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in totalData" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">{{ Number(row.count).toLocaleString() }}</span>
+            </li>
+            <li v-if="!totalData?.length" class="lb-empty">No data yet</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Games Tab -->
+    <div v-else-if="activeTab === 'games'" class="lb-content">
+      <div class="lb-games-header">
+        <span class="lb-games-title">ReOrbit Match</span>
+      </div>
+      <div class="lb-grid">
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--alltime">All Time</div>
+          <div v-if="gamePending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in gameData?.allTime" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">{{ row.score.toLocaleString() }}</span>
+            </li>
+            <li v-if="!gameData?.allTime?.length" class="lb-empty">No scores yet</li>
+          </ul>
+        </div>
+
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--monthly">This Month</div>
+          <div v-if="gamePending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in gameData?.monthly" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">{{ row.score.toLocaleString() }}</span>
+            </li>
+            <li v-if="!gameData?.monthly?.length" class="lb-empty">No scores yet</li>
+          </ul>
+        </div>
+
+        <div class="lb-card">
+          <div class="lb-card-header lb-card-header--weekly">This Week</div>
+          <div v-if="gamePending" class="lb-loading">Loading…</div>
+          <ul v-else class="lb-list">
+            <li v-for="(row, i) in gameData?.weekly" :key="row.username" class="lb-row">
+              <span class="lb-rank">{{ i + 1 }}</span>
+              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <span class="lb-value">{{ row.score.toLocaleString() }}</span>
+            </li>
+            <li v-if="!gameData?.weekly?.length" class="lb-empty">No scores yet</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const activeTab = ref('users')
+
+const { data: pointsData, pending: pointsPending } = useFetch('/api/points-leaderboard', { default: () => [] })
+const { data: earnersData, pending: earnersPending } = useFetch('/api/leaderboard/trending-earners', { default: () => [] })
+const { data: spendersData, pending: spendersPending } = useFetch('/api/leaderboard/trending-spenders', { default: () => [] })
+const { data: acquirersData, pending: acquirersPending } = useFetch('/api/leaderboard/active-ctoon-acquirers', { default: () => [] })
+const { data: uniqueData, pending: uniquePending } = useFetch('/api/leaderboard/unique-ctoons', { default: () => [] })
+const { data: totalData, pending: totalPending } = useFetch('/api/leaderboard/total-ctoons', { default: () => [] })
+const { data: gameData, pending: gamePending } = useFetch('/api/game/reorbitmatch/leaderboard', { default: () => null })
+</script>
+
+<style scoped>
+.leaderboards {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: #001230;
+  color: #fff;
+}
+
+.lb-nav {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  padding: 6px 6px 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  flex-shrink: 0;
+}
+.lb-nav::-webkit-scrollbar { display: none; }
+
+.lb-nav-link {
+  text-decoration: none;
+  margin-left: auto;
+}
+
+.lb-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 8px;
+}
+
+.lb-games-header {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.lb-games-title {
+  font-size: 1.1rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  background: linear-gradient(135deg, #4fc3f7, #ab47bc);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.lb-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.lb-card {
+  background: rgba(10, 25, 55, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.lb-card-header {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 7px 10px;
+  color: #fff;
+}
+
+.lb-card-header--points   { background: linear-gradient(90deg, #1a4a8a 0%, transparent 100%); border-bottom: 1px solid rgba(74,144,226,0.3); }
+.lb-card-header--earners  { background: linear-gradient(90deg, #1a5a2a 0%, transparent 100%); border-bottom: 1px solid rgba(74,200,100,0.3); }
+.lb-card-header--spenders { background: linear-gradient(90deg, #5a1a2a 0%, transparent 100%); border-bottom: 1px solid rgba(226,74,100,0.3); }
+.lb-card-header--acquirers{ background: linear-gradient(90deg, #4a2a1a 0%, transparent 100%); border-bottom: 1px solid rgba(226,144,74,0.3); }
+.lb-card-header--unique   { background: linear-gradient(90deg, #2a1a5a 0%, transparent 100%); border-bottom: 1px solid rgba(144,74,226,0.3); }
+.lb-card-header--total    { background: linear-gradient(90deg, #1a3a5a 0%, transparent 100%); border-bottom: 1px solid rgba(74,180,226,0.3); }
+.lb-card-header--alltime  { background: linear-gradient(90deg, #5a4a00 0%, transparent 100%); border-bottom: 1px solid rgba(226,200,0,0.3); }
+.lb-card-header--monthly  { background: linear-gradient(90deg, #1a4a5a 0%, transparent 100%); border-bottom: 1px solid rgba(74,200,226,0.3); }
+.lb-card-header--weekly   { background: linear-gradient(90deg, #1a3a4a 0%, transparent 100%); border-bottom: 1px solid rgba(74,150,200,0.3); }
+
+.lb-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.lb-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.75rem;
+}
+.lb-row:last-child { border-bottom: none; }
+
+.lb-rank {
+  width: 16px;
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.4);
+  font-weight: 700;
+}
+
+.lb-username {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #7ec8f0;
+  text-decoration: none;
+  font-weight: 600;
+}
+.lb-username:hover { color: #b3e0ff; text-decoration: underline; }
+
+.lb-value {
+  flex-shrink: 0;
+  font-weight: 700;
+  color: #fff;
+  font-size: 0.75rem;
+}
+
+.lb-empty {
+  padding: 12px 10px;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.3);
+  text-align: center;
+}
+
+.lb-loading {
+  padding: 12px 10px;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.3);
+  text-align: center;
+}
+
+@media (max-width: 480px) {
+  .lb-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/pages/newsite/leaderboards.vue
+++ b/pages/newsite/leaderboards.vue
@@ -1,0 +1,35 @@
+<template>
+  <Leaderboards />
+</template>
+
+<script setup>
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Leaderboards',
+  description: 'See the top players on Cartoon ReOrbit — points leaders, cToon collectors, and ReOrbit Match high scores.'
+})
+
+const { clearSidebarMiddle } = useNewsiteLayout()
+clearSidebarMiddle()
+</script>
+
+<style>
+html {
+  min-height: 100vh;
+  background: linear-gradient(
+    to bottom,
+    #000000 0px,
+    #000000 65px,
+    #003466 115px,
+    #003466 100%
+  ) no-repeat fixed !important;
+}
+
+body {
+  background: transparent !important;
+  min-height: 100vh;
+}
+</style>

--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -127,7 +127,7 @@ definePageMeta({ ssr: false })
 // ─── Game constants ────────────────────────────────────────────────────────────
 const TILE_GAP = 3
 const ANIMATION_WIGGLE_MS = 400
-const ANIMATION_REMOVE_MS = 200
+const ANIMATION_REMOVE_MS = 320
 const ANIMATION_FALL_MS   = 280
 const ANIMATION_APPEAR_MS = 180
 const MIN_MATCH = 3
@@ -172,6 +172,7 @@ let pointerStartY = 0
 let pointerDown  = false
 let dragFromIdx  = -1  // tile pressed on in current gesture (immediate visual feedback)
 let dragHoverIdx = -1  // adjacent tile being hovered over as a valid swap target
+let particles    = []  // burst particles [{x,y,vx,vy,color,size,startMs}]
 let configData   = null
 
 // ─── Utility ──────────────────────────────────────────────────────────────────
@@ -190,6 +191,25 @@ function colOf(idx) { return idx % gridSize }
 function isAdjacent(aIdx, bIdx) {
   const ar = rowOf(aIdx), ac = colOf(aIdx), br = rowOf(bIdx), bc = colOf(bIdx)
   return (Math.abs(ar - br) === 1 && ac === bc) || (ar === br && Math.abs(ac - bc) === 1)
+}
+
+function fireExplosion(tileIdx) {
+  const row = rowOf(tileIdx), col = colOf(tileIdx)
+  const cx = tileCenterX(col), cy = tileCenterY(row)
+  const now = performance.now()
+  const colors = ['#FFD700', '#fff', '#FFD700', '#66bbff', '#fff', '#FFD700']
+  for (let i = 0; i < 10; i++) {
+    const angle = (i / 10) * Math.PI * 2 + (Math.random() - 0.5) * 0.6
+    const speed = tileSize * (1.8 + Math.random() * 2.2)
+    particles.push({
+      x: cx, y: cy,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      color: colors[i % colors.length],
+      size: tileSize * (0.07 + Math.random() * 0.07),
+      startMs: now
+    })
+  }
 }
 
 // ─── Match finding ────────────────────────────────────────────────────────────
@@ -252,12 +272,12 @@ function initTiles(b) {
   tiles = b.map((emojiIdx, i) => ({
     emojiIdx,
     state: TS.NORMAL,
-    visualY: 0,       // offset from logical Y in pixels (for falling)
+    visualY: 0,       // current Y offset from logical row (for falling)
+    startVisualY: 0,  // Y offset at animation start (source for easing)
     alpha: 1,
     scale: 1,
     wiggleAngle: 0,
-    animStartMs: 0,
-    targetVisualY: 0
+    animStartMs: 0
   }))
 }
 
@@ -357,17 +377,31 @@ function renderFrame(nowMs) {
       scale = 1 + Math.abs(wobble) * 0.12
     } else if (tile.state === TS.REMOVING) {
       const t = Math.min(elapsed / ANIMATION_REMOVE_MS, 1)
-      alpha = 1 - t
-      scale = 1 - t * 0.4
+      if (t < 0.28) {
+        // Pop: quick scale-up flash
+        const pop = t / 0.28
+        scale = 1 + pop * 0.55
+        alpha = 1
+      } else {
+        // Burst: shrink to nothing while fading
+        const burst = (t - 0.28) / 0.72
+        scale = 1.55 * (1 - burst)
+        alpha = 1 - Math.pow(burst, 0.6)
+        tile.wiggleAngle = (tile.wiggleAngle || 0) + burst * 0.4
+      }
     } else if (tile.state === TS.FALLING) {
       const t = Math.min(elapsed / ANIMATION_FALL_MS, 1)
       const ease = 1 - Math.pow(1 - t, 3)
-      tile.visualY = tile.targetVisualY * (1 - ease)
+      tile.visualY = tile.startVisualY * (1 - ease)
       y = tileTop(row) + tile.visualY
     } else if (tile.state === TS.APPEARING) {
-      const t = Math.min(elapsed / ANIMATION_APPEAR_MS, 1)
-      alpha = t
-      scale = 0.6 + t * 0.4
+      const fadeT = Math.min(elapsed / ANIMATION_APPEAR_MS, 1)
+      const fallT = Math.min(elapsed / ANIMATION_FALL_MS, 1)
+      const ease  = 1 - Math.pow(1 - fallT, 3)
+      alpha = fadeT
+      scale = 0.6 + fadeT * 0.4
+      tile.visualY = tile.startVisualY * (1 - ease)
+      y = tileTop(row) + tile.visualY
     }
 
     ctx.save()
@@ -467,6 +501,30 @@ function renderFrame(nowMs) {
     ctx.setLineDash([])
     ctx.restore()
   }
+
+  // Burst particles from matched tile explosions
+  const PARTICLE_LIFE_MS = 500
+  particles = particles.filter(p => {
+    const age  = nowMs - p.startMs
+    if (age >= PARTICLE_LIFE_MS) return false
+    const t    = age / PARTICLE_LIFE_MS
+    const secs = age / 1000
+    ctx.save()
+    ctx.globalAlpha = Math.pow(1 - t, 1.4)
+    ctx.fillStyle   = p.color
+    ctx.shadowColor = p.color
+    ctx.shadowBlur  = 4
+    ctx.beginPath()
+    ctx.arc(
+      p.x + p.vx * secs,
+      p.y + p.vy * secs + 400 * secs * secs,
+      p.size * (1 - t * 0.6),
+      0, Math.PI * 2
+    )
+    ctx.fill()
+    ctx.restore()
+    return true
+  })
 }
 
 // ─── Game loop ────────────────────────────────────────────────────────────────
@@ -558,10 +616,12 @@ async function runCascade(cascadeLevel) {
   })
   await wait(ANIMATION_WIGGLE_MS)
 
-  // Remove
+  // Remove — pop animation + particle burst
+  const removeNow = performance.now()
   matches.forEach(idx => {
     tiles[idx].state = TS.REMOVING
-    tiles[idx].animStartMs = performance.now()
+    tiles[idx].animStartMs = removeNow
+    fireExplosion(idx)
   })
   await wait(ANIMATION_REMOVE_MS)
 
@@ -618,8 +678,8 @@ async function runCascade(cascadeLevel) {
       } else if (emptyBelow > 0) {
         tiles[idx].state = TS.FALLING
         tiles[idx].animStartMs = fallNow
-        tiles[idx].visualY = -(emptyBelow * (tileSize + TILE_GAP))
-        tiles[idx].targetVisualY = 0
+        tiles[idx].startVisualY = -(emptyBelow * (tileSize + TILE_GAP))
+        tiles[idx].visualY      = tiles[idx].startVisualY
       }
     }
     // Mark top cells as appearing
@@ -630,7 +690,8 @@ async function runCascade(cascadeLevel) {
         tiles[idx].state = TS.APPEARING
         tiles[idx].animStartMs = fallNow
         tiles[idx].alpha = 0
-        tiles[idx].visualY = -((emptyBelow - r) * (tileSize + TILE_GAP))
+        tiles[idx].startVisualY = -((emptyBelow - r) * (tileSize + TILE_GAP))
+        tiles[idx].visualY      = tiles[idx].startVisualY
         topEmpty++
       }
     }
@@ -798,6 +859,7 @@ async function startGame() {
     selectedIdx      = -1
     dragFromIdx      = -1
     dragHoverIdx     = -1
+    particles        = []
     animating        = false
 
     await fetchStatus() // refresh plays left
@@ -872,6 +934,7 @@ onUnmounted(() => {
   justify-content: center;
   min-height: 400px;
   position: relative;
+  background: #001230;
 }
 
 /* Landscape orientation warning */
@@ -1007,6 +1070,7 @@ onUnmounted(() => {
   height: 100%;
   min-height: 400px;
   gap: 0;
+  background: #001230;
 }
 
 /* HUD */

--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -170,6 +170,8 @@ let gridOffset   = { x: 0, y: 0 }
 let pointerStartX = 0
 let pointerStartY = 0
 let pointerDown  = false
+let dragFromIdx  = -1  // tile pressed on in current gesture (immediate visual feedback)
+let dragHoverIdx = -1  // adjacent tile being hovered over as a valid swap target
 let configData   = null
 
 // ─── Utility ──────────────────────────────────────────────────────────────────
@@ -376,7 +378,7 @@ function renderFrame(nowMs) {
 
     // Tile background
     const baseColor = TILE_COLORS[tile.emojiIdx % TILE_COLORS.length]
-    const isSelected = (i === selectedIdx)
+    const isSelected = (i === selectedIdx || i === dragFromIdx || i === dragHoverIdx)
     const isMatched  = matchedSet.has(i)
 
     if (isSelected) {
@@ -446,6 +448,23 @@ function renderFrame(nowMs) {
       ctx.lineTo(tileCenterX(c2), tileCenterY(r2))
       ctx.stroke()
     }
+    ctx.restore()
+  }
+
+  // Draw drag-swap preview line between pressed tile and valid hover target
+  if (dragFromIdx !== -1 && dragHoverIdx !== -1) {
+    ctx.save()
+    ctx.strokeStyle = 'rgba(255, 215, 0, 0.7)'
+    ctx.lineWidth   = Math.max(2, tileSize * 0.06)
+    ctx.lineCap = 'round'
+    ctx.setLineDash([Math.round(tileSize * 0.15), Math.round(tileSize * 0.1)])
+    ctx.shadowColor = '#FFD700'
+    ctx.shadowBlur  = 6
+    ctx.beginPath()
+    ctx.moveTo(tileCenterX(colOf(dragFromIdx)), tileCenterY(rowOf(dragFromIdx)))
+    ctx.lineTo(tileCenterX(colOf(dragHoverIdx)), tileCenterY(rowOf(dragHoverIdx)))
+    ctx.stroke()
+    ctx.setLineDash([])
     ctx.restore()
   }
 }
@@ -647,11 +666,28 @@ function onPointerDown(e) {
   pointerStartX = pos.x
   pointerStartY = pos.y
   canvas.value?.setPointerCapture?.(e.pointerId)
+
+  // Immediately highlight the tile under the pointer
+  dragFromIdx  = hitTest(pos.x, pos.y)
+  dragHoverIdx = -1
 }
 
 function onPointerMove(e) {
   if (!pointerDown) return
   e.preventDefault()
+
+  if (animating || uiState.value !== 'playing' || dragFromIdx === -1) return
+
+  const pos    = getCanvasPos(e)
+  const overIdx = hitTest(pos.x, pos.y)
+
+  if (overIdx !== -1 && overIdx !== dragFromIdx && isAdjacent(dragFromIdx, overIdx)) {
+    const swapped = [...board]
+    ;[swapped[dragFromIdx], swapped[overIdx]] = [swapped[overIdx], swapped[dragFromIdx]]
+    dragHoverIdx = findMatches(swapped).size > 0 ? overIdx : -1
+  } else {
+    dragHoverIdx = -1
+  }
 }
 
 function onPointerUp(e) {
@@ -659,37 +695,57 @@ function onPointerUp(e) {
   e.preventDefault()
   pointerDown = false
 
+  const fromIdx  = dragFromIdx
+  const hoverIdx = dragHoverIdx
+  dragFromIdx  = -1
+  dragHoverIdx = -1
+
   if (animating || uiState.value !== 'playing') return
 
   const pos = getCanvasPos(e)
-  const dx = pos.x - pointerStartX
-  const dy = pos.y - pointerStartY
+  const dx  = pos.x - pointerStartX
+  const dy  = pos.y - pointerStartY
   const dist = Math.sqrt(dx * dx + dy * dy)
   const threshold = tileSize * 0.35
 
-  const fromIdx = hitTest(pointerStartX, pointerStartY)
   if (fromIdx === -1) { selectedIdx = -1; return }
 
+  // Drag released over a valid adjacent swap target → perform swap immediately
+  if (hoverIdx !== -1) {
+    selectedIdx = -1
+    trySwap(fromIdx, hoverIdx)
+    return
+  }
+
   if (dist < threshold) {
-    // Tap: select/deselect
-    if (selectedIdx === fromIdx) {
+    // Tap
+    if (selectedIdx !== -1 && selectedIdx !== fromIdx && isAdjacent(selectedIdx, fromIdx)) {
+      // Two-tap swap: previously selected tile + this tap
+      const prevSel = selectedIdx
       selectedIdx = -1
-    } else if (selectedIdx !== -1 && isAdjacent(selectedIdx, fromIdx)) {
-      trySwap(selectedIdx, fromIdx)
+      trySwap(prevSel, fromIdx)
+    } else if (selectedIdx === fromIdx) {
+      selectedIdx = -1  // tap same tile again: deselect
     } else {
-      selectedIdx = fromIdx
+      selectedIdx = fromIdx  // first tap: select
     }
   } else {
-    // Swipe: determine direction
+    // Swipe: use drag direction as fallback
     const swapIdx = getSwipeTarget(fromIdx, dx, dy)
     if (swapIdx !== -1) {
       selectedIdx = -1
       trySwap(fromIdx, swapIdx)
+    } else {
+      selectedIdx = -1
     }
   }
 }
 
-function onPointerLeave() { pointerDown = false }
+function onPointerLeave() {
+  pointerDown  = false
+  dragFromIdx  = -1
+  dragHoverIdx = -1
+}
 
 function getSwipeTarget(fromIdx, dx, dy) {
   const r = rowOf(fromIdx), c = colOf(fromIdx)
@@ -740,6 +796,8 @@ async function startGame() {
     timeLeft.value   = timeSeconds
     moveLog          = []
     selectedIdx      = -1
+    dragFromIdx      = -1
+    dragHoverIdx     = -1
     animating        = false
 
     await fetchStatus() // refresh plays left

--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -104,8 +104,9 @@
               <span class="modal-lb-value">{{ allTimeHigh.toLocaleString() }}</span>
             </div>
           </div>
-          <div v-if="pointsAwarded > 0" class="modal-points-notice">
-            +{{ pointsAwarded }} game points earned!
+          <div class="modal-points-notice" :class="{ 'modal-points-notice--zero': pointsAwarded === 0 }">
+            <template v-if="pointsAwarded > 0">+{{ pointsAwarded }} game points earned!</template>
+            <template v-else>No game points earned (daily limit reached)</template>
           </div>
           <div class="modal-actions">
             <button v-if="playsLeft > 0" class="btn-start" @click="startGame">
@@ -1258,6 +1259,11 @@ onUnmounted(() => {
   border-radius: 8px;
   padding: 0.5rem 1rem;
   margin-bottom: 1.25rem;
+}
+.modal-points-notice--zero {
+  color: rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.1);
 }
 
 .modal-actions { display: flex; justify-content: center; }

--- a/server/api/game/reorbitmatch/leaderboard.get.js
+++ b/server/api/game/reorbitmatch/leaderboard.get.js
@@ -1,0 +1,68 @@
+import { defineEventHandler } from 'h3'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+
+const CACHE_KEY  = 'reorbitmatch:leaderboard'
+const CACHE_TTL  = 1800  // 30 minutes
+const EXCLUDE_ID = '4f0e8b3b-7d0b-466b-99e7-8996c91d7eb3'
+
+async function fetchLeaderboards() {
+  const [allTime, monthly, weekly] = await Promise.all([
+    prisma.$queryRaw`
+      SELECT u."username", MAX(s."score")::int AS score
+      FROM "ReOrbitMatchScore" s
+      JOIN "User" u ON u."id" = s."userId"
+      WHERE u."active" = true
+        AND COALESCE(u."banned", false) = false
+        AND s."userId" <> ${EXCLUDE_ID}
+      GROUP BY u."id", u."username"
+      ORDER BY score DESC, u."username" ASC
+      LIMIT 10
+    `,
+    prisma.$queryRaw`
+      SELECT u."username", MAX(s."score")::int AS score
+      FROM "ReOrbitMatchScore" s
+      JOIN "User" u ON u."id" = s."userId"
+      WHERE s."createdAt" >= NOW() - INTERVAL '30 days'
+        AND u."active" = true
+        AND COALESCE(u."banned", false) = false
+        AND s."userId" <> ${EXCLUDE_ID}
+      GROUP BY u."id", u."username"
+      ORDER BY score DESC, u."username" ASC
+      LIMIT 10
+    `,
+    prisma.$queryRaw`
+      SELECT u."username", MAX(s."score")::int AS score
+      FROM "ReOrbitMatchScore" s
+      JOIN "User" u ON u."id" = s."userId"
+      WHERE s."createdAt" >= NOW() - INTERVAL '7 days'
+        AND u."active" = true
+        AND COALESCE(u."banned", false) = false
+        AND s."userId" <> ${EXCLUDE_ID}
+      GROUP BY u."id", u."username"
+      ORDER BY score DESC, u."username" ASC
+      LIMIT 10
+    `,
+  ])
+
+  return {
+    allTime: allTime.map(r => ({ username: r.username, score: Number(r.score) })),
+    monthly: monthly.map(r => ({ username: r.username, score: Number(r.score) })),
+    weekly:  weekly.map(r =>  ({ username: r.username, score: Number(r.score) })),
+  }
+}
+
+export default defineEventHandler(async () => {
+  try {
+    const cached = await redis.get(CACHE_KEY)
+    if (cached) return JSON.parse(cached)
+  } catch {}
+
+  const data = await fetchLeaderboards()
+
+  try {
+    await redis.set(CACHE_KEY, JSON.stringify(data), 'EX', CACHE_TTL)
+  } catch {}
+
+  return data
+})


### PR DESCRIPTION
## Summary
This PR adds a comprehensive leaderboards system to the newsite and enhances the ReOrbit Match game with improved visual feedback and animations.

## Key Changes

### New Leaderboards System
- **New component**: `Leaderboards.vue` - displays user and game leaderboards with tabbed interface
  - Users tab: Top Points, Top Earners (7d), Top Spenders (7d), cToon Acquirers (7d), Unique cToons, Total cToons
  - Games tab: ReOrbit Match scores (All Time, This Month, This Week)
  - Responsive 2-column grid layout with loading states
- **New API endpoint**: `server/api/game/reorbitmatch/leaderboard.get.js` - fetches ReOrbit Match leaderboards with Redis caching (30 min TTL)
- **New page**: `pages/newsite/leaderboards.vue` - wrapper page with proper layout and metadata
- **Updated GamesHome**: Added navigation bar with links to Leaderboards page

### ReOrbit Match Gameplay Enhancements
- **Improved tile removal animation**: Two-phase animation with pop effect (scale-up flash) followed by burst shrink with fade
- **Particle burst effects**: Tiles explode into 10 colored particles with physics (gravity, velocity) when matched
- **Enhanced drag-swap interaction**:
  - Visual feedback showing pressed tile and valid swap targets
  - Dashed line preview connecting tiles during drag
  - Immediate swap execution when releasing over valid adjacent tile
  - Improved two-tap swap workflow (select tile, tap adjacent tile)
- **Better falling animation**: Uses easing function for smoother tile descent
- **Improved appearing animation**: New tiles fall into place while fading in
- **UI improvements**: 
  - Message for when daily point limit is reached
  - Increased tile removal animation duration (200ms → 320ms) for better visual impact
  - Added background color to game container

### Component Updates
- **GreenButton**: Added `active` prop for tab state styling with darker green background and inset shadow

## Implementation Details
- Particle system uses `performance.now()` for timing and includes gravity simulation
- Drag interaction tracks `dragFromIdx` and `dragHoverIdx` separately for visual feedback
- Leaderboard queries exclude a specific test user ID and filter by active/non-banned users
- Responsive design: leaderboards use 2-column grid on desktop, 1-column on mobile
- All animations use cubic easing for natural motion feel

https://claude.ai/code/session_01YSp1HBmyUGMQFTQX9cgzzM