### PR TITLE
Fix tower block swing glitch and add game over close buttons

### DIFF
--- a/pages/admin/games.vue
+++ b/pages/admin/games.vue
@@ -7,9 +7,11 @@
     <div class="bg-white rounded-lg shadow-md max-w-2xl mx-auto">
       <!-- Tabs -->
       <div
+        ref="tabsScrollEl"
         class="border-b px-4 pt-4 overflow-x-auto no-scrollbar"
         role="tablist"
         aria-label="Game configuration sections"
+        @wheel="onTabsWheel"
       >
         <div class="flex gap-2 sm:gap-4 min-w-max">
           <button
@@ -986,6 +988,16 @@ const activeTab = ref('Global')
 async function switchTab(k) {
   activeTab.value = k
   if (k === 'TKO' && !tkoLoaded.value) await loadTkoEvents()
+}
+
+// Desktop mouse wheels only scroll vertically by default, so this tab strip (scrollbar
+// hidden for touch-friendly styling) would otherwise be unreachable without a trackpad.
+const tabsScrollEl = ref(null)
+function onTabsWheel(e) {
+  const el = tabsScrollEl.value
+  if (!el || el.scrollWidth <= el.clientWidth) return
+  el.scrollLeft += e.deltaY
+  e.preventDefault()
 }
 
 // ── Settings state ────────────────────────────

--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -92,6 +92,7 @@
     <Teleport to="body">
       <div v-if="uiState === 'gameover'" class="modal-backdrop" @click.self="uiState = 'start'">
         <div class="modal-card" role="dialog" aria-modal="true" aria-label="Game Over">
+          <button class="modal-close" type="button" @click="goToGamesHome" aria-label="Close and return to Games Home">&times;</button>
           <h2 class="modal-title">Game Over!</h2>
           <div class="modal-score-row">
             <span class="modal-score-label">Your Score</span>
@@ -835,6 +836,10 @@ function formatReset(isoString) {
   return new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' }).format(d)
 }
 
+function goToGamesHome() {
+  navigateTo('/newsite/games')
+}
+
 async function startGame() {
   if (starting.value) return
   starting.value = true
@@ -1270,6 +1275,7 @@ onUnmounted(() => {
 }
 
 .modal-card {
+  position: relative;
   background: rgba(10, 25, 55, 0.97);
   border: 1px solid rgba(255,255,255,0.14);
   border-radius: 20px;
@@ -1280,6 +1286,30 @@ onUnmounted(() => {
   overflow-y: auto;
   box-shadow: 0 16px 48px rgba(0,0,0,0.7);
   text-align: center;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.08);
+  color: rgba(255,255,255,0.7);
+  font-size: 1.4rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.modal-close:hover,
+.modal-close:focus-visible {
+  background: rgba(255,255,255,0.18);
+  color: #fff;
 }
 
 .modal-title {

--- a/pages/newsite/tower.vue
+++ b/pages/newsite/tower.vue
@@ -88,6 +88,7 @@
     <Teleport to="body">
       <div v-if="uiState === 'gameover'" class="modal-backdrop" @click.self="uiState = 'start'">
         <div class="modal-card" role="dialog" aria-modal="true" aria-label="Game Over">
+          <button class="modal-close" type="button" @click="goToGamesHome" aria-label="Close and return to Games Home">&times;</button>
           <h2 class="modal-title">{{ maxedOut ? 'Max Height Reached!' : 'Game Over!' }}</h2>
           <div class="modal-score-row">
             <span class="modal-score-label">Your Score</span>
@@ -236,7 +237,11 @@ function triangleWave(tSeconds, speed, amplitude, phaseOffsetSeconds) {
   let phase = ((tSeconds + phaseOffsetSeconds) % period + period) % period
   const quarter = period / 4
   if (phase < quarter) return (phase / quarter) * amplitude
-  if (phase < 3 * quarter) return amplitude - ((phase - quarter) / quarter) * amplitude * 2
+  // Middle leg spans 2*quarter (from +amplitude down to -amplitude), so the slope is
+  // amplitude/quarter, not 2*amplitude/quarter -- the old extra "* 2" here made the block
+  // swing past the board edge (up to 3x amplitude) before snapping back once phase crossed
+  // into the next leg, which is what caused the visible "pull back" glitch on new blocks.
+  if (phase < 3 * quarter) return amplitude - ((phase - quarter) / quarter) * amplitude
   return -amplitude + ((phase - 3 * quarter) / quarter) * amplitude
 }
 
@@ -502,6 +507,10 @@ function formatReset(isoString) {
   if (!isoString) return ''
   const d = new Date(isoString)
   return new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' }).format(d)
+}
+
+function goToGamesHome() {
+  navigateTo('/newsite/games')
 }
 
 async function startGame() {
@@ -912,6 +921,7 @@ onUnmounted(() => {
 }
 
 .modal-card {
+  position: relative;
   background: rgba(10, 25, 55, 0.97);
   border: 1px solid rgba(255,255,255,0.14);
   border-radius: 20px;
@@ -922,6 +932,30 @@ onUnmounted(() => {
   overflow-y: auto;
   box-shadow: 0 16px 48px rgba(0,0,0,0.7);
   text-align: center;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.08);
+  color: rgba(255,255,255,0.7);
+  font-size: 1.4rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.modal-close:hover,
+.modal-close:focus-visible {
+  background: rgba(255,255,255,0.18);
+  color: #fff;
 }
 
 .modal-title {

--- a/server/utils/towerStackEngine.js
+++ b/server/utils/towerStackEngine.js
@@ -71,7 +71,11 @@ function triangleWave(tSeconds, speed, amplitude, phaseOffsetSeconds) {
   let phase = ((tSeconds + phaseOffsetSeconds) % period + period) % period
   const quarter = period / 4
   if (phase < quarter) return (phase / quarter) * amplitude
-  if (phase < 3 * quarter) return amplitude - ((phase - quarter) / quarter) * amplitude * 2
+  // Middle leg spans 2*quarter (from +amplitude down to -amplitude), so the slope is
+  // amplitude/quarter, not 2*amplitude/quarter -- the old extra "* 2" here made the block
+  // swing past the board edge (up to 3x amplitude) before snapping back once phase crossed
+  // into the next leg, which is what caused the visible "pull back" glitch on new blocks.
+  if (phase < 3 * quarter) return amplitude - ((phase - quarter) / quarter) * amplitude
   return -amplitude + ((phase - 3 * quarter) / quarter) * amplitude
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a physics bug in the tower game's block movement and improves UX by adding close buttons to game over modals across multiple games.

## Key Changes

- **Fixed triangle wave calculation bug**: Removed the erroneous `* 2` multiplier in the middle leg of the `triangleWave` function that was causing blocks to swing past the board edge (up to 3x amplitude) before snapping back, creating a visible "pull back" glitch. The middle leg should have a slope of `amplitude/quarter`, not `2*amplitude/quarter`. This fix is applied in both `pages/newsite/tower.vue` and `server/utils/towerStackEngine.js`.

- **Added close buttons to game over modals**: Added a styled close button (×) in the top-right corner of game over modals in both `tower.vue` and `reorbitmatch.vue` that navigates back to the games home page. Includes proper accessibility attributes and hover/focus states.

- **Improved admin games tab navigation**: Added mouse wheel support to the horizontal tab strip in the admin games page so desktop users can scroll tabs without a trackpad, since the scrollbar is hidden for touch-friendly styling.

## Implementation Details

- The `goToGamesHome()` function was added to both game components to handle navigation back to `/newsite/games`
- Modal close buttons use a circular design with semi-transparent background and smooth transitions
- The modal card now uses `position: relative` to properly position the absolute-positioned close button
- Tab wheel scrolling converts vertical scroll events to horizontal scrolling and prevents default behavior

https://claude.ai/code/session_01ChxaPeQGnTztuTbPqnTo6n