### PR TITLE
Optimize background deletion/replacement to prevent transaction timeouts

### DIFF
--- a/server/api/admin/backgrounds/[id].delete.js
+++ b/server/api/admin/backgrounds/[id].delete.js
@@ -43,55 +43,78 @@ export default defineEventHandler(async (event) => {
   })
   const affectedSearchIds = [...new Set(affectedPrizes.map(p => p.cZoneSearchId))]
 
+  // Find affected CZone rows BEFORE opening the transaction. The CZone table
+  // has no index on `background`/`layoutData`, so this predicate requires a
+  // full-table scan with per-row JSONB unnesting — fine as a plain query (no
+  // deadline), but ruinous inside a Prisma interactive transaction, whose
+  // default 5s timeout it can blow past as the table grows, silently rolling
+  // back the whole delete.
+  const affectedCzones = await db.$queryRaw`
+    SELECT id FROM "CZone"
+    WHERE "background" = ${bg.imagePath}
+       OR EXISTS (
+         SELECT 1 FROM jsonb_array_elements("layoutData"->'zones') AS z
+         WHERE z->>'background' = ${bg.imagePath}
+       )
+  `
+  const affectedCzoneIds = affectedCzones.map((r) => r.id)
+
   // All DB operations run in a single transaction.
   // Junction rows with onDelete:Restrict must be deleted before the Background row.
   // File deletion happens AFTER the transaction commits so a DB failure never
   // leaves a missing file with a live DB record pointing at it.
-  await db.$transaction(async (tx) => {
-    await tx.achievementRewardBackground.deleteMany({ where: { backgroundId: id } })
-    await tx.rewardBackground.deleteMany({ where: { backgroundId: id } })
-    await tx.userBackground.deleteMany({ where: { backgroundId: id } })
+  try {
+    await db.$transaction(async (tx) => {
+      await tx.achievementRewardBackground.deleteMany({ where: { backgroundId: id } })
+      await tx.rewardBackground.deleteMany({ where: { backgroundId: id } })
+      await tx.userBackground.deleteMany({ where: { backgroundId: id } })
 
-    // Clear CZone.background (top-level string column)
-    await tx.$executeRaw`
-      UPDATE "CZone"
-      SET "background" = ''
-      WHERE "background" = ${bg.imagePath}
-    `
+      // Targeted by primary key (from the pre-computed list above) so this
+      // stays fast — and within the transaction timeout — no matter how
+      // large the CZone table is.
+      if (affectedCzoneIds.length > 0) {
+        // Clear CZone.background (top-level string column)
+        await tx.$executeRaw`
+          UPDATE "CZone"
+          SET "background" = ''
+          WHERE id = ANY(${affectedCzoneIds}) AND "background" = ${bg.imagePath}
+        `
 
-    // Remove background key from any zone objects inside CZone.layoutData.zones
-    await tx.$executeRaw`
-      UPDATE "CZone"
-      SET "layoutData" = jsonb_set(
-        "layoutData",
-        '{zones}',
-        COALESCE(
-          (SELECT jsonb_agg(
-            CASE WHEN zone->>'background' = ${bg.imagePath}
-              THEN zone - 'background'
-              ELSE zone
-            END
-          ) FROM jsonb_array_elements("layoutData"->'zones') AS zone),
-          '[]'::jsonb
-        )
-      )
-      WHERE jsonb_typeof("layoutData"->'zones') = 'array'
-        AND EXISTS (
-          SELECT 1 FROM jsonb_array_elements("layoutData"->'zones') AS z
-          WHERE z->>'background' = ${bg.imagePath}
-        )
-    `
+        // Remove background key from any zone objects inside CZone.layoutData.zones
+        await tx.$executeRaw`
+          UPDATE "CZone"
+          SET "layoutData" = jsonb_set(
+            "layoutData",
+            '{zones}',
+            COALESCE(
+              (SELECT jsonb_agg(
+                CASE WHEN zone->>'background' = ${bg.imagePath}
+                  THEN zone - 'background'
+                  ELSE zone
+                END
+              ) FROM jsonb_array_elements("layoutData"->'zones') AS zone),
+              '[]'::jsonb
+            )
+          )
+          WHERE id = ANY(${affectedCzoneIds})
+            AND jsonb_typeof("layoutData"->'zones') = 'array'
+        `
+      }
 
-    // Remove this background's filename from CZoneSearchPrize.conditionBackgrounds arrays
-    await tx.$executeRaw`
-      UPDATE "CZoneSearchPrize"
-      SET "conditionBackgrounds" = array_remove("conditionBackgrounds", ${bg.filename})
-      WHERE ${bg.filename} = ANY("conditionBackgrounds")
-    `
+      // Remove this background's filename from CZoneSearchPrize.conditionBackgrounds arrays
+      await tx.$executeRaw`
+        UPDATE "CZoneSearchPrize"
+        SET "conditionBackgrounds" = array_remove("conditionBackgrounds", ${bg.filename})
+        WHERE ${bg.filename} = ANY("conditionBackgrounds")
+      `
 
-    // All child rows cleared — safe to delete the Background row
-    await tx.background.delete({ where: { id } })
-  })
+      // All child rows cleared — safe to delete the Background row
+      await tx.background.delete({ where: { id } })
+    }, { timeout: 20000, maxWait: 5000 })
+  } catch (err) {
+    console.error('[backgrounds/delete] transaction failed:', err)
+    throw createError({ statusCode: 500, statusMessage: 'Failed to delete background' })
+  }
 
   // DB committed — delete image file from disk (non-fatal if missing)
   try { await unlink(fsPathFromFilename(bg.filename)) } catch {}

--- a/server/api/admin/backgrounds/[id]/replace-image.post.js
+++ b/server/api/admin/backgrounds/[id]/replace-image.post.js
@@ -88,6 +88,22 @@ export default defineEventHandler(async (event) => {
   })
   const affectedSearchIds = [...new Set(affectedPrizes.map(p => p.cZoneSearchId))]
 
+  // Find affected CZone rows BEFORE opening the transaction. The CZone table
+  // has no index on `background`/`layoutData`, so this predicate requires a
+  // full-table scan with per-row JSONB unnesting — fine to run as a plain
+  // query (no deadline), but ruinous inside a Prisma interactive transaction,
+  // whose default 5s timeout it can blow past as the table grows, silently
+  // rolling back the whole edit (including the Background row itself).
+  const affectedCzones = await db.$queryRaw`
+    SELECT id FROM "CZone"
+    WHERE "background" = ${oldImagePath}
+       OR EXISTS (
+         SELECT 1 FROM jsonb_array_elements("layoutData"->'zones') AS z
+         WHERE z->>'background' = ${oldImagePath}
+       )
+  `
+  const affectedCzoneIds = affectedCzones.map((r) => r.id)
+
   try {
     await db.$transaction(async (tx) => {
       // Update the Background record
@@ -96,35 +112,37 @@ export default defineEventHandler(async (event) => {
         data: { imagePath: newImagePath, filename: newFilename, width, height, mimeType: imagePart.type }
       })
 
-      // Update CZone.background (top-level column)
-      await tx.$executeRaw`
-        UPDATE "CZone"
-        SET "background" = ${newImagePath}
-        WHERE "background" = ${oldImagePath}
-      `
+      // Targeted by primary key (from the pre-computed list above) so this
+      // stays fast — and within the transaction timeout — no matter how
+      // large the CZone table is.
+      if (affectedCzoneIds.length > 0) {
+        // Update CZone.background (top-level column)
+        await tx.$executeRaw`
+          UPDATE "CZone"
+          SET "background" = ${newImagePath}
+          WHERE id = ANY(${affectedCzoneIds}) AND "background" = ${oldImagePath}
+        `
 
-      // Update background references inside CZone.layoutData.zones JSON
-      await tx.$executeRaw`
-        UPDATE "CZone"
-        SET "layoutData" = jsonb_set(
-          "layoutData",
-          '{zones}',
-          COALESCE(
-            (SELECT jsonb_agg(
-              CASE WHEN zone->>'background' = ${oldImagePath}
-                THEN jsonb_set(zone, '{background}', to_jsonb(${newImagePath}::text))
-                ELSE zone
-              END
-            ) FROM jsonb_array_elements("layoutData"->'zones') AS zone),
-            '[]'::jsonb
+        // Update background references inside CZone.layoutData.zones JSON
+        await tx.$executeRaw`
+          UPDATE "CZone"
+          SET "layoutData" = jsonb_set(
+            "layoutData",
+            '{zones}',
+            COALESCE(
+              (SELECT jsonb_agg(
+                CASE WHEN zone->>'background' = ${oldImagePath}
+                  THEN jsonb_set(zone, '{background}', to_jsonb(${newImagePath}::text))
+                  ELSE zone
+                END
+              ) FROM jsonb_array_elements("layoutData"->'zones') AS zone),
+              '[]'::jsonb
+            )
           )
-        )
-        WHERE jsonb_typeof("layoutData"->'zones') = 'array'
-          AND EXISTS (
-            SELECT 1 FROM jsonb_array_elements("layoutData"->'zones') AS z
-            WHERE z->>'background' = ${oldImagePath}
-          )
-      `
+          WHERE id = ANY(${affectedCzoneIds})
+            AND jsonb_typeof("layoutData"->'zones') = 'array'
+        `
+      }
 
       // Replace old filename with new in CZoneSearchPrize.conditionBackgrounds
       await tx.$executeRaw`
@@ -132,8 +150,9 @@ export default defineEventHandler(async (event) => {
         SET "conditionBackgrounds" = array_replace("conditionBackgrounds", ${oldFilename}, ${newFilename})
         WHERE ${oldFilename} = ANY("conditionBackgrounds")
       `
-    })
+    }, { timeout: 20000, maxWait: 5000 })
   } catch (err) {
+    console.error('[backgrounds/replace-image] transaction failed:', err)
     // Transaction failed — delete the newly written file so it doesn't orphan on disk
     try { await unlink(outPath) } catch {}
     throw createError({ statusCode: 500, statusMessage: 'Failed to replace image' })


### PR DESCRIPTION
## Summary
This PR fixes transaction timeout issues in background deletion and replacement operations by pre-computing affected CZone rows outside the transaction and using primary key filtering instead of full-table scans within the transaction.

## Key Changes
- **Pre-compute affected CZone IDs**: Both endpoints now query for affected CZone rows before opening the transaction, avoiding expensive full-table JSONB scans inside the transaction where they can exceed the 5-second timeout
- **Use primary key filtering**: CZone update queries now filter by `id = ANY(affectedCzoneIds)` instead of scanning the entire table with JSONB predicates, keeping operations fast regardless of table size
- **Increase transaction timeout**: Extended Prisma transaction timeout to 20 seconds with 5-second max wait to provide additional safety margin
- **Add error logging**: Both endpoints now log transaction failures to aid debugging
- **Conditional updates**: Only execute CZone updates if there are affected rows to update

## Implementation Details
The core issue was that CZone table queries on `background` and `layoutData` columns (which require JSONB unnesting) were causing full-table scans inside Prisma interactive transactions. As the CZone table grows, these scans silently exceed the default 5-second timeout, rolling back the entire operation.

The solution separates concerns:
1. **Outside transaction**: Run the expensive full-table scan query to identify affected CZone IDs (no deadline pressure)
2. **Inside transaction**: Use the pre-computed ID list for targeted updates via primary key (fast, predictable)

This pattern is applied to both `[id].delete.js` and `[id]/replace-image.post.js` endpoints.

https://claude.ai/code/session_0194cLsQZGAnV2W3MTUDdUa1