### PR TITLE
Add cMart Sales admin feature + new-pack daily limit default

### DIFF
--- a/components/newsite/AdminManageSales.vue
+++ b/components/newsite/AdminManageSales.vue
@@ -1,0 +1,485 @@
+<template>
+  <div class="admin-manage-sales bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+
+      <div class="flex items-center justify-between mb-3">
+        <h1 class="text-base font-semibold">Manage Sales</h1>
+        <button
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
+          @click="openCreateModal"
+        >+ Create Sale</button>
+      </div>
+
+      <div v-if="loading" class="text-gray-500 py-6 text-center">Loading…</div>
+      <div v-else-if="!sales.length" class="text-gray-500 py-6 text-center">No sales yet. Create one to get started.</div>
+
+      <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+        <article v-for="sale in sales" :key="sale.id" class="bg-white border rounded-lg shadow p-2 flex flex-col gap-2">
+          <div class="flex items-start gap-2">
+            <img
+              v-if="sale.imagePath"
+              :src="sale.imagePath"
+              :alt="sale.name"
+              class="w-14 h-14 object-cover rounded border flex-shrink-0"
+            />
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-1.5 flex-wrap">
+                <span class="font-semibold text-xs truncate">{{ sale.name }}</span>
+                <span :class="statusBadgeClass(sale.status)">{{ statusLabel(sale.status) }}</span>
+              </div>
+              <div class="text-[10px] text-gray-500 mt-0.5">{{ sale.itemCount }} cToon{{ sale.itemCount === 1 ? '' : 's' }}</div>
+            </div>
+          </div>
+
+          <div class="text-[10px] text-gray-600 space-y-0.5">
+            <div><span class="text-gray-500">Start:</span> {{ formatCst(sale.startAt) }}</div>
+            <div><span class="text-gray-500">End:</span> {{ formatCst(sale.endAt) }}</div>
+          </div>
+
+          <div class="mt-auto flex items-center gap-1.5 pt-1">
+            <button class="flex-1 px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50" @click="openEditModal(sale)">Edit</button>
+            <button class="flex-1 px-2 py-1 text-[11px] border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="openDeleteConfirm(sale)">Delete</button>
+          </div>
+        </article>
+      </div>
+    </div>
+
+    <!-- ── Create / Edit modal ─────────────────────────────────────── -->
+    <div v-if="modalMode" class="fixed inset-0 z-50 flex items-center justify-center p-2">
+      <div class="absolute inset-0 bg-black/50" @click="!saving && closeModal()"></div>
+      <div class="relative bg-white w-full max-w-2xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+          <h3 class="text-sm font-semibold">{{ modalMode === 'create' ? 'Create Sale' : 'Edit Sale' }}</h3>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeModal" :disabled="saving">✕</button>
+        </div>
+
+        <div ref="modalBodyEl" class="overflow-y-auto flex-1 px-4 py-3 space-y-4">
+          <div class="grid sm:grid-cols-2 gap-3">
+            <div class="sm:col-span-2 flex flex-col gap-1">
+              <label class="text-xs font-medium">Sale name <span class="text-red-500">*</span></label>
+              <input v-model="form.name" type="text" placeholder="e.g. Summer Blowout" class="border rounded-md px-2 py-1.5 text-sm" />
+            </div>
+
+            <div class="sm:col-span-2 flex flex-col gap-1">
+              <label class="text-xs font-medium">Promo image (optional)</label>
+              <input ref="fileInputEl" type="file" accept="image/png,image/jpeg,image/gif,image/webp" class="text-xs" @change="onFile" />
+              <p class="text-[10px] text-gray-500">Wide image recommended (e.g. 1200×300) — it will be cropped to fit a banner.</p>
+              <img v-if="imagePreview" :src="imagePreview" class="mt-1 w-full max-h-32 object-cover rounded border" />
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Start (CST) <span class="text-red-500">*</span></label>
+              <input v-model="form.startAtLocal" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" />
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">End (CST) <span class="text-red-500">*</span></label>
+              <input v-model="form.endAtLocal" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" />
+            </div>
+            <p v-if="dateError" class="sm:col-span-2 text-[11px] text-red-600">{{ dateError }}</p>
+          </div>
+
+          <hr />
+
+          <div class="space-y-2">
+            <h4 class="text-xs font-semibold">cToons in this sale</h4>
+
+            <div class="relative cto-autocomplete">
+              <input
+                ref="searchInputEl"
+                v-model="search"
+                type="text"
+                placeholder="Search cToons…"
+                class="w-full border rounded-md px-2 py-1.5 text-sm"
+                @focus="onSearchFocus"
+                @keydown.down.prevent="highlightNext"
+                @keydown.up.prevent="highlightPrev"
+                @keydown.enter.prevent="chooseHighlighted"
+              />
+              <ul
+                v-if="suggestionsOpen && suggestions.length"
+                class="absolute z-20 mt-1 w-full overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg divide-y"
+                style="max-height: min(60vw, 40vh);"
+              >
+                <li
+                  v-for="(s, idx) in suggestions"
+                  :key="s.id"
+                  @mousedown.prevent="toggleSelect(s)"
+                  :class="['flex items-center gap-2 px-2 py-1.5 cursor-pointer', idx === highlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
+                >
+                  <img v-if="s.assetPath" :src="s.assetPath" class="w-7 h-7 object-cover rounded border flex-shrink-0" />
+                  <div class="min-w-0 flex-1">
+                    <p class="truncate font-medium flex items-center gap-1">
+                      <span class="truncate">{{ s.name }}</span>
+                      <span v-if="s.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Ed</span>
+                    </p>
+                    <p class="text-[10px] text-gray-500">{{ s.rarity }} · normal {{ (s.price ?? 0).toLocaleString() }} pts</p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <p v-if="!items.length" class="text-[11px] text-gray-500">No cToons selected yet.</p>
+
+            <div v-for="item in items" :key="item.ctoonId" class="border rounded-md p-2">
+              <div class="grid grid-cols-[auto_1fr_auto] items-center gap-2">
+                <img v-if="item.assetPath" :src="item.assetPath" class="w-8 h-8 object-cover rounded border flex-shrink-0" />
+                <div class="min-w-0 flex items-center gap-1">
+                  <span class="truncate font-medium text-xs">{{ item.name }}</span>
+                  <span v-if="item.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Ed</span>
+                </div>
+                <button type="button" class="text-red-700 text-[11px] hover:underline" @click="removeItem(item.ctoonId)">Remove</button>
+              </div>
+              <div class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
+                <label class="flex items-center gap-1">
+                  Sale price
+                  <input v-model.number="item.price" type="number" min="0" class="w-16 border rounded px-1 py-0.5 text-xs" />
+                </label>
+                <label class="flex items-center gap-1">
+                  Per-day limit
+                  <input v-model.number="item.perDayLimit" type="number" min="1" class="w-14 border rounded px-1 py-0.5 text-xs" />
+                </label>
+                <span class="text-gray-500">Normal: {{ (item.normalPrice ?? 0).toLocaleString() }} pts</span>
+              </div>
+            </div>
+          </div>
+
+          <p v-if="submitError" class="text-[11px] text-red-600">{{ submitError }}</p>
+        </div>
+
+        <div class="flex items-center justify-end gap-2 px-4 py-3 border-t flex-shrink-0">
+          <button class="px-3 py-1 text-sm border rounded-md" @click="closeModal" :disabled="saving">Cancel</button>
+          <button
+            class="px-3 py-1 text-sm rounded-md text-white"
+            :class="canSave ? 'bg-blue-600 hover:bg-blue-700' : 'bg-blue-300 cursor-not-allowed'"
+            :disabled="!canSave || saving"
+            @click="submit"
+          >{{ saving ? 'Saving…' : 'Save Sale' }}</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Delete confirmation modal ───────────────────────────────── -->
+    <div v-if="deleteTarget" class="fixed inset-0 z-50 flex items-center justify-center p-2">
+      <div class="absolute inset-0 bg-black/50" @click="!deleting && closeDeleteConfirm()"></div>
+      <div class="relative bg-white w-full max-w-md rounded-lg shadow-lg p-5">
+        <h3 class="text-sm font-semibold">Delete "{{ deleteTarget.name }}"?</h3>
+        <p class="mt-2 text-xs text-gray-600">This permanently removes the sale and its cToon price/limit overrides. This cannot be undone.</p>
+        <p v-if="deleteError" class="mt-2 text-xs text-red-600">{{ deleteError }}</p>
+        <div class="mt-4 flex items-center justify-end gap-2">
+          <button class="px-3 py-1 text-sm border rounded-md" @click="closeDeleteConfirm" :disabled="deleting">Cancel</button>
+          <button
+            class="px-3 py-1 text-sm rounded-md text-white bg-red-600 hover:bg-red-700 disabled:bg-red-300"
+            :disabled="deleting"
+            @click="confirmDelete"
+          >{{ deleting ? 'Deleting…' : 'Delete' }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+
+const sales = ref([])
+const loading = ref(true)
+const ctoonPool = ref([])
+
+async function loadSales() {
+  loading.value = true
+  try {
+    sales.value = await $fetch('/api/admin/sales')
+  } catch (e) {
+    console.error('Failed to load sales', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadCtoonPool() {
+  try {
+    ctoonPool.value = await $fetch('/api/admin/ctoon-pool')
+  } catch (e) {
+    console.error('Failed to load cToon pool', e)
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([loadSales(), loadCtoonPool()])
+})
+
+function formatCst(dt) {
+  if (!dt) return '—'
+  return new Date(dt).toLocaleString('en-US', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit'
+  }) + ' CST'
+}
+
+function statusLabel(status) {
+  if (status === 'active') return 'Active'
+  if (status === 'ended') return 'Ended'
+  return 'Upcoming'
+}
+function statusBadgeClass(status) {
+  const base = 'px-1.5 py-0 rounded text-[10px] font-medium border'
+  if (status === 'active') return `${base} bg-green-100 text-green-800 border-green-200`
+  if (status === 'ended') return `${base} bg-gray-100 text-gray-600 border-gray-300`
+  return `${base} bg-amber-100 text-amber-800 border-amber-200`
+}
+
+function utcToChicagoLocalInput(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago', hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'
+  })
+  const parts = Object.fromEntries(fmt.formatToParts(d).filter(p => p.type !== 'literal').map(p => [p.type, p.value]))
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}`
+}
+
+// ── Modal state ──────────────────────────────────────────────
+const modalMode = ref(null) // 'create' | 'edit'
+const editingSaleId = ref(null)
+const form = ref({ name: '', startAtLocal: '', endAtLocal: '' })
+const items = ref([])
+const imageFile = ref(null)
+const imagePreview = ref('')
+const fileInputEl = ref(null)
+const modalBodyEl = ref(null)
+const saving = ref(false)
+const submitError = ref('')
+
+function resetForm() {
+  form.value = { name: '', startAtLocal: '', endAtLocal: '' }
+  items.value = []
+  imageFile.value = null
+  imagePreview.value = ''
+  submitError.value = ''
+}
+
+function openCreateModal() {
+  resetForm()
+  modalMode.value = 'create'
+  editingSaleId.value = null
+}
+
+async function openEditModal(sale) {
+  resetForm()
+  modalMode.value = 'edit'
+  editingSaleId.value = sale.id
+  try {
+    const full = await $fetch(`/api/admin/sales/${sale.id}`)
+    form.value.name = full.name
+    form.value.startAtLocal = utcToChicagoLocalInput(full.startAt)
+    form.value.endAtLocal = utcToChicagoLocalInput(full.endAt)
+    imagePreview.value = full.imagePath || ''
+    items.value = full.items.map(i => ({
+      ctoonId: i.ctoon.id,
+      name: i.ctoon.name,
+      assetPath: i.ctoon.assetPath,
+      rarity: i.ctoon.rarity,
+      isSecondEdition: i.ctoon.isSecondEdition,
+      normalPrice: i.ctoon.price,
+      price: i.price,
+      perDayLimit: i.perDayLimit
+    }))
+  } catch (e) {
+    submitError.value = e?.data?.statusMessage || e?.message || 'Failed to load sale details.'
+  }
+}
+
+function closeModal() {
+  modalMode.value = null
+  editingSaleId.value = null
+  resetForm()
+}
+
+function onFile(e) {
+  const file = e.target.files[0]
+  if (!file) return
+  const allowed = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+  if (!allowed.includes(file.type)) {
+    alert('Only PNG, JPEG, GIF, or WEBP images are allowed.')
+    if (fileInputEl.value) fileInputEl.value.value = ''
+    return
+  }
+  if (file.size > 5 * 1024 * 1024) {
+    alert('Image must be 5MB or smaller.')
+    if (fileInputEl.value) fileInputEl.value.value = ''
+    return
+  }
+  imageFile.value = file
+  imagePreview.value = URL.createObjectURL(file)
+}
+
+// ── cToon search/select ──────────────────────────────────────
+const search = ref('')
+const searchInputEl = ref(null)
+const suggestionsOpen = ref(false)
+const highlighted = ref(-1)
+
+const selectedIds = computed(() => new Set(items.value.map(i => i.ctoonId)))
+
+const suggestions = computed(() => {
+  const term = search.value.toLowerCase().trim()
+  let list = ctoonPool.value.filter(c => !selectedIds.value.has(c.id))
+  if (term) list = list.filter(c => c.name.toLowerCase().includes(term))
+  return list.slice(0, 50)
+})
+
+function onSearchFocus() {
+  suggestionsOpen.value = true
+  if (process.client) {
+    nextTick(() => {
+      searchInputEl.value?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    })
+  }
+}
+watch(search, () => { suggestionsOpen.value = true })
+
+function highlightNext() {
+  if (!suggestions.value.length) return
+  highlighted.value = (highlighted.value + 1) % suggestions.value.length
+}
+function highlightPrev() {
+  if (!suggestions.value.length) return
+  highlighted.value = (highlighted.value - 1 + suggestions.value.length) % suggestions.value.length
+}
+function chooseHighlighted() {
+  if (highlighted.value >= 0) toggleSelect(suggestions.value[highlighted.value])
+}
+function toggleSelect(c) {
+  items.value.push({
+    ctoonId: c.id,
+    name: c.name,
+    assetPath: c.assetPath,
+    rarity: c.rarity,
+    isSecondEdition: c.isSecondEdition,
+    normalPrice: c.price,
+    price: c.price ?? 0,
+    perDayLimit: 1
+  })
+  search.value = ''
+  suggestionsOpen.value = false
+  highlighted.value = -1
+  searchInputEl.value?.blur()
+}
+function removeItem(ctoonId) {
+  items.value = items.value.filter(i => i.ctoonId !== ctoonId)
+}
+
+function handleOutsideClick(e) {
+  if (!e.target.closest('.cto-autocomplete')) suggestionsOpen.value = false
+}
+onMounted(() => { if (process.client) window.addEventListener('click', handleOutsideClick) })
+onBeforeUnmount(() => { if (process.client) window.removeEventListener('click', handleOutsideClick) })
+
+// ── Validation ───────────────────────────────────────────────
+const dateError = computed(() => {
+  if (!form.value.startAtLocal || !form.value.endAtLocal) return ''
+  if (form.value.endAtLocal <= form.value.startAtLocal) return 'End time must be after start time.'
+  return ''
+})
+
+const itemsValid = computed(() => items.value.every(i =>
+  Number.isInteger(Number(i.price)) && Number(i.price) >= 0 &&
+  Number.isInteger(Number(i.perDayLimit)) && Number(i.perDayLimit) >= 1
+))
+
+const canSave = computed(() =>
+  form.value.name.trim().length > 0 &&
+  !!form.value.startAtLocal && !!form.value.endAtLocal &&
+  !dateError.value &&
+  items.value.length > 0 &&
+  itemsValid.value
+)
+
+// ── Submit ───────────────────────────────────────────────────
+async function submit() {
+  if (!canSave.value || saving.value) return
+  saving.value = true
+  submitError.value = ''
+
+  const meta = {
+    name: form.value.name.trim(),
+    startAtLocal: form.value.startAtLocal,
+    endAtLocal: form.value.endAtLocal,
+    items: items.value.map(i => ({ ctoonId: i.ctoonId, price: Number(i.price), perDayLimit: Number(i.perDayLimit) }))
+  }
+
+  const body = new FormData()
+  body.append('meta', JSON.stringify(meta))
+  if (imageFile.value) body.append('image', imageFile.value)
+
+  try {
+    if (modalMode.value === 'create') {
+      await $fetch('/api/admin/sales', { method: 'POST', body })
+    } else {
+      await $fetch(`/api/admin/sales/${editingSaleId.value}`, { method: 'PATCH', body })
+    }
+    closeModal()
+    await loadSales()
+  } catch (e) {
+    submitError.value = e?.data?.statusMessage || e?.message || 'Failed to save sale.'
+  } finally {
+    saving.value = false
+  }
+}
+
+// ── Delete ───────────────────────────────────────────────────
+const deleteTarget = ref(null)
+const deleting = ref(false)
+const deleteError = ref('')
+
+function openDeleteConfirm(sale) {
+  deleteTarget.value = sale
+  deleteError.value = ''
+}
+function closeDeleteConfirm() {
+  deleteTarget.value = null
+  deleteError.value = ''
+  deleting.value = false
+}
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  deleteError.value = ''
+  try {
+    await $fetch(`/api/admin/sales/${deleteTarget.value.id}`, { method: 'DELETE' })
+    closeDeleteConfirm()
+    await loadSales()
+  } catch (e) {
+    deleteError.value = e?.data?.statusMessage || e?.message || 'Failed to delete sale.'
+    deleting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.admin-manage-sales {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+}
+
+.edition-badge {
+  display: inline-block;
+  flex-shrink: 0;
+  font-size: 0.55rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 5px;
+  border-radius: 10px;
+  background: #7c3aed;
+  color: #fff;
+}
+
+.edition-badge-2nd {
+  background: #7c3aed;
+  color: #fff;
+}
+</style>

--- a/components/newsite/AdminNav.vue
+++ b/components/newsite/AdminNav.vue
@@ -50,7 +50,7 @@ const menus = [
       { id: 'analytics',     label: 'Analytics',    to: '/newsite/admin' },
       { id: 'manageUsers',   label: 'Manage Users', to: '/newsite/admin/manageUsers' },
       { id: 'czoneContest',  label: 'cZone Contest', to: '/newsite/admin/czoneContest' },
-      { id: 'core-placeholder-2', label: 'Placeholder', to: null },
+      { id: 'manageSales',   label: 'Manage Sales', to: '/newsite/admin/manageSales' },
       { id: 'core-placeholder-3', label: 'Placeholder', to: null },
       { id: 'core-placeholder-4', label: 'Placeholder', to: null },
       { id: 'core-placeholder-5', label: 'Placeholder', to: null },

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -102,6 +102,12 @@
       </div>
     </Teleport>
 
+    <!-- ── Section nav (moved here from the sidebar) ───────────────── -->
+    <div class="cm-nav">
+      <GreenButton :active="cmartTab === 'ctoons'" @click="cmartTab = 'ctoons'">cToons</GreenButton>
+      <GreenButton :active="cmartTab === 'packs'" @click="cmartTab = 'packs'">Packs</GreenButton>
+    </div>
+
     <!-- ── Header bar ────────────────────────────────────────────── -->
     <div class="cmart-header">Cartoon ReOrbit cMart</div>
     <div v-if="cmartHalfPriceEnabled" class="cmart-sale-banner">🏷️ 50% Off Sale! All prices are half price.</div>
@@ -116,8 +122,70 @@
           <template #footer-right><div class="skel-line skel-btn" /></template>
         </ShortCard>
       </template>
-      <div v-else-if="!ctoons.length" class="cmart-status">No cToons available.</div>
       <template v-else>
+        <!-- ── Active Sale showcase ─────────────────────────────── -->
+        <div v-if="activeSale" class="sale-showcase">
+          <div class="sale-banner">
+            <img v-if="activeSale.imagePath" :src="activeSale.imagePath" :alt="activeSale.name" class="sale-banner-img" />
+            <div class="sale-banner-title">🔥 {{ activeSale.name }}</div>
+          </div>
+          <div class="sale-grid">
+            <ShortCard
+              v-for="item in activeSale.items"
+              :key="'sale-' + item.ctoon.id"
+              :style="isSaleItemSoldOut(item)
+                ? { '--footer-left-width': '100%', '--footer-right-width': '0%' }
+                : {}"
+            >
+              <template #header>
+                <div class="card-header-wrap" @click.stop="openInfo(item.ctoon)">
+                  <img
+                    v-if="item.ctoon.assetPath"
+                    :src="item.ctoon.assetPath"
+                    :alt="item.ctoon.name"
+                    class="card-img"
+                  />
+                  <SecondEditionOverlay :ctoon="item.ctoon" />
+                  <span
+                    class="owned-badge"
+                    :class="originalOwnedSet.has(item.ctoon.id) ? 'owned-badge--owned' : 'owned-badge--unowned'"
+                  >{{ originalOwnedSet.has(item.ctoon.id) ? 'Owned' : 'Unowned' }}</span>
+                </div>
+              </template>
+              <template #middle>
+                <div class="card-middle-row">
+                  <span class="card-name">{{ item.ctoon.name }}</span>
+                  <span
+                    class="rarity-badge"
+                    :style="{ background: rarityInfo(item.ctoon.rarity).bg, color: rarityInfo(item.ctoon.rarity).fg }"
+                    :title="item.ctoon.rarity"
+                  >{{ rarityInfo(item.ctoon.rarity).label }}</span>
+                </div>
+              </template>
+              <template #footer-left>
+                <span v-if="isSaleItemSoldOut(item)" class="card-sold-out">Sold Out</span>
+                <span v-else class="card-price sale-price-stack">
+                  <span class="sale-price-now">{{ item.price.toLocaleString() }} pts</span>
+                  <span v-if="item.price !== item.ctoon.price" class="pack-price-original">{{ item.ctoon.price.toLocaleString() }}</span>
+                </span>
+              </template>
+              <template #footer-right>
+                <GreenButton
+                  v-if="!isSaleItemSoldOut(item)"
+                  class="card-buy"
+                  :disabled="buyingIds.includes(item.ctoon.id)"
+                  @click="buy(item.ctoon, item.price)"
+                >
+                  {{ buyingIds.includes(item.ctoon.id) ? '…' : 'Buy' }}
+                </GreenButton>
+              </template>
+            </ShortCard>
+          </div>
+          <div class="sale-divider">More cToons</div>
+        </div>
+      </template>
+      <div v-if="!loading && !ctoons.length" class="cmart-status">No cToons available.</div>
+      <template v-else-if="!loading">
         <ShortCard
           v-for="c in ctoons"
           :key="c.id"
@@ -344,10 +412,27 @@ async function openPackPreview(pack) {
 
 const originalOwnedSet = computed(() => new Set(ownedCtoonIds.value))
 
+// ── Active Sale showcase ─────────────────────────────────────
+const activeSale = ref(null)
+
+function isSaleItemSoldOut(item) {
+  const c = item.ctoon
+  return c.quantity != null && c.totalMinted >= c.quantity
+}
+
+async function loadActiveSale() {
+  try {
+    activeSale.value = await $fetch('/api/cmart/active-sale')
+  } catch (err) {
+    console.error('Cmart: failed to load active sale', err)
+  }
+}
+
 // ── Reactive clock for countdowns ────────────────────────────
 const nowTs = ref(Date.now())
 let _tick = null
 let _refreshTimer = null
+let _saleRefreshTimer = null
 
 // Only Defined Number Limit cToons have a 2-phase cap guard.
 // Returns the currently-active cap: initialCap before finalReleaseAt, full
@@ -532,7 +617,8 @@ onMounted(async () => {
   try {
     const [ctoonRes, upgradesRes] = await Promise.all([
       $fetch('/api/cmart'),
-      $fetch('/api/cmart/upgrades-config').catch(() => ({}))
+      $fetch('/api/cmart/upgrades-config').catch(() => ({})),
+      loadActiveSale()
     ])
     allCtoons.value = ctoonRes
     cmartHalfPriceEnabled.value = upgradesRes?.cmartHalfPriceEnabled === true
@@ -545,11 +631,21 @@ onMounted(async () => {
   await fetchPacks()
   await loadOwnedCtoonIds()
   _tick = setInterval(() => { nowTs.value = Date.now() }, 1000)
+  // The Sale's start/end boundary isn't tied to any cToon's own release timer,
+  // so it needs its own light poll (separate from scheduleNextRefresh) to pick
+  // up a sale starting/ending mid-session.
+  _saleRefreshTimer = setInterval(async () => {
+    await loadActiveSale()
+    try {
+      allCtoons.value = await $fetch('/api/cmart')
+    } catch {}
+  }, 60000)
 })
 
 onUnmounted(() => {
   if (_tick) clearInterval(_tick)
   if (_refreshTimer) clearTimeout(_refreshTimer)
+  if (_saleRefreshTimer) clearInterval(_saleRefreshTimer)
 })
 
 function describePurchaseError(err, kind = 'cToon') {
@@ -593,9 +689,12 @@ function describePurchaseError(err, kind = 'cToon') {
   return raw || `Couldn't complete the ${kind} purchase. Please try again.`
 }
 
-async function buy(ctoon) {
+async function buy(ctoon, priceOverride = null) {
   if (buyingIds.value.includes(ctoon.id)) return
-  const price = displayPrice(ctoon.price)
+  // priceOverride is used for Sale showcase purchases (the sale price, not the
+  // normal displayPrice()/half-price calculation) — the server always resolves
+  // the authoritative charge itself regardless of what's sent here.
+  const price = priceOverride != null ? priceOverride : displayPrice(ctoon.price)
   if (user.value && user.value.points < price) {
     showToast(`Not enough points — this cToon costs ${price.toLocaleString()} pts.`, 'error')
     return
@@ -611,7 +710,8 @@ async function buy(ctoon) {
     const [ctoonRes] = await Promise.all([
       $fetch('/api/cmart'),
       fetchSelf({ force: true }),
-      loadOwnedCtoonIds()
+      loadOwnedCtoonIds(),
+      loadActiveSale()
     ])
     allCtoons.value = ctoonRes
     scheduleNextRefresh()
@@ -703,6 +803,16 @@ async function closeOverlay() {
   --img-scale: 0.7;
 }
 
+.cm-nav {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  padding: 6px 6px 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  flex-shrink: 0;
+}
+
 .cmart-header {
   flex-shrink: 0;
   width: 100%;
@@ -716,6 +826,72 @@ async function closeOverlay() {
   color: #ffffff;
   background: var(--OrbitLightBlue);
   box-sizing: border-box;
+}
+
+/* ── Sale showcase ───────────────────────────────────────────── */
+.sale-showcase {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: 2px solid var(--OrbitLightBlue, #3399CC);
+}
+
+.sale-banner {
+  position: relative;
+  width: 100%;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--OrbitDarkBlue, #336699);
+}
+
+.sale-banner-img {
+  display: block;
+  width: 100%;
+  max-height: 160px;
+  object-fit: cover;
+}
+
+.sale-banner-title {
+  padding: 4px 8px;
+  text-align: center;
+  font-size: 1rem;
+  font-weight: bold;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.sale-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-auto-rows: var(--shortcard-height);
+  gap: 4px;
+}
+
+.sale-divider {
+  margin-top: 6px;
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sale-price-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.15;
+}
+
+.sale-price-now {
+  font-size: 0.75rem;
+  color: #ffd700;
+  white-space: nowrap;
 }
 
 .cmart-sale-banner {
@@ -752,7 +928,9 @@ async function closeOverlay() {
   scrollbar-color: var(--OrbitLightBlue) transparent;
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  grid-auto-rows: var(--shortcard-height);
+  /* minmax (not a fixed value) so the full-width sale-showcase row can grow to
+     fit its content while ordinary card rows still size to --shortcard-height. */
+  grid-auto-rows: minmax(var(--shortcard-height), auto);
   grid-auto-flow: row;
   gap: 4px;
   padding: 4px;
@@ -1173,6 +1351,25 @@ async function closeOverlay() {
 
   :global(.pack-reveal-grid) {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .sale-grid {
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: auto;
+  }
+
+  .sale-grid :deep(.sc) {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 3 / 4;
+  }
+
+  .sale-banner-img {
+    max-height: 100px;
+  }
+
+  .sale-banner-title {
+    font-size: 0.85rem;
   }
 }
 

--- a/components/newsite/CmartSidebar.vue
+++ b/components/newsite/CmartSidebar.vue
@@ -1,19 +1,6 @@
 <template>
-  <div class="cmart-sidebar-middle">
-    <div class="cmart-tab-bar">
-      <button
-        class="cmart-tab"
-        :class="{ active: cmartTab === 'ctoons' }"
-        @click="cmartTab = 'ctoons'"
-      >cToons</button>
-      <button
-        class="cmart-tab"
-        :class="{ active: cmartTab === 'packs' }"
-        @click="cmartTab = 'packs'"
-      >Packs</button>
-    </div>
+  <div v-if="cmartTab === 'ctoons'" class="cmart-sidebar-middle">
     <CtoonFilter
-      v-if="cmartTab === 'ctoons'"
       :show-hide-unavailable="true"
       :show-common-filters="true"
       :sort-options="cmartSortOptions"
@@ -37,37 +24,5 @@ const cmartSortOptions = [
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-}
-
-.cmart-tab-bar {
-  display: flex;
-  flex-direction: row;
-  flex-shrink: 0;
-  width: 100%;
-}
-
-.cmart-tab {
-  flex: 1;
-  padding: 5px 4px;
-  font-size: 0.75rem;
-  font-weight: bold;
-  font-family: inherit;
-  color: rgba(255, 255, 255, 0.55);
-  background: rgba(0, 0, 0, 0.2);
-  border: none;
-  border-bottom: 2px solid transparent;
-  cursor: pointer;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
-}
-
-.cmart-tab:hover {
-  color: rgba(255, 255, 255, 0.85);
-  background: rgba(0, 0, 0, 0.15);
-}
-
-.cmart-tab.active {
-  color: #ffffff;
-  background: rgba(0, 0, 0, 0.1);
-  border-bottom-color: var(--OrbitLightBlue, #3399CC);
 }
 </style>

--- a/pages/admin/new-pack.vue
+++ b/pages/admin/new-pack.vue
@@ -447,7 +447,7 @@ const inCmart     = ref(false)
 const scheduledAtLocal    = ref('')
 const scheduledOffAtLocal = ref('')
 const sellOutBehavior     = ref('REMOVE_ON_ANY_RARITY_EMPTY')
-const dailyPurchaseLimit  = ref(null)
+const dailyPurchaseLimit  = ref(5)
 const maxBuysPerUser      = ref(null)
 const globalDefaultMaxBuys = ref(null)
 

--- a/pages/newsite/admin/[[section]].vue
+++ b/pages/newsite/admin/[[section]].vue
@@ -6,6 +6,7 @@
     <div class="newsite-admin-body">
       <AdminAnalytics v-if="!section" />
       <AdminManageUsers v-else-if="section === 'manageUsers'" />
+      <AdminManageSales v-else-if="section === 'manageSales'" />
       <AdminCheatFinder v-else-if="section === 'cheatFinder'" />
       <AdminDeviceFingerprintLogs v-else-if="section === 'deviceFingerprints'" />
       <AdminAuthLogs v-else-if="section === 'authLogs'" />

--- a/prisma/migrations/20260710000000_add_sales/migration.sql
+++ b/prisma/migrations/20260710000000_add_sales/migration.sql
@@ -1,0 +1,76 @@
+-- AlterTable
+ALTER TABLE "CmartPurchaseLog" ADD COLUMN     "saleId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Sale" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "imagePath" TEXT,
+    "startAt" TIMESTAMP(3) NOT NULL,
+    "endAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdById" TEXT NOT NULL,
+
+    CONSTRAINT "Sale_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SaleCtoon" (
+    "id" TEXT NOT NULL,
+    "saleId" TEXT NOT NULL,
+    "ctoonId" TEXT NOT NULL,
+    "price" INTEGER NOT NULL,
+    "perDayLimit" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SaleCtoon_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SaleDailyPurchase" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "ctoonId" TEXT NOT NULL,
+    "saleId" TEXT NOT NULL,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "SaleDailyPurchase_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Sale_startAt_endAt_idx" ON "Sale"("startAt", "endAt");
+
+-- CreateIndex
+CREATE INDEX "SaleCtoon_ctoonId_idx" ON "SaleCtoon"("ctoonId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SaleCtoon_saleId_ctoonId_key" ON "SaleCtoon"("saleId", "ctoonId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SaleDailyPurchase_userId_ctoonId_saleId_windowStart_key" ON "SaleDailyPurchase"("userId", "ctoonId", "saleId", "windowStart");
+
+-- CreateIndex
+CREATE INDEX "CmartPurchaseLog_userId_ctoonId_saleId_createdAt_idx" ON "CmartPurchaseLog"("userId", "ctoonId", "saleId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "CmartPurchaseLog" ADD CONSTRAINT "CmartPurchaseLog_saleId_fkey" FOREIGN KEY ("saleId") REFERENCES "Sale"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Sale" ADD CONSTRAINT "Sale_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SaleCtoon" ADD CONSTRAINT "SaleCtoon_saleId_fkey" FOREIGN KEY ("saleId") REFERENCES "Sale"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SaleCtoon" ADD CONSTRAINT "SaleCtoon_ctoonId_fkey" FOREIGN KEY ("ctoonId") REFERENCES "Ctoon"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SaleDailyPurchase" ADD CONSTRAINT "SaleDailyPurchase_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SaleDailyPurchase" ADD CONSTRAINT "SaleDailyPurchase_ctoonId_fkey" FOREIGN KEY ("ctoonId") REFERENCES "Ctoon"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SaleDailyPurchase" ADD CONSTRAINT "SaleDailyPurchase_saleId_fkey" FOREIGN KEY ("saleId") REFERENCES "Sale"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -294,6 +294,8 @@ model Ctoon {
   cZoneSearchAppearances CZoneSearchAppearance[]
   cZoneSearchCaptures   CZoneSearchCapture[]
   cmartPurchaseLogs     CmartPurchaseLog[]
+  saleItems             SaleCtoon[]
+  saleDailyPurchases    SaleDailyPurchase[]
 
   @@index([isSecondEdition])
   @@index([name])
@@ -444,6 +446,8 @@ model User {
   adImagesCreated          AdImage[]                   @relation("AdImagesCreatedBy")
   winballGrandPrizeCreated WinballGrandPrizeSchedule[] @relation("WinballGrandPrizeCreatedBy")
   announcementsCreated     Announcement[]              @relation("AnnouncementsCreatedBy")
+  salesCreated             Sale[]                      @relation("SaleCreatedBy")
+  saleDailyPurchases       SaleDailyPurchase[]
   // Ban notes relations
   banNotes                 UserBanNote[]               @relation("BanNoteUser")
   banNotesAuthored         UserBanNote[]               @relation("BanNoteAdmin")
@@ -2493,14 +2497,70 @@ model CmartPurchaseLog {
   id        String   @id @default(uuid())
   userId    String
   ctoonId   String
+  saleId    String?
   createdAt DateTime @default(now())
 
   user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
   ctoon Ctoon @relation(fields: [ctoonId], references: [id], onDelete: Cascade)
+  sale  Sale? @relation(fields: [saleId], references: [id], onDelete: SetNull)
 
   @@index([userId, createdAt])
   @@index([ctoonId, createdAt])
   @@index([createdAt])
+  @@index([userId, ctoonId, saleId, createdAt])
+}
+
+// ── cMart Sales ──────────────────────────────────────────────────────────
+
+model Sale {
+  id          String   @id @default(uuid())
+  name        String
+  imagePath   String?
+  startAt     DateTime
+  endAt       DateTime
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  createdById String
+
+  createdBy      User                @relation("SaleCreatedBy", fields: [createdById], references: [id])
+  items          SaleCtoon[]
+  purchaseLogs   CmartPurchaseLog[]
+  dailyPurchases SaleDailyPurchase[]
+
+  @@index([startAt, endAt])
+}
+
+model SaleCtoon {
+  id          String   @id @default(uuid())
+  saleId      String
+  ctoonId     String
+  price       Int
+  perDayLimit Int
+  createdAt   DateTime @default(now())
+
+  sale  Sale  @relation(fields: [saleId], references: [id], onDelete: Cascade)
+  ctoon Ctoon @relation(fields: [ctoonId], references: [id], onDelete: Cascade)
+
+  @@unique([saleId, ctoonId])
+  @@index([ctoonId])
+}
+
+// Atomic per-user/per-cToon/per-sale/per-day purchase counter, used the same
+// way Ctoon.totalMinted is: increment-then-check inside a transaction so the
+// row lock serializes concurrent buyers instead of racing on a count() read.
+model SaleDailyPurchase {
+  id          String   @id @default(uuid())
+  userId      String
+  ctoonId     String
+  saleId      String
+  windowStart DateTime
+  count       Int      @default(0)
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  ctoon Ctoon @relation(fields: [ctoonId], references: [id], onDelete: Cascade)
+  sale  Sale  @relation(fields: [saleId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, ctoonId, saleId, windowStart])
 }
 
 // ── Survey Answers (identity signal + 3000-point reward) ──────────────────────

--- a/server/api/admin/ctoon-pool.get.js
+++ b/server/api/admin/ctoon-pool.get.js
@@ -47,6 +47,7 @@ export default defineEventHandler(async (event) => {
       initialQuantity: true,
       inCmart: true,
       isSecondEdition: true,
+      price: true,
       _count: { select: { owners: true } } // minted so far
     }
   })

--- a/server/api/admin/sales.get.js
+++ b/server/api/admin/sales.get.js
@@ -1,0 +1,27 @@
+// GET /api/admin/sales — list all Sales with item counts + computed status.
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+async function assertAdmin(event) {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  if (!me.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+}
+
+export default defineEventHandler(async (event) => {
+  await assertAdmin(event)
+
+  const now = new Date()
+  const sales = await db.sale.findMany({
+    orderBy: { startAt: 'desc' },
+    include: { _count: { select: { items: true } } }
+  })
+
+  return sales.map(({ _count, ...sale }) => {
+    let status = 'upcoming'
+    if (now >= sale.startAt && now <= sale.endAt) status = 'active'
+    else if (now > sale.endAt) status = 'ended'
+    return { ...sale, itemCount: _count.items, status }
+  })
+})

--- a/server/api/admin/sales.post.js
+++ b/server/api/admin/sales.post.js
@@ -1,0 +1,124 @@
+// POST /api/admin/sales
+// Creates a Sale, optionally saves a promo image to /public/sales/, and
+// records the selected cToons with their sale price + per-day limit.
+// Accepts multipart/form-data with:
+//   • field "meta"  – JSON string { name, startAtLocal, endAtLocal, items: [{ctoonId,price,perDayLimit}] }
+//   • field "image" – optional PNG/JPEG/GIF/WEBP file
+
+import {
+  defineEventHandler,
+  readMultipartFormData,
+  getRequestHeader,
+  createError
+} from 'h3'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { validateSaleMeta, parseSaleWindow } from '@/server/utils/saleValidation'
+import { assertNoSaleOverlap } from '@/server/utils/saleOverlap'
+import { MAX_IMAGE_BYTES, sniffImageType, sanitizeFilename } from '@/server/utils/imageUploadValidation'
+import { clearActiveSaleCache } from '@/server/utils/activeSaleCache'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const baseDir = process.env.NODE_ENV === 'production'
+  ? join(__dirname, '..', '..', '..')
+  : process.cwd()
+
+const ALLOWED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+
+async function assertAdmin(event) {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  if (!me.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  return me
+}
+
+export default defineEventHandler(async (event) => {
+  const me = await assertAdmin(event)
+
+  const parts = await readMultipartFormData(event)
+  let imagePart = null, metaPart = null
+  for (const p of parts) {
+    if (p.filename) imagePart = p
+    else if (p.name === 'meta') metaPart = p
+  }
+  if (!metaPart) throw createError({ statusCode: 400, statusMessage: 'Missing meta field' })
+
+  let meta
+  try { meta = JSON.parse(metaPart.data.toString()) }
+  catch { throw createError({ statusCode: 400, statusMessage: 'meta must be valid JSON' }) }
+
+  validateSaleMeta(meta)
+  const { startAt, endAt } = parseSaleWindow(meta)
+
+  let imagePath = null
+  if (imagePart) {
+    if (imagePart.data.length > MAX_IMAGE_BYTES) {
+      throw createError({ statusCode: 400, statusMessage: 'Image must be 5MB or smaller.' })
+    }
+    if (!ALLOWED_IMAGE_TYPES.includes(imagePart.type)) {
+      throw createError({ statusCode: 400, statusMessage: 'Only PNG, JPEG, GIF, or WEBP images allowed.' })
+    }
+    if (!sniffImageType(imagePart.data)) {
+      throw createError({ statusCode: 400, statusMessage: 'File does not look like a valid image.' })
+    }
+
+    const uploadDir = process.env.NODE_ENV === 'production'
+      ? join(baseDir, 'cartoon-reorbit-images', 'sales')
+      : join(baseDir, 'public', 'sales')
+    await mkdir(uploadDir, { recursive: true })
+    const filename = `${Date.now()}_${sanitizeFilename(imagePart.filename)}`
+    await writeFile(join(uploadDir, filename), imagePart.data)
+    imagePath = process.env.NODE_ENV === 'production'
+      ? `/images/sales/${filename}`
+      : `/sales/${filename}`
+  }
+
+  const ctoonIds = meta.items.map(i => i.ctoonId)
+
+  const sale = await db.$transaction(async (tx) => {
+    await assertNoSaleOverlap(tx, { ctoonIds, startAt, endAt })
+
+    const created = await tx.sale.create({
+      data: {
+        name: meta.name.trim(),
+        imagePath,
+        startAt,
+        endAt,
+        createdById: me.id
+      }
+    })
+
+    await tx.saleCtoon.createMany({
+      data: meta.items.map(i => ({
+        saleId: created.id,
+        ctoonId: i.ctoonId,
+        price: Number(i.price),
+        perDayLimit: Number(i.perDayLimit)
+      }))
+    })
+
+    await logAdminChange(tx, {
+      userId: me.id,
+      area: `Sale:${created.id}`,
+      key: 'create',
+      prevValue: null,
+      newValue: {
+        name: created.name,
+        startAt: created.startAt,
+        endAt: created.endAt,
+        items: meta.items
+      }
+    })
+
+    return created
+  })
+
+  clearActiveSaleCache()
+
+  return { id: sale.id }
+})

--- a/server/api/admin/sales/[id].delete.js
+++ b/server/api/admin/sales/[id].delete.js
@@ -1,0 +1,44 @@
+// DELETE /api/admin/sales/:id
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { clearActiveSaleCache } from '@/server/utils/activeSaleCache'
+
+async function assertAdmin(event) {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  if (!me.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  return me
+}
+
+export default defineEventHandler(async (event) => {
+  const me = await assertAdmin(event)
+  const id = event.context.params.id
+
+  const existing = await db.sale.findUnique({
+    where: { id },
+    include: { items: { select: { ctoonId: true, price: true, perDayLimit: true } } }
+  })
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Sale not found' })
+
+  await db.$transaction(async (tx) => {
+    await tx.sale.delete({ where: { id } })
+    await logAdminChange(tx, {
+      userId: me.id,
+      area: `Sale:${id}`,
+      key: 'delete',
+      prevValue: {
+        name: existing.name,
+        startAt: existing.startAt,
+        endAt: existing.endAt,
+        items: existing.items
+      },
+      newValue: null
+    })
+  })
+
+  clearActiveSaleCache()
+
+  return { success: true }
+})

--- a/server/api/admin/sales/[id].get.js
+++ b/server/api/admin/sales/[id].get.js
@@ -1,0 +1,36 @@
+// GET /api/admin/sales/:id — full detail incl. items, for the edit modal.
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+async function assertAdmin(event) {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  if (!me.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+}
+
+export default defineEventHandler(async (event) => {
+  await assertAdmin(event)
+
+  const id = event.context.params.id
+  const sale = await db.sale.findUnique({
+    where: { id },
+    include: {
+      items: {
+        include: {
+          ctoon: {
+            select: { id: true, name: true, assetPath: true, rarity: true, price: true, isSecondEdition: true }
+          }
+        }
+      }
+    }
+  })
+  if (!sale) throw createError({ statusCode: 404, statusMessage: 'Sale not found' })
+
+  const now = new Date()
+  let status = 'upcoming'
+  if (now >= sale.startAt && now <= sale.endAt) status = 'active'
+  else if (now > sale.endAt) status = 'ended'
+
+  return { ...sale, status }
+})

--- a/server/api/admin/sales/[id].patch.js
+++ b/server/api/admin/sales/[id].patch.js
@@ -1,0 +1,135 @@
+// PATCH /api/admin/sales/:id
+// Same payload shape as POST /api/admin/sales; image is optional (omit to
+// keep the existing one). Item rows are replaced wholesale (delete+recreate)
+// since diffing a composite list isn't worth the complexity here.
+
+import {
+  defineEventHandler,
+  readMultipartFormData,
+  getRequestHeader,
+  createError
+} from 'h3'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { validateSaleMeta, parseSaleWindow } from '@/server/utils/saleValidation'
+import { assertNoSaleOverlap } from '@/server/utils/saleOverlap'
+import { MAX_IMAGE_BYTES, sniffImageType, sanitizeFilename } from '@/server/utils/imageUploadValidation'
+import { clearActiveSaleCache } from '@/server/utils/activeSaleCache'
+
+// Matches the same relative-depth convention used by
+// server/api/admin/packs/[id].patch.js (a file at the identical nesting
+// depth) so production path resolution stays consistent across the admin API.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const baseDir = process.env.NODE_ENV === 'production'
+  ? join(__dirname, '..', '..', '..')
+  : process.cwd()
+
+const ALLOWED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+
+async function assertAdmin(event) {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  if (!me.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  return me
+}
+
+export default defineEventHandler(async (event) => {
+  const me = await assertAdmin(event)
+  const id = event.context.params.id
+
+  const existing = await db.sale.findUnique({
+    where: { id },
+    include: { items: true }
+  })
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Sale not found' })
+
+  const parts = await readMultipartFormData(event)
+  let imagePart = null, metaPart = null
+  for (const p of parts) {
+    if (p.filename) imagePart = p
+    else if (p.name === 'meta') metaPart = p
+  }
+  if (!metaPart) throw createError({ statusCode: 400, statusMessage: 'Missing meta field' })
+
+  let meta
+  try { meta = JSON.parse(metaPart.data.toString()) }
+  catch { throw createError({ statusCode: 400, statusMessage: 'meta must be valid JSON' }) }
+
+  validateSaleMeta(meta)
+  const { startAt, endAt } = parseSaleWindow(meta)
+
+  let imagePath = existing.imagePath
+  if (imagePart) {
+    if (imagePart.data.length > MAX_IMAGE_BYTES) {
+      throw createError({ statusCode: 400, statusMessage: 'Image must be 5MB or smaller.' })
+    }
+    if (!ALLOWED_IMAGE_TYPES.includes(imagePart.type)) {
+      throw createError({ statusCode: 400, statusMessage: 'Only PNG, JPEG, GIF, or WEBP images allowed.' })
+    }
+    if (!sniffImageType(imagePart.data)) {
+      throw createError({ statusCode: 400, statusMessage: 'File does not look like a valid image.' })
+    }
+
+    const uploadDir = process.env.NODE_ENV === 'production'
+      ? join(baseDir, 'cartoon-reorbit-images', 'sales')
+      : join(baseDir, 'public', 'sales')
+    await mkdir(uploadDir, { recursive: true })
+    const filename = `${Date.now()}_${sanitizeFilename(imagePart.filename)}`
+    await writeFile(join(uploadDir, filename), imagePart.data)
+    imagePath = process.env.NODE_ENV === 'production'
+      ? `/images/sales/${filename}`
+      : `/sales/${filename}`
+  }
+
+  const ctoonIds = meta.items.map(i => i.ctoonId)
+
+  const result = await db.$transaction(async (tx) => {
+    await assertNoSaleOverlap(tx, { ctoonIds, startAt, endAt, excludeSaleId: id })
+
+    await tx.sale.update({
+      where: { id },
+      data: {
+        name: meta.name.trim(),
+        imagePath,
+        startAt,
+        endAt
+      }
+    })
+
+    await tx.saleCtoon.deleteMany({ where: { saleId: id } })
+    await tx.saleCtoon.createMany({
+      data: meta.items.map(i => ({
+        saleId: id,
+        ctoonId: i.ctoonId,
+        price: Number(i.price),
+        perDayLimit: Number(i.perDayLimit)
+      }))
+    })
+
+    const changes = [
+      ['name', existing.name, meta.name.trim()],
+      ['startAt', existing.startAt.toISOString(), startAt.toISOString()],
+      ['endAt', existing.endAt.toISOString(), endAt.toISOString()],
+      ['imagePath', existing.imagePath, imagePath],
+      ['items', existing.items.map(i => ({ ctoonId: i.ctoonId, price: i.price, perDayLimit: i.perDayLimit })), meta.items]
+    ]
+    for (const [key, prev, next] of changes) {
+      const prevStr = JSON.stringify(prev)
+      const nextStr = JSON.stringify(next)
+      if (prevStr !== nextStr) {
+        await logAdminChange(tx, { userId: me.id, area: `Sale:${id}`, key, prevValue: prev, newValue: next })
+      }
+    }
+
+    return { id }
+  })
+
+  clearActiveSaleCache()
+
+  return { id: result.id, imagePath }
+})

--- a/server/api/cmart.get.js
+++ b/server/api/cmart.get.js
@@ -29,7 +29,10 @@ export default defineEventHandler(async () => {
   const ctoons = await prisma.ctoon.findMany({
     where: {
       inCmart: true,
-      releaseDate: { lte: twoWeeksAhead }
+      releaseDate: { lte: twoWeeksAhead },
+      // cToons in an active Sale are shown only in the Sale showcase section
+      // (see /api/cmart/active-sale), not duplicated in this normal grid.
+      saleItems: { none: { sale: { startAt: { lte: now }, endAt: { gte: now } } } }
     },
     orderBy: { releaseDate: 'desc' },
     select: {

--- a/server/api/cmart/active-sale.get.js
+++ b/server/api/cmart/active-sale.get.js
@@ -1,0 +1,52 @@
+// GET /api/cmart/active-sale
+// Public endpoint. Returns the currently active Sale (if any) with its items,
+// for the cMart showcase section. Cached briefly (mirrors upgradesConfigCache.js)
+// since this is fetched on every cMart page load and refresh cycle, and there's
+// usually no active sale.
+
+import { defineEventHandler } from 'h3'
+import { prisma } from '@/server/prisma'
+import { getActiveSaleCache, setActiveSaleCache } from '@/server/utils/activeSaleCache'
+
+export default defineEventHandler(async () => {
+  const cached = getActiveSaleCache()
+  if (cached !== undefined) return cached
+
+  const now = new Date()
+  const sale = await prisma.sale.findFirst({
+    where: { startAt: { lte: now }, endAt: { gte: now } },
+    orderBy: { startAt: 'asc' },
+    select: {
+      id: true,
+      name: true,
+      imagePath: true,
+      endAt: true,
+      items: {
+        select: {
+          price: true,
+          perDayLimit: true,
+          ctoon: {
+            select: {
+              id: true,
+              name: true,
+              assetPath: true,
+              rarity: true,
+              price: true,
+              isGtoon: true,
+              quantity: true,
+              totalMinted: true,
+              isSecondEdition: true,
+              secondEditionOverlayX: true,
+              secondEditionOverlayY: true,
+              secondEditionOverlaySize: true
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const result = sale || null
+  setActiveSaleCache(result)
+  return result
+})

--- a/server/api/cmart/buy.post.js
+++ b/server/api/cmart/buy.post.js
@@ -42,25 +42,37 @@ export default defineEventHandler(async (event) => {
       }
     })
 
-    // Allow if in cMart OR part of an active holiday event
+    // Allow if in cMart OR part of an active holiday event OR part of an active Sale.
+    // A Sale grants a cToon temporary cMart availability for its window, even if the
+    // cToon isn't normally listed (inCmart=false) or its releaseDate hasn't passed.
     const now = new Date()
-    const activeHolidayItem = await prisma.holidayEventItem.findFirst({
-      where: {
-        ctoonId,
-        event: {
-          isActive: true,
-          startsAt: { lte: now },
-          endsAt:   { gte: now }
+    const [activeHolidayItem, activeSaleItem] = await Promise.all([
+      prisma.holidayEventItem.findFirst({
+        where: {
+          ctoonId,
+          event: {
+            isActive: true,
+            startsAt: { lte: now },
+            endsAt:   { gte: now }
+          }
         }
-      }
-    })
+      }),
+      prisma.saleCtoon.findFirst({
+        where: {
+          ctoonId,
+          sale: { startAt: { lte: now }, endAt: { gte: now } }
+        },
+        select: { id: true, saleId: true, price: true, perDayLimit: true },
+        orderBy: { createdAt: 'asc' }
+      })
+    ])
 
-    if (!ctoon || (!ctoon.inCmart && !activeHolidayItem)) {
+    if (!ctoon || (!ctoon.inCmart && !activeHolidayItem && !activeSaleItem)) {
       throw createError({ statusCode: 404, statusMessage: 'cToon not for sale, get hacked noob.' })
     }
 
-    // Release window gating (two-phase)
-    if (ctoon.releaseDate && new Date(ctoon.releaseDate).getTime() > now.getTime()) {
+    // Release window gating (two-phase) — a Sale bypasses this the same way inCmart does.
+    if (!activeSaleItem && ctoon.releaseDate && new Date(ctoon.releaseDate).getTime() > now.getTime()) {
       throw createError({ statusCode: 403, statusMessage: 'cToon not released yet.  Quit being a cheater.' })
     }
 
@@ -126,14 +138,23 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    // — Resolve effective price (apply global half-price discount if active)
+    // — Resolve effective price. An active Sale price takes priority over (and is
+    // not stacked with) the global half-price toggle — the two discount mechanisms
+    // are independent. Note: this is only used for the wallet pre-check below; the
+    // worker re-derives the sale price itself right before charging so a stale value
+    // here (e.g. an admin edits/deletes the sale between this check and the job
+    // running) can never overcharge or undercharge the user.
     let effectivePrice = ctoon.price
-    try {
-      const cfg = await prisma.globalGameConfig.findUnique({ where: { id: 'singleton' }, select: { cmartHalfPriceEnabled: true } })
-      if (cfg?.cmartHalfPriceEnabled === true) {
-        effectivePrice = Math.floor(ctoon.price / 2)
-      }
-    } catch {}
+    if (activeSaleItem) {
+      effectivePrice = activeSaleItem.price
+    } else {
+      try {
+        const cfg = await prisma.globalGameConfig.findUnique({ where: { id: 'singleton' }, select: { cmartHalfPriceEnabled: true } })
+        if (cfg?.cmartHalfPriceEnabled === true) {
+          effectivePrice = Math.floor(ctoon.price / 2)
+        }
+      } catch {}
+    }
 
     // — Verify available points (total - active locks)
     const [wallet, activeLocks] = await Promise.all([
@@ -153,8 +174,9 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, statusMessage: 'Not enough available points.' })
     }
 
-    // — Enqueue the mint job
-    const job = await mintQueue.add('mintCtoon', { userId, ctoonId, effectivePrice })
+    // — Enqueue the mint job. saleId tells the worker to re-derive sale price/limit
+    // itself (it does not trust effectivePrice for sale-priced items — see worker).
+    const job = await mintQueue.add('mintCtoon', { userId, ctoonId, effectivePrice, saleId: activeSaleItem?.saleId ?? null })
 
     // — Set up a QueueEvents listener on the same queue
     queueEvents = new QueueEvents(mintQueue.name, { connection: redisConnection })
@@ -176,6 +198,7 @@ export default defineEventHandler(async (event) => {
       if (/sold out/i.test(msg))                statusCode = 410
       else if (/minting period/i.test(msg))      statusCode = 410
       else if (/insufficient points/i.test(msg)) statusCode = 400
+      else if (/daily limit/i.test(msg))         statusCode = 429
       else if (/purchase limit/i.test(msg))      statusCode = 403
       else if (/not-for-sale/i.test(msg))        statusCode = 404
 

--- a/server/utils/activeSaleCache.js
+++ b/server/utils/activeSaleCache.js
@@ -1,0 +1,27 @@
+// server/utils/activeSaleCache.js
+// Short-lived in-memory cache for the currently active cMart Sale, mirroring
+// the pattern in upgradesConfigCache.js. Cleared from the admin sale
+// create/update/delete routes so changes show up promptly; otherwise expires
+// on its own so a sale's start/end boundary is never more than TTL stale.
+
+export const CACHE_TTL_MS = 30 * 1000 // 30 seconds
+
+let _cache = null
+let _cacheAt = 0
+
+export function clearActiveSaleCache() {
+  _cache = null
+  _cacheAt = 0
+}
+
+export function setActiveSaleCache(value) {
+  _cache = value
+  _cacheAt = Date.now()
+}
+
+export function getActiveSaleCache() {
+  if (_cache !== null && Date.now() - _cacheAt < CACHE_TTL_MS) {
+    return _cache
+  }
+  return undefined
+}

--- a/server/utils/centralTime.js
+++ b/server/utils/centralTime.js
@@ -1,0 +1,92 @@
+// server/utils/centralTime.js
+// Shared America/Chicago (CST/CDT) time helpers used by admin-scheduled
+// features (Sales, packs, Winball schedule) to convert "wall clock in
+// Chicago" values to/from UTC without a timezone library.
+
+export function parseLocalYmdHm(s) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})$/.exec(String(s || ''))
+  if (!m) return null
+  return { y: +m[1], m: +m[2], d: +m[3], h: +m[4], mi: +m[5] }
+}
+
+export function centralLocalToUTC(localYmdHm) {
+  const parts = parseLocalYmdHm(localYmdHm)
+  if (!parts) return null
+
+  const { y, m, d, h, mi } = parts
+  const utcGuessMs = Date.UTC(y, m - 1, d, h, mi, 0)
+
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit'
+  })
+  const displayed = Object.fromEntries(
+    fmt.formatToParts(new Date(utcGuessMs))
+      .filter(p => p.type !== 'literal')
+      .map(p => [p.type, p.value])
+  )
+  const zonalMs = Date.UTC(
+    Number(displayed.year),
+    Number(displayed.month) - 1,
+    Number(displayed.day),
+    Number(displayed.hour),
+    Number(displayed.minute),
+    Number(displayed.second)
+  )
+
+  const offsetMs = zonalMs - utcGuessMs
+  return new Date(utcGuessMs - offsetMs)
+}
+
+/**
+ * Returns the start of the current 8pm–7:59pm CST daily window as a UTC Date.
+ * If it's before 8pm Chicago time, the window started yesterday at 8pm.
+ */
+export function getDailyWindowStart(now = new Date()) {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', hour12: false
+  })
+  const parts = Object.fromEntries(
+    fmt.formatToParts(now)
+      .filter(p => p.type !== 'literal')
+      .map(p => [p.type, p.value])
+  )
+
+  let year = +parts.year, month = +parts.month - 1, day = +parts.day
+  const hour = +parts.hour
+
+  if (hour < 20) {
+    const d = new Date(Date.UTC(year, month, day))
+    d.setUTCDate(d.getUTCDate() - 1)
+    year  = d.getUTCFullYear()
+    month = d.getUTCMonth()
+    day   = d.getUTCDate()
+  }
+
+  const utcGuessMs = Date.UTC(year, month, day, 20, 0, 0)
+  const fmtCheck = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit'
+  })
+  const displayed = Object.fromEntries(
+    fmtCheck.formatToParts(new Date(utcGuessMs))
+      .filter(p => p.type !== 'literal')
+      .map(p => [p.type, p.value])
+  )
+  const zonalMs = Date.UTC(
+    Number(displayed.year),
+    Number(displayed.month) - 1,
+    Number(displayed.day),
+    Number(displayed.hour),
+    Number(displayed.minute),
+    Number(displayed.second)
+  )
+  const offsetMs = zonalMs - utcGuessMs
+  return new Date(utcGuessMs - offsetMs)
+}

--- a/server/utils/imageUploadValidation.js
+++ b/server/utils/imageUploadValidation.js
@@ -1,0 +1,30 @@
+// server/utils/imageUploadValidation.js
+// Shared image-upload validation: size cap, magic-byte content sniffing (the
+// multipart "type" field is client-supplied and spoofable, so declared mime
+// type alone is not trusted), and filename sanitization against path
+// traversal.
+
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024 // 5MB
+
+const SIGNATURES = [
+  { type: 'image/png',  bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] },
+  { type: 'image/jpeg', bytes: [0xff, 0xd8, 0xff] },
+  { type: 'image/gif',  bytes: [0x47, 0x49, 0x46, 0x38] },
+]
+
+export function sniffImageType(buf) {
+  if (!buf || buf.length < 4) return null
+  if (buf.length >= 12 && buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') {
+    return 'image/webp'
+  }
+  for (const sig of SIGNATURES) {
+    if (buf.length >= sig.bytes.length && sig.bytes.every((b, i) => buf[i] === b)) {
+      return sig.type
+    }
+  }
+  return null
+}
+
+export function sanitizeFilename(name) {
+  return String(name || 'image').replace(/[^A-Za-z0-9._-]/g, '') || 'image'
+}

--- a/server/utils/saleOverlap.js
+++ b/server/utils/saleOverlap.js
@@ -1,0 +1,32 @@
+// server/utils/saleOverlap.js
+// A cToon cannot belong to two Sales with overlapping date windows.
+// Call inside the create/update transaction, right before writing SaleCtoon
+// rows, to keep the check-then-write race window as small as possible.
+
+import { createError } from 'h3'
+
+export async function assertNoSaleOverlap(client, { ctoonIds, startAt, endAt, excludeSaleId }) {
+  if (!ctoonIds.length) return
+
+  const conflicts = await client.saleCtoon.findMany({
+    where: {
+      ctoonId: { in: ctoonIds },
+      ...(excludeSaleId ? { saleId: { not: excludeSaleId } } : {}),
+      sale: {
+        startAt: { lt: endAt },
+        endAt: { gt: startAt }
+      }
+    },
+    select: {
+      ctoon: { select: { name: true } },
+      sale: { select: { name: true } }
+    }
+  })
+
+  if (conflicts.length) {
+    const desc = conflicts
+      .map(c => `${c.ctoon.name} (already in "${c.sale.name}")`)
+      .join(', ')
+    throw createError({ statusCode: 409, statusMessage: `These cToons overlap with another sale's dates: ${desc}` })
+  }
+}

--- a/server/utils/saleValidation.js
+++ b/server/utils/saleValidation.js
@@ -1,0 +1,51 @@
+// server/utils/saleValidation.js
+import { createError } from 'h3'
+import { parseLocalYmdHm, centralLocalToUTC } from './centralTime.js'
+
+export function validateSaleMeta(meta) {
+  if (!meta?.name || typeof meta.name !== 'string' || !meta.name.trim()) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing or invalid "name"' })
+  }
+  if (meta.name.trim().length > 120) {
+    throw createError({ statusCode: 400, statusMessage: 'Name must be 120 characters or fewer' })
+  }
+  if (!Array.isArray(meta.items) || meta.items.length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'At least one cToon is required' })
+  }
+  const dupCtoon = meta.items.map(i => i.ctoonId).find((id, i, a) => a.indexOf(id) !== i)
+  if (dupCtoon) throw createError({ statusCode: 400, statusMessage: 'Duplicate cToon in sale items' })
+
+  for (const item of meta.items) {
+    if (!item.ctoonId || typeof item.ctoonId !== 'string') {
+      throw createError({ statusCode: 400, statusMessage: 'Each item requires a ctoonId' })
+    }
+    const price = Number(item.price)
+    const limit = Number(item.perDayLimit)
+    if (!Number.isInteger(price) || price < 0) {
+      throw createError({ statusCode: 400, statusMessage: `Invalid sale price for cToon ${item.ctoonId}` })
+    }
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw createError({ statusCode: 400, statusMessage: `Invalid per-day limit for cToon ${item.ctoonId}` })
+    }
+  }
+}
+
+export function parseSaleWindow(meta) {
+  const startAtLocal = String(meta?.startAtLocal || '').trim()
+  const endAtLocal = String(meta?.endAtLocal || '').trim()
+  if (!startAtLocal || !parseLocalYmdHm(startAtLocal)) {
+    throw createError({ statusCode: 400, statusMessage: 'startAtLocal must be "YYYY-MM-DD HH:mm"' })
+  }
+  if (!endAtLocal || !parseLocalYmdHm(endAtLocal)) {
+    throw createError({ statusCode: 400, statusMessage: 'endAtLocal must be "YYYY-MM-DD HH:mm"' })
+  }
+  const startAt = centralLocalToUTC(startAtLocal)
+  const endAt = centralLocalToUTC(endAtLocal)
+  if (!startAt || !endAt || Number.isNaN(startAt.getTime()) || Number.isNaN(endAt.getTime())) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid start/end date-time' })
+  }
+  if (endAt.getTime() <= startAt.getTime()) {
+    throw createError({ statusCode: 400, statusMessage: 'End time must be after start time' })
+  }
+  return { startAt, endAt }
+}

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -1,5 +1,6 @@
 import { Worker } from 'bullmq'
 import { prisma } from '../prisma.js'
+import { getDailyWindowStart } from '../utils/centralTime.js'
 
 const connection = {
   host: process.env.REDIS_HOST,
@@ -16,6 +17,20 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
     // Fetch cToon details
     const ctoon = await prisma.ctoon.findUnique({ where: { id: ctoonId } })
     if (!ctoon) throw new Error('Invalid or not-for-sale cToon')
+
+    // Re-derive the active Sale fresh (never trust the HTTP layer's saleId/price for
+    // charging — an admin could edit/delete the sale, or the job could sit queued,
+    // between buy.post.js's check and this worker running).
+    const activeSale = (!isSpecial)
+      ? await prisma.saleCtoon.findFirst({
+          where: {
+            ctoonId,
+            sale: { startAt: { lte: new Date() }, endAt: { gte: new Date() } }
+          },
+          select: { saleId: true, price: true, perDayLimit: true },
+          orderBy: { createdAt: 'asc' }
+        })
+      : null
 
     // ───────────────────── Time-based mint window guard ─────────────────────
     // Special mints (code redemption, cZone capture) bypass this guard so
@@ -89,13 +104,19 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
     const totalPoints = wallet?.points ?? 0
     const lockedSum = activeLocks.reduce((acc, lock) => acc + (lock.amount || 0), 0)
     const availablePoints = totalPoints - lockedSum
-    const chargePrice = (typeof effectivePrice === 'number' && effectivePrice >= 0) ? effectivePrice : ctoon.price
+    // A freshly-verified active Sale price always wins over the (possibly stale)
+    // effectivePrice passed from the HTTP layer.
+    const chargePrice = activeSale
+      ? activeSale.price
+      : ((typeof effectivePrice === 'number' && effectivePrice >= 0) ? effectivePrice : ctoon.price)
     if (!isSpecial && availablePoints < chargePrice) {
       throw new Error('Insufficient points')
     }
 
-    // Per-user limit enforcement
-    if (!isSpecial) {
+    // Per-user limit enforcement. An active Sale's per-day limit fully replaces the
+    // cToon's normal perUserLimit / timeBasedLimitCount checks for the duration of
+    // the sale (see the atomic SaleDailyPurchase counter inside the transaction below).
+    if (!isSpecial && !activeSale) {
       if (ctoon.mintLimitType === 'timeBased') {
         // ── Time-based release purchase limits (replaces 48h perUserLimit for this type) ──
         // Resolve limit: per-cToon override first, then rarity defaults from global config,
@@ -230,6 +251,26 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
       const isFirstEdition =
         updatedCtoon.initialQuantity === null || mintNumber <= updatedCtoon.initialQuantity
 
+      // 1b) Sale per-day limit — atomic increment-then-check on a single counter row
+      // (same pattern as the totalMinted increment above) so the row lock serializes
+      // concurrent buyers instead of racing on a count() read.
+      if (activeSale) {
+        const windowStart = getDailyWindowStart()
+        const counter = await tx.saleDailyPurchase.upsert({
+          where: {
+            userId_ctoonId_saleId_windowStart: {
+              userId, ctoonId, saleId: activeSale.saleId, windowStart
+            }
+          },
+          create: { userId, ctoonId, saleId: activeSale.saleId, windowStart, count: 1 },
+          update: { count: { increment: 1 } },
+          select: { count: true }
+        })
+        if (counter.count > activeSale.perDayLimit) {
+          throw new Error(`Daily limit reached — you can buy ${activeSale.perDayLimit} of this cToon per day during this sale (resets at 8pm CST)`)
+        }
+      }
+
       // 2) If not special, deduct points + log
       if (!isSpecial) {
         const updated = await tx.userPoints.update({
@@ -270,7 +311,7 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
       // 5) Log cMart purchase for bot-clicker detection metrics
       if (!isSpecial) {
         await tx.cmartPurchaseLog.create({
-          data: { userId, ctoonId }
+          data: { userId, ctoonId, saleId: activeSale?.saleId ?? null }
         })
       }
     })


### PR DESCRIPTION
## Summary

- Adds a **Manage Sales** admin page (`/newsite/admin/manageSales`) where admins can create/edit/delete scheduled cMart Sales: name, optional promo image, CST start/end window, and per-cToon sale price + daily purchase limit.
- Sale pricing/limits are a **non-destructive override** (stored in a `Sale`/`SaleCtoon` join table, never written into the `Ctoon` record), so they revert automatically the instant a sale ends — no cron job required.
- The cMart purchase flow (`buy.post.js` + the `mint.worker.js` BullMQ worker) honors an active sale's price and per-day limit anywhere the cToon can be bought, including cToons not normally listed in cMart. The worker re-derives the sale fresh (never trusts a possibly-stale value from the HTTP layer) and enforces the daily limit with an atomic counter (row-lock serialized, same pattern as the existing mint-number counter) to avoid a race under concurrent buyers.
- cMart's homepage shows a showcase section for the currently active sale at the top of results (reusing `ShortCard`/`SecondEditionOverlay` so 2nd-edition icons render correctly), excluded from the normal grid below to avoid duplicates.
- The cToons/Packs tab switcher moved from the cMart sidebar into green buttons atop the main content, matching the `GamesHome`/`MyCworld` pattern.
- All Sale create/update/delete actions are recorded in the Admin Changes log.
- Unrelated small fix: the **Create Pack** admin page now defaults "Daily purchase limit per user" to `5` instead of blank/unlimited.

## Test plan

- [ ] Run the new Prisma migration (`prisma/migrations/20260710000000_add_sales`) against a dev database and confirm `prisma generate` / app boot succeed.
- [ ] Create a Sale in `/newsite/admin/manageSales` with an image, CST start/end window, and 1+ cToons; confirm it appears in the list with the correct status (Upcoming/Active/Ended) and shows up in the Admin Changes log.
- [ ] Edit and delete a Sale; confirm overlapping-date validation blocks adding a cToon already in another active-window sale.
- [ ] With an active Sale, confirm the showcase section appears at the top of cMart, purchases charge the sale price, the per-day limit is enforced (and resets at 8pm CST), and the cToon does not also appear in the normal grid below.
- [ ] Confirm a cToon purchase for a sale that includes a cToon with `inCmart=false` still succeeds only while the sale is active.
- [ ] After a sale's end time passes, confirm the cToon's normal price/limit apply again with no manual intervention.
- [ ] Verify the cToons/Packs buttons render correctly on mobile at the top of cMart, and the sidebar no longer shows an empty box when the Packs tab is selected.
- [ ] Create a new Pack and confirm "Daily purchase limit per user" now defaults to `5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmMbmt9F3C96C6jw4WuVfV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmMbmt9F3C96C6jw4WuVfV)_