### PR TITLE
Improve Edit Pack admin page layout on mobile

### DIFF
--- a/pages/admin/edit-pack/[id].vue
+++ b/pages/admin/edit-pack/[id].vue
@@ -2,7 +2,7 @@
 <template>
   <Nav />
 
-  <div class="p-8 max-w-6xl mx-auto space-y-14 mt-16 md:mt-20">
+  <div class="p-4 sm:p-8 max-w-6xl mx-auto space-y-10 sm:space-y-14 mt-16 md:mt-20">
     <!-- 🡐 Back & title -->
     <div class="flex items-center gap-4">
       <NuxtLink
@@ -27,7 +27,7 @@
 
       <form
         @submit.prevent="submit"
-        class="space-y-16 bg-white shadow-lg rounded-xl p-8 border border-gray-200"
+        class="space-y-16 bg-white shadow-lg rounded-xl p-4 sm:p-8 border border-gray-200"
       >
         <!-- 1️⃣  BASIC INFO --------------------------------------------------- -->
         <section class="grid lg:grid-cols-2 gap-6">
@@ -192,14 +192,18 @@
                     @mousedown.prevent="toggleSelect(s)"
                     :class="['flex items-center gap-3 px-3 py-2 cursor-pointer',
                              idx===highlighted?'bg-blue-50':'hover:bg-gray-50']">
-                  <img v-if="s.assetPath" :src="s.assetPath"
-                       class="w-8 h-8 object-cover rounded border border-gray-300"/>
-                  <div class="flex-1 truncate">
-                    <p class="truncate font-medium flex items-center gap-2">
+                  <div class="relative shrink-0 w-12 h-12">
+                    <img v-if="s.assetPath" :src="s.assetPath"
+                         class="w-full h-full object-contain rounded border border-gray-300 bg-white"/>
+                    <SecondEditionOverlay :ctoon="s"/>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <p class="truncate font-medium flex flex-wrap items-center gap-1.5">
                       <span class="truncate">{{ s.name }}</span>
                       <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
                         {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
                       </span>
+                      <span v-if="s.inCmart === false" class="exclusive-badge">Pack Exclusive</span>
                     </p>
                     <p class="text-xs text-gray-500">{{ s.rarity }}</p>
                   </div>
@@ -214,56 +218,68 @@
         <section class="space-y-10">
           <div v-for="(ids, rarity) in grouped" :key="rarity"
                class="border border-gray-300 rounded-md">
-            <div class="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-t-md">
-              <div class="flex items-center gap-3">
-                <h3 class="font-medium">{{ rarity }}</h3>
+            <div class="flex flex-wrap items-center gap-3 bg-gray-50 px-4 py-3 rounded-t-md">
+              <h3 class="font-medium">{{ rarity }}</h3>
 
-                <!-- cards / pack -->
-                <div class="flex items-center gap-1">
-                  <input v-model.number="countsByRarity[rarity].count" type="number"
-                         :min="1" :max="ids.length"
-                         class="w-16 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"/>
-                  <span class="text-xs text-gray-500">cards</span>
-                </div>
-
-                <!-- probability -->
-                <div class="flex items-center gap-1 ml-4">
-                  <input v-model.number="countsByRarity[rarity].probabilityPercent" type="number"
-                         min="1" max="100"
-                         class="w-20 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"/>
-                  <span class="text-xs text-gray-500">%</span>
-                </div>
+              <!-- cards / pack -->
+              <div class="flex items-center gap-1">
+                <input v-model.number="countsByRarity[rarity].count" type="number"
+                       :min="1" :max="ids.length"
+                       class="w-16 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"/>
+                <span class="text-xs text-gray-500">cards</span>
               </div>
 
-              <span class="weight-badge"
-                    :class="sumWeights(rarity)===100?'weight-ok':'weight-bad'">
-                {{ sumWeights(rarity) }} %
-              </span>
+              <!-- probability -->
+              <div class="flex items-center gap-1">
+                <input v-model.number="countsByRarity[rarity].probabilityPercent" type="number"
+                       min="1" max="100"
+                       class="w-20 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"/>
+                <span class="text-xs text-gray-500">%</span>
+              </div>
+
+              <div class="flex items-center gap-2 ml-auto">
+                <button type="button" @click="rebalance(rarity)"
+                        class="even-out-btn">
+                  Even out
+                </button>
+                <span class="weight-badge"
+                      :class="sumWeights(rarity)===100?'weight-ok':'weight-bad'">
+                  {{ sumWeights(rarity) }} %
+                </span>
+              </div>
             </div>
 
             <div>
               <div v-for="id in ids" :key="id"
-                   class="group-row flex items-center gap-3 px-4 py-2">
-                <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath"
-                     class="w-10 h-10 object-cover rounded border border-gray-300"/>
-                <div class="flex-1 truncate">
-                  <p class="truncate font-medium flex items-center gap-2">
-                    <span class="truncate">{{ lookup[id]?.name }}</span>
-                    <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
-                  </p>
+                   class="group-row flex flex-wrap items-center gap-3 px-4 py-3">
+                <div class="flex items-center gap-3 flex-1 min-w-[200px]">
+                  <div class="relative shrink-0 w-16 h-16">
+                    <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath"
+                         class="w-full h-full object-contain rounded border border-gray-300 bg-white"/>
+                    <SecondEditionOverlay :ctoon="lookup[id]"/>
+                  </div>
+                  <div class="min-w-0">
+                    <p class="font-medium flex flex-wrap items-center gap-1.5">
+                      <span class="truncate">{{ lookup[id]?.name }}</span>
+                      <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+                      <span v-if="lookup[id]?.inCmart === false" class="exclusive-badge">Pack Exclusive</span>
+                    </p>
+                  </div>
                 </div>
 
-                <div class="flex items-center gap-1">
-                  <input v-model.number="weights[id]" type="number" min="1" max="100"
-                         class="w-20 rounded-md border border-gray-400 px-2 py-1 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-                         @input="onManualWeight(rarity,id)"/>
-                  <span class="text-xs text-gray-500">%</span>
-                </div>
+                <div class="flex items-center gap-3 ml-auto">
+                  <div class="flex items-center gap-1">
+                    <input v-model.number="weights[id]" type="number" min="1" max="100"
+                           class="w-20 rounded-md border border-gray-400 px-2 py-1 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+                           @input="onManualWeight(rarity,id)"/>
+                    <span class="text-xs text-gray-500">%</span>
+                  </div>
 
-                <button type="button" @click="toggleSelect(lookup[id])"
-                        class="text-red-700 hover:underline text-sm">
-                  Remove
-                </button>
+                  <button type="button" @click="toggleSelect(lookup[id])"
+                          class="text-red-700 hover:underline text-sm shrink-0">
+                    Remove
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -612,6 +628,19 @@ async function submit () {
 }
 .edition-badge-2nd { background: #7c3aed; color: #fff; }
 .edition-badge-1st { background: #e5e7eb; color: #374151; }
+.exclusive-badge {
+  display: inline-block;
+  flex-shrink: 0;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: #d97706;
+  color: #fff;
+}
+.even-out-btn { @apply text-xs font-semibold text-blue-700 border border-blue-300 rounded-full px-2.5 py-1 hover:bg-blue-100 whitespace-nowrap; }
 .group-row:not(:last-child){ border-bottom:1px solid theme('colors.gray.200'); }
 input[type='number']{ min-width:4rem; }
 </style>

--- a/pages/admin/packs.vue
+++ b/pages/admin/packs.vue
@@ -43,7 +43,10 @@
                 <th class="px-4 py-3">Name</th>
                 <th class="px-4 py-3">Price</th>
                 <th class="px-4 py-3">Rarity Breakdown</th>
-                <th class="px-4 py-3">In C-mart</th>
+                <th class="px-4 py-3">Status</th>
+                <th class="px-4 py-3">Schedule (CST)</th>
+                <th class="px-4 py-3">Purchased</th>
+                <th class="px-4 py-3">Limits / User</th>
                 <th class="px-4 py-3">Created</th>
                 <th class="px-4 py-3">Action</th>
               </tr>
@@ -61,7 +64,20 @@
                 <td class="px-4 py-3 font-medium text-gray-900">{{ pack.name }}</td>
                 <td class="px-4 py-3">{{ formatPrice(pack.price) }}</td>
                 <td class="px-4 py-3 whitespace-nowrap">{{ formatRarity(pack.rarityConfigs) }}</td>
-                <td class="px-4 py-3">{{ pack.inCmart ? 'Yes' : 'No' }}</td>
+                <td class="px-4 py-3">
+                  <span class="status-badge" :class="`status-${packStatus(pack).tone}`">
+                    {{ packStatus(pack).label }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-xs">
+                  <div><span class="text-gray-500">Start:</span> {{ formatCst(pack.scheduledAt) }}</div>
+                  <div><span class="text-gray-500">End:</span> {{ formatCst(pack.scheduledOffAt) }}</div>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap">{{ pack.purchasedCount.toLocaleString() }}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-xs">
+                  <div>{{ pack.dailyPurchaseLimit != null ? `${pack.dailyPurchaseLimit}/day` : 'Unlimited/day' }}</div>
+                  <div>{{ pack.maxBuysPerUser != null ? `${pack.maxBuysPerUser} total` : 'Unlimited total' }}</div>
+                </td>
                 <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(pack.createdAt) }}</td>
                 <td class="px-4 py-3">
                   <NuxtLink
@@ -95,9 +111,22 @@
                 <!-- Info -->
                 <div class="space-y-1">
                   <h2 class="text-lg font-semibold">{{ pack.name }}</h2>
+                  <p class="text-sm flex items-center gap-2">
+                    <strong>Status:</strong>
+                    <span class="status-badge" :class="`status-${packStatus(pack).tone}`">
+                      {{ packStatus(pack).label }}
+                    </span>
+                  </p>
                   <p class="text-sm"><strong>Price:</strong> {{ formatPrice(pack.price) }}</p>
                   <p class="text-sm"><strong>Rarity:</strong> {{ formatRarity(pack.rarityConfigs) }}</p>
-                  <p class="text-sm"><strong>In C-mart:</strong> {{ pack.inCmart ? 'Yes' : 'No' }}</p>
+                  <p class="text-sm"><strong>Start (CST):</strong> {{ formatCst(pack.scheduledAt) }}</p>
+                  <p class="text-sm"><strong>End (CST):</strong> {{ formatCst(pack.scheduledOffAt) }}</p>
+                  <p class="text-sm"><strong>Purchased:</strong> {{ pack.purchasedCount.toLocaleString() }}</p>
+                  <p class="text-sm">
+                    <strong>Limits:</strong>
+                    {{ pack.dailyPurchaseLimit != null ? `${pack.dailyPurchaseLimit}/day` : 'Unlimited/day' }},
+                    {{ pack.maxBuysPerUser != null ? `${pack.maxBuysPerUser} total` : 'Unlimited total' }}
+                  </p>
                   <p class="text-sm"><strong>Created:</strong> {{ formatDate(pack.createdAt) }}</p>
                 </div>
                 <!-- Edit Button -->
@@ -191,8 +220,40 @@ function formatRarity (arr) {
 function formatDate (d) {
   return new Date(d).toLocaleDateString()
 }
+function formatCst (d) {
+  if (!d) return '—'
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Chicago',
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(d)) + ' CST'
+}
+function packStatus (p) {
+  const now = new Date()
+  const start = p.scheduledAt ? new Date(p.scheduledAt) : null
+  const end = p.scheduledOffAt ? new Date(p.scheduledOffAt) : null
+
+  if (start && now < start) return { label: 'Scheduled', tone: 'blue' }
+  if (end && now >= end) return { label: 'Ended', tone: 'gray' }
+  if (!start && !end) return p.inCmart ? { label: 'Live', tone: 'green' } : { label: 'Not Listed', tone: 'gray' }
+  return { label: 'Live', tone: 'green' }
+}
 
 onMounted(() => {
   fetchPacks()
 })
 </script>
+
+<style scoped>
+.status-badge {
+  display: inline-block;
+  border-radius: 9999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.status-green { background: #dcfce7; color: #15803d; }
+.status-blue  { background: #dbeafe; color: #1d4ed8; }
+.status-gray  { background: #f3f4f6; color: #4b5563; }
+</style>

--- a/server/api/admin/packs.get.js
+++ b/server/api/admin/packs.get.js
@@ -40,17 +40,24 @@ export default defineEventHandler(async (event) => {
     const take = Math.min(Math.max(parseInt(limit, 10) || 50, 1), 200)
     const skip = (pageNum - 1) * take
 
-    const [total, items] = await Promise.all([
+    const [total, rows] = await Promise.all([
       prisma.pack.count(),
       prisma.pack.findMany({
         include: {
-          rarityConfigs: true // include probabilities in list too
+          rarityConfigs: true, // include probabilities in list too
+          _count: { select: { userPacks: true, ctoonOptions: true } }
         },
         orderBy: { createdAt: 'desc' },
         skip,
         take
       })
     ])
+
+    const items = rows.map(({ _count, ...pack }) => ({
+      ...pack,
+      purchasedCount: _count.userPacks,
+      ctoonCount: _count.ctoonOptions
+    }))
 
     return { items, total, page: pageNum, limit: take }
   } catch (err) {


### PR DESCRIPTION
Rework the cToon rarity list and search suggestions to wrap into a
mobile-friendly layout: full-size, uncropped preview images, a 2nd
edition icon overlaid on the artwork, a Pack Exclusive badge for
cToons with inCmart false, and an "Even out" button per rarity group
that redistributes weights evenly to hit 100%.