### PR TITLE
Deduplicate concurrent API requests in useSecondEditionOverlay

### DIFF
--- a/composables/useSecondEditionOverlay.js
+++ b/composables/useSecondEditionOverlay.js
@@ -9,6 +9,12 @@
 // instead of staying a fixed pixel size.
 export const SECOND_EDITION_PREVIEW_SIZE = 220
 
+// Shared across every component instance so the many cToon cards that each
+// call ensureLoaded() on mount (e.g. a cMart grid with hundreds of cards)
+// await one in-flight request instead of each firing their own — otherwise
+// the burst of concurrent fetches can exhaust the browser's connection pool.
+let loadPromise = null
+
 export function useSecondEditionOverlay() {
   const overlay = useState('secondEditionOverlayConfig', () => ({
     path: null,
@@ -19,17 +25,21 @@ export function useSecondEditionOverlay() {
 
   async function ensureLoaded() {
     if (overlay.value.loaded) return
-    try {
-      const cfg = await $fetch('/api/global-config')
-      overlay.value = {
-        path: cfg?.secondEditionOverlayPath || null,
-        width: cfg?.secondEditionOverlayWidth || 32,
-        height: cfg?.secondEditionOverlayHeight || 32,
-        loaded: true
-      }
-    } catch {
-      overlay.value = { path: null, width: null, height: null, loaded: true }
+    if (!loadPromise) {
+      loadPromise = $fetch('/api/global-config')
+        .then(cfg => {
+          overlay.value = {
+            path: cfg?.secondEditionOverlayPath || null,
+            width: cfg?.secondEditionOverlayWidth || 32,
+            height: cfg?.secondEditionOverlayHeight || 32,
+            loaded: true
+          }
+        })
+        .catch(() => {
+          overlay.value = { path: null, width: null, height: null, loaded: true }
+        })
     }
+    await loadPromise
   }
 
   // Renders the overlay centered at (overlayX%, overlayY%) of its container, with


### PR DESCRIPTION
## Summary
This change optimizes the `useSecondEditionOverlay` composable to prevent multiple concurrent requests to the `/api/global-config` endpoint when many component instances call `ensureLoaded()` simultaneously.

## Key Changes
- Introduced a shared `loadPromise` variable that persists across all component instances
- Modified `ensureLoaded()` to check if a request is already in-flight before initiating a new one
- All concurrent callers now await the same promise instead of each firing independent requests
- Refactored error handling to use `.catch()` for consistency with the promise-based approach

## Implementation Details
This addresses a performance issue where rendering many cards (e.g., in a cMart grid with hundreds of items) would cause each card's `ensureLoaded()` call on mount to trigger its own API request. The burst of concurrent fetches could exhaust the browser's connection pool. By sharing a single in-flight request across all instances, we reduce network overhead while maintaining the same functionality.

https://claude.ai/code/session_0171RrxhGt7VaDZY1GviFCm2