### PR TITLE
Add bulk "Make 2nd Ed" action to Manage cToons admin page

### DIFF
--- a/components/MakeSecondEditionModal.vue
+++ b/components/MakeSecondEditionModal.vue
@@ -42,9 +42,29 @@
             />
             <p v-if="showSetNameError" class="text-xs text-red-600 mt-1">Set Name is required.</p>
             <p class="text-xs text-blue-600 mt-1">
-              Every created cToon uses this Set value. All other details (image, name, rarity, series, etc.) are copied
-              from the original.
+              Every created cToon uses this Set value plus the In C-mart / Release DateTime below. All other details
+              (image, name, rarity, series, etc.) are copied from the original.
             </p>
+
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4 pt-4 border-t border-blue-200">
+              <div>
+                <label class="block text-sm font-semibold text-blue-800 mb-1">In C-mart</label>
+                <div class="flex items-center gap-2">
+                  <button type="button" @click="inCmart = true"
+                    :class="['px-3 py-1.5 text-sm rounded border', inCmart === true ? 'bg-green-600 text-white border-green-600' : 'border-gray-300 bg-white hover:bg-gray-50']">
+                    Yes
+                  </button>
+                  <button type="button" @click="inCmart = false"
+                    :class="['px-3 py-1.5 text-sm rounded border', inCmart === false ? 'bg-red-500 text-white border-red-500' : 'border-gray-300 bg-white hover:bg-gray-50']">
+                    No
+                  </button>
+                </div>
+              </div>
+              <div>
+                <label class="block text-sm font-semibold text-blue-800 mb-1">Release DateTime (CDT)</label>
+                <input v-model="releaseDateTime" type="datetime-local" class="w-full border border-gray-300 rounded px-3 py-2 text-sm bg-white" />
+              </div>
+            </div>
           </div>
 
           <!-- Excluded banner -->
@@ -178,6 +198,8 @@ const showSetNameError = ref(false)
 const showExcluded = ref(false)
 const eligible = ref([])
 const excluded = ref([])
+const inCmart = ref(false)
+const releaseDateTime = ref(nextMondayAt8pmChicago())
 
 // ── Date helpers (America/Chicago) — same convention as BulkEditCtoonModal ──
 function nthSundayDay(year, monthNumber) {
@@ -203,6 +225,25 @@ function localToUtcIso(localStr) {
   const d = parseInt(datePart.split('-')[2], 10)
   const offset = isChicagoDst(y, m, d) ? '-05:00' : '-06:00'
   return new Date(`${datePart}T${timePart}:00${offset}`).toISOString()
+}
+
+function nextMondayAt8pmChicago() {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: '2-digit', day: '2-digit', weekday: 'short',
+  })
+  const parts = Object.fromEntries(fmt.formatToParts(new Date()).map(p => [p.type, p.value]))
+  const weekdayMap = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 }
+  const currentDow = weekdayMap[parts.weekday]
+  let daysToAdd = (1 - currentDow + 7) % 7
+  if (daysToAdd === 0) daysToAdd = 7
+
+  const base = new Date(Date.UTC(Number(parts.year), Number(parts.month) - 1, Number(parts.day)))
+  base.setUTCDate(base.getUTCDate() + daysToAdd)
+  const y = base.getUTCFullYear()
+  const m = String(base.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(base.getUTCDate()).padStart(2, '0')
+  return `${y}-${m}-${d}T20:00`
 }
 
 // ── Load data ─────────────────────────────────────────────────────────
@@ -274,6 +315,7 @@ function selectNone() { eligible.value.forEach(r => { r.selected = false }) }
 // ── Submit ────────────────────────────────────────────────────────────
 async function submit() {
   if (!setName.value.trim()) { showSetNameError.value = true; return }
+  if (!releaseDateTime.value) { alert('Release DateTime is required.'); return }
   if (!selectedCount.value) return
 
   saving.value = true
@@ -293,7 +335,12 @@ async function submit() {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ setName: setName.value.trim(), records }),
+      body: JSON.stringify({
+        setName: setName.value.trim(),
+        inCmart: inCmart.value,
+        releaseDate: localToUtcIso(releaseDateTime.value),
+        records,
+      }),
     })
 
     if (!res.ok) {

--- a/server/api/admin/ctoons/make-second-edition.post.js
+++ b/server/api/admin/ctoons/make-second-edition.post.js
@@ -40,6 +40,15 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Set Name is required.' })
   }
 
+  const inCmart = body?.inCmart === true
+  const releaseDate = body?.releaseDate ? new Date(body.releaseDate) : null
+  if (!releaseDate || isNaN(releaseDate)) {
+    throw createError({ statusCode: 400, statusMessage: 'A valid Release DateTime is required.' })
+  }
+  if (releaseDate <= new Date()) {
+    throw createError({ statusCode: 400, statusMessage: 'Release DateTime must be in the future.' })
+  }
+
   const rawRecords = Array.isArray(body?.records) ? body.records : []
   const seen = new Set()
   const records = []
@@ -85,6 +94,10 @@ export default defineEventHandler(async (event) => {
       errors.push({ id: rec.id, name: original.name, error: 'Already has a Second Edition' })
       continue
     }
+    if (inCmart && original.codeOnly) {
+      errors.push({ id: rec.id, name: original.name, error: 'Cannot be Code-Only and in C-mart' })
+      continue
+    }
 
     const mintLimitType = rec.mintLimitType === 'timeBased' ? 'timeBased' : 'defined'
     let mintEndDate = null
@@ -115,9 +128,7 @@ export default defineEventHandler(async (event) => {
           rarity: original.rarity,
           assetPath: original.assetPath,
           soundPath: original.soundPath,
-          releaseDate: original.releaseDate,
           price: original.price,
-          inCmart: original.inCmart,
           codeOnly: original.codeOnly,
           characters: original.characters,
           isGtoon: original.isGtoon,
@@ -127,8 +138,10 @@ export default defineEventHandler(async (event) => {
           abilityKey: original.abilityKey,
           abilityData: original.abilityData,
 
-          // New Set value
+          // Batch-level overrides (apply the same value to every created record)
           set: setName,
+          inCmart,
+          releaseDate,
 
           // Fresh mint pool — starts at 0 minted regardless of the original's counts
           quantity,


### PR DESCRIPTION
## Summary
- Adds a "Make 2nd Ed" button next to "Bulk Edit cToons" on the Manage cToons admin page, enabled only when a filter/search is active
- New `MakeSecondEditionModal.vue`: requires a Set Name, lets the admin set a batch-wide In C-mart (default No) and Release DateTime (default next Monday 8pm Central), auto-excludes cToons that are already a Second Edition or already have one paired, and shows the remaining eligible cToons as selectable rows with per-row mint-cap overrides pre-filled from Rarity Settings
- New `POST /api/admin/ctoons/make-second-edition` endpoint: admin-gated, capped at 150 records per request, batch pre-fetches eligibility to avoid N+1 queries, re-validates eligibility server-side, and creates each Second Edition copying every field from the original (including the image/`assetPath`) except the new Set/In C-mart/Release DateTime, fresh mint counters (starts at 0 minted), and the `isSecondEdition`/`relatedFirstEditionId` pairing
- Extends `bulk-details.post.js` with `isSecondEdition`/`hasSecondEdition` so the new modal can determine eligibility

## Test plan
- [ ] Filter the Manage cToons list by Set/Series/search, click "Make 2nd Ed", confirm the modal shows only eligible cToons (cToons already Second Edition or already paired should be excluded with a note)
- [ ] Confirm the Set Name field is required and blocks submission when empty
- [ ] Confirm In C-mart / Release DateTime defaults render correctly and can be changed
- [ ] Create a batch of Second Editions and confirm the new records appear in the list with the new Set value, the Second Edition overlay badge, 0 minted, and the same image/rarity/series as the originals
- [ ] Try creating a Second Edition for a Code-Only cToon with In C-mart set to Yes and confirm it's rejected with a clear error
- [ ] Verify on a mobile viewport that the modal, button row, and row list remain usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X49GC9MdY7g4ZAFukuD1Ls

---
_Generated by [Claude Code](https://claude.ai/code/session_01X49GC9MdY7g4ZAFukuD1Ls)_