### PR TITLE
Add minting support and Second Edition eligibility to auction creation

### DIFF
--- a/components/newsite/AuctionDetails.vue
+++ b/components/newsite/AuctionDetails.vue
@@ -60,7 +60,8 @@
 
           <!-- Featured notice -->
           <div v-if="auction.isFeatured" class="adet-featured-notice">
-            ⭐ Featured — bidding restricted to users who haven't owned 2 mints in the last 30 days.
+            ⭐ Featured — you can't bid if you already own 2+<template v-if="auction.ctoon.isSecondEdition"> (1st + 2nd edition combined)</template>
+            or have received 2+ in the last 30 days.
           </div>
 
           <!-- ── Place bid ── -->

--- a/pages/admin/add-auction.vue
+++ b/pages/admin/add-auction.vue
@@ -31,7 +31,10 @@
               >
                 <img :src="opt.assetPath" alt="preview" class="w-10 h-10 rounded object-cover border" />
                 <div class="min-w-0">
-                  <div class="font-medium truncate">{{ opt.name }}</div>
+                  <div class="font-medium truncate flex items-center gap-2">
+                    <span class="truncate">{{ opt.name }}</span>
+                    <span v-if="opt.isSecondEdition" class="se-badge">2nd Ed.</span>
+                  </div>
                 <div class="text-xs text-gray-500">
                   {{ opt.rarity }}
                   <span v-if="opt.mintNumber !== null && opt.mintNumber !== undefined"> • Mint #{{ opt.mintNumber }}</span>
@@ -44,7 +47,10 @@
           <div v-if="selected" class="mt-3 flex items-center gap-3">
             <img :src="selected.assetPath" class="w-14 h-14 rounded object-cover border" />
             <div>
-              <div class="font-medium">{{ selected.name }}</div>
+              <div class="font-medium flex items-center gap-2">
+                <span>{{ selected.name }}</span>
+                <span v-if="selected.isSecondEdition" class="se-badge">2nd Ed.</span>
+              </div>
               <div class="text-sm text-gray-500">
                 {{ selected.rarity }}
                 <span v-if="selected.mintNumber !== null && selected.mintNumber !== undefined"> • Mint #{{ selected.mintNumber }}</span>
@@ -98,7 +104,8 @@
             @input="clampCreateCount"
           />
           <p class="text-xs text-gray-500 mt-1">
-            Max: {{ maxOwned }} (based on official account owned mints for this cToon)
+            Official account owns {{ maxOwned }} available. Requesting more will prompt to mint the
+            remainder on save (supply permitting).
           </p>
         </div>
 
@@ -138,6 +145,67 @@
         </div>
       </form>
     </div>
+
+    <!-- Shortfall decision modal -->
+    <div v-if="decision" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
+      <div class="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-xl font-semibold">Not enough owned copies</h2>
+          <button class="text-gray-500 hover:text-gray-700" @click="cancelDecision">X</button>
+        </div>
+
+        <div class="text-sm text-gray-700 space-y-2">
+          <p>
+            You asked to create <strong>{{ decision.requested }}</strong> auction<span v-if="decision.requested !== 1">s</span>,
+            but the official account only has <strong>{{ decision.available }}</strong> available cop<span v-if="decision.available === 1">y</span><span v-else>ies</span>
+            of this cToon.
+          </p>
+          <p class="text-gray-600">
+            Supply cap:
+            <strong>{{ decision.unlimited ? 'Unlimited' : decision.quantity }}</strong>
+            <span v-if="!decision.unlimited"> ({{ decision.totalMinted }} minted, {{ decision.remaining }} left to mint)</span>
+          </p>
+          <p v-if="decision.mintable > 0" class="text-gray-600">
+            “Mint Remaining Needed” would mint <strong>{{ decision.mintable }}</strong> new cop<span v-if="decision.mintable === 1">y</span><span v-else>ies</span>
+            to the official account, then create <strong>{{ decision.willCreateWithMint }}</strong> auction<span v-if="decision.willCreateWithMint !== 1">s</span> total.
+          </p>
+          <p v-if="decision.mintable < (decision.requested - decision.available)" class="text-amber-700">
+            ⚠️ The supply cap limits minting, so this creates fewer than the {{ decision.requested }} you requested.
+          </p>
+          <p v-if="decision.mintable === 0" class="text-amber-700">
+            ⚠️ The supply cap is reached — no new copies can be minted.
+          </p>
+        </div>
+
+        <div class="mt-5 flex flex-col gap-2">
+          <button
+            type="button"
+            :disabled="saving || decision.mintable < 1"
+            class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50"
+            @click="confirmDecision('mint')"
+          >
+            Mint Remaining Needed &amp; Create {{ decision.willCreateWithMint }} Auction<span v-if="decision.willCreateWithMint !== 1">s</span>
+          </button>
+          <button
+            type="button"
+            :disabled="saving || decision.available < 1"
+            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+            @click="confirmDecision('availableOnly')"
+          >
+            Only Create Auctions For Available Mints ({{ decision.available }})
+          </button>
+          <button
+            type="button"
+            :disabled="saving"
+            class="px-4 py-2 rounded border hover:bg-gray-50 disabled:opacity-50"
+            @click="cancelDecision"
+          >
+            Cancel Request Completely
+          </button>
+          <span v-if="error" class="text-red-600 text-sm">{{ error }}</span>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -161,19 +229,18 @@ const releaseEveryHours = ref(1)
 const isFeatured = ref(false)
 const error = ref('')
 const saving = ref(false)
+const decision = ref(null)   // shortfall modal payload from the server
+const basePayload = ref(null) // payload captured at submit, reused by modal choices
 let searchTimer
 
 const hourOptions = Array.from({ length: 24 }, (_, i) => `${String(i).padStart(2, '0')}:00`)
 const maxOwned = computed(() => Number(selected.value?.ownedCount ?? 0))
 
 function clampCreateCount() {
-  const n = Number(createCount.value || 1)
-  const next = Math.max(1, n)
-  if (maxOwned.value >= 1) {
-    createCount.value = Math.min(next, maxOwned.value)
-  } else {
-    createCount.value = next
-  }
+  // Allow requesting more than currently owned — the shortfall is resolved via
+  // the mint/available modal on save. Only enforce a sane minimum of 1.
+  const n = Math.floor(Number(createCount.value))
+  createCount.value = Number.isFinite(n) && n >= 1 ? n : 1
 }
 
 function rarityPrice(r) {
@@ -216,6 +283,7 @@ function selectOption(opt) {
   price.value = rarityPrice(opt.rarity)
   createCount.value = 1
   releaseEveryHours.value = 1
+  decision.value = null
 }
 
 function clearSelected() {
@@ -225,6 +293,7 @@ function clearSelected() {
   results.value = []
   createCount.value = 1
   releaseEveryHours.value = 1
+  decision.value = null
 }
 
 // Convert a local date/hour in America/Chicago to a UTC ISO string
@@ -265,12 +334,12 @@ function chicagoLocalToUtcISO(dateStr, timeStr) {
 
 async function submitForm() {
   error.value = ''
+  decision.value = null
   if (!selected.value) { error.value = 'Select a cToon.'; return }
   if (!startDate.value || !startHour.value) { error.value = 'Set a start date and hour.'; return }
 
   const count = Number(createCount.value || 1)
   if (!Number.isInteger(count) || count < 1) { error.value = 'Create count must be at least 1.'; return }
-  if (count > maxOwned.value) { error.value = `Create count exceeds max owned (${maxOwned.value}).`; return }
   let releaseHours = 0
   if (count > 1) {
     releaseHours = Number(releaseEveryHours.value || 0)
@@ -284,7 +353,7 @@ async function submitForm() {
   const starts = new Date(startsAtUtc)
   if (starts <= new Date()) { error.value = 'Start must be in the future.'; return }
 
-  const payload = {
+  basePayload.value = {
     userCtoonId: selected.value.userCtoonId,
     ctoonId: selected.value.ctoonId,
     pricePoints: Number(price.value || 0),
@@ -295,6 +364,15 @@ async function submitForm() {
     releaseEveryHours: releaseHours
   }
 
+  await send(null)
+}
+
+// Posts the captured payload. `mode` is null on first submit, or 'mint' /
+// 'availableOnly' when the admin resolves a shortfall via the modal.
+async function send(mode) {
+  if (!basePayload.value) return
+  error.value = ''
+  const payload = { ...basePayload.value, ...(mode ? { mintMode: mode } : {}) }
   try {
     saving.value = true
     const res = await fetch('/api/admin/auction-only', {
@@ -305,7 +383,17 @@ async function submitForm() {
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      throw new Error(err.message || 'Save failed')
+      throw new Error(err.message || err.statusMessage || 'Save failed')
+    }
+    const data = await res.json().catch(() => ({}))
+    if (data?.needsDecision) {
+      decision.value = data
+      return
+    }
+    decision.value = null
+    if (typeof data?.count === 'number' && typeof data?.requested === 'number' && data.count < data.requested) {
+      const mintedNote = data.minted > 0 ? ` (minted ${data.minted} new)` : ''
+      alert(`Created ${data.count} of ${data.requested} requested auction(s)${mintedNote}.`)
     }
     window.location.href = '/admin/manage-auctions'
   } catch (e) {
@@ -315,4 +403,30 @@ async function submitForm() {
     saving.value = false
   }
 }
+
+function confirmDecision(mode) {
+  send(mode)
+}
+
+function cancelDecision() {
+  decision.value = null
+  error.value = ''
+}
 </script>
+
+<style scoped>
+.se-badge {
+  display: inline-block;
+  flex-shrink: 0;
+  background: #7c3aed;
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  line-height: 1.2;
+  padding: 1px 6px;
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+</style>

--- a/server/api/admin/auction-only/index.post.js
+++ b/server/api/admin/auction-only/index.post.js
@@ -25,7 +25,8 @@ export default defineEventHandler(async (event) => {
     durationDays,
     isFeatured,
     createCount = 1,
-    releaseEveryHours = 0
+    releaseEveryHours = 0,
+    mintMode // undefined | 'mint' | 'availableOnly' — set by the shortfall modal
   } = body || {}
 
   const isFeaturedFlag = !!isFeatured
@@ -63,58 +64,138 @@ export default defineEventHandler(async (event) => {
 
   if (!ctoonId) throw createError({ statusCode: 400, statusMessage: 'ctoonId required' })
 
-  const pending = await prisma.auctionOnly.findMany({
-    where: { isStarted: false },
-    select: { userCtoonId: true }
-  })
-  const pendingIds = pending.map(p => p.userCtoonId)
+  const TIME_BASED_CAP = 999999999
 
-  const available = await prisma.userCtoon.findMany({
-    where: {
-      userId: owner.id,
-      ctoonId,
-      id: { notIn: pendingIds }
-    },
-    orderBy: [
-      { mintNumber: 'asc' },
-      { createdAt: 'asc' }
-    ],
-    select: { id: true, mintNumber: true, createdAt: true }
-  })
-
-  if (available.length < count) {
-    throw createError({ statusCode: 400, statusMessage: `Not enough owned copies to create ${count} auctions` })
+  // Owner-owned copies of this cToon that are not already scheduled as a pending
+  // (unstarted) AuctionOnly. `client` may be the base prisma or a tx client.
+  async function loadAvailable(client) {
+    const pending = await client.auctionOnly.findMany({
+      where: { isStarted: false },
+      select: { userCtoonId: true }
+    })
+    const pendingIds = pending.map(p => p.userCtoonId)
+    return client.userCtoon.findMany({
+      where: { userId: owner.id, ctoonId, id: { notIn: pendingIds } },
+      orderBy: [{ mintNumber: 'asc' }, { createdAt: 'asc' }],
+      select: { id: true, mintNumber: true, createdAt: true }
+    })
   }
 
-  const sorted = [...available].sort((a, b) => {
-    const aMint = Number.isInteger(a.mintNumber) ? a.mintNumber : Number.POSITIVE_INFINITY
-    const bMint = Number.isInteger(b.mintNumber) ? b.mintNumber : Number.POSITIVE_INFINITY
-    if (aMint !== bMint) return aMint - bMint
-    return a.createdAt.getTime() - b.createdAt.getTime()
+  // Supply snapshot (authoritative cap lives on Ctoon.totalMinted / quantity).
+  const ctoonRow = await prisma.ctoon.findUnique({
+    where: { id: ctoonId },
+    select: { quantity: true, totalMinted: true, initialQuantity: true, mintLimitType: true }
   })
+  if (!ctoonRow) throw createError({ statusCode: 404, statusMessage: 'cToon not found' })
 
-  let userCtoonIds = sorted.map(a => a.id)
-  if (ucIdIn) {
-    if (!userCtoonIds.includes(ucIdIn)) {
-      throw createError({ statusCode: 400, statusMessage: 'Selected copy is already scheduled' })
-    }
-    userCtoonIds = [ucIdIn, ...userCtoonIds.filter(id => id !== ucIdIn)]
-  }
-  userCtoonIds = userCtoonIds.slice(0, count)
+  // "Unlimited" = no hard cap: NULL quantity, or a time-based release still
+  // carrying the sentinel cap (finalized later). Either way we only ever mint
+  // the bounded shortfall, never the raw remaining supply.
+  const unlimited =
+    ctoonRow.quantity === null ||
+    (ctoonRow.mintLimitType === 'timeBased' && ctoonRow.quantity === TIME_BASED_CAP)
+  const remaining = unlimited
+    ? Infinity
+    : Math.max(0, Number(ctoonRow.quantity) - Number(ctoonRow.totalMinted))
 
-  const rows = userCtoonIds.map((id, idx) => {
-    const startsAt = new Date(normStarts.getTime() + idx * releaseHours * 3600000)
-    const endsAt = new Date(startsAt.getTime() + durationDays * 86400000)
+  const availablePre = await loadAvailable(prisma)
+  const availableCountPre = availablePre.length
+
+  // Shortfall without a decision → tell the client so it can show the modal.
+  if (availableCountPre < count && mintMode !== 'mint' && mintMode !== 'availableOnly') {
+    const shortfall = count - availableCountPre
+    const mintable = unlimited ? shortfall : Math.min(shortfall, remaining)
     return {
-      userCtoonId: id,
-      pricePoints,
-      startsAt,
-      endsAt,
-      isFeatured: isFeaturedFlag,
-      createdById: me.id ?? null
+      needsDecision: true,
+      requested: count,
+      available: availableCountPre,
+      unlimited,
+      quantity: unlimited ? null : Number(ctoonRow.quantity),
+      totalMinted: Number(ctoonRow.totalMinted),
+      remaining: unlimited ? null : remaining,
+      mintable,
+      willCreateWithMint: availableCountPre + mintable,
+      willCreateAvailableOnly: availableCountPre
     }
-  })
+  }
 
-  const created = await prisma.auctionOnly.createMany({ data: rows })
-  return { count: created.count }
+  // Atomically mint any needed copies (mint mode only) and create the auctions
+  // together, so a partial mint can never leave orphaned copies or orphaned rows.
+  const result = await prisma.$transaction(async (tx) => {
+    const available = await loadAvailable(tx)
+    const availableCount = available.length
+    const pool = [...available]
+
+    let minted = 0
+    if (mintMode === 'mint') {
+      const need = Math.max(0, count - availableCount)
+      for (let i = 0; i < need; i++) {
+        // Atomic increment with an in-SQL cap guard. Returns 0 rows once the cap
+        // is hit (e.g. a concurrent cMart mint got there first) → stop cleanly
+        // and auction only what we actually minted.
+        const rows = unlimited
+          ? await tx.$queryRaw`
+              UPDATE "Ctoon" SET "totalMinted" = "totalMinted" + 1
+              WHERE id = ${ctoonId}
+              RETURNING "totalMinted", "initialQuantity"`
+          : await tx.$queryRaw`
+              UPDATE "Ctoon" SET "totalMinted" = "totalMinted" + 1
+              WHERE id = ${ctoonId} AND "totalMinted" < "quantity"
+              RETURNING "totalMinted", "initialQuantity"`
+        if (!rows || !rows.length) break
+
+        const mintNumber = Number(rows[0].totalMinted)
+        const iq = rows[0].initialQuantity
+        const initialQuantity = iq == null ? null : Number(iq)
+        const isFirstEdition = initialQuantity === null || mintNumber <= initialQuantity
+
+        const uc = await tx.userCtoon.create({
+          data: { userId: owner.id, ctoonId, mintNumber, isFirstEdition, pricePaid: null },
+          select: { id: true, mintNumber: true, createdAt: true }
+        })
+        await tx.ctoonOwnerLog.create({
+          data: { userId: owner.id, ctoonId, userCtoonId: uc.id, mintNumber: uc.mintNumber }
+        })
+        pool.push(uc)
+        minted++
+      }
+    }
+
+    const finalCount = Math.min(count, pool.length)
+    if (finalCount < 1) {
+      throw createError({ statusCode: 400, statusMessage: 'No copies available to create auctions' })
+    }
+
+    const sorted = [...pool].sort((a, b) => {
+      const aMint = Number.isInteger(a.mintNumber) ? a.mintNumber : Number.POSITIVE_INFINITY
+      const bMint = Number.isInteger(b.mintNumber) ? b.mintNumber : Number.POSITIVE_INFINITY
+      if (aMint !== bMint) return aMint - bMint
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    })
+
+    let userCtoonIds = sorted.map(a => a.id)
+    // Keep the admin's explicitly-selected copy first when present & still available.
+    if (ucIdIn && userCtoonIds.includes(ucIdIn)) {
+      userCtoonIds = [ucIdIn, ...userCtoonIds.filter(id => id !== ucIdIn)]
+    }
+    userCtoonIds = userCtoonIds.slice(0, finalCount)
+
+    const rows = userCtoonIds.map((id, idx) => {
+      const startsAt = new Date(normStarts.getTime() + idx * releaseHours * 3600000)
+      const endsAt = new Date(startsAt.getTime() + durationDays * 86400000)
+      return {
+        userCtoonId: id,
+        pricePoints,
+        startsAt,
+        endsAt,
+        isFeatured: isFeaturedFlag,
+        createdById: me.id ?? null
+      }
+    })
+
+    const created = await tx.auctionOnly.createMany({ data: rows })
+    return { count: created.count, minted, requested: count }
+  }, { timeout: 30000, maxWait: 10000 })
+
+  return result
 })

--- a/server/api/admin/auction-only/owned.get.js
+++ b/server/api/admin/auction-only/owned.get.js
@@ -49,7 +49,7 @@ export default defineEventHandler(async (event) => {
     ],
     take: LIMIT,
     include: {
-      ctoon: { select: { id: true, name: true, rarity: true, assetPath: true } }
+      ctoon: { select: { id: true, name: true, rarity: true, assetPath: true, isSecondEdition: true } }
     }
   })
 
@@ -60,6 +60,7 @@ export default defineEventHandler(async (event) => {
     name: r.ctoon.name,
     rarity: r.ctoon.rarity,
     assetPath: r.ctoon.assetPath,
+    isSecondEdition: r.ctoon.isSecondEdition,
     mintNumber: r.mintNumber
   }))
   const ownedCtoonIds = new Set(owned.map(x => x.ctoonId))
@@ -70,7 +71,7 @@ export default defineEventHandler(async (event) => {
     where: {
       name: { contains: term, mode: 'insensitive' }
     },
-    select: { id: true, name: true, rarity: true, assetPath: true, quantity: true },
+    select: { id: true, name: true, rarity: true, assetPath: true, quantity: true, isSecondEdition: true },
     take: LIMIT * 2
   })
 
@@ -98,6 +99,7 @@ export default defineEventHandler(async (event) => {
       name: c.name,
       rarity: c.rarity,
       assetPath: c.assetPath,
+      isSecondEdition: c.isSecondEdition,
       mintNumber: null
     }))
 

--- a/server/api/auction/[id]/autobid.post.js
+++ b/server/api/auction/[id]/autobid.post.js
@@ -5,9 +5,9 @@ import { useRuntimeConfig } from '#imports'
 import { prisma as db } from '@/server/prisma'
 import { applyProxyAutoBids } from '@/server/utils/autoBid'
 import { scheduleAuctionClose } from '@/server/utils/queues'
+import { assertFeaturedEligibility } from '@/server/utils/featuredEligibility'
 
 const ANTI_SNIPE_MS = 60_000
-const THIRTY_DAYS_MS  = 30 * 24 * 60 * 60 * 1000
 
 export default defineEventHandler(async (event) => {
   const fmt = (n) => Number(n || 0).toLocaleString('en-US')
@@ -41,7 +41,10 @@ export default defineEventHandler(async (event) => {
       creatorId: true,
       isFeatured: true,
       userCtoon: {
-        select: { ctoonId: true }
+        select: {
+          ctoonId: true,
+          ctoon: { select: { isSecondEdition: true, relatedFirstEditionId: true } }
+        }
       }
     }
   })
@@ -56,40 +59,16 @@ export default defineEventHandler(async (event) => {
   }
 
   // --- Featured-auction eligibility (pre-upsert) ---
-  // Block if user currently owns >=2 of this cToon OR has owned >=2 in the last 30 days.
+  // For Second Edition cToons this counts copies across both editions.
   // This check must happen before the upsert so an ineligible user's auto-bid is never saved.
-  if (auc.isFeatured && auc.userCtoon?.ctoonId) {
-    const currentOwned = await db.userCtoon.count({
-      where: {
-        userId,
-        ctoonId: auc.userCtoon.ctoonId,
-        burnedAt: null,
-      }
-    })
-    if (currentOwned >= 2) {
-      throw createError({
-        statusCode: 403,
-        statusMessage: 'You are not eligible to bid on this featured auction',
-      })
+  await assertFeaturedEligibility(db, userId, {
+    isFeatured: auc.isFeatured,
+    ctoon: {
+      ctoonId: auc.userCtoon?.ctoonId,
+      isSecondEdition: auc.userCtoon?.ctoon?.isSecondEdition,
+      relatedFirstEditionId: auc.userCtoon?.ctoon?.relatedFirstEditionId
     }
-
-    const cutoff = new Date(Date.now() - THIRTY_DAYS_MS)
-    const recentOwnerships = await db.ctoonOwnerLog.findMany({
-      where: {
-        userId,
-        ctoonId: auc.userCtoon.ctoonId,
-        createdAt: { gte: cutoff },
-      },
-      select: { userCtoonId: true },
-      distinct: ['userCtoonId'],
-    })
-    if (recentOwnerships.length >= 2) {
-      throw createError({
-        statusCode: 403,
-        statusMessage: 'You are not eligible to bid on this featured auction',
-      })
-    }
-  }
+  })
 
   // --- Available points check for autobid max ---
   const up = await db.userPoints.findUnique({ where: { userId } })
@@ -161,6 +140,7 @@ export default defineEventHandler(async (event) => {
         userCtoon: {
           select: {
             ctoonId: true,
+            ctoon: { select: { isSecondEdition: true, relatedFirstEditionId: true } }
             // mintNumber: true, // add this if you ever need it
           }
         }
@@ -174,42 +154,16 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 403, statusMessage: 'Creators cannot set auto-bids on their own auctions' })
     }
 
-    // Featured-auction eligibility: block if user currently owns >=2 of this cToon
-    // OR has owned >=2 in the last 30 days (distinct userCtoonIds in owner logs)
-    if (fresh.isFeatured && fresh.userCtoon?.ctoonId) {
-      // 1) Current ownership count (unburned)
-      const currentOwned = await tx.userCtoon.count({
-        where: {
-          userId,
-          ctoonId: fresh.userCtoon.ctoonId,
-          burnedAt: null,
-        }
-      })
-      if (currentOwned >= 2) {
-        throw createError({
-          statusCode: 403,
-          statusMessage: 'You are not eligible to bid on this featured auction',
-        })
+    // Featured-auction eligibility (re-checked inside txn). For Second Edition
+    // cToons this counts copies across both editions.
+    await assertFeaturedEligibility(tx, userId, {
+      isFeatured: fresh.isFeatured,
+      ctoon: {
+        ctoonId: fresh.userCtoon?.ctoonId,
+        isSecondEdition: fresh.userCtoon?.ctoon?.isSecondEdition,
+        relatedFirstEditionId: fresh.userCtoon?.ctoon?.relatedFirstEditionId
       }
-
-      // 2) Ownership in last 30 days (distinct items)
-      const cutoff = new Date(Date.now() - THIRTY_DAYS_MS)
-      const recentOwnerships = await tx.ctoonOwnerLog.findMany({
-        where: {
-          userId,
-          ctoonId: fresh.userCtoon.ctoonId,
-          createdAt: { gte: cutoff },
-        },
-        select: { userCtoonId: true },
-        distinct: ['userCtoonId'],
-      })
-      if (recentOwnerships.length >= 2) {
-        throw createError({
-          statusCode: 403,
-          statusMessage: 'You are not eligible to bid on this featured auction',
-        })
-      }
-    }
+    })
 
     // Re-check duplicate constraint inside txn to avoid races
     const dup = await tx.auctionAutoBid.findFirst({

--- a/server/api/auction/[id]/bid.post.js
+++ b/server/api/auction/[id]/bid.post.js
@@ -5,9 +5,9 @@ import { useRuntimeConfig } from '#imports'
 import { prisma as db } from '@/server/prisma'
 import { applyProxyAutoBids, incrementFor } from '@/server/utils/autoBid'
 import { scheduleAuctionClose } from '@/server/utils/queues'
+import { assertFeaturedEligibility } from '@/server/utils/featuredEligibility'
 
 const ANTI_SNIPE_MS = 60_000
-const THIRTY_DAYS_MS  = 30 * 24 * 60 * 60 * 1000
 
 export default defineEventHandler(async (event) => {
   const fmt = (n) => Number(n || 0).toLocaleString('en-US')
@@ -72,6 +72,7 @@ export default defineEventHandler(async (event) => {
         userCtoon: {
           select: {
             ctoonId: true,
+            ctoon: { select: { isSecondEdition: true, relatedFirstEditionId: true } }
             // mintNumber: true, // add this if you ever need it
           }
         }
@@ -86,42 +87,16 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 403, statusMessage: 'Creators cannot bid on their own auctions' })
     }
 
-    // Featured-auction eligibility: block if user currently owns >=2 of this cToon
-    // OR has owned >=2 in the last 30 days (distinct userCtoonIds in owner logs)
-    if (fresh.isFeatured && fresh.userCtoon?.ctoonId) {
-      // 1) Current ownership count (unburned)
-      const currentOwned = await tx.userCtoon.count({
-        where: {
-          userId,
-          ctoonId: fresh.userCtoon.ctoonId,
-          burnedAt: null,
-        }
-      })
-      if (currentOwned >= 2) {
-        throw createError({
-          statusCode: 403,
-          statusMessage: 'You are not eligible to bid on this featured auction',
-        })
+    // Featured-auction eligibility. For Second Edition cToons this counts copies
+    // across both editions (see server/utils/featuredEligibility.js).
+    await assertFeaturedEligibility(tx, userId, {
+      isFeatured: fresh.isFeatured,
+      ctoon: {
+        ctoonId: fresh.userCtoon?.ctoonId,
+        isSecondEdition: fresh.userCtoon?.ctoon?.isSecondEdition,
+        relatedFirstEditionId: fresh.userCtoon?.ctoon?.relatedFirstEditionId
       }
-
-      // 2) Ownership in last 30 days (distinct items)
-      const cutoff = new Date(Date.now() - THIRTY_DAYS_MS)
-      const recentOwnerships = await tx.ctoonOwnerLog.findMany({
-        where: {
-          userId,
-          ctoonId: fresh.userCtoon.ctoonId,
-          createdAt: { gte: cutoff },
-        },
-        select: { userCtoonId: true },
-        distinct: ['userCtoonId'],
-      })
-      if (recentOwnerships.length >= 2) {
-        throw createError({
-          statusCode: 403,
-          statusMessage: 'You are not eligible to bid on this featured auction',
-        })
-      }
-    }
+    })
 
     const now  = new Date()
     const preEnd = new Date(fresh.endAt)

--- a/server/utils/autoBid.js
+++ b/server/utils/autoBid.js
@@ -1,6 +1,7 @@
 // server/utils/autoBid.js
 import { io as createSocket } from 'socket.io-client'
 import { useRuntimeConfig } from '#imports'
+import { checkFeaturedEligibility } from '@/server/utils/featuredEligibility'
 
 /**
  * Public constant so API routes can use the same window everywhere.
@@ -59,6 +60,14 @@ export async function applyProxyAutoBids(tx, auctionId, opts = {}) {
       highestBidderId: true,
       // 👇 needed so first auto-bid equals starting price (not increment from 0)
       initialBet: true, // If your column is named initialBid/initialPrice, rename accordingly
+      // 👇 needed to enforce the featured-auction bidding cap on proxy raises
+      isFeatured: true,
+      userCtoon: {
+        select: {
+          ctoonId: true,
+          ctoon: { select: { isSecondEdition: true, relatedFirstEditionId: true } }
+        }
+      }
     }
   })
   if (!auc) return { finalAuction: null, steps: [] }
@@ -74,12 +83,32 @@ export async function applyProxyAutoBids(tx, auctionId, opts = {}) {
   const startPrice = Math.max(0, auc.initialBet || 0)
 
   // Pull all active autobids + current points up-front
-  const auto = await tx.auctionAutoBid.findMany({
+  let auto = await tx.auctionAutoBid.findMany({
     where: { auctionId, isActive: true },
     orderBy: { createdAt: 'asc' }, // FIFO for ties
     select: { userId: true, createdAt: true, maxAmount: true }
   })
   if (!auto.length) return { finalAuction: auc, steps }
+
+  // Featured cap enforcement for proxy raises: a user who set an auto-bid while
+  // eligible must not have their proxy keep bidding once they cross the featured
+  // ownership threshold. Drop now-ineligible auto-bidders before the proxy loop
+  // so their max can never raise the price. Strictly gated on isFeatured — a
+  // no-op for every ordinary auction.
+  if (auc.isFeatured) {
+    const featuredCtoon = {
+      ctoonId: auc.userCtoon?.ctoonId,
+      isSecondEdition: auc.userCtoon?.ctoon?.isSecondEdition,
+      relatedFirstEditionId: auc.userCtoon?.ctoon?.relatedFirstEditionId
+    }
+    if (featuredCtoon.ctoonId) {
+      const flags = await Promise.all(
+        auto.map(a => checkFeaturedEligibility(tx, a.userId, featuredCtoon))
+      )
+      auto = auto.filter((_, i) => flags[i].eligible)
+      if (!auto.length) return { finalAuction: auc, steps }
+    }
+  }
 
   // Collect balances and active lock sums (all contexts) for availability
   const ids = Array.from(new Set(auto.map(a => a.userId).concat(leader ? [leader] : [])))

--- a/server/utils/featuredEligibility.js
+++ b/server/utils/featuredEligibility.js
@@ -1,0 +1,88 @@
+// server/utils/featuredEligibility.js
+// Shared logic for the "Featured auction" bidding restriction.
+//
+// A featured auction limits how many copies of a scarce cToon a single user can
+// pursue. The base rule (unchanged): a user may not bid if they currently own
+// >= 2 unburned copies, or have *received* >= 2 distinct copies in the last 30
+// days.
+//
+// Second Edition twist: when the auctioned cToon is itself a Second Edition
+// (Ctoon.isSecondEdition = true with a related First Edition), the counts are
+// combined across BOTH editions — owning 1 First + 1 Second edition = 2, and
+// likewise for the 30-day received count. This combined counting applies ONLY
+// when the auctioned cToon is a Second Edition; a featured auction of a plain /
+// First Edition cToon keeps the single-ctoon rule.
+import { createError } from 'h3'
+
+export const FEATURED_THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * Resolve the set of ctoonIds that count toward a featured auction's ownership
+ * cap for the given auctioned cToon.
+ *
+ * @param {{ ctoonId?: string|null, isSecondEdition?: boolean|null, relatedFirstEditionId?: string|null }} ctoon
+ * @returns {string[]}
+ */
+export function resolveFeaturedCtoonIds(ctoon) {
+  if (!ctoon?.ctoonId) return []
+  const ids = [ctoon.ctoonId]
+  // Only combine editions when the auctioned copy is a Second Edition and it is
+  // actually linked to a First Edition. If the link is missing (unlinked data),
+  // fall back to the single-ctoon count rather than counting a bogus id.
+  if (ctoon.isSecondEdition && ctoon.relatedFirstEditionId) {
+    ids.push(ctoon.relatedFirstEditionId)
+  }
+  return Array.from(new Set(ids.filter(Boolean)))
+}
+
+/**
+ * Compute whether a user is eligible to bid on a featured auction.
+ * Non-throwing — returns a structured result so callers can either throw or
+ * filter (e.g. proxy auto-bids).
+ *
+ * @param {import('@prisma/client').PrismaClient} client  prisma or a tx client
+ * @param {string} userId
+ * @param {{ ctoonId?: string|null, isSecondEdition?: boolean|null, relatedFirstEditionId?: string|null }} ctoon
+ * @returns {Promise<{ eligible: boolean, reason?: 'own'|'recent' }>}
+ */
+export async function checkFeaturedEligibility(client, userId, ctoon) {
+  const ctoonIds = resolveFeaturedCtoonIds(ctoon)
+  if (!ctoonIds.length) return { eligible: true }
+
+  // 1) Current ownership across the counted editions (unburned copies only).
+  const currentOwned = await client.userCtoon.count({
+    where: { userId, ctoonId: { in: ctoonIds }, burnedAt: null }
+  })
+  if (currentOwned >= 2) return { eligible: false, reason: 'own' }
+
+  // 2) Distinct copies *received* across the counted editions in the last 30
+  //    days. Counts receipts (not current holdings) per the product rule.
+  const cutoff = new Date(Date.now() - FEATURED_THIRTY_DAYS_MS)
+  const recent = await client.ctoonOwnerLog.findMany({
+    where: { userId, ctoonId: { in: ctoonIds }, createdAt: { gte: cutoff } },
+    select: { userCtoonId: true },
+    distinct: ['userCtoonId']
+  })
+  if (recent.length >= 2) return { eligible: false, reason: 'recent' }
+
+  return { eligible: true }
+}
+
+/**
+ * Throwing guard for the manual-bid / set-autobid endpoints. No-op when the
+ * auction is not featured.
+ *
+ * @param {import('@prisma/client').PrismaClient} client
+ * @param {string} userId
+ * @param {{ isFeatured?: boolean|null, ctoon: object }} auction
+ */
+export async function assertFeaturedEligibility(client, userId, { isFeatured, ctoon }) {
+  if (!isFeatured) return
+  const { eligible } = await checkFeaturedEligibility(client, userId, ctoon)
+  if (!eligible) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: 'You are not eligible to bid on this featured auction'
+    })
+  }
+}


### PR DESCRIPTION
## Summary
This PR extends the auction creation workflow to support on-demand minting when insufficient owned copies are available, and refactors featured auction eligibility logic to handle Second Edition cToons that count ownership across both editions.

## Key Changes

### Auction Creation with Minting
- **Admin auction creation** now accepts a `mintMode` parameter ('mint' or 'availableOnly') to handle shortfalls
- When an admin requests more auctions than owned copies exist, the server returns a decision payload instead of failing
- A new **shortfall modal** in the UI lets admins choose to:
  - Mint remaining needed copies and create all requested auctions
  - Create auctions only for currently available copies
  - Cancel the request entirely
- Minting is performed atomically within a transaction alongside auction creation, with in-SQL cap guards to prevent exceeding supply limits
- The endpoint now loads cToon supply metadata (quantity, totalMinted, mintLimitType) to calculate mintable shortfall and enforce caps

### Featured Auction Eligibility Refactor
- Extracted featured auction eligibility logic into a new shared utility (`server/utils/featuredEligibility.js`)
- **Second Edition support**: when a cToon is a Second Edition with a linked First Edition, ownership counts are combined across both editions
  - A user owning 1 First Edition + 1 Second Edition = 2 copies (ineligible)
  - The 30-day receipt history is also combined across editions
- Applied consistently across manual bids, auto-bids, and proxy auto-bid raises
- Proxy auto-bids now drop ineligible bidders before raising prices, preventing them from influencing the auction outcome

### UI Improvements
- **Add Auction form**: removed hard cap on create count; users can now request more than owned, triggering the shortfall modal
- **Copy selection**: added "2nd Ed." badge to Second Edition cToons in dropdowns and selected display
- **Help text**: updated to explain that requesting more than owned will prompt for minting
- **Modal**: comprehensive shortfall decision UI showing requested count, available count, supply cap, mintable amount, and outcome previews

## Implementation Details
- Minting uses raw SQL `UPDATE ... RETURNING` with atomic increment and cap guards to prevent race conditions
- New `userCtoon` records and `ctoonOwnerLog` entries are created for minted copies within the same transaction
- The `TIME_BASED_CAP` sentinel (999999999) identifies time-based release cToons that haven't been finalized yet
- Featured eligibility checks are now parameterized by ctoon metadata rather than hardcoded, enabling future edition-aware rules

https://claude.ai/code/session_01XzeDAmDDdA7Fn7cCAWRegS