### PR TITLE
Add linkable auction pages, fix pack go-live scheduling, update Discord links

### DIFF
--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -1,16 +1,6 @@
 <template>
   <div class="ah">
 
-    <!-- ── Detail view ────────────────────────────────────────────── -->
-    <AuctionDetails
-      v-if="selectedAuctionId"
-      :auction-id="selectedAuctionId"
-      @back="selectedAuctionId = null"
-    />
-
-    <!-- ── List view ─────────────────────────────────────────────── -->
-    <template v-if="!selectedAuctionId">
-
     <!-- ── Tabs + View toggle ─────────────────────────────────── -->
     <div class="ah-topbar">
       <div class="ah-tabs">
@@ -98,7 +88,7 @@
           </div>
 
           <!-- View button -->
-          <button class="ah-view" @click="selectedAuctionId = item.id">View</button>
+          <button class="ah-view" @click="goToAuction(item.id)">View</button>
         </div>
       </template>
     </div>
@@ -162,7 +152,7 @@
             </span>
           </template>
           <template #footer-right>
-            <button class="ah-card-view-btn" @click.stop="selectedAuctionId = item.id">View</button>
+            <button class="ah-card-view-btn" @click.stop="goToAuction(item.id)">View</button>
           </template>
         </ShortCard>
       </template>
@@ -176,8 +166,6 @@
       <button class="ah-pg-btn" :disabled="activePage >= totalPages"  @click="nextPage">›</button>
     </div>
 
-    </template><!-- end list view -->
-
   </div>
 </template>
 
@@ -186,8 +174,11 @@ const filter   = useNewSiteCtoonFilter()
 const aFilters = useAuctionHouseFilters()
 const cmartCtoons = useState('cmartCtoons', () => [])
 const { open: openCtoonModal } = useCtoonModal()
+const router = useRouter()
 
-const selectedAuctionId = ref(null)
+function goToAuction(id) {
+  router.push(`/newsite/AuctionHouse/${id}`)
+}
 
 const TABS = [
   { id: 'current', label: 'Current'     },

--- a/pages/newsite/AuctionHouse/[id].vue
+++ b/pages/newsite/AuctionHouse/[id].vue
@@ -1,0 +1,45 @@
+<template>
+  <AuctionDetails :auction-id="auctionId" @back="goBack" />
+</template>
+
+<script setup>
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  showAdbar: true,
+  showNav: true,
+  title: 'Auction House',
+  description: 'View this auction on Cartoon ReOrbit and place your bid before time runs out.'
+})
+
+const { setSidebarMiddle } = useNewsiteLayout()
+setSidebarMiddle('AuctionHouseSidebar')
+
+const route  = useRoute()
+const router = useRouter()
+const auctionId = computed(() => route.params.id)
+
+function goBack() {
+  router.push('/newsite/AuctionHouse')
+}
+</script>
+
+<style>
+html {
+  min-height: 100vh;
+  background: linear-gradient(
+    to bottom,
+    #000000 0px,
+    #000000 65px,
+    #003466 115px,
+    #003466 100%
+  ) no-repeat fixed !important;
+}
+
+body {
+  background: transparent !important;
+  min-height: 100vh;
+}
+
+body.page-newsite-auctionhouse-id .sidebar { --sidebar-middle-height: 495px; }
+</style>

--- a/server/api/admin/packs/[id].patch.js
+++ b/server/api/admin/packs/[id].patch.js
@@ -177,6 +177,18 @@ export default defineEventHandler(async (event) => {
 
   /* ── DB transaction ────────────────────────── */
   const result = await db.$transaction(async (tx) => {
+    /* re-arm the auto-listing cron whenever the go-live time actually changes —
+       otherwise a pack that already went live once (sentAt set) would never be
+       picked up again by markScheduledPacksInCmart(), which only considers
+       packs where sentAt is still null */
+    const existing = await tx.pack.findUnique({
+      where: { id: packId },
+      select: { scheduledAt: true }
+    })
+    const prevScheduledAtMs = existing?.scheduledAt ? existing.scheduledAt.getTime() : null
+    const nextScheduledAtMs = scheduledAt ? scheduledAt.getTime() : null
+    const scheduleRearmed = !!scheduledAt && prevScheduledAtMs !== nextScheduledAtMs
+
     /* update pack row */
     await tx.pack.update({
       where: { id: packId },
@@ -190,6 +202,7 @@ export default defineEventHandler(async (event) => {
         maxBuysPerUser:     meta.maxBuysPerUser     != null ? Number(meta.maxBuysPerUser)     : null,
         scheduledOffAt,
         scheduledAt,
+        ...(scheduleRearmed ? { sentAt: null } : {}),
         ...(imagePath ? { imagePath } : {})
       }
     })

--- a/server/api/trade/offers.post.js
+++ b/server/api/trade/offers.post.js
@@ -236,8 +236,8 @@ export default defineEventHandler(async (event) => {
       const BOT_TOKEN = process.env.BOT_TOKEN
       const isProd = process.env.NODE_ENV === 'production'
       const baseUrl = isProd
-        ? 'https://www.cartoonreorbit.com/trade-offers'
-        : 'http://localhost:3000/trade-offers'
+        ? 'https://www.cartoonreorbit.com/newsite/trade'
+        : 'http://localhost:3000/newsite/trade'
 
       // 7a) Open (or fetch) a DM channel with that user
       const dmChannel = await $fetch(

--- a/server/utils/discord.js
+++ b/server/utils/discord.js
@@ -3,8 +3,8 @@ export function auctionLink(auctionId) {
   // Keep this identical to your other DM base URL logic
   const isProd = process.env.NODE_ENV === 'production'
   return isProd
-    ? `https://www.cartoonreorbit.com/auction/${auctionId}`
-    : `http://localhost:3000/auction/${auctionId}`
+    ? `https://www.cartoonreorbit.com/newsite/AuctionHouse/${auctionId}`
+    : `http://localhost:3000/newsite/AuctionHouse/${auctionId}`
 }
 
 function getAnnouncementsBotToken() {


### PR DESCRIPTION
- Add pages/newsite/AuctionHouse/[id].vue so individual auctions have a
  shareable URL; "View" buttons in AuctionHouse.vue now navigate there
  instead of toggling local component state.
- Fix pack go-live scheduling: editing a pack's scheduledAt now resets
  sentAt when the schedule actually changes. Previously, once a pack's
  sentAt was set (e.g. from an earlier go-live), the hourly cron job
  would never re-list it because it only considers packs with
  sentAt: null, silently breaking any later reschedule.
- Point the outbid auction Discord DM at the new
  /newsite/AuctionHouse/:id page instead of the old /auction/:id route.
- Point the new-trade-offer Discord DM at /newsite/trade instead of the
  old /trade-offers page.

Note: the pack review modal already shows second edition overlay icons
on cToon images (added previously in commit 0768656).