### PR TITLE
ReOrbit Match: remove hints, combo as multiplier, configurable combo cooldown

### DIFF
--- a/pages/admin/games.vue
+++ b/pages/admin/games.vue
@@ -746,6 +746,11 @@
               <p class="text-xs text-gray-400 mb-1">Board dimensions (4–10)</p>
               <input type="number" v-model.number="reorbitGridSize" min="4" max="10" class="input" />
             </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Combo Cooldown (ms)</label>
+              <p class="text-xs text-gray-400 mb-1">Time allowed between matches to keep the combo growing (1000–15000). Higher = combos are easier to hold.</p>
+              <input type="number" v-model.number="reorbitComboMs" min="1000" max="15000" step="500" class="input" />
+            </div>
           </div>
 
           <div class="mb-6 border rounded-lg p-4">
@@ -1323,6 +1328,7 @@ async function loadSettings() {
   reorbitTimeSecondsInput.value = ro.reorbitTimeSeconds != null ? String(ro.reorbitTimeSeconds) : ''
   reorbitEmojis.value           = ro.reorbitEmojis ?? []
   reorbitGridSize.value         = ro.reorbitGridSize ?? 8
+  reorbitComboMs.value          = ro.reorbitComboMs ?? 3500
 }
 
 // Win Wheel state
@@ -1714,6 +1720,7 @@ const reorbitPointsPerGame   = ref(50)
 const reorbitTimeSecondsInput = ref('')  // '' = unlimited (null)
 const reorbitEmojis          = ref([])
 const reorbitGridSize        = ref(8)
+const reorbitComboMs         = ref(3500)
 const reorbitEmojiInput      = ref('')
 const loadingReorbit         = ref(false)
 
@@ -1740,7 +1747,8 @@ async function saveReorbitConfig() {
         reorbitPointsPerGame:  reorbitPointsPerGame.value,
         reorbitTimeSeconds:    reorbitTimeSecondsInput.value !== '' ? Number(reorbitTimeSecondsInput.value) : null,
         reorbitEmojis:         reorbitEmojis.value,
-        reorbitGridSize:       reorbitGridSize.value
+        reorbitGridSize:       reorbitGridSize.value,
+        reorbitComboMs:        reorbitComboMs.value
       }
     })
     toastMessage.value = 'ReOrbit Match settings saved!'; toastType.value = 'success'

--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -53,19 +53,13 @@
                 <span class="hud-label">Score</span>
                 <span class="hud-value">{{ score.toLocaleString() }}</span>
               </div>
-              <div class="hud-item" :class="{ 'hud-item--active': combo > 1 }">
+              <div class="hud-item" :class="{ 'hud-item--glow': combo > 1 }">
                 <span class="hud-label">Combo</span>
-                <span class="hud-value">{{ combo }}x</span>
+                <span class="hud-value hud-multiplier">{{ combo }}x</span>
               </div>
               <div v-if="timeSeconds" class="hud-item" :class="{ 'hud-item--warning': timeLeft <= 10 }">
                 <span class="hud-label">Time</span>
                 <span class="hud-value">{{ timeLeft }}s</span>
-              </div>
-            </div>
-            <div class="hud-row hud-row--secondary">
-              <div class="hud-item" :class="{ 'hud-item--glow': multiplier > 1 }">
-                <span class="hud-label">Multiplier</span>
-                <span class="hud-value hud-multiplier">{{ multiplier }}x</span>
               </div>
               <div class="hud-item">
                 <span class="hud-label">Plays Left</span>
@@ -151,7 +145,7 @@
             </li>
             <li>
               <span class="howto-num">4</span>
-              <span>Chain matches <strong>quickly</strong> to build your <strong>combo multiplier</strong> — it climbs up to 8× but resets if you pause too long.</span>
+              <span>Each match you chain in a row raises your <strong>combo multiplier</strong> — 2×, 3×, 4× and up. Keep matching before the combo cools down or it drops back to 1×.</span>
             </li>
             <li>
               <span class="howto-num">5</span>
@@ -180,10 +174,8 @@ const MAX_MATCH = 3          // chain is capped at this many tiles
 
 // Scoring — MUST stay in sync with server/utils/reorbitMatchEngine.js
 const BASE_MATCH_POINTS = 30
-const COMBO_WINDOW_MS   = 2500
-const MAX_COMBO_MULT    = 8
+const DEFAULT_COMBO_WINDOW_MS = 3500  // fallback; server sends the configured value at /start
 
-const HINT_DELAY_MS = 5000
 const FAIL_FLASH_MS = 380
 
 // Tile animation states
@@ -193,8 +185,7 @@ const TS = { NORMAL: 0, REMOVING: 1, FALLING: 2, APPEARING: 3 }
 const uiState    = ref('loading')  // loading | start | playing | gameover | noplays
 const starting   = ref(false)
 const score      = ref(0)
-const combo      = ref(0)
-const multiplier = ref(1)
+const combo      = ref(0)   // the combo streak, which is also the score multiplier
 const timeLeft   = ref(null)
 const playsLeft  = ref(0)
 const finalScore    = ref(0)
@@ -233,17 +224,15 @@ let pointerX    = 0
 let pointerY    = 0
 
 // Combo bookkeeping (mirrors the server's ts-driven combo)
+let comboWindowMs = DEFAULT_COMBO_WINDOW_MS // combo cooldown; set from /start config
 let comboCount  = 0
 let lastLogTs   = null    // relative ts of the previous logged match
 let lastMatchAbs = 0      // performance.now() of the previous match (for idle decay)
 
-// Feedback / hint
+// Feedback
 let particles     = []
 let failFlashSet  = new Set()
 let failFlashUntil = 0
-let hintSet       = new Set()
-let hintActive    = false
-let lastActivityMs = 0
 let reducedMotion = false
 
 let configData = null
@@ -281,7 +270,8 @@ function isEightAdjacent(a, b) {
   return dr <= 1 && dc <= 1 && (dr + dc) > 0
 }
 
-function computeMultiplier(c) { return c <= 1 ? 1 : Math.min(c, MAX_COMBO_MULT) }
+// The combo streak IS the multiplier (1st match 1x, 2nd chained 2x, …), no cap.
+function computeMultiplier(c) { return c < 1 ? 1 : c }
 
 function vibrate(pattern) { try { navigator.vibrate?.(pattern) } catch {} }
 
@@ -315,27 +305,6 @@ function hasPossibleMoves(b) {
     }
   }
   return false
-}
-
-// Find one valid 3-chain for the idle hint (returns [idx, idx, idx] or null)
-function findHint(b) {
-  for (let r = 0; r < gridSize; r++) {
-    for (let c = 0; c < gridSize; c++) {
-      const color = b[idxOf(r, c)]
-      if (color === -1) continue
-      const nbrs = []
-      for (let dr = -1; dr <= 1; dr++) {
-        for (let dc = -1; dc <= 1; dc++) {
-          if (dr === 0 && dc === 0) continue
-          const nr = r + dr, nc = c + dc
-          if (nr < 0 || nr >= gridSize || nc < 0 || nc >= gridSize) continue
-          if (b[idxOf(nr, nc)] === color) nbrs.push(idxOf(nr, nc))
-        }
-      }
-      if (nbrs.length >= 2) return [nbrs[0], idxOf(r, c), nbrs[1]]
-    }
-  }
-  return null
 }
 
 // ─── Particles ──────────────────────────────────────────────────────────────────
@@ -498,13 +467,11 @@ function renderFrame(nowMs) {
 
     const inChain  = chainSet.has(i)
     const inFlash  = flashing && failFlashSet.has(i)
-    const inHint   = hintActive && hintSet.has(i)
 
     ctx.save()
     ctx.globalAlpha = Math.max(0, Math.min(1, alpha))
     ctx.translate(x + tileSize / 2, y + tileSize / 2)
     if (rot) ctx.rotate(rot)
-    if (inHint && !reducedMotion) scale *= 1 + Math.sin(nowMs / 160) * 0.06
     ctx.scale(scale, scale)
 
     const baseColor = TILE_COLORS[tile.emojiIdx % TILE_COLORS.length]
@@ -512,8 +479,6 @@ function renderFrame(nowMs) {
       ctx.shadowColor = '#ff5a5a'; ctx.shadowBlur = 14; ctx.fillStyle = '#ff5a5a'
     } else if (inChain && feedback) {
       ctx.shadowColor = feedback; ctx.shadowBlur = 14; ctx.fillStyle = feedback
-    } else if (inHint) {
-      ctx.shadowColor = '#FFD700'; ctx.shadowBlur = 12; ctx.fillStyle = baseColor
     } else {
       ctx.shadowColor = 'rgba(0,0,0,0.4)'; ctx.shadowBlur = 4; ctx.fillStyle = baseColor
     }
@@ -598,19 +563,9 @@ function gameLoop(nowMs) {
 
   // Combo idle decay (display only; server recomputes authoritative combo from ts)
   if (comboCount > 0) {
-    const alive = (nowMs - lastMatchAbs) <= COMBO_WINDOW_MS
+    const alive = (nowMs - lastMatchAbs) <= comboWindowMs
     const dispC = alive ? comboCount : 0
-    const dispM = alive ? computeMultiplier(comboCount) : 1
     if (combo.value !== dispC) combo.value = dispC
-    if (multiplier.value !== dispM) multiplier.value = dispM
-  }
-
-  // Idle hint
-  if (uiState.value === 'playing' && !animating && !pointerDown && !hintActive) {
-    if (nowMs - lastActivityMs > HINT_DELAY_MS) {
-      const h = findHint(board)
-      if (h) { hintSet = new Set(h); hintActive = true }
-    }
   }
 
   renderFrame(nowMs)
@@ -652,22 +607,20 @@ function settleBoard(removedSet) {
 // ─── Perform a match ─────────────────────────────────────────────────────────
 async function performMatch(cells) {
   animating = true
-  clearHint()
 
   // Log the move (relative ts, clamped so the server's monotonic + min-interval checks pass)
   let ts = Math.round(performance.now() - gameStartTs)
   if (lastLogTs !== null) ts = Math.max(ts, lastLogTs + 101)
   moveLog.push({ cells: cells.map(i => ({ row: rowOf(i), col: colOf(i) })), ts })
 
-  // Combo (identical rule to server: driven purely by ts gaps)
-  if (lastLogTs !== null && (ts - lastLogTs) <= COMBO_WINDOW_MS) comboCount++
+  // Combo (identical rule to server: driven purely by ts gaps); the combo IS the multiplier
+  if (lastLogTs !== null && (ts - lastLogTs) <= comboWindowMs) comboCount++
   else comboCount = 1
   lastLogTs = ts
   lastMatchAbs = performance.now()
   const mult = computeMultiplier(comboCount)
   score.value += BASE_MATCH_POINTS * mult
   combo.value = comboCount
-  multiplier.value = mult
   announce.value = `Matched 3! +${BASE_MATCH_POINTS * mult}. Combo ${comboCount}x.`
   vibrate(30)
 
@@ -714,7 +667,6 @@ async function performMatch(cells) {
   }
 
   animating = false
-  touchActivity()
 
   // Terminal state: no more possible matches (rare with 8-dir; timer is the usual end)
   if (!hasPossibleMoves(board)) endGame()
@@ -729,9 +681,6 @@ function getCanvasPos(e) {
   return { x: e.clientX - rect.left, y: e.clientY - rect.top }
 }
 
-function touchActivity() { lastActivityMs = performance.now(); clearHint() }
-function clearHint() { if (hintActive) { hintActive = false; hintSet = new Set() } }
-
 function onPointerDown(e) {
   if (animating || uiState.value !== 'playing') return
   e.preventDefault()
@@ -739,7 +688,6 @@ function onPointerDown(e) {
   pointerDown = true
   const pos = getCanvasPos(e)
   pointerX = pos.x; pointerY = pos.y
-  touchActivity()
   const idx = hitTest(pos.x, pos.y)
   chain = idx === -1 ? [] : [idx]
   if (idx !== -1) vibrate(8)
@@ -793,7 +741,6 @@ function onPointerUp(e) {
     announce.value = 'No match — connect exactly 3 of the same icon.'
     vibrate([20, 40, 20])
   }
-  touchActivity()
 }
 
 function onPointerLeave() { /* pointer capture keeps events flowing; ignore */ }
@@ -836,10 +783,10 @@ async function startGame() {
     timeSeconds = data.timeSeconds
     fillSeed    = data.fillSeed
     fillRng     = makePRNG(fillSeed)
+    comboWindowMs = data.comboWindowMs ?? DEFAULT_COMBO_WINDOW_MS
 
     score.value      = 0
     combo.value      = 0
-    multiplier.value = 1
     timeLeft.value   = timeSeconds
     moveLog          = []
     chain            = []
@@ -851,8 +798,6 @@ async function startGame() {
     failFlashUntil   = 0
     animating        = false
     ending           = false
-    hintActive       = false
-    hintSet          = new Set()
     announce.value   = ''
 
     await fetchStatus() // refresh plays left
@@ -865,7 +810,6 @@ async function startGame() {
     initTiles(board)
     gameStartTs = performance.now()
     timerStart  = timeSeconds ? performance.now() : null
-    lastActivityMs = performance.now()
     rafId = requestAnimationFrame(gameLoop)
   } catch (err) {
     const msg = err?.data?.statusMessage || err?.message || 'Failed to start game'

--- a/prisma/migrations/20260703000000_add_reorbit_combo_ms/migration.sql
+++ b/prisma/migrations/20260703000000_add_reorbit_combo_ms/migration.sql
@@ -1,0 +1,3 @@
+-- AddField: configurable combo cooldown (ms) for ReOrbit Match
+ALTER TABLE "GameConfig"
+  ADD COLUMN IF NOT EXISTS "reorbitComboMs" INTEGER NOT NULL DEFAULT 3500;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -968,6 +968,7 @@ model GameConfig {
   reorbitTimeSeconds    Int?
   reorbitEmojis         String[] @default([])
   reorbitGridSize       Int     @default(8)
+  reorbitComboMs        Int     @default(3500)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt

--- a/server/api/admin/game-config.get.js
+++ b/server/api/admin/game-config.get.js
@@ -136,7 +136,8 @@ export default defineEventHandler(async (event) => {
             reorbitPointsPerGame: 50,
             reorbitTimeSeconds: null,
             reorbitEmojis: [],
-            reorbitGridSize: 8
+            reorbitGridSize: 8,
+            reorbitComboMs: 3500
           }
         })
       } else {

--- a/server/api/admin/game-config.post.js
+++ b/server/api/admin/game-config.post.js
@@ -107,6 +107,9 @@ function validatePayload(payload) {
     if (payload.reorbitTimeSeconds != null && (typeof payload.reorbitTimeSeconds !== 'number' || payload.reorbitTimeSeconds < 30)) {
       throw createError({ statusCode: 400, statusMessage: '"reorbitTimeSeconds" must be null or a number >= 30' })
     }
+    if (payload.reorbitComboMs == null || typeof payload.reorbitComboMs !== 'number' || payload.reorbitComboMs < 1000 || payload.reorbitComboMs > 15000) {
+      throw createError({ statusCode: 400, statusMessage: '"reorbitComboMs" must be a number between 1000 and 15000' })
+    }
     if (payload.reorbitGridSize == null || typeof payload.reorbitGridSize !== 'number' || payload.reorbitGridSize < 4 || payload.reorbitGridSize > 10) {
       throw createError({ statusCode: 400, statusMessage: '"reorbitGridSize" must be between 4 and 10' })
     }
@@ -152,6 +155,7 @@ export default defineEventHandler(async (event) => {
     reorbitTimeSeconds = null,
     reorbitEmojis = [],
     reorbitGridSize,
+    reorbitComboMs,
     // Winball fields
     leftCupPoints,
     rightCupPoints,
@@ -328,7 +332,8 @@ export default defineEventHandler(async (event) => {
           reorbitPointsPerGame,
           reorbitTimeSeconds: reorbitTimeSeconds || null,
           reorbitEmojis,
-          reorbitGridSize
+          reorbitGridSize,
+          reorbitComboMs
         }
         createData = { ...createData, ...reorbitData }
         updateData = { ...updateData, ...reorbitData }
@@ -494,6 +499,7 @@ export default defineEventHandler(async (event) => {
             ['reorbitPointsPerGame', before?.reorbitPointsPerGame, reorbitPointsPerGame],
             ['reorbitTimeSeconds', before?.reorbitTimeSeconds ?? null, reorbitTimeSeconds || null],
             ['reorbitGridSize', before?.reorbitGridSize, reorbitGridSize],
+            ['reorbitComboMs', before?.reorbitComboMs, reorbitComboMs],
             ['reorbitEmojis', JSON.stringify(before?.reorbitEmojis ?? []), JSON.stringify(reorbitEmojis)]
           ]
           for (const [key, prev, next] of changes) {

--- a/server/api/game/reorbitmatch/end.post.js
+++ b/server/api/game/reorbitmatch/end.post.js
@@ -2,7 +2,7 @@ import { defineEventHandler, readBody, createError } from 'h3'
 import { DateTime } from 'luxon'
 import { prisma } from '@/server/prisma'
 import { redis } from '@/server/utils/redis'
-import { replayGame, MIN_MOVE_INTERVAL_MS, BASE_MATCH_POINTS, MAX_COMBO_MULT } from '@/server/utils/reorbitMatchEngine'
+import { replayGame, MIN_MOVE_INTERVAL_MS, BASE_MATCH_POINTS, DEFAULT_COMBO_WINDOW_MS } from '@/server/utils/reorbitMatchEngine'
 
 const LOCK_TTL_MS = 15_000
 const MAX_BODY_BYTES = 256 * 1024 // 256 KB
@@ -65,6 +65,7 @@ export default defineEventHandler(async (event) => {
 
     const session = JSON.parse(raw)
     const { board, startTime, gridSize, emojiCount, fillSeed } = session
+    const comboWindowMs = session.comboWindowMs ?? DEFAULT_COMBO_WINDOW_MS
     const endTime = Date.now()
     const elapsedMs = endTime - startTime
 
@@ -102,14 +103,15 @@ export default defineEventHandler(async (event) => {
     // Server-side replay (score computed here, NOT from client)
     let computedScore
     try {
-      computedScore = replayGame(board, moveLog, gridSize, emojiCount, fillSeed)
+      computedScore = replayGame(board, moveLog, gridSize, emojiCount, fillSeed, comboWindowMs)
     } catch (err) {
       throw createError({ statusCode: 400, statusMessage: `Invalid move sequence: ${err.message}` })
     }
 
-    // Sanity-check: every match is exactly 3 tiles, so the tightest possible ceiling is
-    // one match per logged move at the max combo multiplier. Defense-in-depth vs replay bugs.
-    const theoreticalMax = moveLog.length * BASE_MATCH_POINTS * MAX_COMBO_MULT
+    // Sanity-check: the combo streak is the multiplier, so the tightest possible ceiling is
+    // an unbroken combo (1x + 2x + … + Nx) = N(N+1)/2 matches at base points. Defense-in-depth.
+    const n = moveLog.length
+    const theoreticalMax = BASE_MATCH_POINTS * (n * (n + 1) / 2)
     computedScore = Math.min(computedScore, theoreticalMax)
 
     // Load config for points-per-game

--- a/server/api/game/reorbitmatch/start.post.js
+++ b/server/api/game/reorbitmatch/start.post.js
@@ -2,7 +2,7 @@ import { defineEventHandler, createError } from 'h3'
 import { DateTime } from 'luxon'
 import { prisma } from '@/server/prisma'
 import { redis } from '@/server/utils/redis'
-import { generateBoard, DEFAULT_EMOJIS } from '@/server/utils/reorbitMatchEngine'
+import { generateBoard, DEFAULT_EMOJIS, DEFAULT_COMBO_WINDOW_MS } from '@/server/utils/reorbitMatchEngine'
 
 const LOCK_TTL_MS = 10_000
 
@@ -42,6 +42,7 @@ export default defineEventHandler(async (event) => {
     const gridSize = config?.reorbitGridSize ?? 8
     const playsPerPeriod = config?.reorbitPlaysPerPeriod ?? 3
     const timeSeconds = config?.reorbitTimeSeconds ?? null
+    const comboWindowMs = config?.reorbitComboMs ?? DEFAULT_COMBO_WINDOW_MS
     const emojis = (config?.reorbitEmojis?.length ? config.reorbitEmojis : null) ?? DEFAULT_EMOJIS
 
     // Check play limit
@@ -74,13 +75,14 @@ export default defineEventHandler(async (event) => {
       gridSize,
       emojiCount: emojis.length,
       sessionToken,
-      fillSeed
+      fillSeed,
+      comboWindowMs
     }), 'EX', ttlSeconds)
 
     // Record the play (inside the lock to prevent TOCTOU)
     await prisma.reOrbitMatchPlay.create({ data: { userId } })
 
-    return { board, gridSize, emojis, timeSeconds, fillSeed }
+    return { board, gridSize, emojis, timeSeconds, fillSeed, comboWindowMs }
   } finally {
     try { await redis.eval(casRelease, 1, lockKey(userId), lockToken) } catch {}
   }

--- a/server/utils/reorbitMatchEngine.js
+++ b/server/utils/reorbitMatchEngine.js
@@ -19,9 +19,8 @@ const MAX_MATCH = 3           // chain is capped at this many tiles
 const MIN_MOVE_INTERVAL_MS = 100 // no human makes two matches faster than this
 
 // Scoring — kept in sync with the client (pages/newsite/reorbitmatch.vue).
-const BASE_MATCH_POINTS = 30      // points for a single 3-match at 1x
-const COMBO_WINDOW_MS   = 2500    // consecutive matches within this window grow the combo
-const MAX_COMBO_MULT    = 8       // multiplier ceiling
+const BASE_MATCH_POINTS = 30            // points for a single 3-match at 1x
+const DEFAULT_COMBO_WINDOW_MS = 3500    // fallback combo window; admin-configurable per game
 
 // splitmix32 seeded PRNG — fast and high-quality for 32-bit seeds.
 // We fold a 128-bit hex token down to a 64-bit pair of seeds.
@@ -121,33 +120,6 @@ function hasPossibleMoves(board, gridSize) {
   return false
 }
 
-// Find one valid 3-chain (returns [{row,col},{row,col},{row,col}]) or null. Used for
-// the client idle hint and to guarantee a generated board is playable.
-function findHint(board, gridSize) {
-  for (let r = 0; r < gridSize; r++) {
-    for (let c = 0; c < gridSize; c++) {
-      const color = board[r * gridSize + c]
-      if (color === -1) continue
-      // Collect same-color 8-neighbors of (r,c).
-      const neighbors = []
-      for (let dr = -1; dr <= 1; dr++) {
-        for (let dc = -1; dc <= 1; dc++) {
-          if (dr === 0 && dc === 0) continue
-          const nr = r + dr
-          const nc = c + dc
-          if (nr < 0 || nr >= gridSize || nc < 0 || nc >= gridSize) continue
-          if (board[nr * gridSize + nc] === color) neighbors.push({ row: nr, col: nc })
-        }
-      }
-      if (neighbors.length >= 2) {
-        // (r,c) is a degree>=2 vertex → center of a 3-path.
-        return [neighbors[0], { row: r, col: c }, neighbors[1]]
-      }
-    }
-  }
-  return null
-}
-
 // Generate a flat board of emoji indices. Deterministic from seedHex. Guarantees at
 // least one valid 3-chain exists (the board is stored server-side, so the exact bytes
 // are authoritative; the guarantee just prevents shipping an instantly-dead board).
@@ -202,16 +174,17 @@ function validateChain(board, cells, gridSize) {
   return color
 }
 
-// Combo multiplier for a given streak length (1-based). Capped at MAX_COMBO_MULT.
+// The combo streak IS the score multiplier: the 1st match is 1x, a 2nd chained match
+// is 2x, a 3rd is 3x, and so on with no cap.
 function getComboMultiplier(combo) {
-  if (combo <= 1) return 1
-  return Math.min(combo, MAX_COMBO_MULT)
+  return combo < 1 ? 1 : combo
 }
 
 // Replay the entire game from the initial board + move log. Returns the authoritative
 // score. Throws if any move is invalid. `fillSeedHex` drives deterministic refills and
-// must be the same value handed to the client at /start.
-function replayGame(initialBoard, moveLog, gridSize, emojiCount, fillSeedHex) {
+// must be the same value handed to the client at /start. `comboWindowMs` is the combo
+// cooldown (admin-configurable) and must match the value handed to the client.
+function replayGame(initialBoard, moveLog, gridSize, emojiCount, fillSeedHex, comboWindowMs = DEFAULT_COMBO_WINDOW_MS) {
   const fillRng = makePRNG(fillSeedHex)
   let board = [...initialBoard]
   let score = 0
@@ -224,7 +197,7 @@ function replayGame(initialBoard, moveLog, gridSize, emojiCount, fillSeedHex) {
 
     // Combo is derived purely from move timestamps so it is reproducible here.
     const ts = move.ts
-    if (lastTs !== null && (ts - lastTs) <= COMBO_WINDOW_MS) combo++
+    if (lastTs !== null && (ts - lastTs) <= comboWindowMs) combo++
     else combo = 1
     lastTs = ts
 
@@ -243,7 +216,6 @@ export {
   generateBoard,
   validateChain,
   hasPossibleMoves,
-  findHint,
   applyGravity,
   fillEmpty,
   getComboMultiplier,
@@ -254,6 +226,5 @@ export {
   MIN_MATCH,
   MAX_MATCH,
   BASE_MATCH_POINTS,
-  COMBO_WINDOW_MS,
-  MAX_COMBO_MULT
+  DEFAULT_COMBO_WINDOW_MS
 }


### PR DESCRIPTION
Follow-up tweaks to the drag-to-connect ReOrbit Match game (#736).

## Changes

### 1. No more hints
Removed the idle hint feature entirely — the game no longer auto-highlights a possible match after inactivity. Stripped `findHint`, the hint state/rendering, and the idle-detection loop from the client (and the now-unused `findHint` from the server engine).

### 2. Combo is the score multiplier
The combo streak now directly multiplies the score: 1st match = 1×, a 2nd chained match = 2×, 3rd = 3×, and so on, with no cap. Removed the separate **Multiplier** HUD tile — the **Combo** tile now shows the live multiplier (gold, glows past 1×). The server score ceiling was rederived for the uncapped model (an unbroken combo of N matches = N(N+1)/2 × base points).

### 3. Configurable combo cooldown
The combo window (how long you can wait between matches before the combo resets) is now admin-configurable per game:
- New `GameConfig.reorbitComboMs` field (+ migration `20260703000000_add_reorbit_combo_ms`), default **3500ms** — a little slower than the previous fixed 2500ms.
- Editable in the **ReOrbit Match** tab of the Manage Games admin page ("Combo Cooldown (ms)", range 1000–15000).
- The value is stored in the game session at `/start` and echoed to the client, so client display, server replay, and authoritative scoring all use the same window.

## Anti-cheat / determinism
The combo is still recomputed server-side from validated move timestamps, and the client/server boards stay bit-identical via the shared fill seed. Re-verified end-to-end: client and server scores match exactly across both a custom (5000ms) and a short (200ms → no combo growth) window; the configured window changes results deterministically.

## Deploy note
Run the new Prisma migration (`20260703000000_add_reorbit_combo_ms`) on deploy — it adds `GameConfig.reorbitComboMs` (default 3500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013oB8GhnqpYskd4w1BZmVy9)_