### PR TITLE
Implement time-based price decay for marketplace packs

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -90,11 +90,13 @@
             @click="packPreviewVisible = false; buyPack(packPreviewPack)"
           >
             <template v-if="buyingPackIds.includes(packPreviewPack?.id)">Purchasing…</template>
-            <template v-else-if="cmartHalfPriceEnabled">
-              Buy for {{ displayPrice(packPreviewPack?.price).toLocaleString() }} pts
-              <span class="pack-price-original">{{ packPreviewPack?.price?.toLocaleString() }}</span>
+            <template v-else>
+              Buy for {{ displayPrice(packBasePrice(packPreviewPack)).toLocaleString() }} pts
+              <span
+                v-if="packPreviewPack && displayPrice(packBasePrice(packPreviewPack)) !== packPreviewPack.price"
+                class="pack-price-original"
+              >{{ packPreviewPack.price.toLocaleString() }}</span>
             </template>
-            <template v-else>Buy for {{ packPreviewPack?.price?.toLocaleString() }} pts</template>
           </GreenButton>
         </div>
       </div>
@@ -208,11 +210,13 @@
             @click="buyPack(pack)"
           >
             <template v-if="buyingPackIds.includes(pack.id)">Purchasing…</template>
-            <template v-else-if="cmartHalfPriceEnabled">
-              Buy for {{ displayPrice(pack.price).toLocaleString() }} pts
-              <span class="pack-price-original">{{ pack.price.toLocaleString() }}</span>
+            <template v-else>
+              Buy for {{ displayPrice(packBasePrice(pack)).toLocaleString() }} pts
+              <span
+                v-if="displayPrice(packBasePrice(pack)) !== pack.price"
+                class="pack-price-original"
+              >{{ pack.price.toLocaleString() }}</span>
             </template>
-            <template v-else>Buy for {{ pack.price.toLocaleString() }} pts</template>
           </GreenButton>
         </div>
       </template>
@@ -275,6 +279,13 @@ const cmartHalfPriceEnabled = ref(false)
 
 function displayPrice(originalPrice) {
   return cmartHalfPriceEnabled.value ? Math.floor(originalPrice / 2) : originalPrice
+}
+
+// Packs decay in price over time server-side; use the decayed price
+// (effectivePrice) as the basis for display/half-price, falling back to
+// the base price if it hasn't been fetched yet.
+function packBasePrice(pack) {
+  return pack?.effectivePrice ?? pack?.price ?? 0
 }
 
 // ── Packs state ──────────────────────────────────────────────
@@ -622,7 +633,7 @@ function resetPackSequence() {
 
 async function buyPack(pack) {
   if (buyingPackIds.value.includes(pack.id)) return
-  const price = displayPrice(pack.price)
+  const price = displayPrice(packBasePrice(pack))
   if (user.value && user.value.points < price) {
     showToast(`Not enough points — this pack costs ${price.toLocaleString()} pts.`, 'error')
     return

--- a/server/api/cmart/packs/[id].get.js
+++ b/server/api/cmart/packs/[id].get.js
@@ -23,6 +23,14 @@
 import { defineEventHandler, createError, getRequestHeader } from 'h3'
 import { prisma as db } from '@/server/prisma'
 
+function computeDecayedPrice(basePrice, sentAt, decayAmount, decayDays, priceFloor) {
+  if (!sentAt || decayAmount <= 0 || decayDays <= 0) return basePrice
+  const msPerDay = 24 * 60 * 60 * 1000
+  const daysSinceListed = Math.floor((Date.now() - new Date(sentAt).getTime()) / msPerDay)
+  const periods = Math.floor(daysSinceListed / decayDays)
+  const decayed = basePrice - periods * decayAmount
+  return Math.max(decayed, priceFloor)
+}
 
 export default defineEventHandler(async (event) => {
   /* ── (Optional) require login ─────────────────────────── */
@@ -39,37 +47,53 @@ export default defineEventHandler(async (event) => {
   if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing id param' })
 
   /* ── query pack (+children) ───────────────────────────── */
-  const pack = await db.pack.findFirst({
-    where: { id, inCmart: true },
-    select: {
-      id: true,
-      name: true,
-      price: true,
-      imagePath: true,
-      rarityConfigs: {
-        select: { rarity: true, count: true, probabilityPercent: true }
-      },
-      ctoonOptions: {
-        select: {
-          weight:  true,
-          ctoonId: true,
-          ctoon:   {
-            select: {
-              name: true, rarity: true, assetPath: true, isGtoon: true, cost: true, power: true,
-              isSecondEdition: true,
-              secondEditionOverlayX: true,
-              secondEditionOverlayY: true,
-              secondEditionOverlaySize: true
+  const [pack, globalCfg] = await Promise.all([
+    db.pack.findFirst({
+      where: { id, inCmart: true },
+      select: {
+        id: true,
+        name: true,
+        price: true,
+        imagePath: true,
+        sentAt: true,
+        rarityConfigs: {
+          select: { rarity: true, count: true, probabilityPercent: true }
+        },
+        ctoonOptions: {
+          select: {
+            weight:  true,
+            ctoonId: true,
+            ctoon:   {
+              select: {
+                name: true, rarity: true, assetPath: true, isGtoon: true, cost: true, power: true,
+                isSecondEdition: true,
+                secondEditionOverlayX: true,
+                secondEditionOverlayY: true,
+                secondEditionOverlaySize: true
+              }
             }
           }
         }
       }
-    }
-  })
+    }),
+    db.globalGameConfig.findUnique({
+      where: { id: 'singleton' },
+      select: {
+        packPriceDecayAmount: true,
+        packPriceDecayDays: true,
+        packPriceFloor: true
+      }
+    })
+  ])
 
   if (!pack) {
     throw createError({ statusCode: 404, statusMessage: 'Pack not found' })
   }
+
+  const decayAmount = globalCfg?.packPriceDecayAmount ?? 100
+  const decayDays   = globalCfg?.packPriceDecayDays   ?? 7
+  const priceFloor  = globalCfg?.packPriceFloor        ?? 700
+  const effectivePrice = computeDecayedPrice(pack.price, pack.sentAt, decayAmount, decayDays, priceFloor)
 
   /* ── flatten ctoonOptions (merge name + rarity) ───────── */
   const flavouredCtoons = pack.ctoonOptions.map(o => ({
@@ -91,6 +115,7 @@ export default defineEventHandler(async (event) => {
     id: pack.id,
     name: pack.name,
     price: pack.price,
+    effectivePrice,
     imagePath: pack.imagePath,
     rarityConfigs: pack.rarityConfigs,
     ctoonOptions: flavouredCtoons


### PR DESCRIPTION
## Summary
This PR implements a time-based price decay system for marketplace packs. Packs now automatically decrease in price over a configurable period, with a minimum floor price, encouraging players to purchase older listings.

## Key Changes

- **Backend (API)**: 
  - Added `computeDecayedPrice()` function that calculates decayed prices based on time elapsed since listing (`sentAt`), configurable decay amount, decay period, and price floor
  - Modified pack query to fetch `sentAt` timestamp and fetch global game configuration (decay settings) in parallel
  - Added `effectivePrice` field to API response representing the time-decayed price
  - Decay configuration uses sensible defaults (100 pts decay per 7 days, 700 pts floor) if not configured

- **Frontend (Vue component)**:
  - Added `packBasePrice()` helper function that uses `effectivePrice` when available, falling back to base `price`
  - Updated price display logic to use decayed price as the basis for all calculations (including half-price promotions)
  - Simplified conditional rendering: removed separate `cmartHalfPriceEnabled` branch and unified price display logic
  - Original price now only shows as strikethrough when it differs from the effective price

## Implementation Details

- Price decay is calculated server-side to prevent client-side manipulation
- The decay uses discrete periods: `Math.floor(daysSinceListed / decayDays)` ensures prices drop in steps rather than continuously
- Global configuration is fetched alongside pack data using `Promise.all()` for efficiency
- The system gracefully handles missing `sentAt` timestamps by returning the base price unchanged

https://claude.ai/code/session_01UbiaNBYmSZhQLTegfk1q8P