### PR TITLE
Add aspect ratio constraint for home image cells on desktop

### DIFF
--- a/pages/newsite/home.vue
+++ b/pages/newsite/home.vue
@@ -99,6 +99,12 @@ html.newsite-home body {
   }
 }
 
+@media (min-width: 769px) {
+  .home-image-cell {
+    aspect-ratio: 374 / 292;
+  }
+}
+
 .home-image-cell {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Added a media query to enforce a specific aspect ratio for home image cells on desktop viewports (769px and wider).

## Key Changes
- Added `@media (min-width: 769px)` breakpoint for `.home-image-cell`
- Set `aspect-ratio: 374 / 292` to maintain consistent image proportions on larger screens
- This ensures home image cells display with a fixed aspect ratio on desktop while allowing flexible sizing on mobile

## Implementation Details
The aspect ratio constraint (374:292) is applied only to viewports 769px and wider, allowing the component to remain responsive on smaller screens while maintaining visual consistency on desktop displays.

https://claude.ai/code/session_01RhSr8aLcHGrVBRPQHzWe74