### PR TITLE
Fix cMart tab buttons to match MyCworld green button styling

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -808,10 +808,11 @@ async function closeOverlay() {
   display: flex;
   flex-direction: row;
   gap: 6px;
-  padding: 6px 6px 0;
+  padding: 6px;
   overflow-x: auto;
   scrollbar-width: none;
   flex-shrink: 0;
+  background: var(--bg-color);
 }
 
 .cmart-header {

--- a/pages/games/winwheel.vue
+++ b/pages/games/winwheel.vue
@@ -371,7 +371,11 @@ async function spinWheel() {
   // New spin: ensure we wait for this round's result modal first
   hasShownResult.value = false
 
-  startSpinSound()
+  // Prime the audio context/buffer now, while we're still inside the click's user-gesture
+  // window -- but don't start the tick sequence's clock yet. That happens once rotation.value
+  // is actually set below, so the audio's slow-down curve stays in sync with the wheel's own
+  // spinDurationMs CSS transition instead of racing ahead of it during the /spin network call.
+  primeSpinSound()
 
   // optimistic
   user.value.points -= spinCost.value
@@ -391,6 +395,7 @@ async function spinWheel() {
     const fullTurns = 5
     const wedgeMid  = startOffset + sliceAngle/2 + sliceIndex*sliceAngle
     rotation.value  = fullTurns*360 - wedgeMid
+    startSpinSound()
 
     setTimeout(async () => {
       stopSpinSound()
@@ -483,10 +488,16 @@ function playSpinSoundOnce() {
   }
 }
 
+function primeSpinSound() {
+  if (!winWheelSoundPath.value) return
+  ensureAudioContext()
+  void prepareSpinSoundBuffer()
+}
+
 function startSpinSound() {
   if (!winWheelSoundPath.value) return
   stopSpinSound()
-  void prepareSpinSoundBuffer()
+  primeSpinSound()
   if (winWheelSoundMode.value === 'once') {
     playSpinSoundOnce()
     return

--- a/pages/newsite/tower.vue
+++ b/pages/newsite/tower.vue
@@ -245,11 +245,15 @@ function triangleWave(tSeconds, speed, amplitude, phaseOffsetSeconds) {
   return -amplitude + ((phase - 3 * quarter) / quarter) * amplitude
 }
 
+// MUST mirror movingCenterAt in towerStackEngine.js exactly (see that file for why the phase
+// offset is anchored to a turning point instead of an arbitrary fraction of the period).
 function movingCenterAt(n, tSeconds) {
   const speed = layerSpeed(n)
   const amplitude = cfg.boardHalfRange
   const period = (4 * amplitude) / speed
-  const phaseOffset = jitter.phaseFrac * period
+  const quarter = period / 4
+  const startsPositive = (jitter.phaseFrac < 0.5) === (n % 2 === 1)
+  const phaseOffset = startsPositive ? quarter : 3 * quarter
   return triangleWave(tSeconds, speed, amplitude, phaseOffset)
 }
 

--- a/pages/newsite/winwheel.vue
+++ b/pages/newsite/winwheel.vue
@@ -309,7 +309,11 @@ const canSpin = computed(() =>
 async function spinWheel() {
   if (!canSpin.value) return
   hasShownResult.value = false
-  startSpinSound()
+  // Prime the audio context/buffer now, while we're still inside the click's user-gesture
+  // window -- but don't start the tick sequence's clock yet. That happens once rotation.value
+  // is actually set below, so the audio's slow-down curve stays in sync with the wheel's own
+  // spinDurationMs CSS transition instead of racing ahead of it during the /spin network call.
+  primeSpinSound()
   user.value.points -= spinCost.value
   spinsLeft.value--
   isSpinning.value = true
@@ -321,6 +325,7 @@ async function spinWheel() {
     const fullTurns = 5
     const wedgeMid  = startOffset + sliceAngle / 2 + sliceIndex * sliceAngle
     rotation.value  = fullTurns * 360 - wedgeMid
+    startSpinSound()
     setTimeout(async () => {
       stopSpinSound()
       await fetchSelf({ force: true })
@@ -408,11 +413,16 @@ function playSpinSoundOnce() {
   }
 }
 
+function primeSpinSound() {
+  if (!winWheelSoundPath.value) return
+  ensureAudioContext()
+  void prepareSpinSoundBuffer()
+}
+
 function startSpinSound() {
   if (!winWheelSoundPath.value) return
   stopSpinSound()
-  ensureAudioContext()
-  void prepareSpinSoundBuffer()
+  primeSpinSound()
   if (winWheelSoundMode.value === 'once') {
     playSpinSoundOnce()
     return

--- a/server/utils/towerStackEngine.js
+++ b/server/utils/towerStackEngine.js
@@ -80,13 +80,20 @@ function triangleWave(tSeconds, speed, amplitude, phaseOffsetSeconds) {
 }
 
 // Center position of the moving block for layer n at elapsed seconds `tSeconds` since that
-// layer began. Axis alternates by parity of n; direction of the initial phase alternates too
-// (deterministic, matches the reference game's left/right/left/right entrance pattern).
+// layer began. Axis alternates by parity of n. Each layer's block must ENTER already at the
+// board edge and slide toward the opposite edge -- never drift outward first -- so the phase
+// offset is anchored to a triangleWave turning point (quarter/3*quarter), not an arbitrary
+// fraction of the period. Which edge it enters from alternates by layer parity (deterministic,
+// matches the reference game's left/right/left/right entrance pattern); the per-session jitter
+// only decides which side layer 1 starts from, preserving jitter's anti-cheat role (see file
+// header) without letting it place the block mid-swing at the start of a layer.
 function movingCenterAt(n, tSeconds, cfg, jitter) {
   const speed = layerSpeed(n, cfg, jitter)
   const amplitude = cfg.boardHalfRange
   const period = (4 * amplitude) / speed
-  const phaseOffset = jitter.phaseFrac * period
+  const quarter = period / 4
+  const startsPositive = (jitter.phaseFrac < 0.5) === (n % 2 === 1)
+  const phaseOffset = startsPositive ? quarter : 3 * quarter
   return triangleWave(tSeconds, speed, amplitude, phaseOffset)
 }
 


### PR DESCRIPTION
The cToons/Packs tab buttons sat directly on the cMart card's white
background, losing the shadow/contrast that makes GreenButton look
3D. Give the .cm-nav strip a navy backdrop matching the page
background so the buttons pop the same way they do on MyCworld.