### PR TITLE
Add Tower Stack game with deterministic physics and anti-cheat replay

### DIFF
--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -36,6 +36,10 @@
         <img v-if="tiles.reorbitmatch" :src="tiles.reorbitmatch" alt="ReOrbit Match" class="tile-img" />
         <span v-else>ReOrbit Match</span>
       </NuxtLink>
+      <NuxtLink to="/newsite/tower" class="quadrant quadrant--tower">
+        <img v-if="tiles.tower" :src="tiles.tower" alt="Tower Stack" class="tile-img" />
+        <span v-else>Tower Stack</span>
+      </NuxtLink>
     </div>
   </div>
 </template>
@@ -71,12 +75,17 @@ const tiles = computed(() => tileData.value ?? {})
 .gameshome {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: repeat(3, 1fr);
+  grid-template-rows: repeat(4, 1fr);
   width: 100%;
   flex: 1;
   gap: 6px;
   padding: 6px;
   box-sizing: border-box;
+}
+
+/* 7th tile spans both columns on its own row */
+.quadrant--tower {
+  grid-column: 1 / -1;
 }
 
 .quadrant {
@@ -121,12 +130,17 @@ const tiles = computed(() => tileData.value ?? {})
 .quadrant--profile    { background: #8a4a1a; }
 .quadrant--tko        { background: #8a1a32; }
 .quadrant--reorbit    { background: #1a6a8a; }
+.quadrant--tower      { background: #5a2a8a; }
 
 @media (max-width: 768px) {
   .gameshome {
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(6, minmax(70px, 1fr));
+    grid-template-rows: repeat(7, minmax(70px, 1fr));
     height: max(300px, calc(100dvh - 276px));
+  }
+
+  .quadrant--tower {
+    grid-column: auto;
   }
 }
 </style>

--- a/components/newsite/Leaderboards.vue
+++ b/components/newsite/Leaderboards.vue
@@ -38,7 +38,16 @@
     <!-- Games Tab -->
     <div v-else-if="activeTab === 'games'" class="lb-content">
       <div class="lb-games-header">
-        <span class="lb-games-title">ReOrbit Match</span>
+        <div class="lb-game-switcher">
+          <button
+            v-for="g in gameOptions"
+            :key="g.key"
+            type="button"
+            class="lb-game-pill"
+            :class="{ 'lb-game-pill--active': selectedGame === g.key }"
+            @click="selectedGame = g.key"
+          >{{ g.label }}</button>
+        </div>
       </div>
       <div class="lb-grid">
         <div v-for="board in gamesBoards" :key="board.key" class="lb-card">
@@ -76,7 +85,37 @@ const { data: spendersData, pending: spendersPending } = useFetch('/api/leaderbo
 const { data: acquirersData, pending: acquirersPending } = useFetch('/api/leaderboard/active-ctoon-acquirers', { default: () => [], headers })
 const { data: uniqueData, pending: uniquePending } = useFetch('/api/leaderboard/unique-ctoons', { default: () => [], headers })
 const { data: totalData, pending: totalPending } = useFetch('/api/leaderboard/total-ctoons', { default: () => [], headers })
-const { data: gameData, pending: gamePending } = useFetch('/api/game/reorbitmatch/leaderboard', { default: () => null, headers })
+
+// Games tab: multiple games now share this leaderboard view. Only the selected game's
+// leaderboard is fetched, and only once the Games tab is actually opened, so visiting the
+// Users tab (the default) never pulls either game's leaderboard data.
+const gameOptions = [
+  { key: 'reorbitmatch', label: 'ReOrbit Match', endpoint: '/api/game/reorbitmatch/leaderboard' },
+  { key: 'tower',        label: 'Tower Stack',   endpoint: '/api/game/tower/leaderboard' }
+]
+const selectedGame = ref('reorbitmatch')
+const gameDataCache = ref({})
+const gamePendingKey = ref(null)
+
+async function loadGameLeaderboard(key) {
+  if (Object.prototype.hasOwnProperty.call(gameDataCache.value, key)) return
+  gamePendingKey.value = key
+  try {
+    const opt = gameOptions.find(g => g.key === key)
+    gameDataCache.value[key] = await $fetch(opt.endpoint, { headers })
+  } catch {
+    gameDataCache.value[key] = null
+  } finally {
+    if (gamePendingKey.value === key) gamePendingKey.value = null
+  }
+}
+
+watch([activeTab, selectedGame], ([tab, game]) => {
+  if (tab === 'games') loadGameLeaderboard(game)
+}, { immediate: true })
+
+const gameData    = computed(() => gameDataCache.value[selectedGame.value] || null)
+const gamePending = computed(() => gamePendingKey.value === selectedGame.value)
 
 const usersBoards = computed(() => [
   {
@@ -173,14 +212,31 @@ const gamesBoards = computed(() => [
   margin-bottom: 10px;
 }
 
-.lb-games-title {
-  font-size: 1.1rem;
-  font-weight: 800;
-  letter-spacing: 0.05em;
+.lb-game-switcher {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.lb-game-pill {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 6px 16px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.lb-game-pill:hover { color: rgba(255, 255, 255, 0.85); }
+
+.lb-game-pill--active {
+  color: #fff;
   background: linear-gradient(135deg, #4fc3f7, #ab47bc);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  border-color: transparent;
 }
 
 .lb-grid {

--- a/pages/admin/games.vue
+++ b/pages/admin/games.vue
@@ -790,6 +790,54 @@
           </button>
         </section>
 
+        <!-- Tower Stack -->
+        <section v-if="activeTab === 'TowerStack'" role="tabpanel" aria-label="Tower Stack Settings">
+          <h2 class="text-2xl font-semibold mb-4">Tower Stack Settings</h2>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Plays Per Period</label>
+              <p class="text-xs text-gray-400 mb-1">Number of games per 24-hour period (resets 8 PM CT)</p>
+              <input type="number" v-model.number="towerPlaysPerPeriod" min="1" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-400 mb-1">Points awarded toward daily cap on game completion</p>
+              <input type="number" v-model.number="towerPointsPerGame" min="0" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Base Speed</label>
+              <p class="text-xs text-gray-400 mb-1">Starting speed of the sliding block (world units/sec)</p>
+              <input type="number" v-model.number="towerBaseSpeed" min="1" step="1" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Speed Growth Per Layer</label>
+              <p class="text-xs text-gray-400 mb-1">How much faster each layer gets (0.03 = +3% per layer)</p>
+              <input type="number" v-model.number="towerSpeedGrowthPerLayer" min="0" step="0.005" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Max Speed Multiplier</label>
+              <p class="text-xs text-gray-400 mb-1">Speed growth caps at this multiple of the base speed</p>
+              <input type="number" v-model.number="towerMaxSpeedMultiplier" min="1" step="0.1" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Perfect Alignment Tolerance</label>
+              <p class="text-xs text-gray-400 mb-1">Taps within this distance of dead-center don't trim the tower's width</p>
+              <input type="number" v-model.number="towerPerfectEpsilon" min="0" step="0.5" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Max Layers</label>
+              <p class="text-xs text-gray-400 mb-1">Run ends automatically past this height (10–2000)</p>
+              <input type="number" v-model.number="towerMaxLayers" min="10" max="2000" class="input" />
+            </div>
+          </div>
+
+          <button @click="saveTowerConfig" :disabled="loadingTower" class="btn-primary">
+            <span v-if="!loadingTower">Save Tower Stack Settings</span>
+            <span v-else>Saving…</span>
+          </button>
+        </section>
+
         <!-- TKO -->
         <section v-if="activeTab === 'TKO'" role="tabpanel" aria-label="TKO Events">
           <h2 class="text-2xl font-semibold mb-4">TKO Events</h2>
@@ -931,7 +979,8 @@ const tabs = [
   { key: 'Clash',        label: 'gToon Clash' },
   { key: 'Winwheel',     label: 'Win Wheel' },
   { key: 'TKO',          label: 'TKO' },
-  { key: 'ReOrbitMatch', label: 'ReOrbit Match' }
+  { key: 'ReOrbitMatch', label: 'ReOrbit Match' },
+  { key: 'TowerStack',   label: 'Tower Stack' }
 ]
 const activeTab = ref('Global')
 async function switchTab(k) {
@@ -1252,6 +1301,7 @@ async function loadSettings() {
   gameTileImages.value.clash        = g.gameTileClashImagePath        || ''
   gameTileImages.value.tko          = g.gameTileTkoImagePath          || ''
   gameTileImages.value.reorbitmatch = g.gameTileReorbitmatchImagePath || ''
+  gameTileImages.value.tower        = g.gameTileTowerImagePath        || ''
 
   const wb = await $fetch('/api/admin/game-config?gameName=Winball')
   leftCupPoints.value  = wb.leftCupPoints
@@ -1329,6 +1379,15 @@ async function loadSettings() {
   reorbitEmojis.value           = ro.reorbitEmojis ?? []
   reorbitGridSize.value         = ro.reorbitGridSize ?? 8
   reorbitComboMs.value          = ro.reorbitComboMs ?? 3500
+
+  const tw = await $fetch('/api/admin/game-config?gameName=TowerStack')
+  towerPlaysPerPeriod.value      = tw.towerPlaysPerPeriod ?? 3
+  towerPointsPerGame.value       = tw.towerPointsPerGame ?? 50
+  towerBaseSpeed.value           = tw.towerBaseSpeed ?? 90
+  towerSpeedGrowthPerLayer.value = tw.towerSpeedGrowthPerLayer ?? 0.03
+  towerMaxSpeedMultiplier.value  = tw.towerMaxSpeedMultiplier ?? 2.5
+  towerPerfectEpsilon.value      = tw.towerPerfectEpsilon ?? 4
+  towerMaxLayers.value           = tw.towerMaxLayers ?? 800
 }
 
 // Win Wheel state
@@ -1667,11 +1726,12 @@ const gameTileSlots = [
   { slot: 'winwheel',     label: 'Win Wheel' },
   { slot: 'clash',        label: 'gToons Clash' },
   { slot: 'tko',          label: 'TKO' },
-  { slot: 'reorbitmatch', label: 'ReOrbit Match' }
+  { slot: 'reorbitmatch', label: 'ReOrbit Match' },
+  { slot: 'tower',        label: 'Tower Stack' }
 ]
-const gameTileImages = ref({ winball: '', lotto: '', winwheel: '', clash: '', tko: '', reorbitmatch: '' })
-const gameTileFiles  = ref({ winball: null, lotto: null, winwheel: null, clash: null, tko: null, reorbitmatch: null })
-const uploadingGameTile = ref({ winball: false, lotto: false, winwheel: false, clash: false, tko: false, reorbitmatch: false })
+const gameTileImages = ref({ winball: '', lotto: '', winwheel: '', clash: '', tko: '', reorbitmatch: '', tower: '' })
+const gameTileFiles  = ref({ winball: null, lotto: null, winwheel: null, clash: null, tko: null, reorbitmatch: null, tower: null })
+const uploadingGameTile = ref({ winball: false, lotto: false, winwheel: false, clash: false, tko: false, reorbitmatch: false, tower: false })
 
 function onGameTileFile(slot, e) {
   gameTileFiles.value[slot] = e.target.files?.[0] || null
@@ -1724,6 +1784,16 @@ const reorbitComboMs         = ref(3500)
 const reorbitEmojiInput      = ref('')
 const loadingReorbit         = ref(false)
 
+// ── Tower Stack ────────────────────────────────
+const towerPlaysPerPeriod      = ref(3)
+const towerPointsPerGame       = ref(50)
+const towerBaseSpeed           = ref(90)
+const towerSpeedGrowthPerLayer = ref(0.03)
+const towerMaxSpeedMultiplier  = ref(2.5)
+const towerPerfectEpsilon      = ref(4)
+const towerMaxLayers           = ref(800)
+const loadingTower              = ref(false)
+
 function addReorbitEmoji() {
   const e = reorbitEmojiInput.value.trim()
   if (!e) return
@@ -1757,6 +1827,31 @@ async function saveReorbitConfig() {
     toastMessage.value = 'Error saving ReOrbit Match settings'; toastType.value = 'error'
   } finally {
     loadingReorbit.value = false
+  }
+}
+
+async function saveTowerConfig() {
+  loadingTower.value = true; toastMessage.value = ''
+  try {
+    await $fetch('/api/admin/game-config', {
+      method: 'POST',
+      body: {
+        gameName:                 'TowerStack',
+        towerPlaysPerPeriod:      towerPlaysPerPeriod.value,
+        towerPointsPerGame:       towerPointsPerGame.value,
+        towerBaseSpeed:           towerBaseSpeed.value,
+        towerSpeedGrowthPerLayer: towerSpeedGrowthPerLayer.value,
+        towerMaxSpeedMultiplier:  towerMaxSpeedMultiplier.value,
+        towerPerfectEpsilon:      towerPerfectEpsilon.value,
+        towerMaxLayers:           towerMaxLayers.value
+      }
+    })
+    toastMessage.value = 'Tower Stack settings saved!'; toastType.value = 'success'
+  } catch (err) {
+    console.error(err)
+    toastMessage.value = 'Error saving Tower Stack settings'; toastType.value = 'error'
+  } finally {
+    loadingTower.value = false
   }
 }
 

--- a/pages/newsite/tower.vue
+++ b/pages/newsite/tower.vue
@@ -1,0 +1,1010 @@
+<template>
+  <div>
+    <NuxtLayout name="newsite-template" :show-adbar="true" :show-nav="true">
+      <div class="tower-wrapper">
+        <!-- Landscape warning -->
+        <div class="landscape-warning" aria-live="polite">
+          <span>Rotate your device to portrait for the best experience</span>
+        </div>
+
+        <!-- Loading state -->
+        <div v-if="uiState === 'loading'" class="center-content">
+          <div class="spinner" aria-label="Loading game…"></div>
+        </div>
+
+        <!-- No plays left -->
+        <div v-else-if="uiState === 'noplays'" class="center-content">
+          <div class="start-card">
+            <h1 class="game-title">Tower Stack</h1>
+            <p class="no-plays-text">No plays left today.</p>
+            <p class="reset-text">Resets {{ resetLabel }}</p>
+          </div>
+        </div>
+
+        <!-- Start screen -->
+        <div v-else-if="uiState === 'start'" class="center-content">
+          <div class="start-card">
+            <h1 class="game-title">Tower Stack</h1>
+            <p class="start-sub">Tap to drop blocks onto the base. Align blocks correctly for a stable tower and boost your score. Keep stacking without errors for the best results.</p>
+            <div class="plays-info">
+              <span class="plays-badge">{{ playsLeft }} play{{ playsLeft !== 1 ? 's' : '' }} left</span>
+              <span class="reset-text">· Resets {{ resetLabel }}</span>
+            </div>
+            <button class="btn-start" @click="startGame" :disabled="starting">
+              {{ starting ? 'Launching…' : 'Play' }}
+            </button>
+            <button class="btn-howto" @click="showHowTo = true" aria-label="How to play">
+              <svg class="howto-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/>
+                <path d="M9.1 9a3 3 0 1 1 4.4 3c-.9.6-1.5 1-1.5 2.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                <circle cx="12" cy="17.4" r="1.2" fill="currentColor"/>
+              </svg>
+              <span>How to Play</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Active game -->
+        <div v-else-if="uiState === 'playing'" class="game-area" role="main" aria-label="Tower Stack game board">
+          <!-- HUD -->
+          <div class="hud" role="status" aria-live="polite" aria-atomic="true">
+            <div class="hud-row hud-row--primary">
+              <div class="hud-item">
+                <span class="hud-label">Score</span>
+                <span class="hud-value">{{ score.toLocaleString() }}</span>
+              </div>
+              <div class="hud-item">
+                <span class="hud-label">Best</span>
+                <span class="hud-value">{{ Math.max(allTimeHigh, score).toLocaleString() }}</span>
+              </div>
+              <div class="hud-item">
+                <span class="hud-label">Plays Left</span>
+                <span class="hud-value">{{ playsLeft }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Canvas board -->
+          <div class="canvas-container" ref="canvasContainer">
+            <canvas
+              ref="canvas"
+              class="game-canvas"
+              :style="{ touchAction: 'none' }"
+              draggable="false"
+              @pointerdown="onTap"
+              @dragstart.prevent
+              @contextmenu.prevent
+              aria-label="Tower Stack game board"
+              role="img"
+            ></canvas>
+          </div>
+          <p class="sr-only" aria-live="polite">{{ announce }}</p>
+          <div class="game-hint" aria-hidden="true">Tap anywhere to drop the block — keep a steady rhythm</div>
+        </div>
+      </div>
+    </NuxtLayout>
+
+    <!-- Game Over Modal (teleported outside transform context) -->
+    <Teleport to="body">
+      <div v-if="uiState === 'gameover'" class="modal-backdrop" @click.self="uiState = 'start'">
+        <div class="modal-card" role="dialog" aria-modal="true" aria-label="Game Over">
+          <h2 class="modal-title">{{ maxedOut ? 'Max Height Reached!' : 'Game Over!' }}</h2>
+          <div class="modal-score-row">
+            <span class="modal-score-label">Your Score</span>
+            <span class="modal-score-value">{{ finalScore.toLocaleString() }}</span>
+          </div>
+          <div class="modal-divider"></div>
+          <div class="modal-leaderboard">
+            <div class="modal-lb-row">
+              <span class="modal-lb-label">This Week's Best</span>
+              <span class="modal-lb-value">{{ weekHigh.toLocaleString() }}</span>
+            </div>
+            <div class="modal-lb-row">
+              <span class="modal-lb-label">Your All-Time Best</span>
+              <span class="modal-lb-value">{{ allTimeHigh.toLocaleString() }}</span>
+            </div>
+          </div>
+          <div class="modal-points-notice" :class="{ 'modal-points-notice--zero': pointsAwarded === 0 }">
+            <template v-if="pointsAwarded > 0">+{{ pointsAwarded }} game points earned!</template>
+            <template v-else>No game points earned (daily limit reached)</template>
+          </div>
+          <div class="modal-actions">
+            <button v-if="playsLeft > 0" class="btn-start" @click="startGame">
+              Play Again ({{ playsLeft }} left)
+            </button>
+            <button v-else class="btn-secondary" @click="uiState = 'noplays'">
+              No Plays Left
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- How to Play Modal -->
+    <Teleport to="body">
+      <div v-if="showHowTo" class="modal-backdrop" @click.self="showHowTo = false">
+        <div class="modal-card modal-card--howto" role="dialog" aria-modal="true" aria-label="How to Play">
+          <h2 class="modal-title">How to Play</h2>
+          <ol class="howto-list">
+            <li>
+              <span class="howto-num">1</span>
+              <span><strong>Tap anywhere</strong> to drop the sliding block onto the tower.</span>
+            </li>
+            <li>
+              <span class="howto-num">2</span>
+              <span>Land it <strong>lined up</strong> with the block below to keep the tower stable. Any part that hangs off gets trimmed away.</span>
+            </li>
+            <li>
+              <span class="howto-num">3</span>
+              <span>A <strong>near-perfect</strong> tap keeps the tower's width — miss by too much and there's nothing left to land on.</span>
+            </li>
+            <li>
+              <span class="howto-num">4</span>
+              <span>Each block you keep adds <strong>+1</strong> to your score. The tower speeds up the higher you climb.</span>
+            </li>
+            <li>
+              <span class="howto-num">5</span>
+              <span>Maintain a <strong>steady rhythm</strong> to perfect your timing — one miss and the run ends.</span>
+            </li>
+          </ol>
+          <div class="modal-actions">
+            <button class="btn-start" @click="showHowTo = false">Got it!</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({ ssr: false })
+
+// ─── Shared world/physics constants — MUST stay in sync with server/utils/towerStackEngine.js ──
+const BASE_WIDTH = 100
+const BOARD_HALF_RANGE = 60
+const MIN_MOVE_INTERVAL_MS = 150
+
+// ─── Rendering-only constants (no server sync needed — purely visual) ──────────────────────────
+const LAYER_HEIGHT = 26          // world units per block
+const RENDER_WINDOW = 16         // only the last N committed layers are ever drawn (perf: culling)
+const MAX_PARTICLES = 70         // hard cap on live falling-chip particles
+const CAMERA_FOLLOW_RATE = 5.5   // lerp speed (per second) toward camera target
+const ISO_COS = Math.cos(Math.PI / 6)
+const ISO_SIN = Math.sin(Math.PI / 6)
+
+// ─── Reactive UI state ──────────────────────────────────────────────────────────
+const uiState    = ref('loading')  // loading | start | playing | gameover | noplays
+const starting   = ref(false)
+const score      = ref(0)
+const playsLeft  = ref(0)
+const finalScore    = ref(0)
+const weekHigh      = ref(0)
+const allTimeHigh   = ref(0)
+const pointsAwarded = ref(0)
+const maxedOut       = ref(false)
+const resetLabel = ref('')
+const announce   = ref('')
+const showHowTo  = ref(false)
+
+const canvas          = ref(null)
+const canvasContainer = ref(null)
+
+// ─── Non-reactive game internals ──────────────────────────────────────────────
+let cfg         = null   // { baseSpeed, speedGrowthPerLayer, maxSpeedMultiplier, perfectEpsilon, maxLayers, baseWidth, boardHalfRange }
+let jitter      = { phaseFrac: 0, speedMult: 1 }
+let currentRect = null   // { xCenter, xWidth, zCenter, zWidth } — last committed footprint
+let renderLayers = []    // bounded ring buffer of the last RENDER_WINDOW committed layers, for drawing only
+let moveLog     = []     // [{ ts }] sent to the server at game end
+let layerIndex  = 1      // n of the block currently in flight
+let layerStartTs = 0     // ts (ms since gameStartPerf, pause-adjusted) when the current layer began sliding
+let lastLogTs   = null
+let gameStartPerf = 0
+let totalPausedMs = 0
+let pauseBeganAtPerf = null
+let ending      = false
+let rafId       = null
+let ctx         = null
+let cw = 0, ch = 0
+let dpr = 1
+let cameraY = 0
+let cameraTargetY = 0
+let particles   = []
+let bgGradient  = null
+let reducedMotion = false
+
+// ─── Deterministic per-session jitter (MUST mirror deriveJitter in towerStackEngine.js) ────────
+function deriveJitter(jitterSeed) {
+  let h1 = 0x811c9dc5, h2 = 0x1000193
+  for (let i = 0; i < jitterSeed.length; i++) {
+    const c = jitterSeed.charCodeAt(i)
+    h1 = (h1 ^ c) >>> 0; h1 = Math.imul(h1, 0x01000193) >>> 0
+    h2 = (h2 ^ c) >>> 0; h2 = Math.imul(h2, 0x85ebca6b) >>> 0
+  }
+  return {
+    phaseFrac: (h1 >>> 0) / 4294967296,
+    speedMult: 0.92 + ((h2 >>> 0) / 4294967296) * 0.16
+  }
+}
+
+function layerSpeed(n) {
+  const growth = Math.min(1 + n * cfg.speedGrowthPerLayer, cfg.maxSpeedMultiplier)
+  return cfg.baseSpeed * growth * jitter.speedMult
+}
+
+function triangleWave(tSeconds, speed, amplitude, phaseOffsetSeconds) {
+  const period = (4 * amplitude) / speed
+  let phase = ((tSeconds + phaseOffsetSeconds) % period + period) % period
+  const quarter = period / 4
+  if (phase < quarter) return (phase / quarter) * amplitude
+  if (phase < 3 * quarter) return amplitude - ((phase - quarter) / quarter) * amplitude * 2
+  return -amplitude + ((phase - 3 * quarter) / quarter) * amplitude
+}
+
+function movingCenterAt(n, tSeconds) {
+  const speed = layerSpeed(n)
+  const amplitude = cfg.boardHalfRange
+  const period = (4 * amplitude) / speed
+  const phaseOffset = jitter.phaseFrac * period
+  return triangleWave(tSeconds, speed, amplitude, phaseOffset)
+}
+
+function axisForLayer(n) { return n % 2 === 1 ? 'x' : 'z' }
+
+// Mirrors applyDrop in towerStackEngine.js exactly (client-side prediction for instant visual
+// feedback; the server always recomputes the authoritative score independently at /end).
+function applyDrop(n, tSeconds, rect) {
+  const axis = axisForLayer(n)
+  const movingCenter = movingCenterAt(n, tSeconds)
+  const prevCenter = axis === 'x' ? rect.xCenter : rect.zCenter
+  const prevWidth   = axis === 'x' ? rect.xWidth  : rect.zWidth
+
+  if (Math.abs(movingCenter - prevCenter) <= cfg.perfectEpsilon) {
+    return { hit: true, rect: { ...rect }, movingCenter, trimmed: false }
+  }
+
+  const prevMin = prevCenter - prevWidth / 2
+  const prevMax = prevCenter + prevWidth / 2
+  const curMin = movingCenter - prevWidth / 2
+  const curMax = movingCenter + prevWidth / 2
+  const overlapMin = Math.max(prevMin, curMin)
+  const overlapMax = Math.min(prevMax, curMax)
+  const overlapWidth = overlapMax - overlapMin
+
+  if (overlapWidth <= 0) return { hit: false, rect, movingCenter, trimmed: true }
+
+  const newCenter = (overlapMin + overlapMax) / 2
+  const newRect = { ...rect }
+  if (axis === 'x') { newRect.xCenter = newCenter; newRect.xWidth = overlapWidth }
+  else { newRect.zCenter = newCenter; newRect.zWidth = overlapWidth }
+  return { hit: true, rect: newRect, movingCenter, trimmed: true }
+}
+
+function vibrate(pattern) { try { navigator.vibrate?.(pattern) } catch {} }
+
+// ─── Isometric projection ──────────────────────────────────────────────────────
+let scale = 1
+function worldToScreen(x, z, y) {
+  const isoX = (x - z) * ISO_COS
+  const isoY = (x + z) * ISO_SIN
+  return {
+    sx: cw / 2 + isoX * scale,
+    sy: ch * 0.6 + isoY * scale - (y - cameraY) * scale
+  }
+}
+
+function hueForLayer(n) { return (200 + n * 6) % 360 }
+
+function drawBlock(rect, yBottom, yTop, hue) {
+  const x0 = rect.xCenter - rect.xWidth / 2, x1 = rect.xCenter + rect.xWidth / 2
+  const z0 = rect.zCenter - rect.zWidth / 2, z1 = rect.zCenter + rect.zWidth / 2
+
+  const A = worldToScreen(x0, z0, yTop)
+  const B = worldToScreen(x1, z0, yTop)
+  const C = worldToScreen(x1, z1, yTop)
+  const D = worldToScreen(x0, z1, yTop)
+  const Bp = worldToScreen(x1, z0, yBottom)
+  const Cp = worldToScreen(x1, z1, yBottom)
+  const Dp = worldToScreen(x0, z1, yBottom)
+
+  // Off-screen cull (cheap bounding check before touching the path API)
+  if (Math.max(A.sy, B.sy, C.sy, D.sy, Bp.sy, Cp.sy, Dp.sy) < -40) return
+  if (Math.min(A.sy, B.sy, C.sy, D.sy) > ch + 40) return
+
+  const top   = `hsl(${hue}, 68%, 58%)`
+  const right = `hsl(${hue}, 60%, 42%)`
+  const front = `hsl(${hue}, 60%, 33%)`
+
+  ctx.fillStyle = top
+  ctx.beginPath()
+  ctx.moveTo(A.sx, A.sy); ctx.lineTo(B.sx, B.sy); ctx.lineTo(C.sx, C.sy); ctx.lineTo(D.sx, D.sy)
+  ctx.closePath(); ctx.fill()
+
+  ctx.fillStyle = right
+  ctx.beginPath()
+  ctx.moveTo(B.sx, B.sy); ctx.lineTo(C.sx, C.sy); ctx.lineTo(Cp.sx, Cp.sy); ctx.lineTo(Bp.sx, Bp.sy)
+  ctx.closePath(); ctx.fill()
+
+  ctx.fillStyle = front
+  ctx.beginPath()
+  ctx.moveTo(C.sx, C.sy); ctx.lineTo(D.sx, D.sy); ctx.lineTo(Dp.sx, Dp.sy); ctx.lineTo(Cp.sx, Cp.sy)
+  ctx.closePath(); ctx.fill()
+}
+
+// ─── Canvas sizing ────────────────────────────────────────────────────────────
+function resizeCanvas() {
+  if (!canvas.value || !canvasContainer.value) return
+  const { width, height } = canvasContainer.value.getBoundingClientRect()
+  dpr = Math.min(window.devicePixelRatio || 1, 2) // perf: never rasterize above 2x, even on 3x-DPR phones
+  canvas.value.width  = width  * dpr
+  canvas.value.height = height * dpr
+  canvas.value.style.width  = `${width}px`
+  canvas.value.style.height = `${height}px`
+  ctx = canvas.value.getContext('2d')
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  cw = width; ch = height
+  scale = (cw * 0.42) / (BASE_WIDTH * ISO_COS)
+  bgGradient = ctx.createLinearGradient(0, 0, 0, ch)
+  bgGradient.addColorStop(0, '#0a1e42')
+  bgGradient.addColorStop(1, '#001230')
+}
+
+// ─── Particles (falling overhang chips) ────────────────────────────────────────
+function spawnChip(rect, axis, side, yBottom, yTop, hue) {
+  if (particles.length >= MAX_PARTICLES) return
+  const cx = axis === 'x' ? (side === 'lo' ? rect.xCenter - rect.xWidth / 2 - 8 : rect.xCenter + rect.xWidth / 2 + 8) : rect.xCenter
+  const cz = axis === 'z' ? (side === 'lo' ? rect.zCenter - rect.zWidth / 2 - 8 : rect.zCenter + rect.zWidth / 2 + 8) : rect.zCenter
+  const p = worldToScreen(cx, cz, (yBottom + yTop) / 2)
+  particles.push({
+    sx: p.sx, sy: p.sy, vy: -20, vx: (Math.random() - 0.5) * 40,
+    size: 10, hue, alpha: 1, startMs: performance.now(), life: 900
+  })
+}
+
+function updateAndDrawParticles(nowMs) {
+  let write = 0
+  for (let read = 0; read < particles.length; read++) {
+    const p = particles[read]
+    const age = nowMs - p.startMs
+    if (age >= p.life) continue // drop (in-place compaction, no per-frame array alloc)
+    const t = age / 1000
+    const sy = p.sy + p.vy * t + 260 * t * t
+    const sx = p.sx + p.vx * t
+    const alpha = Math.max(0, 1 - age / p.life)
+    ctx.save()
+    ctx.globalAlpha = alpha
+    ctx.fillStyle = `hsl(${p.hue}, 60%, 45%)`
+    ctx.fillRect(sx - p.size / 2, sy - p.size / 2, p.size, p.size)
+    ctx.restore()
+    particles[write++] = p
+  }
+  particles.length = write
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+function renderFrame(nowMs, tSecondsCurrent) {
+  if (!ctx) return
+  ctx.fillStyle = bgGradient || '#001230'
+  ctx.fillRect(0, 0, cw, ch)
+
+  // Committed layers, oldest-to-newest so nearer blocks paint over farther ones.
+  for (let i = 0; i < renderLayers.length; i++) {
+    const layer = renderLayers[i]
+    drawBlock(layer.rect, layer.n * LAYER_HEIGHT, (layer.n + 1) * LAYER_HEIGHT, layer.hue)
+  }
+
+  // In-flight moving block
+  if (uiState.value === 'playing' && !ending && currentRect) {
+    const movingCenter = movingCenterAt(layerIndex, tSecondsCurrent)
+    const axis = axisForLayer(layerIndex)
+    const movingRect = { ...currentRect }
+    if (axis === 'x') movingRect.xCenter = movingCenter
+    else movingRect.zCenter = movingCenter
+    drawBlock(movingRect, layerIndex * LAYER_HEIGHT, (layerIndex + 1) * LAYER_HEIGHT, hueForLayer(layerIndex))
+  }
+
+  updateAndDrawParticles(nowMs)
+}
+
+// ─── Game loop ────────────────────────────────────────────────────────────────
+let paused = false
+function gameLoop(nowPerf) {
+  if (!canvas.value || paused) { rafId = null; return }
+
+  const elapsedMs = (nowPerf - gameStartPerf) - totalPausedMs
+  const tSeconds = Math.max(0, elapsedMs - layerStartTs) / 1000
+
+  const dt = 1 / 60
+  cameraY += (cameraTargetY - cameraY) * Math.min(1, (reducedMotion ? 1 : CAMERA_FOLLOW_RATE * dt))
+
+  renderFrame(nowPerf, tSeconds)
+  rafId = requestAnimationFrame(gameLoop)
+}
+
+function pauseGame() {
+  if (paused) return
+  paused = true
+  pauseBeganAtPerf = performance.now()
+  if (rafId) { cancelAnimationFrame(rafId); rafId = null }
+}
+function resumeGame() {
+  if (!paused || uiState.value !== 'playing') return
+  if (pauseBeganAtPerf != null) totalPausedMs += performance.now() - pauseBeganAtPerf
+  pauseBeganAtPerf = null
+  paused = false
+  rafId = requestAnimationFrame(gameLoop)
+}
+
+// ─── Tap handling ───────────────────────────────────────────────────────────────
+function onTap(e) {
+  if (uiState.value !== 'playing' || ending || paused) return
+  e.preventDefault()
+
+  const nowPerf = performance.now()
+  let ts = Math.round((nowPerf - gameStartPerf) - totalPausedMs)
+  if (lastLogTs !== null) ts = Math.max(ts, lastLogTs + MIN_MOVE_INTERVAL_MS + 1)
+
+  const tSeconds = Math.max(0, ts - layerStartTs) / 1000
+  const { hit, rect, trimmed, movingCenter } = applyDrop(layerIndex, tSeconds, currentRect)
+  const axis = axisForLayer(layerIndex)
+  const hue = hueForLayer(layerIndex)
+
+  if (!hit) {
+    // Whole block misses — falls away, run ends.
+    spawnChip(currentRect, axis, movingCenter > (axis === 'x' ? currentRect.xCenter : currentRect.zCenter) ? 'hi' : 'lo',
+      layerIndex * LAYER_HEIGHT, (layerIndex + 1) * LAYER_HEIGHT, hue)
+    vibrate([20, 40, 20])
+    announce.value = `Missed! Final score ${score.value}.`
+    endGame()
+    return
+  }
+
+  if (trimmed) {
+    const prevCenter = axis === 'x' ? currentRect.xCenter : currentRect.zCenter
+    spawnChip(currentRect, axis, movingCenter > prevCenter ? 'hi' : 'lo', layerIndex * LAYER_HEIGHT, (layerIndex + 1) * LAYER_HEIGHT, hue)
+  }
+
+  currentRect = rect
+  moveLog.push({ ts })
+  lastLogTs = ts
+  layerIndex++
+  layerStartTs = ts
+  score.value++
+  vibrate(10)
+  announce.value = `Block ${score.value} placed.`
+
+  renderLayers.push({ n: layerIndex - 1, rect: { ...currentRect }, hue })
+  if (renderLayers.length > RENDER_WINDOW) renderLayers.shift()
+
+  cameraTargetY = (layerIndex) * LAYER_HEIGHT
+
+  if (layerIndex > cfg.maxLayers) {
+    maxedOut.value = true
+    announce.value = `Max height reached! Final score ${score.value}.`
+    endGame()
+  }
+}
+
+// ─── Game lifecycle ────────────────────────────────────────────────────────────
+async function fetchStatus() {
+  try {
+    const data = await $fetch('/api/game/tower/status', { credentials: 'include' })
+    playsLeft.value   = data.playsLeft
+    weekHigh.value    = data.weekHigh
+    allTimeHigh.value = data.allTimeHigh
+    resetLabel.value  = formatReset(data.playsResetAt)
+    uiState.value = data.playsLeft > 0 ? 'start' : 'noplays'
+  } catch {
+    uiState.value = 'start'
+  }
+}
+
+function formatReset(isoString) {
+  if (!isoString) return ''
+  const d = new Date(isoString)
+  return new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' }).format(d)
+}
+
+async function startGame() {
+  if (starting.value) return
+  starting.value = true
+  try {
+    const data = await $fetch('/api/game/tower/start', { method: 'POST', credentials: 'include' })
+    cfg = data.config
+    jitter = deriveJitter(data.jitterSeed)
+
+    currentRect = { xCenter: 0, xWidth: cfg.baseWidth, zCenter: 0, zWidth: cfg.baseWidth }
+    renderLayers = [{ n: 0, rect: { ...currentRect }, hue: hueForLayer(0) }]
+    moveLog = []
+    layerIndex = 1
+    layerStartTs = 0
+    lastLogTs = null
+    particles = []
+    score.value = 0
+    maxedOut.value = false
+    ending = false
+    totalPausedMs = 0
+    pauseBeganAtPerf = null
+    paused = false
+    announce.value = ''
+    cameraY = 0
+    cameraTargetY = LAYER_HEIGHT
+
+    await fetchStatus()
+    playsLeft.value = Math.max(0, playsLeft.value - 1) // optimistic
+
+    uiState.value = 'playing'
+    await nextTick()
+
+    resizeCanvas()
+    gameStartPerf = performance.now()
+    rafId = requestAnimationFrame(gameLoop)
+  } catch (err) {
+    const msg = err?.data?.statusMessage || err?.message || 'Failed to start game'
+    alert(msg)
+  } finally {
+    starting.value = false
+  }
+}
+
+async function endGame() {
+  if (ending) return
+  ending = true
+  if (rafId) { cancelAnimationFrame(rafId); rafId = null }
+
+  finalScore.value = score.value
+
+  try {
+    const result = await $fetch('/api/game/tower/end', {
+      method: 'POST',
+      credentials: 'include',
+      body: { moveLog }
+    })
+    pointsAwarded.value = result.pointsAwarded ?? 0
+    if (typeof result.score === 'number') finalScore.value = result.score
+    const status = await $fetch('/api/game/tower/status', { credentials: 'include' })
+    weekHigh.value    = status.weekHigh
+    allTimeHigh.value = status.allTimeHigh
+    playsLeft.value   = status.playsLeft
+  } catch {
+    pointsAwarded.value = 0
+  }
+
+  uiState.value = 'gameover'
+}
+
+// ─── Resize / visibility / orientation lifecycle ────────────────────────────────
+let resizeObserver = null
+let landscapeMql = null
+function onVisibilityChange() { if (document.hidden) pauseGame(); else resumeGame() }
+function onLandscapeChange() { if (landscapeMql?.matches) pauseGame(); else resumeGame() }
+
+onMounted(async () => {
+  reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false
+  await fetchStatus()
+  resizeObserver = new ResizeObserver(() => {
+    if (uiState.value === 'playing') resizeCanvas()
+  })
+  if (canvasContainer.value) resizeObserver.observe(canvasContainer.value)
+
+  landscapeMql = window.matchMedia('(orientation: landscape) and (max-height: 480px)')
+  landscapeMql.addEventListener?.('change', onLandscapeChange)
+  document.addEventListener('visibilitychange', onVisibilityChange)
+})
+
+onUnmounted(() => {
+  if (rafId) { cancelAnimationFrame(rafId); rafId = null }
+  resizeObserver?.disconnect()
+  document.removeEventListener('visibilitychange', onVisibilityChange)
+  landscapeMql?.removeEventListener?.('change', onLandscapeChange)
+})
+</script>
+
+<style scoped>
+.tower-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  position: relative;
+  background: #001230;
+}
+
+/* Landscape orientation warning */
+.landscape-warning {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  background: rgba(0, 10, 30, 0.97);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 2rem;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (orientation: landscape) and (max-height: 480px) {
+  .landscape-warning { display: flex; }
+}
+
+.center-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 300px;
+}
+
+/* Start/No-plays card */
+.start-card {
+  background: rgba(10, 25, 55, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 2rem 2.5rem;
+  text-align: center;
+  max-width: 340px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.game-title {
+  font-size: clamp(1.4rem, 5vw, 2rem);
+  font-weight: 800;
+  color: #fff;
+  margin: 0 0 0.5rem;
+  background: linear-gradient(135deg, #66bbff, #fff 50%, #ffd700);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.start-sub {
+  color: rgba(255,255,255,0.65);
+  font-size: 0.875rem;
+  margin: 0 0 1.25rem;
+}
+
+.plays-info {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.plays-badge {
+  background: rgba(102, 187, 255, 0.2);
+  border: 1px solid rgba(102, 187, 255, 0.4);
+  color: #66bbff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+}
+
+.reset-text {
+  color: rgba(255,255,255,0.4);
+  font-size: 0.75rem;
+}
+
+.no-plays-text {
+  color: rgba(255,255,255,0.7);
+  font-size: 1rem;
+  margin: 0 0 0.5rem;
+}
+
+.btn-start {
+  background: linear-gradient(135deg, #1a6e3c, #3399cc);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 2.5rem;
+  cursor: pointer;
+  transition: filter 0.15s, transform 0.1s;
+  min-width: 140px;
+}
+.btn-start:hover { filter: brightness(1.15); }
+.btn-start:active { transform: scale(0.97); }
+.btn-start:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-secondary {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  font-weight: 600;
+  font-size: 0.9rem;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 10px;
+  padding: 0.65rem 2rem;
+  cursor: pointer;
+}
+
+/* How to Play trigger */
+.btn-howto {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  margin-top: 0.9rem;
+  background: transparent;
+  color: rgba(255,255,255,0.6);
+  font-weight: 600;
+  font-size: 0.8rem;
+  border: none;
+  padding: 0.35rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.btn-howto:hover { color: #66bbff; }
+.howto-icon { flex-shrink: 0; }
+
+/* How to Play modal */
+.modal-card--howto { text-align: left; }
+
+.howto-list {
+  list-style: none;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+.howto-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  color: rgba(255,255,255,0.8);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+.howto-list strong { color: #fff; font-weight: 700; }
+.howto-num {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #1a6e3c, #3399cc);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
+}
+
+/* Spinner */
+.spinner {
+  width: 40px; height: 40px;
+  border: 3px solid rgba(255,255,255,0.1);
+  border-top-color: #66bbff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Game area */
+.game-area {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  gap: 0;
+  background: #001230;
+  overscroll-behavior: contain;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+}
+
+/* HUD */
+.hud {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  background: rgba(0, 10, 30, 0.8);
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  flex-shrink: 0;
+}
+
+.hud-row {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: nowrap;
+}
+
+.hud-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 8px;
+  padding: 4px 12px;
+  min-width: 64px;
+}
+
+.hud-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.45);
+  line-height: 1;
+}
+
+.hud-value {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.2;
+}
+
+/* Canvas */
+.canvas-container {
+  flex: 1;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  min-height: 200px;
+  overscroll-behavior: contain;
+}
+
+.game-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+}
+
+/* How-to hint under the board */
+.game-hint {
+  flex-shrink: 0;
+  text-align: center;
+  color: rgba(255,255,255,0.4);
+  font-size: 0.72rem;
+  padding: 4px 8px 6px;
+}
+
+/* Screen-reader-only live region */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Modal */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  backdrop-filter: blur(4px);
+}
+
+.modal-card {
+  background: rgba(10, 25, 55, 0.97);
+  border: 1px solid rgba(255,255,255,0.14);
+  border-radius: 20px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 360px;
+  max-height: min(90dvh, 520px);
+  overflow-y: auto;
+  box-shadow: 0 16px 48px rgba(0,0,0,0.7);
+  text-align: center;
+}
+
+.modal-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #fff;
+  margin: 0 0 1.25rem;
+  background: linear-gradient(135deg, #ffd700, #fff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.modal-score-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 1.25rem;
+}
+
+.modal-score-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.5);
+}
+
+.modal-score-value {
+  font-size: 3rem;
+  font-weight: 900;
+  color: #ffd700;
+  line-height: 1;
+}
+
+.modal-divider {
+  height: 1px;
+  background: rgba(255,255,255,0.1);
+  margin: 0 0 1.25rem;
+}
+
+.modal-leaderboard { margin-bottom: 1rem; }
+
+.modal-lb-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.modal-lb-row:last-child { border-bottom: none; }
+
+.modal-lb-label {
+  font-size: 0.8rem;
+  color: rgba(255,255,255,0.6);
+}
+
+.modal-lb-value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.modal-points-notice {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #66cc00;
+  background: rgba(102, 204, 0, 0.1);
+  border: 1px solid rgba(102, 204, 0, 0.25);
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1.25rem;
+}
+.modal-points-notice--zero {
+  color: rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.modal-actions { display: flex; justify-content: center; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation: none; }
+}
+</style>

--- a/prisma/migrations/20260709000000_add_tower_stack/migration.sql
+++ b/prisma/migrations/20260709000000_add_tower_stack/migration.sql
@@ -1,0 +1,43 @@
+-- AddField: Tower Stack settings on GameConfig
+ALTER TABLE "GameConfig"
+  ADD COLUMN IF NOT EXISTS "towerPlaysPerPeriod"      INTEGER NOT NULL DEFAULT 3,
+  ADD COLUMN IF NOT EXISTS "towerPointsPerGame"       INTEGER NOT NULL DEFAULT 50,
+  ADD COLUMN IF NOT EXISTS "towerBaseSpeed"           DOUBLE PRECISION NOT NULL DEFAULT 90,
+  ADD COLUMN IF NOT EXISTS "towerSpeedGrowthPerLayer" DOUBLE PRECISION NOT NULL DEFAULT 0.03,
+  ADD COLUMN IF NOT EXISTS "towerMaxSpeedMultiplier"  DOUBLE PRECISION NOT NULL DEFAULT 2.5,
+  ADD COLUMN IF NOT EXISTS "towerPerfectEpsilon"       DOUBLE PRECISION NOT NULL DEFAULT 4,
+  ADD COLUMN IF NOT EXISTS "towerMaxLayers"            INTEGER NOT NULL DEFAULT 800;
+
+-- AddField: Tower Stack tile image on GlobalGameConfig
+ALTER TABLE "GlobalGameConfig"
+  ADD COLUMN IF NOT EXISTS "gameTileTowerImagePath" TEXT;
+
+-- CreateTable: TowerStackScore
+CREATE TABLE IF NOT EXISTS "TowerStackScore" (
+  "id"        TEXT         NOT NULL,
+  "userId"    TEXT         NOT NULL,
+  "score"     INTEGER      NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "TowerStackScore_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: TowerStackPlay
+CREATE TABLE IF NOT EXISTS "TowerStackPlay" (
+  "id"        TEXT         NOT NULL,
+  "userId"    TEXT         NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "TowerStackPlay_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "TowerStackScore_userId_score_idx"    ON "TowerStackScore"("userId", "score");
+CREATE INDEX IF NOT EXISTS "TowerStackScore_createdAt_idx"        ON "TowerStackScore"("createdAt");
+CREATE INDEX IF NOT EXISTS "TowerStackScore_userId_createdAt_idx" ON "TowerStackScore"("userId", "createdAt");
+CREATE INDEX IF NOT EXISTS "TowerStackPlay_userId_createdAt_idx"  ON "TowerStackPlay"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "TowerStackScore" ADD CONSTRAINT "TowerStackScore_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "TowerStackPlay" ADD CONSTRAINT "TowerStackPlay_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -500,6 +500,10 @@ model User {
   reOrbitMatchScores ReOrbitMatchScore[]
   reOrbitMatchPlays  ReOrbitMatchPlay[]
 
+  // Tower Stack
+  towerStackScores TowerStackScore[]
+  towerStackPlays  TowerStackPlay[]
+
   @@unique([discordId, active]) // at most one active user per Discord ID
 }
 
@@ -970,6 +974,15 @@ model GameConfig {
   reorbitGridSize       Int     @default(8)
   reorbitComboMs        Int     @default(3500)
 
+  // — Tower Stack settings —
+  towerPlaysPerPeriod      Int   @default(3)
+  towerPointsPerGame       Int   @default(50)
+  towerBaseSpeed           Float @default(90)
+  towerSpeedGrowthPerLayer Float @default(0.03)
+  towerMaxSpeedMultiplier  Float @default(2.5)
+  towerPerfectEpsilon      Float @default(4)
+  towerMaxLayers           Int   @default(800)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 }
@@ -1016,6 +1029,7 @@ model GlobalGameConfig {
   gameTileClashImagePath        String?
   gameTileTkoImagePath          String?
   gameTileReorbitmatchImagePath String?
+  gameTileTowerImagePath        String?
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 }
@@ -2560,6 +2574,31 @@ model ReOrbitMatchScore {
 }
 
 model ReOrbitMatchPlay {
+  id        String   @id @default(uuid())
+  userId    String
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId, createdAt])
+}
+
+// ── Tower Stack ────────────────────────────────────────────────────────────────
+
+model TowerStackScore {
+  id        String   @id @default(uuid())
+  userId    String
+  score     Int
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId, score])
+  @@index([createdAt])
+  @@index([userId, createdAt])
+}
+
+model TowerStackPlay {
   id        String   @id @default(uuid())
   userId    String
   createdAt DateTime @default(now())

--- a/server/api/admin/game-config.get.js
+++ b/server/api/admin/game-config.get.js
@@ -140,6 +140,19 @@ export default defineEventHandler(async (event) => {
             reorbitComboMs: 3500
           }
         })
+      } else if (gameName === 'TowerStack') {
+        config = await db.gameConfig.create({
+          data: {
+            gameName,
+            towerPlaysPerPeriod: 3,
+            towerPointsPerGame: 50,
+            towerBaseSpeed: 90,
+            towerSpeedGrowthPerLayer: 0.03,
+            towerMaxSpeedMultiplier: 2.5,
+            towerPerfectEpsilon: 4,
+            towerMaxLayers: 800
+          }
+        })
       } else {
         throw createError({
           statusCode: 400,

--- a/server/api/admin/game-config.post.js
+++ b/server/api/admin/game-config.post.js
@@ -125,6 +125,28 @@ function validatePayload(payload) {
         throw createError({ statusCode: 400, statusMessage: 'Each emoji must be a non-empty string' })
       }
     }
+  } else if (payload.gameName === 'TowerStack') {
+    if (payload.towerPlaysPerPeriod == null || typeof payload.towerPlaysPerPeriod !== 'number' || payload.towerPlaysPerPeriod < 1) {
+      throw createError({ statusCode: 400, statusMessage: '"towerPlaysPerPeriod" must be a positive number' })
+    }
+    if (payload.towerPointsPerGame == null || typeof payload.towerPointsPerGame !== 'number' || payload.towerPointsPerGame < 0) {
+      throw createError({ statusCode: 400, statusMessage: '"towerPointsPerGame" must be a non-negative number' })
+    }
+    if (payload.towerBaseSpeed == null || typeof payload.towerBaseSpeed !== 'number' || payload.towerBaseSpeed <= 0) {
+      throw createError({ statusCode: 400, statusMessage: '"towerBaseSpeed" must be a positive number' })
+    }
+    if (payload.towerSpeedGrowthPerLayer == null || typeof payload.towerSpeedGrowthPerLayer !== 'number' || payload.towerSpeedGrowthPerLayer < 0) {
+      throw createError({ statusCode: 400, statusMessage: '"towerSpeedGrowthPerLayer" must be a non-negative number' })
+    }
+    if (payload.towerMaxSpeedMultiplier == null || typeof payload.towerMaxSpeedMultiplier !== 'number' || payload.towerMaxSpeedMultiplier < 1) {
+      throw createError({ statusCode: 400, statusMessage: '"towerMaxSpeedMultiplier" must be a number >= 1' })
+    }
+    if (payload.towerPerfectEpsilon == null || typeof payload.towerPerfectEpsilon !== 'number' || payload.towerPerfectEpsilon < 0) {
+      throw createError({ statusCode: 400, statusMessage: '"towerPerfectEpsilon" must be a non-negative number' })
+    }
+    if (payload.towerMaxLayers == null || typeof payload.towerMaxLayers !== 'number' || payload.towerMaxLayers < 10 || payload.towerMaxLayers > 2000) {
+      throw createError({ statusCode: 400, statusMessage: '"towerMaxLayers" must be between 10 and 2000' })
+    }
   } else {
     throw createError({ statusCode: 400, statusMessage: `Unknown gameName "${payload.gameName}"` })
   }
@@ -156,6 +178,14 @@ export default defineEventHandler(async (event) => {
     reorbitEmojis = [],
     reorbitGridSize,
     reorbitComboMs,
+    // TowerStack fields
+    towerPlaysPerPeriod,
+    towerPointsPerGame,
+    towerBaseSpeed,
+    towerSpeedGrowthPerLayer,
+    towerMaxSpeedMultiplier,
+    towerPerfectEpsilon,
+    towerMaxLayers,
     // Winball fields
     leftCupPoints,
     rightCupPoints,
@@ -337,6 +367,18 @@ export default defineEventHandler(async (event) => {
         }
         createData = { ...createData, ...reorbitData }
         updateData = { ...updateData, ...reorbitData }
+      } else if (gameName === 'TowerStack') {
+        const towerData = {
+          towerPlaysPerPeriod,
+          towerPointsPerGame,
+          towerBaseSpeed,
+          towerSpeedGrowthPerLayer,
+          towerMaxSpeedMultiplier,
+          towerPerfectEpsilon,
+          towerMaxLayers
+        }
+        createData = { ...createData, ...towerData }
+        updateData = { ...updateData, ...towerData }
       } else if (gameName === 'Clash' || gameName === 'TKO') {
         createData = { ...createData, pointsPerWin }
         updateData = { ...updateData, pointsPerWin }
@@ -505,6 +547,21 @@ export default defineEventHandler(async (event) => {
           for (const [key, prev, next] of changes) {
             if (String(prev) !== String(next)) {
               await logAdminChange(tx, { userId: me.id, area: 'GameConfig:ReOrbitMatch', key, prevValue: prev, newValue: next })
+            }
+          }
+        } else if (gameName === 'TowerStack') {
+          const changes = [
+            ['towerPlaysPerPeriod', before?.towerPlaysPerPeriod, towerPlaysPerPeriod],
+            ['towerPointsPerGame', before?.towerPointsPerGame, towerPointsPerGame],
+            ['towerBaseSpeed', before?.towerBaseSpeed, towerBaseSpeed],
+            ['towerSpeedGrowthPerLayer', before?.towerSpeedGrowthPerLayer, towerSpeedGrowthPerLayer],
+            ['towerMaxSpeedMultiplier', before?.towerMaxSpeedMultiplier, towerMaxSpeedMultiplier],
+            ['towerPerfectEpsilon', before?.towerPerfectEpsilon, towerPerfectEpsilon],
+            ['towerMaxLayers', before?.towerMaxLayers, towerMaxLayers]
+          ]
+          for (const [key, prev, next] of changes) {
+            if (prev !== next) {
+              await logAdminChange(tx, { userId: me.id, area: 'GameConfig:TowerStack', key, prevValue: prev, newValue: next })
             }
           }
         } else if (gameName === 'Clash' || gameName === 'TKO') {

--- a/server/api/admin/game-tile-image.delete.js
+++ b/server/api/admin/game-tile-image.delete.js
@@ -8,7 +8,8 @@ const SLOT_FIELD = {
   winwheel:     'gameTileWinwheelImagePath',
   clash:        'gameTileClashImagePath',
   tko:          'gameTileTkoImagePath',
-  reorbitmatch: 'gameTileReorbitmatchImagePath'
+  reorbitmatch: 'gameTileReorbitmatchImagePath',
+  tower:        'gameTileTowerImagePath'
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/admin/game-tile-image.post.js
+++ b/server/api/admin/game-tile-image.post.js
@@ -23,7 +23,8 @@ const SLOT_FIELD = {
   winwheel:     'gameTileWinwheelImagePath',
   clash:        'gameTileClashImagePath',
   tko:          'gameTileTkoImagePath',
-  reorbitmatch: 'gameTileReorbitmatchImagePath'
+  reorbitmatch: 'gameTileReorbitmatchImagePath',
+  tower:        'gameTileTowerImagePath'
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/game-tile-images.get.js
+++ b/server/api/game-tile-images.get.js
@@ -10,7 +10,8 @@ export default defineEventHandler(async () => {
       gameTileWinwheelImagePath:     true,
       gameTileClashImagePath:        true,
       gameTileTkoImagePath:          true,
-      gameTileReorbitmatchImagePath: true
+      gameTileReorbitmatchImagePath: true,
+      gameTileTowerImagePath:        true
     }
   })
 
@@ -20,6 +21,7 @@ export default defineEventHandler(async () => {
     winwheel:     cfg?.gameTileWinwheelImagePath     ?? null,
     clash:        cfg?.gameTileClashImagePath        ?? null,
     tko:          cfg?.gameTileTkoImagePath          ?? null,
-    reorbitmatch: cfg?.gameTileReorbitmatchImagePath ?? null
+    reorbitmatch: cfg?.gameTileReorbitmatchImagePath ?? null,
+    tower:        cfg?.gameTileTowerImagePath        ?? null
   }
 })

--- a/server/api/game/tower/end.post.js
+++ b/server/api/game/tower/end.post.js
@@ -1,0 +1,165 @@
+import { defineEventHandler, readBody, createError } from 'h3'
+import { DateTime } from 'luxon'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { replayTowerGame, hasRoboticCadence, TOWER_MIN_MOVE_INTERVAL_MS, MAX_LAYERS_HARD_CAP } from '@/server/utils/towerStackEngine'
+
+const LOCK_TTL_MS = 15_000
+const MAX_BODY_BYTES = 64 * 1024 // 64 KB — a moveLog entry is just { ts }, far smaller than ReOrbit's cell arrays
+
+function lockKey(userId) { return `towerstack:lock:${userId}` }
+function sessionKey(userId) { return `towerstack:session:${userId}` }
+
+function getDailyBoundary() {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  let b = chicagoNow.set({ hour: 20, minute: 0, second: 0, millisecond: 0 })
+  if (chicagoNow < b) b = b.minus({ days: 1 })
+  return b.toUTC().toJSDate()
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  // Body size guard before full parse
+  const contentLength = Number(event.node.req.headers['content-length'] || 0)
+  if (contentLength > MAX_BODY_BYTES) {
+    throw createError({ statusCode: 413, statusMessage: 'Request too large' })
+  }
+
+  const body = await readBody(event)
+  if (!Array.isArray(body?.moveLog)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid request body' })
+  }
+
+  const { moveLog } = body
+
+  // Absolute move-count cap, independent of session TTL, before any expensive work.
+  if (moveLog.length > MAX_LAYERS_HARD_CAP) {
+    throw createError({ statusCode: 400, statusMessage: 'Move log exceeds maximum' })
+  }
+
+  // Per-user lock (same key as /start — serializes with concurrent start requests too)
+  const lockToken = crypto.randomUUID()
+  let lockAcquired = false
+  try {
+    const r = await redis.set(lockKey(userId), lockToken, 'NX', 'PX', LOCK_TTL_MS)
+    lockAcquired = r === 'OK'
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+  if (!lockAcquired) throw createError({ statusCode: 429, statusMessage: 'Request already in progress' })
+
+  const casRelease = `if redis.call("get",KEYS[1])==ARGV[1] then return redis.call("del",KEYS[1]) else return 0 end`
+
+  try {
+    // Banned check
+    const user = await prisma.user.findUnique({ where: { id: userId }, select: { banned: true } })
+    if (user?.banned) throw createError({ statusCode: 403, statusMessage: 'Account suspended' })
+
+    // Atomically consume session — prevents replay attack
+    const raw = await redis.getdel(sessionKey(userId))
+    if (!raw) throw createError({ statusCode: 409, statusMessage: 'Game session not found or expired. Start a new game.' })
+
+    const session = JSON.parse(raw)
+    const { startTime, jitterSeed, cfg } = session
+    const endTime = Date.now()
+    const elapsedMs = endTime - startTime
+
+    // Layer count can never exceed what the snapshotted config allows for this session.
+    if (moveLog.length > (cfg.maxLayers ?? MAX_LAYERS_HARD_CAP)) {
+      throw createError({ statusCode: 400, statusMessage: 'Move log exceeds session layer limit' })
+    }
+
+    // Validate move timestamps up front (engine re-validates monotonicity/pacing during
+    // replay too, but checking the log's span against wall-clock elapsed time here catches
+    // logs that don't even internally match how long the session has been open).
+    if (moveLog.length > 0) {
+      const firstTs = moveLog[0].ts
+      const lastTs = moveLog[moveLog.length - 1].ts
+
+      if (typeof firstTs !== 'number' || typeof lastTs !== 'number') {
+        throw createError({ statusCode: 400, statusMessage: 'Invalid move timestamps' })
+      }
+      if (lastTs - firstTs > elapsedMs + 1000) {
+        throw createError({ statusCode: 400, statusMessage: 'Move timestamps exceed elapsed time' })
+      }
+
+      const maxTheoreticalMoves = Math.ceil(elapsedMs / TOWER_MIN_MOVE_INTERVAL_MS) + 10
+      if (moveLog.length > maxTheoreticalMoves) {
+        throw createError({ statusCode: 400, statusMessage: 'Move log exceeds theoretical maximum' })
+      }
+
+      // Anomaly check: reject suspiciously uniform (robotic) tap cadence. Defense-in-depth,
+      // not a substitute for the timing checks above — see towerStackEngine.js header.
+      if (hasRoboticCadence(moveLog)) {
+        throw createError({ statusCode: 400, statusMessage: 'Move timing rejected' })
+      }
+    }
+
+    // Server-side replay (score computed here, NOT from client)
+    let computedScore
+    try {
+      computedScore = replayTowerGame(moveLog, jitterSeed, cfg)
+    } catch (err) {
+      throw createError({ statusCode: 400, statusMessage: `Invalid move sequence: ${err.message}` })
+    }
+
+    // Defense-in-depth: score can never exceed the number of submitted moves.
+    computedScore = Math.min(computedScore, moveLog.length)
+
+    // Load config for points-per-game
+    const gameConfig = await prisma.gameConfig.findUnique({
+      where: { gameName: 'TowerStack' },
+      select: { towerPointsPerGame: true }
+    })
+    const basePointsPerGame = gameConfig?.towerPointsPerGame ?? 50
+
+    // Sanity-check pointsPerGame against daily limit
+    const globalConfig = await prisma.globalGameConfig.findUnique({
+      where: { id: 'singleton' },
+      select: { dailyPointLimit: true }
+    })
+    const dailyLimit = globalConfig?.dailyPointLimit ?? 100
+    const pointsPerGame = Math.min(basePointsPerGame, dailyLimit)
+
+    // Award points within daily cap (same Prisma transaction pattern as ReOrbit Match)
+    const boundary = getDailyBoundary()
+    let pointsAwarded = 0
+
+    if (pointsPerGame > 0) {
+      try {
+        await prisma.$transaction(async (tx) => {
+          const agg = await tx.gamePointLog.aggregate({
+            where: { userId, createdAt: { gte: boundary } },
+            _sum: { points: true }
+          })
+          const usedToday = Number(agg._sum?.points || 0)
+          const toGive = Math.min(pointsPerGame, Math.max(0, dailyLimit - usedToday))
+          pointsAwarded = toGive
+
+          if (toGive > 0) {
+            await tx.gamePointLog.create({ data: { userId, points: toGive } })
+            const updated = await tx.userPoints.upsert({
+              where: { userId },
+              create: { userId, points: toGive },
+              update: { points: { increment: toGive } }
+            })
+            await tx.pointsLog.create({
+              data: { userId, direction: 'increase', points: toGive, total: updated.points, method: 'Game - Tower Stack' }
+            })
+          }
+        })
+      } catch {
+        // Points award failure is non-fatal — score is still recorded
+      }
+    }
+
+    // Save score record
+    await prisma.towerStackScore.create({ data: { userId, score: computedScore } })
+
+    return { score: computedScore, pointsAwarded }
+  } finally {
+    try { await redis.eval(casRelease, 1, lockKey(userId), lockToken) } catch {}
+  }
+})

--- a/server/api/game/tower/leaderboard.get.js
+++ b/server/api/game/tower/leaderboard.get.js
@@ -1,0 +1,90 @@
+import { defineEventHandler } from 'h3'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { mergeViewerRow } from '@/server/utils/leaderboardRank'
+
+const CACHE_KEY  = 'towerstack:leaderboard:v1'
+const CACHE_TTL  = 1800  // 30 minutes
+const EXCLUDE_ID = '4f0e8b3b-7d0b-466b-99e7-8996c91d7eb3'
+
+const PERIOD_FILTERS = {
+  allTime: '',
+  monthly: `AND s."createdAt" >= NOW() - INTERVAL '30 days'`,
+  weekly:  `AND s."createdAt" >= NOW() - INTERVAL '7 days'`,
+}
+
+function rankedTop11(period) {
+  const dateFilter = PERIOD_FILTERS[period]
+  return prisma.$queryRawUnsafe(`
+    SELECT u."id" AS "userId", u."username", u."avatar", MAX(s."score")::int AS "score",
+           (ROW_NUMBER() OVER (ORDER BY MAX(s."score") DESC, u."username" ASC))::int AS rank
+    FROM "TowerStackScore" s
+    JOIN "User" u ON u."id" = s."userId"
+    WHERE u."active" = true
+      AND COALESCE(u."banned", false) = false
+      AND s."userId" <> '${EXCLUDE_ID}'
+      ${dateFilter}
+    GROUP BY u."id", u."username", u."avatar"
+    ORDER BY rank
+    LIMIT 11;
+  `)
+}
+
+function rankedViewer(period, userId) {
+  const dateFilter = PERIOD_FILTERS[period]
+  return prisma.$queryRawUnsafe(`
+    WITH ranked AS (
+      SELECT u."id" AS "userId", u."username", u."avatar", MAX(s."score")::int AS "score",
+             (ROW_NUMBER() OVER (ORDER BY MAX(s."score") DESC, u."username" ASC))::int AS rank
+      FROM "TowerStackScore" s
+      JOIN "User" u ON u."id" = s."userId"
+      WHERE u."active" = true
+        AND COALESCE(u."banned", false) = false
+        AND s."userId" <> '${EXCLUDE_ID}'
+        ${dateFilter}
+      GROUP BY u."id", u."username", u."avatar"
+    )
+    SELECT * FROM ranked WHERE "userId" = $1;
+  `, userId)
+}
+
+async function fetchTop11() {
+  const [allTime, monthly, weekly] = await Promise.all([
+    rankedTop11('allTime'),
+    rankedTop11('monthly'),
+    rankedTop11('weekly'),
+  ])
+  return { allTime, monthly, weekly }
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId || null
+
+  let top11
+  try {
+    const cached = await redis.get(CACHE_KEY)
+    if (cached) top11 = JSON.parse(cached)
+  } catch {}
+
+  if (!top11) {
+    top11 = await fetchTop11()
+    try {
+      await redis.set(CACHE_KEY, JSON.stringify(top11), 'EX', CACHE_TTL)
+    } catch {}
+  }
+
+  const result = {}
+  for (const p of ['allTime', 'monthly', 'weekly']) {
+    const rows = top11[p]
+    let viewerRow = null
+    if (userId && !rows.some(r => r.userId === userId)) {
+      try {
+        const res = await rankedViewer(p, userId)
+        viewerRow = res[0] || null
+      } catch {}
+    }
+    result[p] = mergeViewerRow(rows, viewerRow, userId)
+  }
+
+  return result
+})

--- a/server/api/game/tower/start.post.js
+++ b/server/api/game/tower/start.post.js
@@ -1,0 +1,89 @@
+import { defineEventHandler, createError } from 'h3'
+import { DateTime } from 'luxon'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { BASE_WIDTH, BOARD_HALF_RANGE } from '@/server/utils/towerStackEngine'
+
+const LOCK_TTL_MS = 10_000
+const SESSION_TTL_SECONDS = 1800 // 30 min — generous for a long human run, bounds the "solve offline then wait" window
+
+function lockKey(userId) { return `towerstack:lock:${userId}` }
+function sessionKey(userId) { return `towerstack:session:${userId}` }
+
+function getDailyBoundary() {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  let b = chicagoNow.set({ hour: 20, minute: 0, second: 0, millisecond: 0 })
+  if (chicagoNow < b) b = b.minus({ days: 1 })
+  return b.toUTC().toJSDate()
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  // Banned-user check
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { banned: true } })
+  if (user?.banned) throw createError({ statusCode: 403, statusMessage: 'Account suspended' })
+
+  // Per-user lock prevents concurrent /start requests (play-limit TOCTOU)
+  const lockToken = crypto.randomUUID()
+  let lockAcquired = false
+  try {
+    const r = await redis.set(lockKey(userId), lockToken, 'NX', 'PX', LOCK_TTL_MS)
+    lockAcquired = r === 'OK'
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+  if (!lockAcquired) throw createError({ statusCode: 429, statusMessage: 'Request already in progress' })
+
+  const casRelease = `if redis.call("get",KEYS[1])==ARGV[1] then return redis.call("del",KEYS[1]) else return 0 end`
+
+  try {
+    const gameConfig = await prisma.gameConfig.findUnique({ where: { gameName: 'TowerStack' } })
+    const playsPerPeriod = gameConfig?.towerPlaysPerPeriod ?? 3
+
+    // Physics constants, snapshotted into the session so admin edits mid-game can't desync
+    // a live replay at /end.
+    const cfg = {
+      baseSpeed: gameConfig?.towerBaseSpeed ?? 90,
+      speedGrowthPerLayer: gameConfig?.towerSpeedGrowthPerLayer ?? 0.03,
+      maxSpeedMultiplier: gameConfig?.towerMaxSpeedMultiplier ?? 2.5,
+      perfectEpsilon: gameConfig?.towerPerfectEpsilon ?? 4,
+      maxLayers: gameConfig?.towerMaxLayers ?? 800,
+      baseWidth: BASE_WIDTH,
+      boardHalfRange: BOARD_HALF_RANGE
+    }
+
+    // Check play limit
+    const boundary = getDailyBoundary()
+    const playsToday = await prisma.towerStackPlay.count({
+      where: { userId, createdAt: { gte: boundary } }
+    })
+    if (playsToday >= playsPerPeriod) {
+      const nextReset = new Date(boundary.getTime() + 24 * 60 * 60 * 1000)
+      throw createError({
+        statusCode: 429,
+        statusMessage: 'Daily play limit reached',
+        data: { nextReset: nextReset.toISOString() }
+      })
+    }
+
+    // Per-session jitter seed — shared openly with the client (it must know it to render the
+    // true motion), but fresh every game so a solved-once tap sequence can't be replayed
+    // across sessions. See towerStackEngine.js header for the full threat-model note.
+    const jitterSeed = crypto.randomUUID().replace(/-/g, '')
+
+    await redis.set(sessionKey(userId), JSON.stringify({
+      startTime: Date.now(),
+      jitterSeed,
+      cfg
+    }), 'EX', SESSION_TTL_SECONDS)
+
+    // Record the play (inside the lock to prevent TOCTOU)
+    await prisma.towerStackPlay.create({ data: { userId } })
+
+    return { config: cfg, jitterSeed }
+  } finally {
+    try { await redis.eval(casRelease, 1, lockKey(userId), lockToken) } catch {}
+  }
+})

--- a/server/api/game/tower/status.get.js
+++ b/server/api/game/tower/status.get.js
@@ -1,0 +1,54 @@
+import { defineEventHandler, createError } from 'h3'
+import { DateTime } from 'luxon'
+import { prisma } from '@/server/prisma'
+
+function getDailyBoundary() {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  let b = chicagoNow.set({ hour: 20, minute: 0, second: 0, millisecond: 0 })
+  if (chicagoNow < b) b = b.minus({ days: 1 })
+  return b.toUTC().toJSDate()
+}
+
+function getWeekBoundary() {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  const dow = chicagoNow.weekday % 7 // luxon: Mon=1…Sun=7; we want Mon=0
+  const monday = chicagoNow.minus({ days: dow === 0 ? 6 : dow - 1 }).set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+  return monday.toUTC().toJSDate()
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const config = await prisma.gameConfig.findUnique({ where: { gameName: 'TowerStack' } })
+  const playsPerPeriod = config?.towerPlaysPerPeriod ?? 3
+
+  const boundary = getDailyBoundary()
+  const weekBoundary = getWeekBoundary()
+  const nextReset = new Date(boundary.getTime() + 24 * 60 * 60 * 1000)
+
+  const [playsToday, allTimeHigh, weekHigh] = await Promise.all([
+    prisma.towerStackPlay.count({
+      where: { userId, createdAt: { gte: boundary } }
+    }),
+    prisma.towerStackScore.aggregate({
+      where: { userId },
+      _max: { score: true }
+    }),
+    prisma.towerStackScore.aggregate({
+      where: { createdAt: { gte: weekBoundary } },
+      _max: { score: true }
+    })
+  ])
+
+  return {
+    config: {
+      playsPerPeriod,
+      pointsPerGame: config?.towerPointsPerGame ?? 50
+    },
+    playsLeft: Math.max(0, playsPerPeriod - playsToday),
+    playsResetAt: nextReset.toISOString(),
+    allTimeHigh: allTimeHigh._max.score ?? 0,
+    weekHigh: weekHigh._max.score ?? 0
+  }
+})

--- a/server/utils/towerStackEngine.js
+++ b/server/utils/towerStackEngine.js
@@ -1,0 +1,190 @@
+// Server-only Tower Stack game engine. Never import this from pages/ or components/.
+//
+// Game model: classic "Stack"-style tapping game.
+//  - Layer 0 is the fixed base block, centered at (x:0, z:0), width `baseWidth` on both axes.
+//  - Each subsequent layer n>=1 has a block that slides back and forth along ONE axis —
+//    alternating X/Z by parity of n (deterministic, not random, matching the reference game).
+//  - The player taps to drop the moving block. The block's footprint on the trim axis is
+//    intersected with the block below; anything hanging off is cut away. If there is no
+//    overlap at all, the drop misses and the run ends.
+//  - A near-perfect tap (within `perfectEpsilon` of dead center) is NOT trimmed at all, so
+//    a precise player can hold a wide tower indefinitely — this is a stability mechanic,
+//    not a scoring bonus (score is always +1 per successful drop; see product decision).
+//  - Movement is pure deterministic math (no PRNG) EXCEPT for a per-session phase/speed jitter
+//    derived from a per-session `jitterSeed` — see `deriveJitter`.
+//
+// Anti-cheat: the authoritative score is recomputed here by replaying the client's tap
+// timestamps against the exact same deterministic physics, server-side. The client can draw
+// whatever it wants; only a replay that survives `replayTowerGame` counts.
+//
+// On the jitter seed: the client MUST know the exact same phase/speed jitter the server uses
+// in order to render the moving block's true motion in real time (same constraint as
+// reorbitMatchEngine's fillSeed) — so it cannot be a secret withheld from the client. What it
+// buys us instead is per-session uniqueness: `jitterSeed` is a fresh random value handed to
+// the client at /start (like fillSeed) and stored in the session for replay at /end. This
+// defeats a *static* exploit — solving the optimal tap sequence once from public GameConfig
+// constants and replaying/sharing it forever across every session — because the jitter differs
+// every game. It does NOT, on its own, stop a bot that re-derives the optimal sequence fresh
+// each session from the /start response before ever rendering a frame; that ceiling is the
+// same one ReOrbit Match already accepts (its board + fillSeed are equally solvable offline),
+// and is further narrowed here by TOWER_MIN_MOVE_INTERVAL_MS and `hasRoboticCadence` below.
+
+const TOWER_MIN_MOVE_INTERVAL_MS = 150 // no legitimate human sustains a faster tap-to-tap cadence
+const MAX_LAYERS_HARD_CAP = 2000 // absolute DoS guard, independent of admin-configured towerMaxLayers
+
+// Shared "world unit" constants — not admin-configurable (they're a coordinate-system choice,
+// not a difficulty knob), so they live here rather than in GameConfig. The client uses the
+// same values purely to scale its isometric rendering; the server never trusts anything the
+// client says about them.
+const BASE_WIDTH = 100
+const BOARD_HALF_RANGE = 60
+
+// Deterministic per-session jitter derived from `jitterSeed` (a random hex string generated
+// fresh at /start and shared with the client, same trust model as fillSeed). Perturbs phase
+// and speed slightly per session — see the file header for what this does and doesn't defend.
+function deriveJitter(jitterSeed) {
+  // FNV-1a style fold of the hex seed into two independent [0,1) floats.
+  let h1 = 0x811c9dc5, h2 = 0x1000193
+  for (let i = 0; i < jitterSeed.length; i++) {
+    const c = jitterSeed.charCodeAt(i)
+    h1 = (h1 ^ c) >>> 0; h1 = Math.imul(h1, 0x01000193) >>> 0
+    h2 = (h2 ^ c) >>> 0; h2 = Math.imul(h2, 0x85ebca6b) >>> 0
+  }
+  const phaseJitter = (h1 >>> 0) / 4294967296        // [0,1)
+  const speedJitter  = (h2 >>> 0) / 4294967296        // [0,1)
+  return {
+    phaseFrac: phaseJitter,                            // fraction of one traversal period
+    speedMult: 0.92 + speedJitter * 0.16                // ±8% speed multiplier
+  }
+}
+
+// Deterministic speed for layer n, given base config + session jitter.
+function layerSpeed(n, cfg, jitter) {
+  const growth = Math.min(1 + n * cfg.speedGrowthPerLayer, cfg.maxSpeedMultiplier)
+  return cfg.baseSpeed * growth * jitter.speedMult
+}
+
+// Triangle wave in [-amplitude, amplitude], deterministic function of elapsed seconds since
+// the layer started. Reflects at the edges (constant-speed back-and-forth motion).
+function triangleWave(tSeconds, speed, amplitude, phaseOffsetSeconds) {
+  const period = (4 * amplitude) / speed // full back-and-forth cycle
+  let phase = ((tSeconds + phaseOffsetSeconds) % period + period) % period
+  const quarter = period / 4
+  if (phase < quarter) return (phase / quarter) * amplitude
+  if (phase < 3 * quarter) return amplitude - ((phase - quarter) / quarter) * amplitude * 2
+  return -amplitude + ((phase - 3 * quarter) / quarter) * amplitude
+}
+
+// Center position of the moving block for layer n at elapsed seconds `tSeconds` since that
+// layer began. Axis alternates by parity of n; direction of the initial phase alternates too
+// (deterministic, matches the reference game's left/right/left/right entrance pattern).
+function movingCenterAt(n, tSeconds, cfg, jitter) {
+  const speed = layerSpeed(n, cfg, jitter)
+  const amplitude = cfg.boardHalfRange
+  const period = (4 * amplitude) / speed
+  const phaseOffset = jitter.phaseFrac * period
+  return triangleWave(tSeconds, speed, amplitude, phaseOffset)
+}
+
+function axisForLayer(n) { return n % 2 === 1 ? 'x' : 'z' }
+
+// Apply one tap. `rect` is the current placed footprint {xCenter,xWidth,zCenter,zWidth}.
+// Returns { hit:boolean, rect: newRect } — `hit:false` means the drop missed entirely.
+function applyDrop(n, tSeconds, rect, cfg, jitter) {
+  const axis = axisForLayer(n)
+  const movingCenter = movingCenterAt(n, tSeconds, cfg, jitter)
+  const prevCenter = axis === 'x' ? rect.xCenter : rect.zCenter
+  const prevWidth   = axis === 'x' ? rect.xWidth  : rect.zWidth
+
+  if (Math.abs(movingCenter - prevCenter) <= cfg.perfectEpsilon) {
+    // Perfect: no trim, footprint unchanged.
+    return { hit: true, rect: { ...rect } }
+  }
+
+  const prevMin = prevCenter - prevWidth / 2
+  const prevMax = prevCenter + prevWidth / 2
+  const curMin = movingCenter - prevWidth / 2
+  const curMax = movingCenter + prevWidth / 2
+  const overlapMin = Math.max(prevMin, curMin)
+  const overlapMax = Math.min(prevMax, curMax)
+  const overlapWidth = overlapMax - overlapMin
+
+  if (overlapWidth <= 0) return { hit: false, rect }
+
+  const newCenter = (overlapMin + overlapMax) / 2
+  const newRect = { ...rect }
+  if (axis === 'x') { newRect.xCenter = newCenter; newRect.xWidth = overlapWidth }
+  else { newRect.zCenter = newCenter; newRect.zWidth = overlapWidth }
+  return { hit: true, rect: newRect }
+}
+
+// Replay the entire game from a tap-timestamp log. `moveLog` is [{ ts }] — one entry per
+// successful drop, in the order they happened. `jitterSeed` is the per-session seed handed to
+// the client at /start (see file header). `cfg` are the physics constants snapshotted into the
+// session at /start. Throws on malformed input. Returns the authoritative score (= number of
+// successful, in-order, correctly-paced drops), stopping at (and not counting) the first miss
+// it detects, exactly as a real run would.
+function replayTowerGame(moveLog, jitterSeed, cfg) {
+  if (!Array.isArray(moveLog)) throw new Error('moveLog must be an array')
+  const maxLayers = Math.min(cfg.maxLayers ?? MAX_LAYERS_HARD_CAP, MAX_LAYERS_HARD_CAP)
+  if (moveLog.length > maxLayers) throw new Error('Move log exceeds maximum layers')
+
+  const jitter = deriveJitter(jitterSeed)
+  let rect = {
+    xCenter: 0, xWidth: cfg.baseWidth,
+    zCenter: 0, zWidth: cfg.baseWidth
+  }
+  let lastTs = null
+  let score = 0
+
+  for (let i = 0; i < moveLog.length; i++) {
+    const move = moveLog[i]
+    const ts = move?.ts
+    if (typeof ts !== 'number' || !Number.isFinite(ts)) throw new Error('Invalid move timestamp')
+    if (lastTs !== null) {
+      if (ts < lastTs) throw new Error('Move timestamps must be monotonically increasing')
+      if (ts - lastTs < TOWER_MIN_MOVE_INTERVAL_MS) throw new Error('Moves submitted too fast')
+    }
+    lastTs = ts
+
+    const n = i + 1 // layer index; layer 0 is the fixed base
+    // Elapsed seconds since THIS layer began sliding: the layer starts the instant the
+    // previous layer's drop resolved, i.e. at the previous move's ts (or game start for n=1).
+    const layerStartTs = i === 0 ? 0 : moveLog[i - 1].ts
+    const tSeconds = Math.max(0, ts - layerStartTs) / 1000
+
+    const { hit, rect: newRect } = applyDrop(n, tSeconds, rect, cfg, jitter)
+    if (!hit) break // miss ends the run; this tap does not score
+    rect = newRect
+    score++
+  }
+
+  return score
+}
+
+// Tap-cadence anomaly check: reject move logs whose inter-tap intervals are suspiciously
+// uniform (near-zero variance), which is characteristic of a scripted/replayed log rather
+// than human timing. Requires at least a handful of taps to be meaningful.
+function hasRoboticCadence(moveLog, { minSamples = 6, stdDevFloorMs = 12 } = {}) {
+  if (!Array.isArray(moveLog) || moveLog.length < minSamples) return false
+  const intervals = []
+  for (let i = 1; i < moveLog.length; i++) intervals.push(moveLog[i].ts - moveLog[i - 1].ts)
+  const mean = intervals.reduce((a, b) => a + b, 0) / intervals.length
+  const variance = intervals.reduce((a, b) => a + (b - mean) ** 2, 0) / intervals.length
+  const stdDev = Math.sqrt(variance)
+  return stdDev < stdDevFloorMs
+}
+
+export {
+  deriveJitter,
+  layerSpeed,
+  movingCenterAt,
+  axisForLayer,
+  applyDrop,
+  replayTowerGame,
+  hasRoboticCadence,
+  TOWER_MIN_MOVE_INTERVAL_MS,
+  MAX_LAYERS_HARD_CAP,
+  BASE_WIDTH,
+  BOARD_HALF_RANGE
+}


### PR DESCRIPTION
## Summary
Implements Tower Stack, a new tapping game where players stack blocks by dropping them onto a moving tower. The game features deterministic physics with per-session jitter, server-side replay validation for anti-cheat, and integrates with the existing game points and leaderboard systems.

## Key Changes

### Game Implementation
- **Client-side game page** (`pages/newsite/tower.vue`): Full isometric 3D rendering with canvas-based physics simulation, particle effects for falling chips, and responsive UI with modals for game-over and how-to-play screens
- **Server-side physics engine** (`server/utils/towerStackEngine.js`): Deterministic block movement using triangle-wave motion, per-session jitter derivation to prevent static exploit solutions, and authoritative score replay validation
- **Game lifecycle endpoints**:
  - `/api/game/tower/start.post.js`: Initializes game session with snapshotted config and jitter seed
  - `/api/game/tower/end.post.js`: Validates move log, replays physics server-side, awards points, and prevents concurrent plays
  - `/api/game/tower/status.get.js`: Returns play count, daily reset time, and leaderboard highs
  - `/api/game/tower/leaderboard.get.js`: Ranked leaderboard with all-time, monthly, and weekly periods

### Anti-Cheat & Security
- **Deterministic replay validation**: Server replays client's tap timestamps against identical physics to verify score authenticity
- **Per-session jitter**: Fresh random seed per game prevents pre-computed optimal tap sequences from being reused across sessions
- **Move cadence validation**: Enforces minimum 150ms between taps to detect robotic/bot-like patterns
- **Session atomicity**: Redis-based locking and one-time session consumption prevents replay attacks and concurrent play exploits
- **Request size limits**: 64KB body cap and hard layer count cap (2000) guard against DoS

### Database & Configuration
- **Schema additions** (`prisma/schema.prisma` + migration): New `TowerStackScore` and `TowerStackPlay` tables, plus 7 configurable physics parameters on `GameConfig`
- **Admin panel** (`pages/admin/games.vue`): Settings for plays per period, points per game, speed curves, and max layers
- **Game tile integration** (`components/newsite/GamesHome.vue`): Tower Stack tile added to games home with image support

### Leaderboard Integration
- **Multi-game leaderboards** (`components/newsite/Leaderboards.vue`): Games tab now switches between ReOrbit Match and Tower Stack leaderboards
- **Ranked queries**: All-time, monthly, and weekly rankings with 30-minute Redis cache

## Notable Implementation Details

- **Isometric projection**: Blocks rendered in 3D isometric view with proper depth sorting and off-screen culling
- **Deterministic motion**: Triangle-wave sliding motion with phase/speed jitter derived from FNV-1a hash of session seed
- **Client-server sync**: Client uses identical physics constants and jitter derivation as server for real-time rendering; server always recomputes authoritative score
- **Accessibility**: ARIA labels, screen-reader announcements, reduced-motion support, and landscape orientation warnings
- **Performance**: Bounded particle pool (70 max), render window culling (last 16 layers only), 2x DPR cap on high-DPI devices
- **Play limits**: Daily reset at 8 PM Chicago time, per-user locking prevents TOCTOU race conditions on play consumption

https://claude.ai/code/session_019141euMJU5TEhGPmLaYXgg