### PR TITLE
Show edition badges in edit-pack cToon autofill

### DIFF
--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -160,7 +160,10 @@
                     >
                       <img :src="c.assetPath" class="tr-sug-ctoon-img" />
                       <div>
-                        <div>{{ c.name }}</div>
+                        <div class="tr-suggest-name-row">
+                          <span>{{ c.name }}</span>
+                          <span v-if="c.isSecondEdition" class="tm-2nd-badge">2nd Edition</span>
+                        </div>
                         <div class="tr-suggest-dim">Highest Mint #{{ c.highestMint ?? '—' }}</div>
                       </div>
                     </button>
@@ -1627,6 +1630,7 @@ onBeforeUnmount(() => {
 .tr-booster-tag { margin-left: auto; font-size: 0.55rem; padding: 1px 4px; border-radius: 9999px; background: rgba(251,191,36,0.25); color: #fbbf24; border: 1px solid rgba(251,191,36,0.35); }
 .tr-tradeable-tag { margin-left: auto; font-size: 0.55rem; padding: 1px 4px; border-radius: 9999px; background: rgba(74,222,128,0.2); color: #4ade80; border: 1px solid rgba(74,222,128,0.3); }
 .tr-ctoon-back-row { display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-bottom: 1px solid rgba(255,255,255,0.1); }
+.tr-suggest-name-row { display: flex; align-items: center; gap: 6px; }
 .tr-ctoon-back { background: none; border: none; color: var(--OrbitLightBlue); font-size: 0.65rem; cursor: pointer; font-family: inherit; padding: 0; }
 
 .tr-selected-user {

--- a/pages/admin/addHolidayEvent.vue
+++ b/pages/admin/addHolidayEvent.vue
@@ -82,7 +82,12 @@
             >
               <img v-if="s.assetPath" :src="s.assetPath" class="w-8 h-8 object-cover rounded border border-gray-300" />
               <div class="flex-1 truncate">
-                <p class="truncate font-medium">{{ s.name }}</p>
+                <p class="truncate font-medium flex items-center gap-2">
+                  <span class="truncate">{{ s.name }}</span>
+                  <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                    {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                  </span>
+                </p>
                 <p class="text-xs text-gray-500">{{ s.rarity }}</p>
               </div>
             </li>
@@ -94,7 +99,10 @@
           <div v-for="id in itemIds" :key="id" class="flex items-center gap-3 px-4 py-2">
             <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-10 h-10 object-cover rounded border border-gray-300" />
             <div class="flex-1 truncate">
-              <p class="truncate font-medium">{{ lookup[id]?.name }}</p>
+              <p class="truncate font-medium flex items-center gap-2">
+                <span class="truncate">{{ lookup[id]?.name }}</span>
+                <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+              </p>
               <p class="text-xs text-gray-500">{{ lookup[id]?.rarity }}</p>
             </div>
             <button type="button" @click="toggleItem(lookup[id])" class="text-red-700 hover:underline text-sm focus-visible:outline-red-700">
@@ -183,7 +191,12 @@
             >
               <img v-if="s.assetPath" :src="s.assetPath" class="w-8 h-8 object-cover rounded border border-gray-300" />
               <div class="flex-1 truncate">
-                <p class="truncate font-medium">{{ s.name }}</p>
+                <p class="truncate font-medium flex items-center gap-2">
+                  <span class="truncate">{{ s.name }}</span>
+                  <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                    {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                  </span>
+                </p>
                 <p class="text-xs text-gray-500">{{ s.rarity }}</p>
               </div>
             </li>
@@ -195,7 +208,10 @@
           <div v-for="id in poolIds" :key="id" class="flex items-center gap-3 px-4 py-2">
             <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-10 h-10 object-cover rounded border border-gray-300" />
             <div class="flex-1 truncate">
-              <p class="truncate font-medium">{{ lookup[id]?.name }}</p>
+              <p class="truncate font-medium flex items-center gap-2">
+                <span class="truncate">{{ lookup[id]?.name }}</span>
+                <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+              </p>
             </div>
             <div class="flex items-center gap-1">
               <input v-model.number="poolWeights[id]" type="number" min="0" max="100"
@@ -468,4 +484,16 @@ async function submit() {
 
 <style scoped>
 .cto-autocomplete ul { z-index: 60; }
+.edition-badge {
+  display: inline-block;
+  flex-shrink: 0;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+.edition-badge-2nd { background: #7c3aed; color: #fff; }
+.edition-badge-1st { background: #e5e7eb; color: #374151; }
 </style>

--- a/pages/admin/edit-holidayevent/[id].vue
+++ b/pages/admin/edit-holidayevent/[id].vue
@@ -71,7 +71,12 @@
             >
               <img v-if="s.assetPath" :src="s.assetPath" class="w-8 h-8 object-cover rounded border border-gray-300" />
               <div class="flex-1 truncate">
-                <p class="truncate font-medium">{{ s.name }}</p>
+                <p class="truncate font-medium flex items-center gap-2">
+                  <span class="truncate">{{ s.name }}</span>
+                  <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                    {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                  </span>
+                </p>
                 <p class="text-xs text-gray-500">{{ s.rarity }}</p>
               </div>
             </li>
@@ -82,7 +87,10 @@
           <div v-for="id in itemIds" :key="id" class="flex items-center gap-3 px-4 py-2">
             <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-10 h-10 object-cover rounded border border-gray-300" />
             <div class="flex-1 truncate">
-              <p class="truncate font-medium">{{ lookup[id]?.name }}</p>
+              <p class="truncate font-medium flex items-center gap-2">
+                <span class="truncate">{{ lookup[id]?.name }}</span>
+                <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+              </p>
               <p class="text-xs text-gray-500">{{ lookup[id]?.rarity }}</p>
             </div>
             <button type="button" @click="toggleItem(lookup[id])" class="text-red-700 hover:underline text-sm focus-visible:outline-red-700">
@@ -129,7 +137,12 @@
             >
               <img v-if="s.assetPath" :src="s.assetPath" class="w-8 h-8 object-cover rounded border border-gray-300" />
               <div class="flex-1 truncate">
-                <p class="truncate font-medium">{{ s.name }}</p>
+                <p class="truncate font-medium flex items-center gap-2">
+                  <span class="truncate">{{ s.name }}</span>
+                  <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                    {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                  </span>
+                </p>
                 <p class="text-xs text-gray-500">{{ s.rarity }}</p>
               </div>
             </li>
@@ -140,7 +153,10 @@
           <div v-for="id in poolIds" :key="id" class="flex items-center gap-3 px-4 py-2">
             <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-10 h-10 object-cover rounded border border-gray-300" />
             <div class="flex-1 truncate">
-              <p class="truncate font-medium">{{ lookup[id]?.name }}</p>
+              <p class="truncate font-medium flex items-center gap-2">
+                <span class="truncate">{{ lookup[id]?.name }}</span>
+                <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+              </p>
             </div>
             <div class="flex items-center gap-1">
               <input v-model.number="poolWeights[id]" type="number" min="0" max="100" class="w-20 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600" />
@@ -388,4 +404,16 @@ async function submit() {
 
 <style scoped>
 .cto-autocomplete ul { z-index: 60; }
+.edition-badge {
+  display: inline-block;
+  flex-shrink: 0;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+.edition-badge-2nd { background: #7c3aed; color: #fff; }
+.edition-badge-1st { background: #e5e7eb; color: #374151; }
 </style>

--- a/pages/admin/edit-pack/[id].vue
+++ b/pages/admin/edit-pack/[id].vue
@@ -195,7 +195,12 @@
                   <img v-if="s.assetPath" :src="s.assetPath"
                        class="w-8 h-8 object-cover rounded border border-gray-300"/>
                   <div class="flex-1 truncate">
-                    <p class="truncate font-medium">{{ s.name }}</p>
+                    <p class="truncate font-medium flex items-center gap-2">
+                      <span class="truncate">{{ s.name }}</span>
+                      <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                        {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                      </span>
+                    </p>
                     <p class="text-xs text-gray-500">{{ s.rarity }}</p>
                   </div>
                 </li>
@@ -242,7 +247,10 @@
                 <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath"
                      class="w-10 h-10 object-cover rounded border border-gray-300"/>
                 <div class="flex-1 truncate">
-                  <p class="truncate font-medium">{{ lookup[id]?.name }}</p>
+                  <p class="truncate font-medium flex items-center gap-2">
+                    <span class="truncate">{{ lookup[id]?.name }}</span>
+                    <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+                  </p>
                 </div>
 
                 <div class="flex items-center gap-1">
@@ -592,6 +600,18 @@ async function submit () {
 .weight-badge { @apply inline-block rounded-full px-2 py-0.5 text-xs font-semibold; }
 .weight-ok  { @apply bg-green-100 text-green-700; }
 .weight-bad { @apply bg-red-100 text-red-700; }
+.edition-badge {
+  display: inline-block;
+  flex-shrink: 0;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+.edition-badge-2nd { background: #7c3aed; color: #fff; }
+.edition-badge-1st { background: #e5e7eb; color: #374151; }
 .group-row:not(:last-child){ border-bottom:1px solid theme('colors.gray.200'); }
 input[type='number']{ min-width:4rem; }
 </style>

--- a/pages/admin/manage-czone-search.vue
+++ b/pages/admin/manage-czone-search.vue
@@ -228,7 +228,12 @@
                   >
                     <img :src="ctoon.assetPath" class="h-10 w-auto rounded" />
                     <div>
-                      <p class="font-medium">{{ ctoon.name }}</p>
+                      <p class="font-medium flex items-center gap-2">
+                        <span class="truncate">{{ ctoon.name }}</span>
+                        <span :class="ctoon.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                          {{ ctoon.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                        </span>
+                      </p>
                       <p class="text-xs text-gray-500">{{ ctoon.rarity }}</p>
                     </div>
                   </li>
@@ -246,7 +251,10 @@
                     <button type="button" class="flex items-center gap-3 flex-1 text-left" @click="togglePrizeRow(row)">
                       <img :src="row.ctoon.assetPath" class="h-10 w-auto rounded" />
                       <div>
-                        <div class="font-medium">{{ row.ctoon.name }}</div>
+                        <div class="font-medium flex items-center gap-2">
+                          <span>{{ row.ctoon.name }}</span>
+                          <span v-if="row.ctoon.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+                        </div>
                         <div class="text-xs text-gray-500">{{ row.ctoon.rarity }}</div>
                       </div>
                     </button>
@@ -349,7 +357,12 @@
                               >
                                 <img :src="ctoon.assetPath" class="h-8 w-auto rounded" />
                                 <div>
-                                  <p class="font-medium">{{ ctoon.name }}</p>
+                                  <p class="font-medium flex items-center gap-2">
+                                    <span class="truncate">{{ ctoon.name }}</span>
+                                    <span :class="ctoon.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                                      {{ ctoon.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                                    </span>
+                                  </p>
                                   <p class="text-xs text-gray-500">{{ ctoon.rarity }}</p>
                                 </div>
                               </li>
@@ -357,7 +370,10 @@
                           </div>
                           <div v-if="row.conditionCtoonInZone" class="mt-2 flex items-center gap-3 bg-white border rounded px-2 py-1">
                             <img :src="row.conditionCtoonInZone.assetPath" class="h-8 w-auto rounded" />
-                            <div class="flex-1 text-sm">{{ row.conditionCtoonInZone.name }}</div>
+                            <div class="flex-1 text-sm flex items-center gap-2">
+                              <span>{{ row.conditionCtoonInZone.name }}</span>
+                              <span v-if="row.conditionCtoonInZone.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+                            </div>
                             <button type="button" class="text-xs text-red-600" @click="clearConditionCtoonInZone(row)">Remove</button>
                           </div>
                         </div>
@@ -391,7 +407,12 @@
                               >
                                 <img :src="ctoon.assetPath" class="h-8 w-auto rounded" />
                                 <div>
-                                  <p class="font-medium">{{ ctoon.name }}</p>
+                                  <p class="font-medium flex items-center gap-2">
+                                    <span class="truncate">{{ ctoon.name }}</span>
+                                    <span :class="ctoon.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                                      {{ ctoon.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                                    </span>
+                                  </p>
                                   <p class="text-xs text-gray-500">{{ ctoon.rarity }}</p>
                                 </div>
                               </li>
@@ -400,7 +421,10 @@
                           <div v-if="row.conditionUserOwnsList.length" class="space-y-2">
                             <div v-for="entry in row.conditionUserOwnsList" :key="entry.ctoonId" class="flex items-center gap-3 bg-white border rounded px-2 py-1">
                               <img v-if="entry.ctoon?.assetPath" :src="entry.ctoon.assetPath" class="h-8 w-auto rounded" />
-                              <div class="flex-1 text-sm">{{ entry.ctoon?.name || entry.ctoonId }}</div>
+                              <div class="flex-1 text-sm flex items-center gap-2">
+                                <span>{{ entry.ctoon?.name || entry.ctoonId }}</span>
+                                <span v-if="entry.ctoon?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+                              </div>
                               <div class="flex items-center gap-2">
                                 <label class="text-xs text-gray-500"># Owned</label>
                                 <input v-model.number="entry.count" type="number" min="1" step="1" class="w-20 border rounded px-2 py-1" />
@@ -1424,3 +1448,18 @@ onMounted(async () => {
   await Promise.all([loadSearches(), loadBackgrounds()])
 })
 </script>
+
+<style scoped>
+.edition-badge {
+  display: inline-block;
+  flex-shrink: 0;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+.edition-badge-2nd { background: #7c3aed; color: #fff; }
+.edition-badge-1st { background: #e5e7eb; color: #374151; }
+</style>

--- a/pages/admin/new-pack.vue
+++ b/pages/admin/new-pack.vue
@@ -302,7 +302,12 @@
                   class="w-8 h-8 object-cover rounded border border-gray-300"
                 />
                 <div class="flex-1 truncate">
-                  <p class="truncate font-medium">{{ s.name }}</p>
+                  <p class="truncate font-medium flex items-center gap-2">
+                    <span class="truncate">{{ s.name }}</span>
+                    <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                      {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                    </span>
+                  </p>
                   <p class="text-xs text-gray-500">{{ s.rarity }}</p>
                 </div>
               </li>
@@ -374,7 +379,10 @@
                 class="w-10 h-10 object-cover rounded border border-gray-300"
               />
               <div class="flex-1 truncate">
-                <p class="truncate font-medium">{{ lookup[id]?.name }}</p>
+                <p class="truncate font-medium flex items-center gap-2">
+                  <span class="truncate">{{ lookup[id]?.name }}</span>
+                  <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+                </p>
               </div>
 
               <!-- weight -->
@@ -778,6 +786,18 @@ async function submit() {
 }
 .weight-ok  { @apply bg-green-100 text-green-700; }
 .weight-bad { @apply bg-red-100   text-red-700;   }
+.edition-badge {
+  display: inline-block;
+  flex-shrink: 0;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+.edition-badge-2nd { background: #7c3aed; color: #fff; }
+.edition-badge-1st { background: #e5e7eb; color: #374151; }
 .group-row:not(:last-child) {
   border-bottom: 1px solid theme('colors.gray.200');
 }

--- a/server/api/admin/ctoon-pool.get.js
+++ b/server/api/admin/ctoon-pool.get.js
@@ -46,6 +46,7 @@ export default defineEventHandler(async (event) => {
       quantity: true,         // total supply (null = unlimited)
       initialQuantity: true,
       inCmart: true,
+      isSecondEdition: true,
       _count: { select: { owners: true } } // minted so far
     }
   })

--- a/server/api/admin/ctoons/by-ids.post.js
+++ b/server/api/admin/ctoons/by-ids.post.js
@@ -21,7 +21,7 @@ export default defineEventHandler(async (event) => {
 
   const ctoons = await db.ctoon.findMany({
     where: { id: { in: ids } },
-    select: { id: true, name: true, rarity: true, assetPath: true }
+    select: { id: true, name: true, rarity: true, assetPath: true, isSecondEdition: true }
   })
 
   return ctoons

--- a/server/api/admin/czone-searches.get.js
+++ b/server/api/admin/czone-searches.get.js
@@ -25,7 +25,7 @@ export default defineEventHandler(async (event) => {
         orderBy: { chancePercent: 'desc' },
         include: {
           ctoon: {
-            select: { id: true, name: true, rarity: true, assetPath: true }
+            select: { id: true, name: true, rarity: true, assetPath: true, isSecondEdition: true }
           }
         }
       }

--- a/server/api/trade/search-ctoons.get.js
+++ b/server/api/trade/search-ctoons.get.js
@@ -30,7 +30,7 @@ export default defineEventHandler(async (event) => {
         mintNumber: true,
         user: { select: { username: true, avatar: true } },
         tradeListItems: { select: { userId: true } },
-        ctoon: { select: { id: true, name: true, assetPath: true } }
+        ctoon: { select: { id: true, name: true, assetPath: true, isSecondEdition: true } }
       }
     })
 
@@ -39,6 +39,7 @@ export default defineEventHandler(async (event) => {
       ctoonId: row.ctoon.id,
       name: row.ctoon.name,
       assetPath: row.ctoon.assetPath,
+      isSecondEdition: row.ctoon.isSecondEdition,
       mintNumber: row.mintNumber,
       ownerUsername: row.user.username,
       ownerAvatar: row.user.avatar,
@@ -57,6 +58,7 @@ export default defineEventHandler(async (event) => {
       c."id" AS "ctoonId",
       c."name" AS "name",
       c."assetPath" AS "assetPath",
+      c."isSecondEdition" AS "isSecondEdition",
       MAX(uc."mintNumber") AS "highestMint"
     FROM "UserCtoon" uc
     JOIN "Ctoon" c ON c."id" = uc."ctoonId"
@@ -78,6 +80,7 @@ export default defineEventHandler(async (event) => {
     ctoonId: row.ctoonId,
     name: row.name,
     assetPath: row.assetPath,
+    isSecondEdition: row.isSecondEdition,
     highestMint: row.highestMint ?? 0
   }))
 })


### PR DESCRIPTION
Add isSecondEdition to the admin ctoon-pool API response and render a
1st/2nd Edition badge in the Add cToons autocomplete suggestions and
selected cToon rows, so admins can tell duplicate-named editions apart.