### PR TITLE
Add second edition overlay support to card pack previews

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -78,6 +78,7 @@
                   :class="originalOwnedSet.has(item.ctoonId) ? 'owned-badge--owned' : 'owned-badge--unowned'"
                 >{{ originalOwnedSet.has(item.ctoonId) ? 'Owned' : 'Unowned' }}</span>
                 <img v-if="item.assetPath" :src="item.assetPath" :alt="item.name" class="pack-preview-ctoon-img" />
+                <SecondEditionOverlay :ctoon="item" />
                 <p class="pack-preview-ctoon-name">{{ item.name }}</p>
                 <p class="pack-preview-ctoon-weight">{{ item.weight }}% chance</p>
               </div>

--- a/server/api/cmart/packs/[id].get.js
+++ b/server/api/cmart/packs/[id].get.js
@@ -53,7 +53,15 @@ export default defineEventHandler(async (event) => {
         select: {
           weight:  true,
           ctoonId: true,
-          ctoon:   { select: { name: true, rarity: true, assetPath: true, isGtoon: true, cost: true, power: true } }
+          ctoon:   {
+            select: {
+              name: true, rarity: true, assetPath: true, isGtoon: true, cost: true, power: true,
+              isSecondEdition: true,
+              secondEditionOverlayX: true,
+              secondEditionOverlayY: true,
+              secondEditionOverlaySize: true
+            }
+          }
         }
       }
     }
@@ -72,7 +80,11 @@ export default defineEventHandler(async (event) => {
     isGtoon: o.ctoon.isGtoon,
     cost:    o.ctoon.cost,
     power:   o.ctoon.power,
-    weight:  o.weight
+    weight:  o.weight,
+    isSecondEdition:          o.ctoon.isSecondEdition,
+    secondEditionOverlayX:    o.ctoon.secondEditionOverlayX,
+    secondEditionOverlayY:    o.ctoon.secondEditionOverlayY,
+    secondEditionOverlaySize: o.ctoon.secondEditionOverlaySize
   }))
 
   return {


### PR DESCRIPTION
## Summary
This PR adds support for displaying second edition overlays on cards in the card market pack preview interface. The changes extend the pack API endpoint to fetch second edition metadata and update the frontend component to render the overlay.

## Key Changes
- **API Enhancement**: Extended the `packs/[id].get.js` endpoint to query and return second edition properties from the ctoon model:
  - `isSecondEdition`
  - `secondEditionOverlayX`
  - `secondEditionOverlayY`
  - `secondEditionOverlaySize`

- **Frontend Update**: Modified `Cmart.vue` component to render a new `SecondEditionOverlay` component, passing the card item data to display the overlay on applicable cards

## Implementation Details
- The second edition overlay data is now included in the API response alongside existing card properties (name, rarity, cost, power, etc.)
- The overlay component is conditionally rendered in the pack preview, allowing cards marked as second edition to display the appropriate visual indicator
- No changes to existing card properties or display logic

https://claude.ai/code/session_01VwsaEcJbB1VTkZiAzNGW5s