### PR TITLE
Redesign ReOrbit Match to drag-to-connect "Dots"-style gameplay

### DIFF
--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -33,6 +33,14 @@
             <button class="btn-start" @click="startGame" :disabled="starting">
               {{ starting ? 'Launching…' : 'Play' }}
             </button>
+            <button class="btn-howto" @click="showHowTo = true" aria-label="How to play">
+              <svg class="howto-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/>
+                <path d="M9.1 9a3 3 0 1 1 4.4 3c-.9.6-1.5 1-1.5 2.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                <circle cx="12" cy="17.4" r="1.2" fill="currentColor"/>
+              </svg>
+              <span>How to Play</span>
+            </button>
           </div>
         </div>
 
@@ -122,6 +130,40 @@
         </div>
       </div>
     </Teleport>
+
+    <!-- How to Play Modal -->
+    <Teleport to="body">
+      <div v-if="showHowTo" class="modal-backdrop" @click.self="showHowTo = false">
+        <div class="modal-card modal-card--howto" role="dialog" aria-modal="true" aria-label="How to Play">
+          <h2 class="modal-title">How to Play</h2>
+          <ol class="howto-list">
+            <li>
+              <span class="howto-num">1</span>
+              <span>Press and hold on a tile, then <strong>slide your finger or mouse</strong> across the board — up, down, sideways, or diagonally.</span>
+            </li>
+            <li>
+              <span class="howto-num">2</span>
+              <span>Connect <strong>exactly 3 tiles of the same icon</strong>. The trail glows <span class="howto-green">green</span> when your picks match and <span class="howto-red">red</span> when they don't.</span>
+            </li>
+            <li>
+              <span class="howto-num">3</span>
+              <span><strong>Let go</strong> to clear a matching trio. The tiles pop, everything above drops down, and new tiles fill in from the top.</span>
+            </li>
+            <li>
+              <span class="howto-num">4</span>
+              <span>Chain matches <strong>quickly</strong> to build your <strong>combo multiplier</strong> — it climbs up to 8× but resets if you pause too long.</span>
+            </li>
+            <li>
+              <span class="howto-num">5</span>
+              <span>Score as much as you can before time runs out. Slid onto a wrong tile? Slide back a step to undo it.</span>
+            </li>
+          </ol>
+          <div class="modal-actions">
+            <button class="btn-start" @click="showHowTo = false">Got it!</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -161,6 +203,7 @@ const allTimeHigh   = ref(0)
 const pointsAwarded = ref(0)
 const resetLabel = ref('')
 const announce   = ref('')
+const showHowTo  = ref(false)
 
 const canvas          = ref(null)
 const canvasContainer = ref(null)
@@ -1003,6 +1046,62 @@ onUnmounted(() => {
   padding: 0.65rem 2rem;
   cursor: pointer;
 }
+
+/* How to Play trigger */
+.btn-howto {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  margin-top: 0.9rem;
+  background: transparent;
+  color: rgba(255,255,255,0.6);
+  font-weight: 600;
+  font-size: 0.8rem;
+  border: none;
+  padding: 0.35rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.btn-howto:hover { color: #66bbff; }
+.howto-icon { flex-shrink: 0; }
+
+/* How to Play modal */
+.modal-card--howto { text-align: left; }
+
+.howto-list {
+  list-style: none;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+.howto-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  color: rgba(255,255,255,0.8);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+.howto-list strong { color: #fff; font-weight: 700; }
+.howto-num {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #1a6e3c, #3399cc);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
+}
+.howto-green { color: #3ddc84; font-weight: 700; }
+.howto-red   { color: #ff5a5a; font-weight: 700; }
 
 /* Spinner */
 .spinner {

--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -25,7 +25,7 @@
         <div v-else-if="uiState === 'start'" class="center-content">
           <div class="start-card">
             <h1 class="game-title">ReOrbit Match</h1>
-            <p class="start-sub">Match 3 or more orbiting icons to score!</p>
+            <p class="start-sub">Slide your finger across 3 matching icons — any direction — to clear them. Chain matches fast to build your combo!</p>
             <div class="plays-info">
               <span class="plays-badge">{{ playsLeft }} play{{ playsLeft !== 1 ? 's' : '' }} left</span>
               <span class="reset-text">· Resets {{ resetLabel }}</span>
@@ -45,7 +45,7 @@
                 <span class="hud-label">Score</span>
                 <span class="hud-value">{{ score.toLocaleString() }}</span>
               </div>
-              <div class="hud-item" :class="{ 'hud-item--active': combo > 0 }">
+              <div class="hud-item" :class="{ 'hud-item--active': combo > 1 }">
                 <span class="hud-label">Combo</span>
                 <span class="hud-value">{{ combo }}x</span>
               </div>
@@ -76,10 +76,13 @@
               @pointerup="onPointerUp"
               @pointermove="onPointerMove"
               @pointerleave="onPointerLeave"
+              @pointercancel="onPointerCancel"
               aria-label="Match-3 game grid"
               role="img"
             ></canvas>
           </div>
+          <p class="sr-only" aria-live="polite">{{ announce }}</p>
+          <div class="game-hint" aria-hidden="true">Slide across 3 of the same icon — any direction, diagonals too</div>
         </div>
       </div>
     </NuxtLayout>
@@ -127,76 +130,175 @@ definePageMeta({ ssr: false })
 
 // ─── Game constants ────────────────────────────────────────────────────────────
 const TILE_GAP = 3
-const ANIMATION_WIGGLE_MS = 400
-const ANIMATION_REMOVE_MS = 320
+const ANIMATION_REMOVE_MS = 300
 const ANIMATION_FALL_MS   = 280
-const ANIMATION_APPEAR_MS = 180
-const MIN_MATCH = 3
+const ANIMATION_APPEAR_MS = 200
+const MIN_MATCH = 3          // a valid match is exactly this many tiles
+const MAX_MATCH = 3          // chain is capped at this many tiles
 
-// Tile states
-const TS = { NORMAL: 0, SELECTED: 1, WIGGLE: 2, REMOVING: 3, FALLING: 4, APPEARING: 5 }
+// Scoring — MUST stay in sync with server/utils/reorbitMatchEngine.js
+const BASE_MATCH_POINTS = 30
+const COMBO_WINDOW_MS   = 2500
+const MAX_COMBO_MULT    = 8
 
-// ─── State ────────────────────────────────────────────────────────────────────
-const uiState   = ref('loading')  // loading | start | playing | gameover | noplays
-const starting  = ref(false)
-const score     = ref(0)
-const combo     = ref(0)
+const HINT_DELAY_MS = 5000
+const FAIL_FLASH_MS = 380
+
+// Tile animation states
+const TS = { NORMAL: 0, REMOVING: 1, FALLING: 2, APPEARING: 3 }
+
+// ─── Reactive UI state ──────────────────────────────────────────────────────────
+const uiState    = ref('loading')  // loading | start | playing | gameover | noplays
+const starting   = ref(false)
+const score      = ref(0)
+const combo      = ref(0)
 const multiplier = ref(1)
-const timeLeft  = ref(null)
-const playsLeft = ref(0)
-const finalScore  = ref(0)
-const weekHigh    = ref(0)
-const allTimeHigh = ref(0)
+const timeLeft   = ref(null)
+const playsLeft  = ref(0)
+const finalScore    = ref(0)
+const weekHigh      = ref(0)
+const allTimeHigh   = ref(0)
 const pointsAwarded = ref(0)
-const resetLabel  = ref('')
+const resetLabel = ref('')
+const announce   = ref('')
 
-const canvas         = ref(null)
+const canvas          = ref(null)
 const canvasContainer = ref(null)
 
 // ─── Non-reactive game internals ──────────────────────────────────────────────
-let board        = []   // flat array of emoji indices
-let emojis       = []   // emoji strings
-let gridSize     = 8
-let timeSeconds  = null
-let moveLog      = []   // [{fromRow,fromCol,toRow,toCol,ts}]
-let tiles        = []   // per-tile animation state
-let selectedIdx  = -1
-let animating    = false
-let gameStartTs  = 0
-let rafId        = null
-let timerStart   = null
-let ctx          = null
-let tileSize     = 0
-let gridOffset   = { x: 0, y: 0 }
-let pointerStartX = 0
-let pointerStartY = 0
-let pointerDown  = false
-let dragFromIdx  = -1  // tile pressed on in current gesture (immediate visual feedback)
-let dragHoverIdx = -1  // adjacent tile being hovered over as a valid swap target
-let particles    = []  // burst particles [{x,y,vx,vy,color,size,startMs}]
-let configData   = null
+let board       = []    // flat array of emoji indices
+let emojis      = []     // emoji strings
+let gridSize    = 8
+let timeSeconds = null
+let fillSeed    = null
+let fillRng     = null   // deterministic refill stream (shared with server)
+let moveLog     = []     // [{ cells:[{row,col}x3], ts }]
+let tiles       = []     // per-tile animation state
+let animating   = false
+let ending      = false  // guards endGame against double-fire
+let gameStartTs = 0
+let rafId       = null
+let timerStart  = null
+let ctx         = null
+let tileSize    = 0
+let gridOffset  = { x: 0, y: 0 }
 
-// ─── Utility ──────────────────────────────────────────────────────────────────
-function getMultiplier(c) {
-  if (c < 2) return 1
-  if (c < 4) return 2
-  if (c < 6) return 4
-  if (c < 8) return 8
-  return 16
+// Drag / chain state
+let pointerDown = false
+let chain       = []      // ordered tile indices in the current drag
+let pointerX    = 0
+let pointerY    = 0
+
+// Combo bookkeeping (mirrors the server's ts-driven combo)
+let comboCount  = 0
+let lastLogTs   = null    // relative ts of the previous logged match
+let lastMatchAbs = 0      // performance.now() of the previous match (for idle decay)
+
+// Feedback / hint
+let particles     = []
+let failFlashSet  = new Set()
+let failFlashUntil = 0
+let hintSet       = new Set()
+let hintActive    = false
+let lastActivityMs = 0
+let reducedMotion = false
+
+let configData = null
+
+// ─── Deterministic PRNG (byte-identical to server makePRNG) ────────────────────
+function makePRNG(seedHex) {
+  const hi = parseInt(seedHex.slice(0, 8), 16) >>> 0
+  const lo = parseInt(seedHex.slice(8, 16), 16) >>> 0
+  let s0 = hi >>> 0
+  let s1 = lo >>> 0
+  return function () {
+    s0 = (s0 + 0x9e3779b9) >>> 0
+    let z = s0
+    z = Math.imul(z ^ (z >>> 16), 0x85ebca6b) >>> 0
+    z = Math.imul(z ^ (z >>> 13), 0xc2b2ae35) >>> 0
+    z = (z ^ (z >>> 16)) >>> 0
+    s1 = (s1 + 0x6c62272e) >>> 0
+    let w = s1
+    w = Math.imul(w ^ (w >>> 16), 0x85ebca6b) >>> 0
+    w = Math.imul(w ^ (w >>> 13), 0xc2b2ae35) >>> 0
+    w = (w ^ (w >>> 16)) >>> 0
+    return ((z ^ w) >>> 0) / 4294967296
+  }
 }
 
+// ─── Grid helpers ───────────────────────────────────────────────────────────────
 function idxOf(row, col) { return row * gridSize + col }
 function rowOf(idx) { return Math.floor(idx / gridSize) }
 function colOf(idx) { return idx % gridSize }
 
-function isAdjacent(aIdx, bIdx) {
-  const ar = rowOf(aIdx), ac = colOf(aIdx), br = rowOf(bIdx), bc = colOf(bIdx)
-  return (Math.abs(ar - br) === 1 && ac === bc) || (ar === br && Math.abs(ac - bc) === 1)
+// 8-directional adjacency (Chebyshev distance exactly 1)
+function isEightAdjacent(a, b) {
+  const dr = Math.abs(rowOf(a) - rowOf(b))
+  const dc = Math.abs(colOf(a) - colOf(b))
+  return dr <= 1 && dc <= 1 && (dr + dc) > 0
 }
 
+function computeMultiplier(c) { return c <= 1 ? 1 : Math.min(c, MAX_COMBO_MULT) }
+
+function vibrate(pattern) { try { navigator.vibrate?.(pattern) } catch {} }
+
+// ─── Game-over detection (8-connected same-color component of size >= 3) ─────────
+function hasPossibleMoves(b) {
+  const n = gridSize * gridSize
+  const visited = new Uint8Array(n)
+  const stack = []
+  for (let start = 0; start < n; start++) {
+    if (visited[start]) continue
+    const color = b[start]
+    if (color === -1) { visited[start] = 1; continue }
+    stack.length = 0
+    stack.push(start)
+    visited[start] = 1
+    let size = 0
+    while (stack.length) {
+      const idx = stack.pop()
+      size++
+      if (size >= MIN_MATCH) return true
+      const r = rowOf(idx), c = colOf(idx)
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr === 0 && dc === 0) continue
+          const nr = r + dr, nc = c + dc
+          if (nr < 0 || nr >= gridSize || nc < 0 || nc >= gridSize) continue
+          const nidx = nr * gridSize + nc
+          if (!visited[nidx] && b[nidx] === color) { visited[nidx] = 1; stack.push(nidx) }
+        }
+      }
+    }
+  }
+  return false
+}
+
+// Find one valid 3-chain for the idle hint (returns [idx, idx, idx] or null)
+function findHint(b) {
+  for (let r = 0; r < gridSize; r++) {
+    for (let c = 0; c < gridSize; c++) {
+      const color = b[idxOf(r, c)]
+      if (color === -1) continue
+      const nbrs = []
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr === 0 && dc === 0) continue
+          const nr = r + dr, nc = c + dc
+          if (nr < 0 || nr >= gridSize || nc < 0 || nc >= gridSize) continue
+          if (b[idxOf(nr, nc)] === color) nbrs.push(idxOf(nr, nc))
+        }
+      }
+      if (nbrs.length >= 2) return [nbrs[0], idxOf(r, c), nbrs[1]]
+    }
+  }
+  return null
+}
+
+// ─── Particles ──────────────────────────────────────────────────────────────────
 function fireExplosion(tileIdx) {
-  const row = rowOf(tileIdx), col = colOf(tileIdx)
-  const cx = tileCenterX(col), cy = tileCenterY(row)
+  if (reducedMotion) return
+  const cx = tileCenterX(colOf(tileIdx)), cy = tileCenterY(rowOf(tileIdx))
   const now = performance.now()
   const colors = ['#FFD700', '#fff', '#FFD700', '#66bbff', '#fff', '#FFD700']
   for (let i = 0; i < 10; i++) {
@@ -213,71 +315,15 @@ function fireExplosion(tileIdx) {
   }
 }
 
-// ─── Match finding ────────────────────────────────────────────────────────────
-function findMatches(b) {
-  const matched = new Set()
-  // Horizontal
-  for (let r = 0; r < gridSize; r++) {
-    let c = 0
-    while (c < gridSize) {
-      const v = b[idxOf(r, c)]
-      if (v === -1) { c++; continue }
-      let len = 1
-      while (c + len < gridSize && b[idxOf(r, c + len)] === v) len++
-      if (len >= MIN_MATCH) for (let k = 0; k < len; k++) matched.add(idxOf(r, c + k))
-      c += len
-    }
-  }
-  // Vertical
-  for (let c = 0; c < gridSize; c++) {
-    let r = 0
-    while (r < gridSize) {
-      const v = b[idxOf(r, c)]
-      if (v === -1) { r++; continue }
-      let len = 1
-      while (r + len < gridSize && b[idxOf(r + len, c)] === v) len++
-      if (len >= MIN_MATCH) for (let k = 0; k < len; k++) matched.add(idxOf(r + k, c))
-      r += len
-    }
-  }
-  return matched
-}
-
-function hasPossibleMoves(b) {
-  for (let r = 0; r < gridSize; r++) {
-    for (let c = 0; c < gridSize; c++) {
-      const idx = idxOf(r, c)
-      if (c + 1 < gridSize) {
-        const copy = [...b]; [copy[idx], copy[idxOf(r, c + 1)]] = [copy[idxOf(r, c + 1)], copy[idx]]
-        if (findMatches(copy).size > 0) return true
-      }
-      if (r + 1 < gridSize) {
-        const copy = [...b]; [copy[idx], copy[idxOf(r + 1, c)]] = [copy[idxOf(r + 1, c)], copy[idx]]
-        if (findMatches(copy).size > 0) return true
-      }
-    }
-  }
-  return false
-}
-
-function scoreGroup(cells, b) {
-  const n = cells.size
-  let base = n * 10
-  if (n >= 5) base = Math.round(base * 2)
-  else if (n === 4) base = Math.round(base * 1.5)
-  return base
-}
-
-// ─── Tile animation state helpers ─────────────────────────────────────────────
+// ─── Tile animation state ──────────────────────────────────────────────────────
 function initTiles(b) {
-  tiles = b.map((emojiIdx, i) => ({
+  tiles = b.map((emojiIdx) => ({
     emojiIdx,
     state: TS.NORMAL,
-    visualY: 0,       // current Y offset from logical row (for falling)
-    startVisualY: 0,  // Y offset at animation start (source for easing)
+    visualY: 0,
+    startVisualY: 0,
     alpha: 1,
     scale: 1,
-    wiggleAngle: 0,
     animStartMs: 0
   }))
 }
@@ -337,16 +383,22 @@ const TILE_COLORS = [
   '#4a0050', '#00404a', '#3a2a00', '#003a70'
 ]
 
+// Color of the in-progress chain feedback: green while all-same-so-far, red otherwise.
+function chainFeedbackColor() {
+  if (chain.length === 0) return null
+  const first = board[chain[0]]
+  const allSame = chain.every(i => board[i] === first)
+  return allSame ? '#3ddc84' : '#ff5a5a'
+}
+
 function renderFrame(nowMs) {
   if (!ctx) return
   const w = canvas.value.width / devicePixelRatio
   const h = canvas.value.height / devicePixelRatio
 
-  // Background
   ctx.fillStyle = '#001230'
   ctx.fillRect(0, 0, w, h)
 
-  // Board background glow
   const boardPx = tileSize * gridSize + TILE_GAP * (gridSize + 1)
   const grd = ctx.createRadialGradient(
     gridOffset.x + boardPx / 2, gridOffset.y + boardPx / 2, 0,
@@ -357,9 +409,9 @@ function renderFrame(nowMs) {
   ctx.fillStyle = grd
   ctx.fillRect(gridOffset.x, gridOffset.y, boardPx, boardPx)
 
-  // Collect match connections to draw last
-  const matchedSet = findMatches(board)
-  const connections = []
+  const feedback = chainFeedbackColor()
+  const chainSet = new Set(chain)
+  const flashing = nowMs < failFlashUntil
 
   for (let i = 0; i < tiles.length; i++) {
     const tile = tiles[i]
@@ -370,77 +422,68 @@ function renderFrame(nowMs) {
     let y = tileTop(row) + tile.visualY
     let alpha = tile.alpha
     let scale = tile.scale
+    let rot = 0
 
-    if (tile.state === TS.WIGGLE) {
-      const t = Math.min(elapsed / ANIMATION_WIGGLE_MS, 1)
-      const wobble = Math.sin(t * Math.PI * 6) * (1 - t)
-      tile.wiggleAngle = wobble * 0.2
-      scale = 1 + Math.abs(wobble) * 0.12
-    } else if (tile.state === TS.REMOVING) {
+    if (tile.state === TS.REMOVING) {
       const t = Math.min(elapsed / ANIMATION_REMOVE_MS, 1)
-      if (t < 0.28) {
-        // Pop: quick scale-up flash
-        const pop = t / 0.28
-        scale = 1 + pop * 0.55
+      if (reducedMotion) {
+        alpha = 1 - t
+        scale = 1
+      } else if (t < 0.28) {
+        scale = 1 + (t / 0.28) * 0.55
         alpha = 1
       } else {
-        // Burst: shrink to nothing while fading
         const burst = (t - 0.28) / 0.72
         scale = 1.55 * (1 - burst)
         alpha = 1 - Math.pow(burst, 0.6)
-        tile.wiggleAngle = (tile.wiggleAngle || 0) + burst * 0.4
+        rot = burst * 0.4
       }
     } else if (tile.state === TS.FALLING) {
       const t = Math.min(elapsed / ANIMATION_FALL_MS, 1)
-      const ease = 1 - Math.pow(1 - t, 3)
+      const ease = reducedMotion ? t : 1 - Math.pow(1 - t, 3)
       tile.visualY = tile.startVisualY * (1 - ease)
       y = tileTop(row) + tile.visualY
     } else if (tile.state === TS.APPEARING) {
       const fadeT = Math.min(elapsed / ANIMATION_APPEAR_MS, 1)
       const fallT = Math.min(elapsed / ANIMATION_FALL_MS, 1)
-      const ease  = 1 - Math.pow(1 - fallT, 3)
+      const ease  = reducedMotion ? fallT : 1 - Math.pow(1 - fallT, 3)
       alpha = fadeT
-      scale = 0.6 + fadeT * 0.4
+      scale = reducedMotion ? 1 : 0.6 + fadeT * 0.4
       tile.visualY = tile.startVisualY * (1 - ease)
       y = tileTop(row) + tile.visualY
     }
 
+    const inChain  = chainSet.has(i)
+    const inFlash  = flashing && failFlashSet.has(i)
+    const inHint   = hintActive && hintSet.has(i)
+
     ctx.save()
     ctx.globalAlpha = Math.max(0, Math.min(1, alpha))
     ctx.translate(x + tileSize / 2, y + tileSize / 2)
-    ctx.rotate(tile.wiggleAngle || 0)
+    if (rot) ctx.rotate(rot)
+    if (inHint && !reducedMotion) scale *= 1 + Math.sin(nowMs / 160) * 0.06
     ctx.scale(scale, scale)
 
-    // Tile background
     const baseColor = TILE_COLORS[tile.emojiIdx % TILE_COLORS.length]
-    const isSelected = (i === selectedIdx || i === dragFromIdx || i === dragHoverIdx)
-    const isMatched  = matchedSet.has(i)
-
-    if (isSelected) {
-      ctx.shadowColor = '#FFD700'
-      ctx.shadowBlur  = 12
-      ctx.fillStyle = '#FFD700'
-    } else if (isMatched && tile.state !== TS.WIGGLE && tile.state !== TS.REMOVING) {
-      ctx.shadowColor = '#fff'
-      ctx.shadowBlur  = 8
-      ctx.fillStyle = '#3a80ff'
+    if (inFlash) {
+      ctx.shadowColor = '#ff5a5a'; ctx.shadowBlur = 14; ctx.fillStyle = '#ff5a5a'
+    } else if (inChain && feedback) {
+      ctx.shadowColor = feedback; ctx.shadowBlur = 14; ctx.fillStyle = feedback
+    } else if (inHint) {
+      ctx.shadowColor = '#FFD700'; ctx.shadowBlur = 12; ctx.fillStyle = baseColor
     } else {
-      ctx.shadowColor = 'rgba(0,0,0,0.4)'
-      ctx.shadowBlur  = 4
-      ctx.fillStyle = baseColor
+      ctx.shadowColor = 'rgba(0,0,0,0.4)'; ctx.shadowBlur = 4; ctx.fillStyle = baseColor
     }
     drawRoundRect(-tileSize / 2, -tileSize / 2, tileSize, tileSize, Math.round(tileSize * 0.12))
     ctx.fill()
     ctx.shadowBlur = 0
 
-    // Shimmer edge for selected
-    if (isSelected) {
+    if (inChain || inFlash) {
       ctx.strokeStyle = '#fff'
       ctx.lineWidth = 2
       ctx.stroke()
     }
 
-    // Emoji
     const fontSize = Math.round(tileSize * 0.52)
     ctx.font = `${fontSize}px serif`
     ctx.textAlign = 'center'
@@ -451,64 +494,41 @@ function renderFrame(nowMs) {
     ctx.fillText(emojis[tile.emojiIdx] || '?', 0, 1)
     ctx.shadowBlur = 0
     ctx.restore()
-
-    // Collect connections for matched tiles that are wiggling
-    if ((tile.state === TS.WIGGLE || matchedSet.has(i)) && tile.state !== TS.REMOVING) {
-      if (col + 1 < gridSize) {
-        const nidx = idxOf(row, col + 1)
-        if (matchedSet.has(nidx)) {
-          connections.push([col, row, col + 1, row])
-        }
-      }
-      if (row + 1 < gridSize) {
-        const nidx = idxOf(row + 1, col)
-        if (matchedSet.has(nidx)) {
-          connections.push([col, row, col, row + 1])
-        }
-      }
-    }
   }
 
-  // Draw connection lines
-  if (connections.length > 0) {
+  // Chain connecting line + live segment to the pointer
+  if (chain.length > 0 && feedback) {
     ctx.save()
-    ctx.strokeStyle = 'rgba(255, 220, 50, 0.85)'
-    ctx.lineWidth   = Math.max(2, tileSize * 0.06)
+    ctx.strokeStyle = feedback
+    ctx.lineWidth = Math.max(3, tileSize * 0.09)
     ctx.lineCap = 'round'
-    ctx.shadowColor = '#FFD700'
-    ctx.shadowBlur  = 8
-    for (const [c1, r1, c2, r2] of connections) {
-      ctx.beginPath()
-      ctx.moveTo(tileCenterX(c1), tileCenterY(r1))
-      ctx.lineTo(tileCenterX(c2), tileCenterY(r2))
-      ctx.stroke()
-    }
-    ctx.restore()
-  }
-
-  // Draw drag-swap preview line between pressed tile and valid hover target
-  if (dragFromIdx !== -1 && dragHoverIdx !== -1) {
-    ctx.save()
-    ctx.strokeStyle = 'rgba(255, 215, 0, 0.7)'
-    ctx.lineWidth   = Math.max(2, tileSize * 0.06)
-    ctx.lineCap = 'round'
-    ctx.setLineDash([Math.round(tileSize * 0.15), Math.round(tileSize * 0.1)])
-    ctx.shadowColor = '#FFD700'
-    ctx.shadowBlur  = 6
+    ctx.lineJoin = 'round'
+    ctx.shadowColor = feedback
+    ctx.shadowBlur = 10
     ctx.beginPath()
-    ctx.moveTo(tileCenterX(colOf(dragFromIdx)), tileCenterY(rowOf(dragFromIdx)))
-    ctx.lineTo(tileCenterX(colOf(dragHoverIdx)), tileCenterY(rowOf(dragHoverIdx)))
+    ctx.moveTo(tileCenterX(colOf(chain[0])), tileCenterY(rowOf(chain[0])))
+    for (let k = 1; k < chain.length; k++) {
+      ctx.lineTo(tileCenterX(colOf(chain[k])), tileCenterY(rowOf(chain[k])))
+    }
     ctx.stroke()
-    ctx.setLineDash([])
+    if (pointerDown && chain.length < MAX_MATCH) {
+      const last = chain[chain.length - 1]
+      ctx.setLineDash([Math.round(tileSize * 0.16), Math.round(tileSize * 0.12)])
+      ctx.beginPath()
+      ctx.moveTo(tileCenterX(colOf(last)), tileCenterY(rowOf(last)))
+      ctx.lineTo(pointerX, pointerY)
+      ctx.stroke()
+      ctx.setLineDash([])
+    }
     ctx.restore()
   }
 
-  // Burst particles from matched tile explosions
+  // Burst particles
   const PARTICLE_LIFE_MS = 500
   particles = particles.filter(p => {
-    const age  = nowMs - p.startMs
+    const age = nowMs - p.startMs
     if (age >= PARTICLE_LIFE_MS) return false
-    const t    = age / PARTICLE_LIFE_MS
+    const t = age / PARTICLE_LIFE_MS
     const secs = age / 1000
     ctx.save()
     ctx.globalAlpha = Math.pow(1 - t, 1.4)
@@ -516,12 +536,7 @@ function renderFrame(nowMs) {
     ctx.shadowColor = p.color
     ctx.shadowBlur  = 4
     ctx.beginPath()
-    ctx.arc(
-      p.x + p.vx * secs,
-      p.y + p.vy * secs + 400 * secs * secs,
-      p.size * (1 - t * 0.6),
-      0, Math.PI * 2
-    )
+    ctx.arc(p.x + p.vx * secs, p.y + p.vy * secs + 400 * secs * secs, p.size * (1 - t * 0.6), 0, Math.PI * 2)
     ctx.fill()
     ctx.restore()
     return true
@@ -532,186 +547,137 @@ function renderFrame(nowMs) {
 function gameLoop(nowMs) {
   if (!canvas.value) return
 
-  // Timer
   if (timeSeconds && timerStart !== null) {
     const elapsed = (nowMs - timerStart) / 1000
     timeLeft.value = Math.max(0, Math.ceil(timeSeconds - elapsed))
     if (timeLeft.value === 0) { endGame(); return }
   }
 
+  // Combo idle decay (display only; server recomputes authoritative combo from ts)
+  if (comboCount > 0) {
+    const alive = (nowMs - lastMatchAbs) <= COMBO_WINDOW_MS
+    const dispC = alive ? comboCount : 0
+    const dispM = alive ? computeMultiplier(comboCount) : 1
+    if (combo.value !== dispC) combo.value = dispC
+    if (multiplier.value !== dispM) multiplier.value = dispM
+  }
+
+  // Idle hint
+  if (uiState.value === 'playing' && !animating && !pointerDown && !hintActive) {
+    if (nowMs - lastActivityMs > HINT_DELAY_MS) {
+      const h = findHint(board)
+      if (h) { hintSet = new Set(h); hintActive = true }
+    }
+  }
+
   renderFrame(nowMs)
   rafId = requestAnimationFrame(gameLoop)
 }
 
-// ─── Swap & cascade logic ─────────────────────────────────────────────────────
-async function trySwap(fromIdx, toIdx) {
-  if (animating) return
-  const fr = rowOf(fromIdx), fc = colOf(fromIdx)
-  const tr = rowOf(toIdx),   tc = colOf(toIdx)
+// ─── Deterministic settle (gravity + refill) matching the server exactly ────────
+// Returns { newBoard, survivors:[{dest,fall}], newcomers:[{dest,fall}] }.
+function settleBoard(removedSet) {
+  const n = gridSize * gridSize
+  const newBoard = new Array(n).fill(-1)
+  const survivors = []
+  const newcomers = []
 
-  moveLog.push({ fromRow: fr, fromCol: fc, toRow: tr, toCol: tc, ts: performance.now() - gameStartTs })
-
-  const swapped = [...board]
-  ;[swapped[fromIdx], swapped[toIdx]] = [swapped[toIdx], swapped[fromIdx]]
-  const matches = findMatches(swapped)
-
-  if (matches.size === 0) {
-    // Invalid swap — brief shake on both tiles
-    combo.value = 0
-    multiplier.value = getMultiplier(0)
-    selectedIdx = -1
-    return
+  for (let col = 0; col < gridSize; col++) {
+    let write = gridSize - 1
+    for (let r = gridSize - 1; r >= 0; r--) {
+      const idx = idxOf(r, col)
+      if (!removedSet.has(idx)) {
+        const dest = idxOf(write, col)
+        newBoard[dest] = board[idx]
+        if (write !== r) survivors.push({ dest, fall: write - r })
+        write--
+      }
+    }
+    const newCount = write + 1 // rows 0..write are freshly spawned
+    for (let d = 0; d <= write; d++) {
+      newcomers.push({ dest: idxOf(d, col), fall: newCount })
+    }
   }
 
-  animating = true
-  selectedIdx = -1
-  board = swapped
-  combo.value++
-  multiplier.value = getMultiplier(combo.value)
-
-  await runCascade(1)
-
-  if (!hasPossibleMoves(board)) endGame()
-  animating = false
+  // Fill placeholders row-major with the shared PRNG — same order as server fillEmpty.
+  for (let i = 0; i < n; i++) {
+    if (newBoard[i] === -1) newBoard[i] = Math.floor(fillRng() * emojis.length)
+  }
+  return { newBoard, survivors, newcomers }
 }
 
-function wait(ms) { return new Promise(r => setTimeout(r, ms)) }
+// ─── Perform a match ─────────────────────────────────────────────────────────
+async function performMatch(cells) {
+  animating = true
+  clearHint()
 
-async function runCascade(cascadeLevel) {
-  const matches = findMatches(board)
-  if (matches.size === 0) return
+  // Log the move (relative ts, clamped so the server's monotonic + min-interval checks pass)
+  let ts = Math.round(performance.now() - gameStartTs)
+  if (lastLogTs !== null) ts = Math.max(ts, lastLogTs + 101)
+  moveLog.push({ cells: cells.map(i => ({ row: rowOf(i), col: colOf(i) })), ts })
 
-  // Score this cascade
-  const cascadeMultiplier = 1 + (cascadeLevel - 1) * 0.5
-  let roundScore = 0
-  matches.forEach(idx => { /* counted by group below */ })
+  // Combo (identical rule to server: driven purely by ts gaps)
+  if (lastLogTs !== null && (ts - lastLogTs) <= COMBO_WINDOW_MS) comboCount++
+  else comboCount = 1
+  lastLogTs = ts
+  lastMatchAbs = performance.now()
+  const mult = computeMultiplier(comboCount)
+  score.value += BASE_MATCH_POINTS * mult
+  combo.value = comboCount
+  multiplier.value = mult
+  announce.value = `Matched 3! +${BASE_MATCH_POINTS * mult}. Combo ${comboCount}x.`
+  vibrate(30)
 
-  // Group connected matches for scoring
-  const seen = new Set()
-  for (const idx of matches) {
-    if (seen.has(idx)) continue
-    // BFS to find the group
-    const group = new Set([idx])
-    const queue = [idx]
-    while (queue.length) {
-      const cur = queue.shift()
-      const r = rowOf(cur), c = colOf(cur)
-      for (const [nr, nc] of [[r-1,c],[r+1,c],[r,c-1],[r,c+1]]) {
-        const nidx = idxOf(nr, nc)
-        if (nr >= 0 && nr < gridSize && nc >= 0 && nc < gridSize && matches.has(nidx) && !group.has(nidx)) {
-          group.add(nidx); queue.push(nidx)
-        }
-      }
-    }
-    group.forEach(i => seen.add(i))
-    roundScore += scoreGroup(group, board)
-  }
-
-  score.value += Math.floor(roundScore * cascadeMultiplier * multiplier.value)
-
-  // Wiggle animation
+  // Removal animation
   const now = performance.now()
-  matches.forEach(idx => {
-    tiles[idx].state = TS.WIGGLE
-    tiles[idx].animStartMs = now
-  })
-  await wait(ANIMATION_WIGGLE_MS)
-
-  // Remove — pop animation + particle burst
-  const removeNow = performance.now()
-  matches.forEach(idx => {
+  const removedSet = new Set(cells)
+  for (const idx of cells) {
     tiles[idx].state = TS.REMOVING
-    tiles[idx].animStartMs = removeNow
+    tiles[idx].animStartMs = now
     fireExplosion(idx)
-  })
+  }
   await wait(ANIMATION_REMOVE_MS)
 
-  // Apply gravity to board and animate fall
-  const newBoard = [...board]
-  matches.forEach(idx => { newBoard[idx] = -1 })
-
-  // Calculate fall distances before gravity
-  const fallDistances = new Array(newBoard.length).fill(0)
-  for (let c = 0; c < gridSize; c++) {
-    let emptyCount = 0
-    for (let r = gridSize - 1; r >= 0; r--) {
-      const idx = idxOf(r, c)
-      if (newBoard[idx] === -1) {
-        emptyCount++
-      } else if (emptyCount > 0) {
-        fallDistances[idx] = emptyCount
-      }
-    }
-  }
-
-  // Apply gravity to board
-  for (let c = 0; c < gridSize; c++) {
-    let empty = gridSize - 1
-    for (let r = gridSize - 1; r >= 0; r--) {
-      const idx = idxOf(r, c)
-      if (newBoard[idx] !== -1) {
-        newBoard[idxOf(empty, c)] = newBoard[idx]
-        if (empty !== r) newBoard[idx] = -1
-        empty--
-      }
-    }
-  }
-
-  // Fill empty cells with new random tiles
-  const newNow = performance.now()
-  for (let i = 0; i < newBoard.length; i++) {
-    if (newBoard[i] === -1) {
-      newBoard[i] = Math.floor(Math.random() * emojis.length)
-    }
-  }
-
+  // Settle deterministically
+  const { newBoard, survivors, newcomers } = settleBoard(removedSet)
   board = newBoard
   initTiles(board)
 
-  // Animate falling tiles
   const fallNow = performance.now()
-  for (let c = 0; c < gridSize; c++) {
-    let emptyBelow = 0
-    for (let r = gridSize - 1; r >= 0; r--) {
-      const idx = idxOf(r, c)
-      if (matches.has(idx)) {
-        emptyBelow++
-      } else if (emptyBelow > 0) {
-        tiles[idx].state = TS.FALLING
-        tiles[idx].animStartMs = fallNow
-        tiles[idx].startVisualY = -(emptyBelow * (tileSize + TILE_GAP))
-        tiles[idx].visualY      = tiles[idx].startVisualY
-      }
-    }
-    // Mark top cells as appearing
-    let topEmpty = 0
-    for (let r = 0; r < gridSize; r++) {
-      const idx = idxOf(r, c)
-      if (tiles[idx].state === TS.NORMAL && r < emptyBelow) {
-        tiles[idx].state = TS.APPEARING
-        tiles[idx].animStartMs = fallNow
-        tiles[idx].alpha = 0
-        tiles[idx].startVisualY = -((emptyBelow - r) * (tileSize + TILE_GAP))
-        tiles[idx].visualY      = tiles[idx].startVisualY
-        topEmpty++
-      }
-    }
+  const step = tileSize + TILE_GAP
+  for (const { dest, fall } of survivors) {
+    const t = tiles[dest]
+    t.state = TS.FALLING
+    t.startVisualY = -(fall * step)
+    t.visualY = t.startVisualY
+    t.animStartMs = fallNow
   }
-
+  for (const { dest, fall } of newcomers) {
+    const t = tiles[dest]
+    t.state = TS.APPEARING
+    t.alpha = 0
+    t.startVisualY = -(fall * step)
+    t.visualY = t.startVisualY
+    t.animStartMs = fallNow
+  }
   await wait(ANIMATION_FALL_MS + 50)
 
-  // Reset animation states
-  tiles.forEach(t => {
+  for (const t of tiles) {
     if (t.state === TS.FALLING || t.state === TS.APPEARING) {
       t.state = TS.NORMAL
       t.visualY = 0
       t.alpha = 1
     }
-  })
+  }
 
-  // Check for chain reaction
-  await runCascade(cascadeLevel + 1)
+  animating = false
+  touchActivity()
+
+  // Terminal state: no more possible matches (rare with 8-dir; timer is the usual end)
+  if (!hasPossibleMoves(board)) endGame()
 }
+
+function wait(ms) { return new Promise(r => setTimeout(r, ms)) }
 
 // ─── Input handling ────────────────────────────────────────────────────────────
 function getCanvasPos(e) {
@@ -720,105 +686,79 @@ function getCanvasPos(e) {
   return { x: e.clientX - rect.left, y: e.clientY - rect.top }
 }
 
+function touchActivity() { lastActivityMs = performance.now(); clearHint() }
+function clearHint() { if (hintActive) { hintActive = false; hintSet = new Set() } }
+
 function onPointerDown(e) {
   if (animating || uiState.value !== 'playing') return
   e.preventDefault()
+  canvas.value?.setPointerCapture?.(e.pointerId)
   pointerDown = true
   const pos = getCanvasPos(e)
-  pointerStartX = pos.x
-  pointerStartY = pos.y
-  canvas.value?.setPointerCapture?.(e.pointerId)
-
-  // Immediately highlight the tile under the pointer
-  dragFromIdx  = hitTest(pos.x, pos.y)
-  dragHoverIdx = -1
+  pointerX = pos.x; pointerY = pos.y
+  touchActivity()
+  const idx = hitTest(pos.x, pos.y)
+  chain = idx === -1 ? [] : [idx]
+  if (idx !== -1) vibrate(8)
 }
 
 function onPointerMove(e) {
   if (!pointerDown) return
   e.preventDefault()
+  const pos = getCanvasPos(e)
+  pointerX = pos.x; pointerY = pos.y
+  if (animating || uiState.value !== 'playing' || chain.length === 0) return
 
-  if (animating || uiState.value !== 'playing' || dragFromIdx === -1) return
+  const idx = hitTest(pos.x, pos.y)
+  if (idx === -1) return
+  const last = chain[chain.length - 1]
+  if (idx === last) return
 
-  const pos    = getCanvasPos(e)
-  const overIdx = hitTest(pos.x, pos.y)
-
-  if (overIdx !== -1 && overIdx !== dragFromIdx && isAdjacent(dragFromIdx, overIdx)) {
-    const swapped = [...board]
-    ;[swapped[dragFromIdx], swapped[overIdx]] = [swapped[overIdx], swapped[dragFromIdx]]
-    dragHoverIdx = findMatches(swapped).size > 0 ? overIdx : -1
-  } else {
-    dragHoverIdx = -1
+  // Backtrack: sliding onto the second-to-last cell pops the last one off.
+  if (chain.length >= 2 && idx === chain[chain.length - 2]) {
+    chain.pop()
+    vibrate(6)
+    return
   }
+  if (chain.includes(idx)) return         // ignore other revisits
+  if (chain.length >= MAX_MATCH) return    // hard cap at 3
+  if (!isEightAdjacent(last, idx)) return  // keep the drag path contiguous
+
+  chain.push(idx)
+  vibrate(8)
 }
 
 function onPointerUp(e) {
   if (!pointerDown) return
   e.preventDefault()
   pointerDown = false
+  canvas.value?.releasePointerCapture?.(e.pointerId)
 
-  const fromIdx  = dragFromIdx
-  const hoverIdx = dragHoverIdx
-  dragFromIdx  = -1
-  dragHoverIdx = -1
-
+  const c = chain
+  chain = []
   if (animating || uiState.value !== 'playing') return
 
-  const pos = getCanvasPos(e)
-  const dx  = pos.x - pointerStartX
-  const dy  = pos.y - pointerStartY
-  const dist = Math.sqrt(dx * dx + dy * dy)
-  const threshold = tileSize * 0.35
-
-  if (fromIdx === -1) { selectedIdx = -1; return }
-
-  // Drag released over a valid adjacent swap target → perform swap immediately
-  if (hoverIdx !== -1) {
-    selectedIdx = -1
-    trySwap(fromIdx, hoverIdx)
-    return
+  if (c.length === MIN_MATCH) {
+    const first = board[c[0]]
+    const allSame = c.every(i => board[i] === first)
+    if (allSame) { performMatch(c); return }
   }
-
-  if (dist < threshold) {
-    // Tap
-    if (selectedIdx !== -1 && selectedIdx !== fromIdx && isAdjacent(selectedIdx, fromIdx)) {
-      // Two-tap swap: previously selected tile + this tap
-      const prevSel = selectedIdx
-      selectedIdx = -1
-      trySwap(prevSel, fromIdx)
-    } else if (selectedIdx === fromIdx) {
-      selectedIdx = -1  // tap same tile again: deselect
-    } else {
-      selectedIdx = fromIdx  // first tap: select
-    }
-  } else {
-    // Swipe: use drag direction as fallback
-    const swapIdx = getSwipeTarget(fromIdx, dx, dy)
-    if (swapIdx !== -1) {
-      selectedIdx = -1
-      trySwap(fromIdx, swapIdx)
-    } else {
-      selectedIdx = -1
-    }
+  // Invalid selection — brief red flash + error haptic so it never reads as "broken".
+  if (c.length > 0) {
+    failFlashSet = new Set(c)
+    failFlashUntil = performance.now() + FAIL_FLASH_MS
+    announce.value = 'No match — connect exactly 3 of the same icon.'
+    vibrate([20, 40, 20])
   }
+  touchActivity()
 }
 
-function onPointerLeave() {
-  pointerDown  = false
-  dragFromIdx  = -1
-  dragHoverIdx = -1
-}
+function onPointerLeave() { /* pointer capture keeps events flowing; ignore */ }
 
-function getSwipeTarget(fromIdx, dx, dy) {
-  const r = rowOf(fromIdx), c = colOf(fromIdx)
-  let tr, tc
-  if (Math.abs(dx) > Math.abs(dy)) {
-    tc = dx > 0 ? c + 1 : c - 1; tr = r
-  } else {
-    tr = dy > 0 ? r + 1 : r - 1; tc = c
-  }
-  if (tr < 0 || tr >= gridSize || tc < 0 || tc >= gridSize) return -1
-  return idxOf(tr, tc)
+function onPointerCancel(e) {
+  pointerDown = false
+  canvas.value?.releasePointerCapture?.(e.pointerId)
+  chain = []
 }
 
 // ─── Game lifecycle ────────────────────────────────────────────────────────────
@@ -851,17 +791,26 @@ async function startGame() {
     emojis      = data.emojis
     gridSize    = data.gridSize
     timeSeconds = data.timeSeconds
+    fillSeed    = data.fillSeed
+    fillRng     = makePRNG(fillSeed)
 
     score.value      = 0
     combo.value      = 0
     multiplier.value = 1
     timeLeft.value   = timeSeconds
     moveLog          = []
-    selectedIdx      = -1
-    dragFromIdx      = -1
-    dragHoverIdx     = -1
+    chain            = []
     particles        = []
+    comboCount       = 0
+    lastLogTs        = null
+    lastMatchAbs     = 0
+    failFlashSet     = new Set()
+    failFlashUntil   = 0
     animating        = false
+    ending           = false
+    hintActive       = false
+    hintSet          = new Set()
+    announce.value   = ''
 
     await fetchStatus() // refresh plays left
     playsLeft.value  = Math.max(0, playsLeft.value - 1) // optimistic
@@ -873,6 +822,7 @@ async function startGame() {
     initTiles(board)
     gameStartTs = performance.now()
     timerStart  = timeSeconds ? performance.now() : null
+    lastActivityMs = performance.now()
     rafId = requestAnimationFrame(gameLoop)
   } catch (err) {
     const msg = err?.data?.statusMessage || err?.message || 'Failed to start game'
@@ -883,9 +833,12 @@ async function startGame() {
 }
 
 async function endGame() {
+  if (ending) return
+  ending = true
   if (rafId) { cancelAnimationFrame(rafId); rafId = null }
 
   finalScore.value = score.value
+  announce.value = `Game over. Final score ${score.value}.`
 
   try {
     const result = await $fetch('/api/game/reorbitmatch/end', {
@@ -894,7 +847,7 @@ async function endGame() {
       body: { moveLog }
     })
     pointsAwarded.value = result.pointsAwarded ?? 0
-    // Refresh high scores
+    if (typeof result.score === 'number') finalScore.value = result.score
     const status = await $fetch('/api/game/reorbitmatch/status', { credentials: 'include' })
     weekHigh.value    = status.weekHigh
     allTimeHigh.value = status.allTimeHigh
@@ -906,17 +859,15 @@ async function endGame() {
   uiState.value = 'gameover'
 }
 
-// ─── Resize observer ──────────────────────────────────────────────────────────
+// ─── Resize observer & lifecycle ────────────────────────────────────────────────
 let resizeObserver = null
 onMounted(async () => {
+  reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false
   await fetchStatus()
   resizeObserver = new ResizeObserver(() => {
     if (uiState.value === 'playing') resizeCanvas()
   })
   if (canvasContainer.value) resizeObserver.observe(canvasContainer.value)
-
-  // Haptic helper (Android only)
-  window._vibrate = (ms) => { try { navigator.vibrate?.(ms) } catch {} }
 })
 
 onUnmounted(() => {
@@ -1161,6 +1112,28 @@ onUnmounted(() => {
   display: block;
   width: 100%;
   height: 100%;
+}
+
+/* How-to hint under the board */
+.game-hint {
+  flex-shrink: 0;
+  text-align: center;
+  color: rgba(255,255,255,0.4);
+  font-size: 0.72rem;
+  padding: 4px 8px 6px;
+}
+
+/* Screen-reader-only live region */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Modal */

--- a/server/api/game/reorbitmatch/end.post.js
+++ b/server/api/game/reorbitmatch/end.post.js
@@ -2,11 +2,12 @@ import { defineEventHandler, readBody, createError } from 'h3'
 import { DateTime } from 'luxon'
 import { prisma } from '@/server/prisma'
 import { redis } from '@/server/utils/redis'
-import { replayGame, MIN_MOVE_INTERVAL_MS } from '@/server/utils/reorbitMatchEngine'
+import { replayGame, MIN_MOVE_INTERVAL_MS, BASE_MATCH_POINTS, MAX_COMBO_MULT } from '@/server/utils/reorbitMatchEngine'
 
 const LOCK_TTL_MS = 15_000
 const MAX_BODY_BYTES = 256 * 1024 // 256 KB
 const MAX_MOVES_PER_SECOND = 10   // 1 move per 100ms max
+const MAX_MOVES = 5000            // absolute cap on replayed moves (DoS guard)
 
 function lockKey(userId) { return `reorbitmatch:lock:${userId}` }
 function sessionKey(userId) { return `reorbitmatch:session:${userId}` }
@@ -35,6 +36,11 @@ export default defineEventHandler(async (event) => {
 
   const { moveLog } = body
 
+  // Absolute move-count cap, independent of session TTL, before any expensive work.
+  if (moveLog.length > MAX_MOVES) {
+    throw createError({ statusCode: 400, statusMessage: 'Move log exceeds maximum' })
+  }
+
   // Per-user lock (same key as /start — serializes with concurrent start requests too)
   const lockToken = crypto.randomUUID()
   let lockAcquired = false
@@ -58,7 +64,7 @@ export default defineEventHandler(async (event) => {
     if (!raw) throw createError({ statusCode: 409, statusMessage: 'Game session not found or expired. Start a new game.' })
 
     const session = JSON.parse(raw)
-    const { board, startTime, gridSize, emojiCount, sessionToken } = session
+    const { board, startTime, gridSize, emojiCount, fillSeed } = session
     const endTime = Date.now()
     const elapsedMs = endTime - startTime
 
@@ -96,13 +102,14 @@ export default defineEventHandler(async (event) => {
     // Server-side replay (score computed here, NOT from client)
     let computedScore
     try {
-      computedScore = replayGame(board, moveLog, gridSize, emojiCount, sessionToken)
+      computedScore = replayGame(board, moveLog, gridSize, emojiCount, fillSeed)
     } catch (err) {
       throw createError({ statusCode: 400, statusMessage: `Invalid move sequence: ${err.message}` })
     }
 
-    // Sanity-check: cap at game-theoretical max (gridSize² tiles * 10pts * 2x size bonus * 16x combo * 50 cascades)
-    const theoreticalMax = gridSize * gridSize * 10 * 2 * 16 * 50
+    // Sanity-check: every match is exactly 3 tiles, so the tightest possible ceiling is
+    // one match per logged move at the max combo multiplier. Defense-in-depth vs replay bugs.
+    const theoreticalMax = moveLog.length * BASE_MATCH_POINTS * MAX_COMBO_MULT
     computedScore = Math.min(computedScore, theoreticalMax)
 
     // Load config for points-per-game

--- a/server/api/game/reorbitmatch/start.post.js
+++ b/server/api/game/reorbitmatch/start.post.js
@@ -58,9 +58,14 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Generate board from a 128-bit random session token (never sent to client)
+    // Generate board from a 128-bit random session token (never sent to client).
     const sessionToken = crypto.randomUUID().replace(/-/g, '')
     const board = generateBoard(gridSize, emojis.length, sessionToken)
+
+    // Separate, non-secret seed for tile refills. Shared with the client so both sides
+    // refill deterministically and the boards stay bit-identical. It is INDEPENDENT of
+    // the sessionToken so revealing it leaks no board-generation entropy.
+    const fillSeed = crypto.randomUUID().replace(/-/g, '')
 
     const ttlSeconds = timeSeconds ? timeSeconds + 120 : 600
     await redis.set(sessionKey(userId), JSON.stringify({
@@ -68,13 +73,14 @@ export default defineEventHandler(async (event) => {
       startTime: Date.now(),
       gridSize,
       emojiCount: emojis.length,
-      sessionToken
+      sessionToken,
+      fillSeed
     }), 'EX', ttlSeconds)
 
     // Record the play (inside the lock to prevent TOCTOU)
     await prisma.reOrbitMatchPlay.create({ data: { userId } })
 
-    return { board, gridSize, emojis, timeSeconds }
+    return { board, gridSize, emojis, timeSeconds, fillSeed }
   } finally {
     try { await redis.eval(casRelease, 1, lockKey(userId), lockToken) } catch {}
   }

--- a/server/utils/reorbitMatchEngine.js
+++ b/server/utils/reorbitMatchEngine.js
@@ -1,13 +1,31 @@
 // Server-only ReOrbit Match game engine. Never import this from pages/ or components/.
+//
+// Game model: drag-to-connect ("Dots"-style).
+//  - The player drags across the grid to select a chain of EXACTLY 3 tiles.
+//  - Adjacency is 8-directional (orthogonal + diagonal).
+//  - A move clears the 3 selected tiles ONLY if they all share the same color/emoji.
+//  - There are NO auto-cascades: only the manually selected tiles are removed. Tiles
+//    above fall down (gravity) and empty cells are refilled from the top.
+//  - Scoring: a flat amount per 3-match, multiplied by a combo multiplier that grows
+//    when matches are made in quick succession and resets after a pause.
+//
+// Anti-cheat: the board is generated server-side from a secret session token. Refills
+// use a SEPARATE, non-secret fillSeed that is shared with the client so both sides stay
+// bit-identical. The authoritative score is recomputed here by replaying the move log.
 
 const DEFAULT_EMOJIS = ['⭐', '🌙', '🚀', '🌍', '⚡', '💫', '🪐', '🎯']
-const MIN_MATCH = 3
-const MIN_MOVE_INTERVAL_MS = 100 // no human moves faster than 100ms
+const MIN_MATCH = 3           // a valid match is exactly this many tiles
+const MAX_MATCH = 3           // chain is capped at this many tiles
+const MIN_MOVE_INTERVAL_MS = 100 // no human makes two matches faster than this
+
+// Scoring — kept in sync with the client (pages/newsite/reorbitmatch.vue).
+const BASE_MATCH_POINTS = 30      // points for a single 3-match at 1x
+const COMBO_WINDOW_MS   = 2500    // consecutive matches within this window grow the combo
+const MAX_COMBO_MULT    = 8       // multiplier ceiling
 
 // splitmix32 seeded PRNG — fast and high-quality for 32-bit seeds.
-// We use a 128-bit session token and fold it down to a 64-bit pair of seeds.
+// We fold a 128-bit hex token down to a 64-bit pair of seeds.
 function makePRNG(seedHex) {
-  // Take first 16 hex chars as two 32-bit integers
   const hi = parseInt(seedHex.slice(0, 8), 16) >>> 0
   const lo = parseInt(seedHex.slice(8, 16), 16) >>> 0
   let s0 = hi >>> 0
@@ -30,105 +48,14 @@ function makePRNG(seedHex) {
   }
 }
 
-// Generate a flat board array of emoji indices
-function generateBoard(gridSize, emojiCount, seedHex) {
-  const rng = makePRNG(seedHex)
-  const board = []
-  const size = gridSize * gridSize
-
-  // Fill avoiding immediate 3-in-a-row matches at generation time
-  for (let i = 0; i < size; i++) {
-    const row = Math.floor(i / gridSize)
-    const col = i % gridSize
-    let emojiIdx
-    let attempts = 0
-    do {
-      emojiIdx = Math.floor(rng() * emojiCount)
-      attempts++
-    } while (attempts < 20 && wouldCreateMatchAt(board, row, col, gridSize, emojiIdx))
-    board.push(emojiIdx)
-  }
-  return board
+// 8-directional adjacency: two cells are neighbors iff Chebyshev distance is exactly 1.
+function isEightAdjacent(r1, c1, r2, c2) {
+  const dr = Math.abs(r1 - r2)
+  const dc = Math.abs(c1 - c2)
+  return dr <= 1 && dc <= 1 && (dr + dc) > 0
 }
 
-function wouldCreateMatchAt(board, row, col, gridSize, emojiIdx) {
-  const idx = row * gridSize + col
-  // Check left-left
-  if (col >= 2) {
-    const l1 = idx - 1
-    const l2 = idx - 2
-    if (board[l1] === emojiIdx && board[l2] === emojiIdx) return true
-  }
-  // Check up-up
-  if (row >= 2) {
-    const u1 = (row - 1) * gridSize + col
-    const u2 = (row - 2) * gridSize + col
-    if (board[u1] === emojiIdx && board[u2] === emojiIdx) return true
-  }
-  return false
-}
-
-// Returns array of match groups, each group is an array of {row, col} cells
-function findMatches(board, gridSize) {
-  const matched = new Set()
-  const groups = []
-
-  // Horizontal
-  for (let row = 0; row < gridSize; row++) {
-    let col = 0
-    while (col < gridSize) {
-      const baseIdx = row * gridSize + col
-      const baseVal = board[baseIdx]
-      if (baseVal === -1) { col++; continue }
-      let len = 1
-      while (col + len < gridSize && board[row * gridSize + col + len] === baseVal) len++
-      if (len >= MIN_MATCH) {
-        const group = []
-        for (let k = 0; k < len; k++) {
-          const key = `${row},${col + k}`
-          if (!matched.has(key)) { matched.add(key); group.push({ row, col: col + k }) }
-        }
-        if (group.length > 0) groups.push(group)
-      }
-      col += len
-    }
-  }
-
-  // Vertical
-  for (let col = 0; col < gridSize; col++) {
-    let row = 0
-    while (row < gridSize) {
-      const baseIdx = row * gridSize + col
-      const baseVal = board[baseIdx]
-      if (baseVal === -1) { row++; continue }
-      let len = 1
-      while (row + len < gridSize && board[(row + len) * gridSize + col] === baseVal) len++
-      if (len >= MIN_MATCH) {
-        const group = []
-        for (let k = 0; k < len; k++) {
-          const key = `${row + k},${col}`
-          if (!matched.has(key)) { matched.add(key); group.push({ row: row + k, col }) }
-        }
-        if (group.length > 0) groups.push(group)
-      }
-      row += len
-    }
-  }
-
-  return groups
-}
-
-function removeMatches(board, groups, gridSize) {
-  const copy = [...board]
-  for (const group of groups) {
-    for (const { row, col } of group) {
-      copy[row * gridSize + col] = -1
-    }
-  }
-  return copy
-}
-
-// Apply gravity: tiles fall down into empty slots (-1)
+// Apply gravity: tiles fall down into empty slots (-1). Column order preserved.
 function applyGravity(board, gridSize) {
   const copy = [...board]
   for (let col = 0; col < gridSize; col++) {
@@ -144,7 +71,8 @@ function applyGravity(board, gridSize) {
   return copy
 }
 
-// Fill empty cells (top rows) using PRNG
+// Fill empty cells (-1) in row-major order using the shared PRNG. The iteration order
+// here MUST match the client exactly so both boards stay identical after every refill.
 function fillEmpty(board, gridSize, emojiCount, rng) {
   const copy = [...board]
   for (let i = 0; i < copy.length; i++) {
@@ -153,114 +81,179 @@ function fillEmpty(board, gridSize, emojiCount, rng) {
   return copy
 }
 
-function applySwap(board, fromRow, fromCol, toRow, toCol, gridSize) {
-  const copy = [...board]
-  const fromIdx = fromRow * gridSize + fromCol
-  const toIdx = toRow * gridSize + toCol
-  ;[copy[fromIdx], copy[toIdx]] = [copy[toIdx], copy[fromIdx]]
-  return copy
-}
-
-function isAdjacent(fromRow, fromCol, toRow, toCol) {
-  const dr = Math.abs(toRow - fromRow)
-  const dc = Math.abs(toCol - fromCol)
-  return (dr === 1 && dc === 0) || (dr === 0 && dc === 1)
-}
-
-// Returns true if any swap on the board produces a match
+// Does any valid move exist? Equivalent (for k=3) to: some color has a same-color
+// 8-connected component of size >= 3. Proof: a size>=3 component's spanning tree has a
+// vertex of degree >= 2, giving a simple 3-vertex path = a draggable 3-chain. O(n).
 function hasPossibleMoves(board, gridSize) {
-  for (let row = 0; row < gridSize; row++) {
-    for (let col = 0; col < gridSize; col++) {
-      // Try swap right
-      if (col + 1 < gridSize) {
-        const b = applySwap(board, row, col, row, col + 1, gridSize)
-        if (findMatches(b, gridSize).length > 0) return true
-      }
-      // Try swap down
-      if (row + 1 < gridSize) {
-        const b = applySwap(board, row, col, row + 1, col, gridSize)
-        if (findMatches(b, gridSize).length > 0) return true
+  const n = gridSize * gridSize
+  const visited = new Uint8Array(n)
+  const stack = []
+  for (let start = 0; start < n; start++) {
+    if (visited[start]) continue
+    const color = board[start]
+    if (color === -1) { visited[start] = 1; continue }
+    // Flood-fill the same-color 8-connected component.
+    stack.length = 0
+    stack.push(start)
+    visited[start] = 1
+    let size = 0
+    while (stack.length) {
+      const idx = stack.pop()
+      size++
+      if (size >= MIN_MATCH) return true
+      const r = Math.floor(idx / gridSize)
+      const c = idx % gridSize
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr === 0 && dc === 0) continue
+          const nr = r + dr
+          const nc = c + dc
+          if (nr < 0 || nr >= gridSize || nc < 0 || nc >= gridSize) continue
+          const nidx = nr * gridSize + nc
+          if (!visited[nidx] && board[nidx] === color) {
+            visited[nidx] = 1
+            stack.push(nidx)
+          }
+        }
       }
     }
   }
   return false
 }
 
-function getMultiplier(combo) {
-  if (combo < 2)  return 1
-  if (combo < 4)  return 2
-  if (combo < 6)  return 4
-  if (combo < 8)  return 8
-  return 16
+// Find one valid 3-chain (returns [{row,col},{row,col},{row,col}]) or null. Used for
+// the client idle hint and to guarantee a generated board is playable.
+function findHint(board, gridSize) {
+  for (let r = 0; r < gridSize; r++) {
+    for (let c = 0; c < gridSize; c++) {
+      const color = board[r * gridSize + c]
+      if (color === -1) continue
+      // Collect same-color 8-neighbors of (r,c).
+      const neighbors = []
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr === 0 && dc === 0) continue
+          const nr = r + dr
+          const nc = c + dc
+          if (nr < 0 || nr >= gridSize || nc < 0 || nc >= gridSize) continue
+          if (board[nr * gridSize + nc] === color) neighbors.push({ row: nr, col: nc })
+        }
+      }
+      if (neighbors.length >= 2) {
+        // (r,c) is a degree>=2 vertex → center of a 3-path.
+        return [neighbors[0], { row: r, col: c }, neighbors[1]]
+      }
+    }
+  }
+  return null
 }
 
-function scoreGroup(group) {
-  const n = group.length
-  const base = n * 10
-  if (n >= 5) return Math.round(base * 2)
-  if (n === 4) return Math.round(base * 1.5)
-  return base
-}
-
-// Replay entire game from initial board and move log. Returns computed score.
-// Throws if a move is invalid.
-export function replayGame(initialBoard, moveLog, gridSize, emojiCount, seedHex) {
+// Generate a flat board of emoji indices. Deterministic from seedHex. Guarantees at
+// least one valid 3-chain exists (the board is stored server-side, so the exact bytes
+// are authoritative; the guarantee just prevents shipping an instantly-dead board).
+function generateBoard(gridSize, emojiCount, seedHex) {
   const rng = makePRNG(seedHex)
-  // Advance rng to the same state used after board generation
-  // (We need to consume the rng calls made during generateBoard to keep state consistent)
-  // Actually we just pass the same seed for fill operations
-  const fillRng = makePRNG(seedHex.slice(16, 32) || seedHex)
+  const size = gridSize * gridSize
+  const board = new Array(size)
+  for (let i = 0; i < size; i++) board[i] = Math.floor(rng() * emojiCount)
 
+  if (!hasPossibleMoves(board, gridSize)) {
+    // Deterministic fallback: force a same-color L in the top-left corner. The three
+    // cells (0,0),(0,1),(1,0) are mutually 8-adjacent → a guaranteed size-3 component.
+    const color = board[0]
+    board[1] = color                 // (0,1)
+    board[gridSize] = color          // (1,0)
+  }
+  return board
+}
+
+// Validate a single chain move against the current board. Returns the matched color.
+// Throws on any malformed / illegal move. Never trusts client-supplied colors.
+function validateChain(board, cells, gridSize) {
+  if (!Array.isArray(cells) || cells.length !== MIN_MATCH) {
+    throw new Error('Chain must have exactly 3 cells')
+  }
+
+  const keys = new Set()
+  for (const cell of cells) {
+    if (!cell || !Number.isInteger(cell.row) || !Number.isInteger(cell.col)) {
+      throw new Error('Cell coordinates must be integers')
+    }
+    if (cell.row < 0 || cell.row >= gridSize || cell.col < 0 || cell.col >= gridSize) {
+      throw new Error('Cell out of bounds')
+    }
+    keys.add(`${cell.row},${cell.col}`)
+  }
+  if (keys.size !== MIN_MATCH) throw new Error('Chain cells must be distinct')
+
+  // Consecutive cells must be 8-adjacent (a connected drag path).
+  for (let i = 1; i < cells.length; i++) {
+    if (!isEightAdjacent(cells[i - 1].row, cells[i - 1].col, cells[i].row, cells[i].col)) {
+      throw new Error('Chain cells must be 8-adjacent in sequence')
+    }
+  }
+
+  // All cells must share the same non-empty color, read from the server's board.
+  const color = board[cells[0].row * gridSize + cells[0].col]
+  if (color === -1 || color == null) throw new Error('Chain includes an empty cell')
+  for (const { row, col } of cells) {
+    if (board[row * gridSize + col] !== color) throw new Error('Chain colors do not match')
+  }
+  return color
+}
+
+// Combo multiplier for a given streak length (1-based). Capped at MAX_COMBO_MULT.
+function getComboMultiplier(combo) {
+  if (combo <= 1) return 1
+  return Math.min(combo, MAX_COMBO_MULT)
+}
+
+// Replay the entire game from the initial board + move log. Returns the authoritative
+// score. Throws if any move is invalid. `fillSeedHex` drives deterministic refills and
+// must be the same value handed to the client at /start.
+function replayGame(initialBoard, moveLog, gridSize, emojiCount, fillSeedHex) {
+  const fillRng = makePRNG(fillSeedHex)
   let board = [...initialBoard]
   let score = 0
   let combo = 0
+  let lastTs = null
 
   for (const move of moveLog) {
-    const { fromRow, fromCol, toRow, toCol } = move
+    const cells = move?.cells
+    validateChain(board, cells, gridSize) // throws on any illegal move
 
-    // Validate move is within bounds and adjacent
-    if (
-      fromRow < 0 || fromRow >= gridSize || fromCol < 0 || fromCol >= gridSize ||
-      toRow < 0 || toRow >= gridSize || toCol < 0 || toCol >= gridSize
-    ) throw new Error('Move out of bounds')
+    // Combo is derived purely from move timestamps so it is reproducible here.
+    const ts = move.ts
+    if (lastTs !== null && (ts - lastTs) <= COMBO_WINDOW_MS) combo++
+    else combo = 1
+    lastTs = ts
 
-    if (!isAdjacent(fromRow, fromCol, toRow, toCol)) throw new Error('Non-adjacent swap')
+    score += BASE_MATCH_POINTS * getComboMultiplier(combo)
 
-    const swapped = applySwap(board, fromRow, fromCol, toRow, toCol, gridSize)
-    const initialMatches = findMatches(swapped, gridSize)
-
-    if (initialMatches.length === 0) {
-      // Invalid swap (no match) — still recorded by client as a rejected move
-      // Do not update board, do not increment combo
-      combo = 0
-      continue
-    }
-
-    // Valid swap — apply cascade
-    combo++
-    const multiplier = getMultiplier(combo)
-    let cascadeBoard = swapped
-    let cascadeLevel = 0
-
-    while (true) {
-      const matches = findMatches(cascadeBoard, gridSize)
-      if (matches.length === 0) break
-
-      const cascadeMultiplier = 1 + cascadeLevel * 0.5
-      for (const group of matches) {
-        score += Math.round(scoreGroup(group) * cascadeMultiplier * multiplier)
-      }
-
-      cascadeBoard = removeMatches(cascadeBoard, matches, gridSize)
-      cascadeBoard = applyGravity(cascadeBoard, gridSize)
-      cascadeBoard = fillEmpty(cascadeBoard, gridSize, emojiCount, fillRng)
-      cascadeLevel++
-    }
-
-    board = cascadeBoard
+    // Remove exactly the selected tiles, then settle once. No cascade.
+    for (const { row, col } of cells) board[row * gridSize + col] = -1
+    board = applyGravity(board, gridSize)
+    board = fillEmpty(board, gridSize, emojiCount, fillRng)
   }
 
   return Math.floor(score)
 }
 
-export { generateBoard, findMatches, hasPossibleMoves, applySwap, applyGravity, fillEmpty, getMultiplier, DEFAULT_EMOJIS, MIN_MOVE_INTERVAL_MS }
+export {
+  generateBoard,
+  validateChain,
+  hasPossibleMoves,
+  findHint,
+  applyGravity,
+  fillEmpty,
+  getComboMultiplier,
+  isEightAdjacent,
+  replayGame,
+  DEFAULT_EMOJIS,
+  MIN_MOVE_INTERVAL_MS,
+  MIN_MATCH,
+  MAX_MATCH,
+  BASE_MATCH_POINTS,
+  COMBO_WINDOW_MS,
+  MAX_COMBO_MULT
+}


### PR DESCRIPTION
## Summary
Completely redesigned the ReOrbit Match game from a swap-based match-3 to a drag-to-connect "Dots"-style mechanic. Players now drag across exactly 3 tiles of the same color in any direction (including diagonals) to clear them, with no auto-cascades. This is a fundamental gameplay shift affecting both client and server logic.

## Key Changes

### Gameplay Mechanics
- **Input model**: Changed from adjacent-tile swaps to continuous drag-to-select chains
  - Players press and drag across the grid to select tiles
  - Backtracking (sliding onto the previous tile) undoes the last selection
  - Hard cap at exactly 3 tiles per match
  - 8-directional adjacency (orthogonal + diagonal neighbors)
  
- **Match validation**: Only the 3 manually selected tiles are removed (no auto-cascades)
  - Server validates each chain is contiguous, 8-adjacent, and monochromatic
  - Deterministic gravity + refill using shared PRNG seed (fillSeed)
  - No more horizontal/vertical line-matching logic

- **Scoring & Combo**:
  - Flat 30 points per 3-match, multiplied by combo (1–8×)
  - Combo driven purely by timestamp gaps (≤2.5s between moves)
  - Resets after idle pause (no longer tied to match count)

### Client-Side (pages/newsite/reorbitmatch.vue)
- Replaced swap/cascade logic with chain-building state machine
  - `chain[]` tracks the current drag path (ordered tile indices)
  - `chainFeedbackColor()` shows green for valid (all-same) chains, red otherwise
  - Live visual feedback: glowing line from first to last selected tile, dashed line to pointer
  
- New "How to Play" modal with step-by-step instructions
- Idle hint system: after 5s of inactivity, highlights a valid 3-chain
- Fail flash feedback: invalid moves briefly flash red
- Reduced motion support (respects prefers-reduced-motion)
- Vibration feedback on tile selection and backtrack
- Screen reader announcements for match results

- Simplified animation states: removed WIGGLE, kept REMOVING/FALLING/APPEARING
- Updated HUD: combo badge only shows when combo > 1

### Server-Side (server/utils/reorbitMatchEngine.js)
- New `validateChain()`: validates client-supplied 3-cell chains
  - Checks bounds, distinctness, 8-adjacency, and color match
  - Never trusts client color data; reads from authoritative board
  
- Replaced `findMatches()` (line-based) with `hasPossibleMoves()` (8-connected component)
  - Detects game-over when no valid 3-chains exist
  
- New `findHint()`: finds one valid 3-chain for client idle hint
- Simplified `generateBoard()`: no longer avoids initial matches (not needed for drag model)
- Updated `replayGame()`: replays move log with new chain format and combo logic
- Deterministic refill: both client and server use same PRNG (fillSeed) for identical boards

### API Changes
- `/start` endpoint now returns `fillSeed` (shared with client for deterministic refills)
- `/end` endpoint validates move log format and replays game to compute authoritative score
- Move log format changed from `{fromRow, fromCol, toRow, toCol, ts}` to `{cells: [{row, col}×3], ts}`

## Notable Implementation Details
- **Deterministic PRNG**: Byte-identical splitmix32 implementation on both client and server ensures boards stay synchronized after every refill
- **Combo bookkeeping**: Purely timestamp-driven (matching server logic) with client-side idle decay for display
- **Anti-cheat**: Board generated from secret session token; move log replayed server-side to compute authoritative score
- **Accessibility**: ARIA labels, live regions for announcements, keyboard-friendly modal
- **Performance**: Removed wiggle animation; simplified tile state machine; optimized

https://claude.ai/code/session_013oB8GhnqpYskd4w1BZmVy9