### PR TITLE
Update home image styling: remove aspect ratio and change object-fit

### DIFF
--- a/pages/newsite/home.vue
+++ b/pages/newsite/home.vue
@@ -99,12 +99,6 @@ html.newsite-home body {
   }
 }
 
-@media (min-width: 769px) {
-  .home-image-cell {
-    aspect-ratio: 374 / 292;
-  }
-}
-
 .home-image-cell {
   display: flex;
   align-items: center;
@@ -120,7 +114,7 @@ html.newsite-home body {
   max-height: 100%;
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: fill;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
Updated the styling for home image cells to improve image display behavior by removing the fixed aspect ratio constraint and changing the object-fit property.

## Key Changes
- Removed the `@media (min-width: 769px)` breakpoint rule that enforced a 374/292 aspect ratio on `.home-image-cell`
- Changed the `object-fit` property from `contain` to `fill` for `.home-image-cell img`

## Implementation Details
These changes allow images to fill their container completely without maintaining a specific aspect ratio, which may provide better visual coverage and a more flexible layout across different screen sizes. The removal of the media query simplifies the responsive design logic for this component.

https://claude.ai/code/session_01TG3KKZzuBGS7ETMniAqB4D