### PR TITLE
Add bulk "Make 2nd Ed" action to Manage cToons admin page

### DIFF
--- a/components/MakeSecondEditionModal.vue
+++ b/components/MakeSecondEditionModal.vue
@@ -1,0 +1,313 @@
+<template>
+  <div class="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-4 overflow-y-auto">
+    <div class="bg-white rounded-lg w-full max-w-4xl my-8 flex flex-col shadow-xl">
+
+      <!-- Header -->
+      <div class="flex items-center justify-between px-6 py-4 border-b sticky top-0 bg-white z-10 rounded-t-lg">
+        <h2 class="text-xl font-semibold">Make 2nd Edition cToons</h2>
+        <button @click="$emit('close')" class="text-gray-400 hover:text-gray-600 text-2xl leading-none">&times;</button>
+      </div>
+
+      <!-- Loading state -->
+      <div v-if="loading" class="flex items-center justify-center py-20">
+        <div class="text-gray-500">Loading cToon details…</div>
+      </div>
+
+      <!-- Over-limit state -->
+      <div v-else-if="tooMany" class="p-6">
+        <p class="text-red-600 text-sm">
+          {{ ctoonIds.length }} cToons are currently filtered, which is more than the {{ maxBatch }}-record limit for
+          this action. Narrow your Set/Series/search filter and try again.
+        </p>
+        <div class="mt-4 flex justify-end">
+          <button @click="$emit('close')" class="px-4 py-2 border border-gray-300 rounded text-sm hover:bg-gray-100">Close</button>
+        </div>
+      </div>
+
+      <template v-else>
+        <div class="p-6 space-y-5">
+
+          <!-- Set Name (required) -->
+          <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <label class="block text-sm font-semibold text-blue-800 mb-1">
+              Set Name for 2nd Editions <span class="text-red-600">*</span>
+            </label>
+            <input
+              v-model="setName"
+              type="text"
+              placeholder="e.g. Summer 2026 Second Editions"
+              class="w-full border rounded px-3 py-2 text-sm"
+              :class="showSetNameError ? 'border-red-400' : 'border-gray-300'"
+              @input="showSetNameError = false"
+            />
+            <p v-if="showSetNameError" class="text-xs text-red-600 mt-1">Set Name is required.</p>
+            <p class="text-xs text-blue-600 mt-1">
+              Every created cToon uses this Set value. All other details (image, name, rarity, series, etc.) are copied
+              from the original.
+            </p>
+          </div>
+
+          <!-- Excluded banner -->
+          <div v-if="excluded.length" class="border border-amber-300 bg-amber-50 rounded-lg">
+            <button
+              type="button"
+              @click="showExcluded = !showExcluded"
+              class="w-full flex items-center justify-between px-4 py-3 text-sm text-amber-800 font-medium text-left"
+            >
+              <span>{{ excluded.length }} cToon{{ excluded.length !== 1 ? 's' : '' }} excluded (already a Second Edition or already paired)</span>
+              <span class="flex-shrink-0 ml-2">{{ showExcluded ? '▲' : '▼' }}</span>
+            </button>
+            <ul v-if="showExcluded" class="px-4 pb-3 space-y-1.5">
+              <li v-for="row in excluded" :key="row.id" class="text-xs text-amber-700 flex items-center gap-2">
+                <img :src="row.assetPath" :alt="row.name" class="h-6 w-auto object-contain flex-shrink-0" />
+                <span class="truncate">{{ row.name }}</span>
+                <span class="text-amber-500 flex-shrink-0">— {{ row.reason }}</span>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Eligible rows -->
+          <div v-if="eligible.length">
+            <div class="flex items-center justify-between mb-3 gap-2">
+              <h3 class="text-sm font-semibold text-gray-700">
+                {{ selectedCount }} of {{ eligible.length }} selected
+              </h3>
+              <div class="flex gap-3 text-xs flex-shrink-0">
+                <button type="button" @click="selectAll" class="text-indigo-600 hover:underline">Select all</button>
+                <button type="button" @click="selectNone" class="text-indigo-600 hover:underline">Select none</button>
+              </div>
+            </div>
+
+            <div class="space-y-2">
+              <div v-for="row in eligible" :key="row.id" class="border rounded-lg overflow-hidden">
+                <label class="flex items-center gap-3 px-3 py-3 min-h-[56px] cursor-pointer bg-gray-50">
+                  <input type="checkbox" v-model="row.selected" class="h-5 w-5 rounded border-gray-300 text-indigo-600 flex-shrink-0" />
+                  <img :src="row.assetPath" :alt="row.name" class="h-10 w-auto object-contain flex-shrink-0" />
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium text-sm truncate">{{ row.name }}</div>
+                    <div class="text-xs text-gray-500 truncate">
+                      {{ row.rarity }}
+                      · Qty {{ row.mintLimitType === 'timeBased' ? 'Time-based' : (row.quantity ?? '∞') }}
+                      · Init {{ row.mintLimitType === 'timeBased' ? '—' : (row.initialQuantity ?? '∞') }}
+                      · Limit {{ row.perUserLimit ?? '∞' }}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    @click.prevent="row.expanded = !row.expanded"
+                    class="text-xs text-indigo-600 hover:underline flex-shrink-0 px-2 py-2"
+                  >
+                    {{ row.expanded ? 'Done' : 'Edit' }}
+                  </button>
+                </label>
+
+                <div v-if="row.expanded" class="p-3 border-t grid grid-cols-1 sm:grid-cols-2 gap-3 bg-white">
+                  <div>
+                    <label class="block text-xs font-medium text-gray-500 mb-1">Mint Limit</label>
+                    <select v-model="row.mintLimitType" class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm bg-white">
+                      <option value="defined">Defined Number Limit</option>
+                      <option value="timeBased">Time Based Limit</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="block text-xs font-medium text-gray-500 mb-1">Per-User Limit</label>
+                    <input v-model.number="row.perUserLimit" type="number" min="0" class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+                  </div>
+                  <template v-if="row.mintLimitType !== 'timeBased'">
+                    <div>
+                      <label class="block text-xs font-medium text-gray-500 mb-1">Total Quantity</label>
+                      <input v-model.number="row.quantity" type="number" min="0" class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+                    </div>
+                    <div>
+                      <label class="block text-xs font-medium text-gray-500 mb-1">Initial Quantity</label>
+                      <input v-model.number="row.initialQuantity" type="number" min="0" class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+                    </div>
+                  </template>
+                  <div v-else>
+                    <label class="block text-xs font-medium text-gray-500 mb-1">Mint End Date (CDT)</label>
+                    <input v-model="row.mintEndDate" type="datetime-local" class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div v-else class="text-center text-gray-500 py-8 text-sm">
+            No eligible cToons in the current filter — every matching cToon is already a Second Edition or already has one.
+          </div>
+
+        </div>
+
+        <!-- Footer -->
+        <div class="border-t px-6 py-4 flex items-center justify-between bg-gray-50 rounded-b-lg sticky bottom-0 gap-3">
+          <span class="text-sm text-gray-500">{{ selectedCount }} record{{ selectedCount !== 1 ? 's' : '' }} selected</span>
+          <div class="flex gap-3">
+            <button @click="$emit('close')" class="px-4 py-2 border border-gray-300 rounded text-sm hover:bg-gray-100">
+              Cancel
+            </button>
+            <button
+              @click="submit"
+              :disabled="saving || selectedCount === 0"
+              class="px-5 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {{ saving ? 'Creating…' : `Create ${selectedCount} Second Edition${selectedCount !== 1 ? 's' : ''}` }}
+            </button>
+          </div>
+        </div>
+      </template>
+
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+const props = defineProps({
+  ctoonIds: { type: Array, required: true },
+})
+const emit = defineEmits(['close', 'saved'])
+
+const maxBatch = 150
+const tooMany = computed(() => props.ctoonIds.length > maxBatch)
+
+const loading = ref(true)
+const saving = ref(false)
+const setName = ref('')
+const showSetNameError = ref(false)
+const showExcluded = ref(false)
+const eligible = ref([])
+const excluded = ref([])
+
+// ── Date helpers (America/Chicago) — same convention as BulkEditCtoonModal ──
+function nthSundayDay(year, monthNumber) {
+  const monthIdx = monthNumber - 1
+  const first = new Date(Date.UTC(year, monthIdx, 1))
+  const firstDow = first.getUTCDay()
+  const firstSunday = 1 + ((7 - firstDow) % 7)
+  if (monthNumber === 3) return firstSunday + 7
+  if (monthNumber === 11) return firstSunday
+  return firstSunday
+}
+function isChicagoDst(y, m, d) {
+  if (m < 3 || m > 11) return false
+  if (m > 3 && m < 11) return true
+  if (m === 3) return d >= nthSundayDay(y, 3)
+  if (m === 11) return d < nthSundayDay(y, 11)
+  return false
+}
+function localToUtcIso(localStr) {
+  if (!localStr) return null
+  const [datePart, timePart] = localStr.split('T')
+  const [y, m] = datePart.split('-').map(n => parseInt(n, 10))
+  const d = parseInt(datePart.split('-')[2], 10)
+  const offset = isChicagoDst(y, m, d) ? '-05:00' : '-06:00'
+  return new Date(`${datePart}T${timePart}:00${offset}`).toISOString()
+}
+
+// ── Load data ─────────────────────────────────────────────────────────
+onMounted(async () => {
+  if (tooMany.value) { loading.value = false; return }
+  try {
+    const [detailsRes, rdRes] = await Promise.all([
+      fetch('/api/admin/ctoons/bulk-details', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: props.ctoonIds }),
+      }),
+      fetch('/api/rarity-defaults').catch(() => null),
+    ])
+
+    let rarityDefaults = null
+    if (rdRes?.ok) {
+      const rdJson = await rdRes.json()
+      rarityDefaults = rdJson?.defaults || null
+    }
+
+    if (!detailsRes.ok) throw new Error('Failed to load cToon details')
+    const ctoons = await detailsRes.json()
+
+    const map = Object.fromEntries(ctoons.map(c => [c.id, c]))
+    const elig = []
+    const excl = []
+    for (const id of props.ctoonIds) {
+      const c = map[id]
+      if (!c) continue
+      if (c.isSecondEdition) {
+        excl.push({ id: c.id, name: c.name, assetPath: c.assetPath, reason: 'Already a Second Edition' })
+        continue
+      }
+      if (c.hasSecondEdition) {
+        excl.push({ id: c.id, name: c.name, assetPath: c.assetPath, reason: 'Already has a Second Edition' })
+        continue
+      }
+      const d = rarityDefaults?.[c.rarity]
+      elig.push({
+        id: c.id,
+        name: c.name,
+        assetPath: c.assetPath,
+        rarity: c.rarity,
+        selected: true,
+        expanded: false,
+        mintLimitType: 'defined',
+        quantity: d?.totalQuantity ?? null,
+        initialQuantity: d?.initialQuantity ?? null,
+        perUserLimit: d?.perUserLimit ?? null,
+        mintEndDate: '',
+      })
+    }
+    eligible.value = elig
+    excluded.value = excl
+  } catch (err) {
+    console.error('[MakeSecondEditionModal] load error', err)
+  } finally {
+    loading.value = false
+  }
+})
+
+const selectedCount = computed(() => eligible.value.filter(r => r.selected).length)
+
+function selectAll() { eligible.value.forEach(r => { r.selected = true }) }
+function selectNone() { eligible.value.forEach(r => { r.selected = false }) }
+
+// ── Submit ────────────────────────────────────────────────────────────
+async function submit() {
+  if (!setName.value.trim()) { showSetNameError.value = true; return }
+  if (!selectedCount.value) return
+
+  saving.value = true
+  try {
+    const records = eligible.value
+      .filter(r => r.selected)
+      .map(r => ({
+        id: r.id,
+        mintLimitType: r.mintLimitType,
+        quantity: r.mintLimitType === 'timeBased' ? null : r.quantity,
+        initialQuantity: r.mintLimitType === 'timeBased' ? null : r.initialQuantity,
+        perUserLimit: r.perUserLimit,
+        mintEndDate: r.mintLimitType === 'timeBased' && r.mintEndDate ? localToUtcIso(r.mintEndDate) : null,
+      }))
+
+    const res = await fetch('/api/admin/ctoons/make-second-edition', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ setName: setName.value.trim(), records }),
+    })
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.statusMessage || 'Failed to create Second Editions')
+    }
+
+    const data = await res.json()
+    emit('saved', data)
+  } catch (err) {
+    console.error('[MakeSecondEditionModal] submit error', err)
+    alert(err.message || 'An error occurred while creating Second Editions.')
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/pages/admin/ctoons.vue
+++ b/pages/admin/ctoons.vue
@@ -5,7 +5,7 @@
     <div class="max-w-6xl mx-auto bg-white rounded-lg shadow p-6 mt-16 md:mt-20">
       <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between mb-6 space-y-4 lg:space-y-0">
         <h1 class="text-2xl font-semibold">All cToons</h1>
-        <div class="flex space-x-2">
+        <div class="flex flex-wrap gap-2">
           <NuxtLink
             to="/admin/addCtoon"
             class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
@@ -32,6 +32,20 @@
             :title="isSearching ? 'Bulk edit filtered cToons' : 'Apply a filter or search first to enable bulk edit'"
           >
             Bulk Edit cToons
+          </button>
+
+          <button
+            :disabled="!isSearching"
+            @click="openMakeSecondEdition"
+            :class="[
+              'px-4 py-2 rounded font-medium transition-colors',
+              isSearching
+                ? 'bg-purple-600 text-white hover:bg-purple-700'
+                : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+            ]"
+            :title="isSearching ? 'Create Second Edition versions of the filtered cToons' : 'Apply a filter or search first to enable Make 2nd Ed'"
+          >
+            Make 2nd Ed
           </button>
         </div>
       </div>
@@ -267,6 +281,14 @@
       @close="showBulkEditModal = false"
       @saved="onBulkSaved"
     />
+
+    <!-- Make 2nd Ed Modal -->
+    <MakeSecondEditionModal
+      v-if="showMakeSecondEditionModal"
+      :ctoon-ids="displayedCtoons.map(c => c.id)"
+      @close="showMakeSecondEditionModal = false"
+      @saved="onMakeSecondEditionSaved"
+    />
   </div>
 </template>
 
@@ -276,6 +298,7 @@ definePageMeta({ title: 'Admin - cToons', middleware: ['auth','admin'], layout: 
 import { ref, onMounted, onBeforeUnmount, computed, watch, nextTick } from 'vue'
 import Nav from '~/components/Nav.vue'
 import BulkEditCtoonModal from '~/components/BulkEditCtoonModal.vue'
+import MakeSecondEditionModal from '~/components/MakeSecondEditionModal.vue'
 import { formatQuantity, TIME_BASED_CAP } from '~/utils/formatQuantity'
 
 /* Meta options from API */
@@ -291,6 +314,28 @@ function openBulkEdit() {
 async function onBulkSaved() {
   showBulkEditModal.value = false
   // Re-run current search/browse to reflect updates
+  if (isSearching.value) {
+    const q = String(searchTerm.value || '').trim()
+    await runSearch({ q: q.length >= 3 ? q : '', set: selectedSet.value, series: selectedSeries.value })
+  } else {
+    await loadPage(currentPage.value)
+  }
+}
+
+/* Make 2nd Ed modal */
+const showMakeSecondEditionModal = ref(false)
+function openMakeSecondEdition() {
+  if (!isSearching.value) return
+  showMakeSecondEditionModal.value = true
+}
+async function onMakeSecondEditionSaved(result) {
+  showMakeSecondEditionModal.value = false
+  const created = result?.created?.length || 0
+  const failed = result?.errors?.length || 0
+  let msg = `Created ${created} Second Edition${created !== 1 ? 's' : ''}.`
+  if (failed) msg += ` ${failed} record${failed !== 1 ? 's' : ''} could not be created.`
+  alert(msg)
+  // Re-run current search/browse to reflect the new records
   if (isSearching.value) {
     const q = String(searchTerm.value || '').trim()
     await runSearch({ q: q.length >= 3 ? q : '', set: selectedSet.value, series: selectedSeries.value })

--- a/server/api/admin/ctoons/bulk-details.post.js
+++ b/server/api/admin/ctoons/bulk-details.post.js
@@ -40,8 +40,15 @@ export default defineEventHandler(async (event) => {
       mintLimitType: true,
       mintEndDate: true,
       type: true,
+      isSecondEdition: true,
+      relatedSecondEdition: { select: { id: true } },
     }
   })
 
-  return ctoons
+  // Flatten the relation into a simple boolean for consumers (e.g. the
+  // Make 2nd Ed modal) that just need to know eligibility, not the id.
+  return ctoons.map(c => {
+    const { relatedSecondEdition, ...rest } = c
+    return { ...rest, hasSecondEdition: Boolean(relatedSecondEdition) }
+  })
 })

--- a/server/api/admin/ctoons/make-second-edition.post.js
+++ b/server/api/admin/ctoons/make-second-edition.post.js
@@ -1,0 +1,193 @@
+// server/api/admin/ctoons/make-second-edition.post.js
+// Bulk-creates Second Edition duplicates of the given cToons: same values
+// (including assetPath/image) as the original, but a new Set name, fresh
+// mint counters, and the isSecondEdition/relatedFirstEditionId pairing.
+import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { scheduleMintEnd } from '@/server/utils/queues'
+
+const MAX_BATCH = 150
+const TIME_BASED_CAP = 999999999
+const MAX_SET_NAME_LEN = 191
+
+function toNonNegIntOrNull(v) {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  if (!Number.isFinite(n) || n < 0) return null
+  return Math.floor(n)
+}
+
+export default defineEventHandler(async (event) => {
+  // 1) Admin check
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  // 2) Parse + validate body
+  const body = await readBody(event)
+
+  const setName = String(body?.setName || '').trim().slice(0, MAX_SET_NAME_LEN)
+  if (!setName) {
+    throw createError({ statusCode: 400, statusMessage: 'Set Name is required.' })
+  }
+
+  const rawRecords = Array.isArray(body?.records) ? body.records : []
+  const seen = new Set()
+  const records = []
+  for (const r of rawRecords) {
+    const id = String(r?.id || '').trim()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    records.push({ ...r, id })
+  }
+  if (!records.length) return { success: true, created: [], errors: [] }
+  if (records.length > MAX_BATCH) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Too many records in one request (max ${MAX_BATCH}) — narrow your filter and try again.`,
+    })
+  }
+
+  const ids = records.map(r => r.id)
+
+  // 3) Batch pre-fetch originals + existing pairings (avoids per-row N+1 lookups)
+  const [originals, pairedRows] = await Promise.all([
+    prisma.ctoon.findMany({ where: { id: { in: ids } }, include: { imageHash: true } }),
+    prisma.ctoon.findMany({
+      where: { relatedFirstEditionId: { in: ids } },
+      select: { relatedFirstEditionId: true },
+    }),
+  ])
+  const originalsById = new Map(originals.map(o => [o.id, o]))
+  const alreadyPaired = new Set(pairedRows.map(p => p.relatedFirstEditionId))
+
+  const batchId = randomUUID()
+  const created = []
+  const errors = []
+
+  for (const rec of records) {
+    const original = originalsById.get(rec.id)
+    if (!original) { errors.push({ id: rec.id, error: 'Not found' }); continue }
+    if (original.isSecondEdition) {
+      errors.push({ id: rec.id, name: original.name, error: 'Already a Second Edition' })
+      continue
+    }
+    if (alreadyPaired.has(rec.id)) {
+      errors.push({ id: rec.id, name: original.name, error: 'Already has a Second Edition' })
+      continue
+    }
+
+    const mintLimitType = rec.mintLimitType === 'timeBased' ? 'timeBased' : 'defined'
+    let mintEndDate = null
+    if (mintLimitType === 'timeBased') {
+      mintEndDate = rec.mintEndDate ? new Date(rec.mintEndDate) : null
+      if (!mintEndDate || isNaN(mintEndDate)) {
+        errors.push({ id: rec.id, name: original.name, error: 'Mint End Date is required for Time Based Limit.' })
+        continue
+      }
+    }
+
+    const quantity = mintLimitType === 'timeBased' ? TIME_BASED_CAP : toNonNegIntOrNull(rec.quantity)
+    const initialQuantity = mintLimitType === 'timeBased' ? TIME_BASED_CAP : toNonNegIntOrNull(rec.initialQuantity)
+    const perUserLimit = toNonNegIntOrNull(rec.perUserLimit)
+    if (initialQuantity != null && quantity != null && initialQuantity > quantity) {
+      errors.push({ id: rec.id, name: original.name, error: 'Initial quantity cannot exceed total quantity.' })
+      continue
+    }
+
+    try {
+      const newCtoon = await prisma.ctoon.create({
+        data: {
+          // Copied verbatim from the first edition
+          name: original.name,
+          series: original.series,
+          description: original.description,
+          type: original.type,
+          rarity: original.rarity,
+          assetPath: original.assetPath,
+          soundPath: original.soundPath,
+          releaseDate: original.releaseDate,
+          price: original.price,
+          inCmart: original.inCmart,
+          codeOnly: original.codeOnly,
+          characters: original.characters,
+          isGtoon: original.isGtoon,
+          gtoonType: original.gtoonType,
+          cost: original.cost,
+          power: original.power,
+          abilityKey: original.abilityKey,
+          abilityData: original.abilityData,
+
+          // New Set value
+          set: setName,
+
+          // Fresh mint pool — starts at 0 minted regardless of the original's counts
+          quantity,
+          initialQuantity,
+          perUserLimit,
+          mintLimitType,
+          mintEndDate,
+          totalMinted: 0,
+
+          // Two-phase release scheduling doesn't carry forward to a re-release
+          initialReleaseAt: null,
+          finalReleaseAt: null,
+          initialReleaseQty: null,
+          finalReleaseQty: null,
+          timeBasedLimitCount: mintLimitType === 'timeBased' ? original.timeBasedLimitCount : null,
+          timeBasedLimitWindowDays: mintLimitType === 'timeBased' ? original.timeBasedLimitWindowDays : null,
+
+          // Second Edition pairing
+          isSecondEdition: true,
+          relatedFirstEditionId: original.id,
+          secondEditionOverlayX: 75,
+          secondEditionOverlayY: 75,
+          secondEditionOverlaySize: 100,
+
+          imageHash: original.imageHash
+            ? {
+                create: {
+                  phash: original.imageHash.phash,
+                  dhash: original.imageHash.dhash,
+                  bucket: original.imageHash.bucket,
+                },
+              }
+            : undefined,
+        },
+      })
+
+      try {
+        await logAdminChange(prisma, {
+          userId: me.id,
+          area: `Ctoon:${newCtoon.id}`,
+          key: 'create-second-edition',
+          prevValue: null,
+          newValue: { batchId, relatedFirstEditionId: original.id, name: newCtoon.name, set: setName },
+        })
+      } catch {}
+
+      if (mintLimitType === 'timeBased' && mintEndDate) {
+        try {
+          await scheduleMintEnd(newCtoon.id, mintEndDate)
+        } catch (err) {
+          console.error(`[make-second-edition] Failed to schedule mint-end for ${newCtoon.id}:`, err)
+        }
+      }
+
+      created.push({ id: newCtoon.id, originalId: original.id, name: newCtoon.name })
+    } catch (err) {
+      errors.push({ id: rec.id, name: original.name, error: err.message || 'Create failed' })
+    }
+  }
+
+  return { success: true, count: created.length, created, errors }
+})


### PR DESCRIPTION
Lets an admin duplicate the currently filtered cToons as Second Edition
records in one action: a required Set Name field, auto-excludes cToons
that are already a Second Edition or already paired, per-row mint-cap
overrides pre-filled from rarity defaults (fresh pool, starts at 0
minted), and reuses the original's image/asset and all other fields.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X49GC9MdY7g4ZAFukuD1Ls