### PR TITLE
Add edit and delete functionality for background images

### DIFF
--- a/pages/admin/backgrounds.vue
+++ b/pages/admin/backgrounds.vue
@@ -31,7 +31,7 @@
             <label class="text-sm font-medium">Image (PNG, GIF, or JPEG)</label>
             <input ref="fileInput" type="file" accept="image/png,image/gif,image/jpeg" @change="onFile"
               class="block w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-600 file:text-white hover:file:bg-blue-700" />
-            <p class="text-xs text-gray-500">Exactly <strong>510×344</strong> or <strong>512×346</strong> or <strong>800x600</strong> px.</p>
+            <p class="text-xs text-gray-500">Exactly <strong>510×344</strong> or <strong>512×346</strong> or <strong>800×600</strong> px.</p>
           </div>
 
           <button type="submit" :disabled="!imageFile || uploading" :title="!imageFile ? 'Choose an image' : ''"
@@ -58,40 +58,193 @@
         </div>
 
         <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
-        <div v-for="bg in backgrounds" :key="bg.id" class="bg-white rounded-xl border border-gray-200 shadow overflow-hidden">
-          <img :src="bg.imagePath" :alt="bg.label || 'Background'" class="w-full h-44 object-cover" />
-          <div class="p-4 space-y-2 text-sm">
-            <div class="font-medium truncate">{{ bg.label || '—' }}</div>
-            <div class="text-gray-600">{{ bg.width }}×{{ bg.height }} • {{ shortMime(bg.mimeType) }}</div>
-            <div class="flex items-center gap-2">
-              <span class="text-gray-600 shrink-0">Visibility:</span>
-              <button
-                @click="toggleVisibility(bg)"
-                :disabled="!!saving[bg.id]"
-                :title="bg.visibility === 'PUBLIC' ? 'Click to make Code Only' : 'Click to make Public'"
-                :class="[
-                  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold transition-colors min-h-[28px]',
-                  bg.visibility === 'PUBLIC'
-                    ? 'bg-green-100 text-green-800 hover:bg-green-200'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
-                  saving[bg.id] ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'
-                ]"
-              >
-                <span v-if="saving[bg.id]" class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                {{ fromEnum(bg.visibility) }}
+          <div v-for="bg in backgrounds" :key="bg.id" class="bg-white rounded-xl border border-gray-200 shadow overflow-hidden">
+            <img :src="bg.imagePath" :alt="bg.label || 'Background'" class="w-full h-44 object-cover" />
+            <div class="p-4 space-y-2 text-sm">
+              <div class="font-medium truncate">{{ bg.label || '—' }}</div>
+              <div class="text-gray-600">{{ bg.width }}×{{ bg.height }} • {{ shortMime(bg.mimeType) }}</div>
+              <div class="flex items-center gap-2">
+                <span class="text-gray-600 shrink-0">Visibility:</span>
+                <button
+                  @click="toggleVisibility(bg)"
+                  :disabled="!!saving[bg.id]"
+                  :title="bg.visibility === 'PUBLIC' ? 'Click to make Code Only' : 'Click to make Public'"
+                  :class="[
+                    'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold transition-colors min-h-[28px]',
+                    bg.visibility === 'PUBLIC'
+                      ? 'bg-green-100 text-green-800 hover:bg-green-200'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+                    saving[bg.id] ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'
+                  ]"
+                >
+                  <span v-if="saving[bg.id]" class="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                  {{ fromEnum(bg.visibility) }}
+                </button>
+              </div>
+              <div class="text-gray-500">Added: {{ formatDate(bg.createdAt) }}</div>
+            </div>
+            <div class="px-4 pb-4 flex gap-2">
+              <button @click="openEdit(bg)"
+                class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                Edit
+              </button>
+              <button @click="openDelete(bg)"
+                class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500">
+                Delete
               </button>
             </div>
-            <div class="text-gray-500">Added: {{ formatDate(bg.createdAt) }}</div>
           </div>
-          <!-- <div class="px-4 pb-4">
-            <button @click="remove(bg)" class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500">
-              Delete
-            </button>
-          </div> -->
         </div>
-      </div>
       </template>
     </section>
+  </div>
+
+  <!-- ── Edit Modal ──────────────────────────────────────────────────── -->
+  <div v-if="editModal.show" class="fixed inset-0 z-50 flex items-center justify-center">
+    <div class="absolute inset-0 bg-black/50" @click="closeEdit" />
+    <div class="relative bg-white rounded-lg shadow-lg w-full max-w-xl max-h-[90vh] flex flex-col">
+      <div class="p-4 border-b flex items-center justify-between flex-shrink-0">
+        <h2 class="text-lg font-semibold">Edit Background</h2>
+        <button class="text-gray-500 hover:text-gray-700 text-xl leading-none" @click="closeEdit">&times;</button>
+      </div>
+
+      <div class="p-4 overflow-y-auto flex-1 space-y-4">
+        <!-- Label -->
+        <div class="flex flex-col gap-1">
+          <label class="text-sm font-medium">Label</label>
+          <input v-model="editModal.label" type="text" placeholder="e.g. Night City"
+            class="rounded-md border border-gray-400 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-600 focus:border-blue-600" />
+        </div>
+
+        <!-- Visibility -->
+        <div class="flex flex-col gap-1">
+          <label class="text-sm font-medium">Visibility</label>
+          <select v-model="editModal.visibility"
+            class="rounded-md border border-gray-400 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-600 focus:border-blue-600">
+            <option value="PUBLIC">Public</option>
+            <option value="CODE_ONLY">Code only</option>
+          </select>
+        </div>
+
+        <!-- Replace image -->
+        <div class="flex flex-col gap-1">
+          <label class="text-sm font-medium">Replace Image (optional)</label>
+          <div class="text-xs text-gray-500 mb-1">
+            Current: {{ editModal.bg?.width }}×{{ editModal.bg?.height }} px
+          </div>
+          <input ref="editFileInput" type="file" accept="image/png,image/gif,image/jpeg"
+            @change="onEditFile"
+            class="block w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200" />
+          <p class="text-xs text-gray-500">Exactly <strong>510×344</strong>, <strong>512×346</strong>, or <strong>800×600</strong> px. All cZones using this background will be updated to the new image.</p>
+        </div>
+
+        <!-- Dimension mismatch warning -->
+        <div v-if="editModal.dimensionWarning" class="rounded-md bg-yellow-50 border border-yellow-300 px-3 py-2 text-sm text-yellow-800">
+          {{ editModal.dimensionWarning }}
+        </div>
+
+        <!-- New image preview -->
+        <div v-if="editModal.imagePreview" class="flex flex-col gap-1">
+          <div class="text-xs text-gray-500 font-medium">New image preview:</div>
+          <img :src="editModal.imagePreview" alt="New image preview" class="max-w-full rounded-md border border-gray-300 max-h-48 object-contain" />
+        </div>
+
+        <div v-if="editModal.error" class="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+          {{ editModal.error }}
+        </div>
+      </div>
+
+      <div class="p-4 border-t flex justify-end gap-2 flex-shrink-0">
+        <button class="px-4 py-2 rounded border border-gray-300 text-sm font-medium" @click="closeEdit">Cancel</button>
+        <button
+          class="px-4 py-2 rounded bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="editModal.saving"
+          @click="saveEdit">
+          <span v-if="!editModal.saving">Save</span>
+          <span v-else>Saving…</span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Delete Confirmation Modal ───────────────────────────────────── -->
+  <div v-if="deleteModal.show" class="fixed inset-0 z-50 flex items-center justify-center">
+    <div class="absolute inset-0 bg-black/50" @click="closeDelete" />
+    <div class="relative bg-white rounded-lg shadow-lg w-full max-w-md flex flex-col">
+      <div class="p-4 border-b flex items-center justify-between flex-shrink-0">
+        <h2 class="text-lg font-semibold text-red-700">Delete Background</h2>
+        <button class="text-gray-500 hover:text-gray-700 text-xl leading-none" @click="closeDelete">&times;</button>
+      </div>
+
+      <div class="p-4 space-y-4">
+        <p class="text-sm text-gray-700">
+          You are about to permanently delete
+          <strong>{{ deleteModal.bg?.label || 'this background' }}</strong>.
+          This cannot be undone.
+        </p>
+
+        <!-- Loading usage -->
+        <div v-if="deleteModal.loading" class="text-sm text-gray-500 flex items-center gap-2">
+          <span class="inline-block w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
+          Checking usage…
+        </div>
+
+        <!-- Usage summary -->
+        <div v-else-if="deleteModal.usage" class="rounded-md border border-gray-200 divide-y text-sm">
+          <div class="px-3 py-2 flex justify-between">
+            <span class="text-gray-600">Player owners (will lose it)</span>
+            <span :class="deleteModal.usage.userCount > 0 ? 'font-semibold text-red-700' : 'text-gray-500'">
+              {{ deleteModal.usage.userCount }}
+            </span>
+          </div>
+          <div class="px-3 py-2 flex justify-between">
+            <span class="text-gray-600">cZones using this background</span>
+            <span :class="deleteModal.usage.czoneCount > 0 ? 'font-semibold text-amber-700' : 'text-gray-500'">
+              {{ deleteModal.usage.czoneCount }}
+            </span>
+          </div>
+          <div class="px-3 py-2 flex justify-between">
+            <span class="text-gray-600">Claim code reward slots (will be removed)</span>
+            <span :class="deleteModal.usage.rewardBackgroundCount > 0 ? 'font-semibold text-amber-700' : 'text-gray-500'">
+              {{ deleteModal.usage.rewardBackgroundCount }}
+            </span>
+          </div>
+          <div class="px-3 py-2 flex justify-between">
+            <span class="text-gray-600">Achievement reward slots (will be removed)</span>
+            <span :class="deleteModal.usage.achievementRewardCount > 0 ? 'font-semibold text-amber-700' : 'text-gray-500'">
+              {{ deleteModal.usage.achievementRewardCount }}
+            </span>
+          </div>
+          <div class="px-3 py-2 flex justify-between">
+            <span class="text-gray-600">cZone search conditions (will be cleared)</span>
+            <span :class="deleteModal.usage.searchPrizeCount > 0 ? 'font-semibold text-red-700' : 'text-gray-500'">
+              {{ deleteModal.usage.searchPrizeCount }}
+            </span>
+          </div>
+        </div>
+
+        <!-- Active search condition warning -->
+        <div v-if="deleteModal.usage?.searchPrizeCount > 0"
+          class="rounded-md bg-red-50 border border-red-300 px-3 py-2 text-sm text-red-800">
+          This background is a condition on {{ deleteModal.usage.searchPrizeCount }} active search prize{{ deleteModal.usage.searchPrizeCount === 1 ? '' : 's' }}. Deleting it will permanently disable those conditions — players won't be able to satisfy them.
+        </div>
+
+        <div v-if="deleteModal.error" class="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+          {{ deleteModal.error }}
+        </div>
+      </div>
+
+      <div class="p-4 border-t flex justify-end gap-2 flex-shrink-0">
+        <button class="px-4 py-2 rounded border border-gray-300 text-sm font-medium" @click="closeDelete">Cancel</button>
+        <button
+          class="px-4 py-2 rounded bg-red-600 text-white text-sm font-medium hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="deleteModal.loading || deleteModal.deleting"
+          @click="confirmDelete">
+          <span v-if="deleteModal.deleting">Deleting…</span>
+          <span v-else>Delete permanently</span>
+        </button>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -99,8 +252,9 @@
 definePageMeta({ title: 'Admin - Backgrounds', middleware: ['auth','admin'], layout: 'admin' })
 import { ref, reactive } from 'vue'
 
+// ── Upload form state ──────────────────────────────────────────────────
 const label = ref('')
-const visibility = ref('public') // 'public' | 'code-only'
+const visibility = ref('public')
 const imageFile = ref(null)
 const imagePreview = ref('')
 const uploading = ref(false)
@@ -108,35 +262,71 @@ const fileInput = ref(null)
 const saving = reactive({})
 const updateError = ref('')
 
+// ── Edit modal state ───────────────────────────────────────────────────
+const editModal = reactive({
+  show: false,
+  bg: null,
+  label: '',
+  visibility: 'PUBLIC',
+  imageFile: null,
+  imagePreview: '',
+  dimensionWarning: '',
+  saving: false,
+  error: ''
+})
+const editFileInput = ref(null)
+
+// ── Delete modal state ─────────────────────────────────────────────────
+const deleteModal = reactive({
+  show: false,
+  bg: null,
+  loading: false,
+  usage: null,
+  deleting: false,
+  error: ''
+})
+
+// ── Helpers ────────────────────────────────────────────────────────────
 function shortMime(m) { return (m||'').replace('image/','').toUpperCase() }
 function fromEnum(v) { return v === 'CODE_ONLY' ? 'Code only' : 'Public' }
 function formatDate(d) { return new Date(d).toLocaleString() }
 
-function onFile(e) {
-  const file = e.target.files[0]
+const ALLOWED_SIZES = [[510,344],[512,346],[800,600]]
+
+function validateImageFile(file, onValid, onError) {
   if (!file) return
   if (!['image/png','image/gif','image/jpeg'].includes(file.type)) {
-    alert('Only PNG, GIF, or JPEG allowed.')
-    fileInput.value.value = ''
+    onError('Only PNG, GIF, or JPEG allowed.')
     return
   }
-  // Client‑side size check (extra safety; server also validates)
   const url = URL.createObjectURL(file)
   const img = new Image()
   img.onload = () => {
-    const ok = (img.width === 510 && img.height === 344) || (img.width === 512 && img.height === 346) || (img.width === 800 && img.height === 600)
+    const ok = ALLOWED_SIZES.some(([w,h]) => img.width === w && img.height === h)
     if (!ok) {
-      alert('Image must be exactly 510×344 or 512×346 or 800x600 px.')
-      fileInput.value.value = ''
       URL.revokeObjectURL(url)
-      imageFile.value = null
-      imagePreview.value = ''
+      onError('Image must be exactly 510×344, 512×346, or 800×600 px.')
       return
     }
-    imageFile.value = file
-    imagePreview.value = url
+    onValid(file, url, img.width, img.height)
   }
   img.src = url
+}
+
+// ── Upload form ────────────────────────────────────────────────────────
+function onFile(e) {
+  const file = e.target.files[0]
+  if (!file) return
+  validateImageFile(
+    file,
+    (f, url) => { imageFile.value = f; imagePreview.value = url },
+    (msg) => {
+      alert(msg)
+      fileInput.value.value = ''
+      imageFile.value = null
+      imagePreview.value = ''
+    }
+  )
 }
 
 const { data: backgrounds, pending, error } = await useFetch('/api/admin/backgrounds', {
@@ -172,7 +362,6 @@ async function submit() {
   form.append('image', imageFile.value)
   try {
     await $fetch('/api/admin/backgrounds', { method: 'POST', body: form })
-    // reset
     label.value = ''
     visibility.value = 'public'
     fileInput.value.value = ''
@@ -187,14 +376,137 @@ async function submit() {
   }
 }
 
-async function remove(bg) {
-  if (!confirm('Delete this background? This cannot be undone.')) return
+// ── Edit modal ─────────────────────────────────────────────────────────
+function openEdit(bg) {
+  editModal.bg = bg
+  editModal.label = bg.label || ''
+  editModal.visibility = bg.visibility
+  editModal.imageFile = null
+  editModal.imagePreview = ''
+  editModal.dimensionWarning = ''
+  editModal.error = ''
+  editModal.saving = false
+  editModal.show = true
+}
+
+function closeEdit() {
+  if (editModal.saving) return
+  editModal.show = false
+  if (editModal.imagePreview) URL.revokeObjectURL(editModal.imagePreview)
+  editModal.imageFile = null
+  editModal.imagePreview = ''
+  if (editFileInput.value) editFileInput.value.value = ''
+}
+
+function onEditFile(e) {
+  const file = e.target.files[0]
+  if (!file) {
+    editModal.imageFile = null
+    editModal.imagePreview = ''
+    editModal.dimensionWarning = ''
+    return
+  }
+  validateImageFile(
+    file,
+    (f, url, w, h) => {
+      if (editModal.imagePreview) URL.revokeObjectURL(editModal.imagePreview)
+      editModal.imageFile = f
+      editModal.imagePreview = url
+      const orig = editModal.bg
+      editModal.dimensionWarning = (w !== orig.width || h !== orig.height)
+        ? `Warning: new image is ${w}×${h} but original is ${orig.width}×${orig.height}. cZones designed around the original size may look different.`
+        : ''
+    },
+    (msg) => {
+      alert(msg)
+      if (editFileInput.value) editFileInput.value.value = ''
+      editModal.imageFile = null
+      editModal.imagePreview = ''
+      editModal.dimensionWarning = ''
+    }
+  )
+}
+
+async function saveEdit() {
+  const bg = editModal.bg
+  const labelChanged = editModal.label !== (bg.label || '')
+  const visibilityChanged = editModal.visibility !== bg.visibility
+  const hasNewImage = !!editModal.imageFile
+
+  if (!labelChanged && !visibilityChanged && !hasNewImage) {
+    closeEdit()
+    return
+  }
+
+  editModal.saving = true
+  editModal.error = ''
+
   try {
-    await $fetch(`/api/admin/backgrounds/${bg.id}`, { method: 'DELETE' })
+    if (labelChanged || visibilityChanged) {
+      const updated = await $fetch(`/api/admin/backgrounds/${bg.id}`, {
+        method: 'PATCH',
+        body: { label: editModal.label.trim() || null, visibility: editModal.visibility }
+      })
+      bg.label = updated.label
+      bg.visibility = updated.visibility
+    }
+
+    if (hasNewImage) {
+      const form = new FormData()
+      form.append('image', editModal.imageFile)
+      const updated = await $fetch(`/api/admin/backgrounds/${bg.id}/replace-image`, {
+        method: 'POST',
+        body: form
+      })
+      bg.imagePath = updated.imagePath
+      bg.filename = updated.filename
+      bg.width = updated.width
+      bg.height = updated.height
+      bg.mimeType = updated.mimeType
+    }
+
+    closeEdit()
     await refreshNuxtData('backgrounds')
   } catch (err) {
-    console.error(err)
-    alert(err?.data?.statusMessage || 'Failed to delete background')
+    editModal.error = err?.data?.statusMessage || 'Failed to save changes'
+  } finally {
+    editModal.saving = false
+  }
+}
+
+// ── Delete modal ───────────────────────────────────────────────────────
+async function openDelete(bg) {
+  deleteModal.bg = bg
+  deleteModal.usage = null
+  deleteModal.loading = true
+  deleteModal.error = ''
+  deleteModal.deleting = false
+  deleteModal.show = true
+
+  try {
+    deleteModal.usage = await $fetch(`/api/admin/backgrounds/${bg.id}/usage`)
+  } catch (err) {
+    deleteModal.error = 'Failed to load usage data'
+  } finally {
+    deleteModal.loading = false
+  }
+}
+
+function closeDelete() {
+  if (deleteModal.deleting) return
+  deleteModal.show = false
+}
+
+async function confirmDelete() {
+  deleteModal.deleting = true
+  deleteModal.error = ''
+  try {
+    await $fetch(`/api/admin/backgrounds/${deleteModal.bg.id}`, { method: 'DELETE' })
+    closeDelete()
+    await refreshNuxtData('backgrounds')
+  } catch (err) {
+    deleteModal.error = err?.data?.statusMessage || 'Failed to delete background'
+    deleteModal.deleting = false
   }
 }
 </script>

--- a/server/api/admin/backgrounds/[id].delete.js
+++ b/server/api/admin/backgrounds/[id].delete.js
@@ -1,0 +1,114 @@
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { unlink } from 'node:fs/promises'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { redis } from '@/server/utils/redis'
+import { clearSearchesCache } from '@/server/api/czone/[username]/searches.get'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+// In production this file is at server/api/admin/backgrounds/ — 4 levels up to project root.
+// In dev, process.cwd() is always the project root.
+const baseDir = process.env.NODE_ENV === 'production'
+  ? join(__dirname, '..', '..', '..', '..')
+  : process.cwd()
+
+function fsPathFromFilename(filename) {
+  return process.env.NODE_ENV === 'production'
+    ? join(baseDir, 'cartoon-reorbit-images', 'backgrounds', filename)
+    : join(baseDir, 'public', 'backgrounds', filename)
+}
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const id = event.context.params?.id
+  const bg = await db.background.findUnique({ where: { id } })
+  if (!bg) throw createError({ statusCode: 404, statusMessage: 'Background not found' })
+
+  // Collect affected search IDs before deletion so we can invalidate cache after
+  const affectedPrizes = await db.cZoneSearchPrize.findMany({
+    where: { conditionBackgrounds: { has: bg.filename } },
+    select: { cZoneSearchId: true }
+  })
+  const affectedSearchIds = [...new Set(affectedPrizes.map(p => p.cZoneSearchId))]
+
+  // All DB operations run in a single transaction.
+  // Junction rows with onDelete:Restrict must be deleted before the Background row.
+  // File deletion happens AFTER the transaction commits so a DB failure never
+  // leaves a missing file with a live DB record pointing at it.
+  await db.$transaction(async (tx) => {
+    await tx.achievementRewardBackground.deleteMany({ where: { backgroundId: id } })
+    await tx.rewardBackground.deleteMany({ where: { backgroundId: id } })
+    await tx.userBackground.deleteMany({ where: { backgroundId: id } })
+
+    // Clear CZone.background (top-level string column)
+    await tx.$executeRaw`
+      UPDATE "CZone"
+      SET "background" = ''
+      WHERE "background" = ${bg.imagePath}
+    `
+
+    // Remove background key from any zone objects inside CZone.layoutData.zones
+    await tx.$executeRaw`
+      UPDATE "CZone"
+      SET "layoutData" = jsonb_set(
+        "layoutData",
+        '{zones}',
+        COALESCE(
+          (SELECT jsonb_agg(
+            CASE WHEN zone->>'background' = ${bg.imagePath}
+              THEN zone - 'background'
+              ELSE zone
+            END
+          ) FROM jsonb_array_elements("layoutData"->'zones') AS zone),
+          '[]'::jsonb
+        )
+      )
+      WHERE jsonb_typeof("layoutData"->'zones') = 'array'
+        AND EXISTS (
+          SELECT 1 FROM jsonb_array_elements("layoutData"->'zones') AS z
+          WHERE z->>'background' = ${bg.imagePath}
+        )
+    `
+
+    // Remove this background's filename from CZoneSearchPrize.conditionBackgrounds arrays
+    await tx.$executeRaw`
+      UPDATE "CZoneSearchPrize"
+      SET "conditionBackgrounds" = array_remove("conditionBackgrounds", ${bg.filename})
+      WHERE ${bg.filename} = ANY("conditionBackgrounds")
+    `
+
+    // All child rows cleared — safe to delete the Background row
+    await tx.background.delete({ where: { id } })
+  })
+
+  // DB committed — delete image file from disk (non-fatal if missing)
+  try { await unlink(fsPathFromFilename(bg.filename)) } catch {}
+
+  // Invalidate Redis cache for any cZone searches that had this background as a condition
+  for (const searchId of affectedSearchIds) {
+    try { await redis.del(`czone:search-meta:${searchId}`) } catch {}
+  }
+  if (affectedSearchIds.length > 0) clearSearchesCache()
+
+  await logAdminChange(db, {
+    userId: me.id,
+    area: 'Background',
+    key: 'delete',
+    prevValue: bg.imagePath,
+    newValue: null
+  })
+
+  return { ok: true }
+})

--- a/server/api/admin/backgrounds/[id].patch.js
+++ b/server/api/admin/backgrounds/[id].patch.js
@@ -17,27 +17,38 @@ export default defineEventHandler(async (event) => {
   }
 
   const id = event.context.params?.id
-  const { visibility } = await readBody(event)
+  const body = await readBody(event)
+  const updates = {}
 
-  if (!VALID_VISIBILITY.includes(visibility)) {
-    throw createError({ statusCode: 400, statusMessage: 'visibility must be PUBLIC or CODE_ONLY' })
+  if ('visibility' in body) {
+    if (!VALID_VISIBILITY.includes(body.visibility)) {
+      throw createError({ statusCode: 400, statusMessage: 'visibility must be PUBLIC or CODE_ONLY' })
+    }
+    updates.visibility = body.visibility
+  }
+
+  if ('label' in body) {
+    updates.label = body.label?.trim() || null
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Nothing to update' })
   }
 
   const bg = await db.background.findUnique({ where: { id } })
   if (!bg) throw createError({ statusCode: 404, statusMessage: 'Background not found' })
 
-  const updated = await db.background.update({
-    where: { id },
-    data: { visibility }
-  })
+  const updated = await db.background.update({ where: { id }, data: updates })
 
-  await logAdminChange(db, {
-    userId: me.id,
-    area: 'Background',
-    key: 'visibility',
-    prevValue: bg.visibility,
-    newValue: visibility
-  })
+  for (const [key, newValue] of Object.entries(updates)) {
+    await logAdminChange(db, {
+      userId: me.id,
+      area: 'Background',
+      key,
+      prevValue: bg[key],
+      newValue
+    })
+  }
 
-  return { id: updated.id, visibility: updated.visibility }
+  return { id: updated.id, label: updated.label, visibility: updated.visibility }
 })

--- a/server/api/admin/backgrounds/[id]/replace-image.post.js
+++ b/server/api/admin/backgrounds/[id]/replace-image.post.js
@@ -1,0 +1,168 @@
+import { defineEventHandler, readMultipartFormData, getRequestHeader, createError } from 'h3'
+import { mkdir, writeFile, unlink } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { prisma as db } from '@/server/prisma'
+import { imageSize } from 'image-size'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { redis } from '@/server/utils/redis'
+import { clearSearchesCache } from '@/server/api/czone/[username]/searches.get'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+// In production this file is at server/api/admin/backgrounds/[id]/ — 5 levels up to project root.
+// In dev, process.cwd() is always the project root.
+const baseDir = process.env.NODE_ENV === 'production'
+  ? join(__dirname, '..', '..', '..', '..', '..')
+  : process.cwd()
+
+const ALLOWED_MIMES = ['image/png', 'image/jpeg', 'image/gif']
+const ALLOWED_SIZES = [[510, 344], [512, 346], [800, 600]]
+
+function sanitize(name = '') {
+  return name.replace(/[^A-Za-z0-9._-]/g, '') || 'image'
+}
+
+function fsPathFromFilename(filename) {
+  return process.env.NODE_ENV === 'production'
+    ? join(baseDir, 'cartoon-reorbit-images', 'backgrounds', filename)
+    : join(baseDir, 'public', 'backgrounds', filename)
+}
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const id = event.context.params?.id
+  const bg = await db.background.findUnique({ where: { id } })
+  if (!bg) throw createError({ statusCode: 404, statusMessage: 'Background not found' })
+
+  const parts = await readMultipartFormData(event)
+  if (!parts?.length) throw createError({ statusCode: 400, statusMessage: 'multipart/form-data expected' })
+
+  let imagePart = null
+  for (const part of parts) {
+    if (part.filename) { imagePart = part; break }
+  }
+  if (!imagePart) throw createError({ statusCode: 400, statusMessage: 'Image file is required.' })
+  if (!ALLOWED_MIMES.includes(imagePart.type)) {
+    throw createError({ statusCode: 400, statusMessage: 'Only PNG, GIF, or JPEG allowed.' })
+  }
+
+  const { width, height } = imageSize(imagePart.data)
+  const isAllowedSize = ALLOWED_SIZES.some(([w, h]) => w === width && h === height)
+  if (!isAllowedSize) {
+    const supported = ALLOWED_SIZES.map(s => s.join('×')).join(', ')
+    throw createError({ statusCode: 400, statusMessage: `Image must be exactly ${supported}.` })
+  }
+
+  const uploadDir = process.env.NODE_ENV === 'production'
+    ? join(baseDir, 'cartoon-reorbit-images', 'backgrounds')
+    : join(baseDir, 'public', 'backgrounds')
+
+  await mkdir(uploadDir, { recursive: true })
+
+  const orig = sanitize(imagePart.filename)
+  const newFilename = `${Date.now()}_${orig}`
+  const outPath = join(uploadDir, newFilename)
+  await writeFile(outPath, imagePart.data)
+
+  const newImagePath = process.env.NODE_ENV === 'production'
+    ? `/images/backgrounds/${newFilename}`
+    : `/backgrounds/${newFilename}`
+
+  const oldFilename = bg.filename
+  const oldImagePath = bg.imagePath
+
+  // Collect affected search IDs before the transaction so we can invalidate cache after
+  const affectedPrizes = await db.cZoneSearchPrize.findMany({
+    where: { conditionBackgrounds: { has: oldFilename } },
+    select: { cZoneSearchId: true }
+  })
+  const affectedSearchIds = [...new Set(affectedPrizes.map(p => p.cZoneSearchId))]
+
+  try {
+    await db.$transaction(async (tx) => {
+      // Update the Background record
+      await tx.background.update({
+        where: { id },
+        data: { imagePath: newImagePath, filename: newFilename, width, height, mimeType: imagePart.type }
+      })
+
+      // Update CZone.background (top-level column)
+      await tx.$executeRaw`
+        UPDATE "CZone"
+        SET "background" = ${newImagePath}
+        WHERE "background" = ${oldImagePath}
+      `
+
+      // Update background references inside CZone.layoutData.zones JSON
+      await tx.$executeRaw`
+        UPDATE "CZone"
+        SET "layoutData" = jsonb_set(
+          "layoutData",
+          '{zones}',
+          COALESCE(
+            (SELECT jsonb_agg(
+              CASE WHEN zone->>'background' = ${oldImagePath}
+                THEN jsonb_set(zone, '{background}', to_jsonb(${newImagePath}::text))
+                ELSE zone
+              END
+            ) FROM jsonb_array_elements("layoutData"->'zones') AS zone),
+            '[]'::jsonb
+          )
+        )
+        WHERE jsonb_typeof("layoutData"->'zones') = 'array'
+          AND EXISTS (
+            SELECT 1 FROM jsonb_array_elements("layoutData"->'zones') AS z
+            WHERE z->>'background' = ${oldImagePath}
+          )
+      `
+
+      // Replace old filename with new in CZoneSearchPrize.conditionBackgrounds
+      await tx.$executeRaw`
+        UPDATE "CZoneSearchPrize"
+        SET "conditionBackgrounds" = array_replace("conditionBackgrounds", ${oldFilename}, ${newFilename})
+        WHERE ${oldFilename} = ANY("conditionBackgrounds")
+      `
+    })
+  } catch (err) {
+    // Transaction failed — delete the newly written file so it doesn't orphan on disk
+    try { await unlink(outPath) } catch {}
+    throw createError({ statusCode: 500, statusMessage: 'Failed to replace image' })
+  }
+
+  // DB committed — now safe to remove the old file
+  try { await unlink(fsPathFromFilename(oldFilename)) } catch {}
+
+  // Invalidate Redis cache for any affected cZone searches
+  for (const searchId of affectedSearchIds) {
+    try { await redis.del(`czone:search-meta:${searchId}`) } catch {}
+  }
+  if (affectedSearchIds.length > 0) clearSearchesCache()
+
+  await logAdminChange(db, {
+    userId: me.id,
+    area: 'Background',
+    key: 'image',
+    prevValue: oldImagePath,
+    newValue: newImagePath
+  })
+
+  return {
+    id,
+    imagePath: newImagePath,
+    filename: newFilename,
+    width,
+    height,
+    mimeType: imagePart.type,
+    dimensionChanged: width !== bg.width || height !== bg.height
+  }
+})

--- a/server/api/admin/backgrounds/[id]/usage.get.js
+++ b/server/api/admin/backgrounds/[id]/usage.get.js
@@ -1,0 +1,57 @@
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const id = event.context.params?.id
+  const bg = await db.background.findUnique({ where: { id } })
+  if (!bg) throw createError({ statusCode: 404, statusMessage: 'Background not found' })
+
+  const [
+    userCount,
+    rewardBackgroundCount,
+    achievementRewardCount,
+    czoneRows,
+    searchPrizeRows
+  ] = await Promise.all([
+    db.userBackground.count({ where: { backgroundId: id } }),
+    db.rewardBackground.count({ where: { backgroundId: id } }),
+    db.achievementRewardBackground.count({ where: { backgroundId: id } }),
+    db.$queryRaw`
+      SELECT COUNT(*)::int AS count
+      FROM "CZone" cz
+      WHERE cz."background" = ${bg.imagePath}
+        OR (
+          jsonb_typeof(cz."layoutData"->'zones') = 'array'
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(cz."layoutData"->'zones') AS z
+            WHERE z->>'background' = ${bg.imagePath}
+          )
+        )
+    `,
+    db.$queryRaw`
+      SELECT COUNT(*)::int AS count
+      FROM "CZoneSearchPrize"
+      WHERE ${bg.filename} = ANY("conditionBackgrounds")
+    `
+  ])
+
+  return {
+    userCount,
+    rewardBackgroundCount,
+    achievementRewardCount,
+    czoneCount: Number(czoneRows?.[0]?.count ?? 0),
+    searchPrizeCount: Number(searchPrizeRows?.[0]?.count ?? 0)
+  }
+})


### PR DESCRIPTION
## Summary
Extends the admin backgrounds management interface with full CRUD capabilities. Users can now edit background metadata (label, visibility) and replace images, as well as delete backgrounds with detailed usage warnings.

## Key Changes

**Frontend (pages/admin/backgrounds.vue)**
- Added Edit modal for updating background label, visibility, and replacing images with dimension validation
- Added Delete confirmation modal with usage analytics (player owners, cZones, reward slots, search conditions)
- Refactored image validation into reusable `validateImageFile()` helper
- Fixed typo: `800x600` → `800×600` for consistency
- Improved code organization with clear state sections and comments

**Backend API Endpoints**
- **PATCH `/api/admin/backgrounds/[id]`**: Enhanced to support both `label` and `visibility` updates (previously visibility-only)
- **POST `/api/admin/backgrounds/[id]/replace-image`**: New endpoint to replace background image while updating all references in CZones and search conditions
- **DELETE `/api/admin/backgrounds/[id]`**: New endpoint with transactional cleanup of all dependent records
- **GET `/api/admin/backgrounds/[id]/usage`**: New endpoint providing usage statistics before deletion

## Notable Implementation Details

- **Transactional integrity**: All database modifications use transactions to ensure consistency; file deletion only occurs after DB commit succeeds
- **Cascading updates**: Image replacement updates references in CZone top-level `background` field, nested zone objects in `layoutData`, and `CZoneSearchPrize.conditionBackgrounds` arrays
- **Cache invalidation**: Redis cache cleared for affected cZone searches after image replacement or deletion
- **Dimension warnings**: Users warned when replacing with different-sized images that may affect cZone layouts
- **Admin audit logging**: All changes logged via `logAdminChange()` utility

https://claude.ai/code/session_01XNGgJ3KREhNxJAtbkJ1f18