### PR TITLE
Fix delete modal state not resetting after background deletion

### DIFF
--- a/pages/admin/backgrounds.vue
+++ b/pages/admin/backgrounds.vue
@@ -502,6 +502,7 @@ async function confirmDelete() {
   deleteModal.error = ''
   try {
     await $fetch(`/api/admin/backgrounds/${deleteModal.bg.id}`, { method: 'DELETE' })
+    deleteModal.deleting = false
     closeDelete()
     await refreshNuxtData('backgrounds')
   } catch (err) {


### PR DESCRIPTION
## Summary
Fixed a bug where the delete modal's loading state was not being reset after successfully deleting a background, potentially leaving the UI in an inconsistent state.

## Key Changes
- Added `deleteModal.deleting = false` after successful API deletion request to properly reset the loading state before closing the delete modal

## Implementation Details
The delete confirmation flow now correctly resets the `deleting` flag immediately after the DELETE request completes successfully. This ensures the modal UI reflects the correct state and prevents any visual inconsistencies or disabled button states from persisting after the deletion operation finishes.

https://claude.ai/code/session_017rt9vyhZohfzFfkHP81EFo