### PR TITLE
ReOrbit Match: prevent board selection/highlight while dragging

### DIFF
--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -74,11 +74,14 @@
               ref="canvas"
               class="game-canvas"
               :style="{ touchAction: 'none' }"
+              draggable="false"
               @pointerdown="onPointerDown"
               @pointerup="onPointerUp"
               @pointermove="onPointerMove"
               @pointerleave="onPointerLeave"
               @pointercancel="onPointerCancel"
+              @dragstart.prevent
+              @contextmenu.prevent
               aria-label="Match-3 game grid"
               role="img"
             ></canvas>
@@ -1066,6 +1069,13 @@ onUnmounted(() => {
   min-height: 400px;
   gap: 0;
   background: #001230;
+  /* Dragging to match must never select text/UI or fire the mobile tap-highlight */
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
 }
 
 /* HUD */
@@ -1155,6 +1165,12 @@ onUnmounted(() => {
   display: block;
   width: 100%;
   height: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
 }
 
 /* How-to hint under the board */


### PR DESCRIPTION
Stops the game board from being selected/highlighted while you drag to match, so it doesn't get in the way of playing.

## Changes
On the ReOrbit Match game area and canvas:
- `user-select: none` (all vendor prefixes) — dragging no longer selects the board or surrounding HUD text.
- `-webkit-tap-highlight-color: transparent` — removes the grey/blue flash on tap (mobile).
- `-webkit-touch-callout: none` — no long-press "save image / copy" callout.
- `draggable="false"` + `@dragstart.prevent` — the canvas can't be dragged as an element.
- `@contextmenu.prevent` — a long-press or right-click won't pop a context menu mid-drag.

CSS-only plus two harmless canvas event guards; no gameplay or scoring logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013oB8GhnqpYskd4w1BZmVy9)_