### PR TITLE
Fix cMart sale banner image display and background

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -114,28 +114,20 @@
 
     <!-- ── cToons grid ───────────────────────────────────────────── -->
     <div v-if="cmartTab === 'ctoons'" class="cmart-grid">
-      <template v-if="loading">
-        <ShortCard v-for="n in 100" :key="'skel-' + n" class="skel-card">
-          <template #header><div class="skel-img" /></template>
-          <template #middle><div class="skel-line skel-name" /></template>
-          <template #footer-left><div class="skel-line skel-price" /></template>
-          <template #footer-right><div class="skel-line skel-btn" /></template>
-        </ShortCard>
-      </template>
-      <template v-else>
-        <!-- ── Active Sale showcase ─────────────────────────────── -->
-        <div v-if="activeSale" class="sale-showcase">
-          <div class="sale-banner">
-            <img
-              v-if="activeSale.imagePath && !saleImageFailed"
-              :src="activeSale.imagePath"
-              :alt="activeSale.name"
-              class="sale-banner-img"
-              @error="saleImageFailed = true"
-            />
-            <div v-else class="sale-banner-title sale-banner-title--fallback">🔥 {{ activeSale.name }}</div>
-          </div>
-          <div class="sale-grid">
+      <!-- ── Active Sale showcase (sits above the cards grid, sized to its
+           own content — not a grid item, see .cmart-grid CSS note) ────── -->
+      <div v-if="!loading && activeSale" class="sale-showcase">
+        <div class="sale-banner">
+          <img
+            v-if="activeSale.imagePath && !saleImageFailed"
+            :src="activeSale.imagePath"
+            :alt="activeSale.name"
+            class="sale-banner-img"
+            @error="saleImageFailed = true"
+          />
+          <div v-else class="sale-banner-title sale-banner-title--fallback">🔥 {{ activeSale.name }}</div>
+        </div>
+        <div class="sale-grid">
             <ShortCard
               v-for="item in activeSale.items"
               :key="'sale-' + item.ctoon.id"
@@ -186,12 +178,20 @@
                 </GreenButton>
               </template>
             </ShortCard>
-          </div>
-          <div class="sale-divider">More cToons</div>
         </div>
-      </template>
-      <div v-if="!loading && !ctoons.length" class="cmart-status">No cToons available.</div>
-      <template v-else-if="!loading">
+        <div class="sale-divider">More cToons</div>
+      </div>
+
+      <div v-if="loading" class="cmart-cards-grid">
+        <ShortCard v-for="n in 100" :key="'skel-' + n" class="skel-card">
+          <template #header><div class="skel-img" /></template>
+          <template #middle><div class="skel-line skel-name" /></template>
+          <template #footer-left><div class="skel-line skel-price" /></template>
+          <template #footer-right><div class="skel-line skel-btn" /></template>
+        </ShortCard>
+      </div>
+      <div v-else-if="!ctoons.length" class="cmart-status">No cToons available.</div>
+      <div v-else class="cmart-cards-grid">
         <ShortCard
           v-for="c in ctoons"
           :key="c.id"
@@ -250,7 +250,7 @@
             </template>
           </template>
         </ShortCard>
-      </template>
+      </div>
     </div>
 
     <!-- ── Packs grid ────────────────────────────────────────────── -->
@@ -841,9 +841,9 @@ async function closeOverlay() {
 
 /* ── Sale showcase ───────────────────────────────────────────── */
 .sale-showcase {
-  grid-column: 1 / -1;
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   gap: 4px;
   padding: 6px;
   margin-bottom: 4px;
@@ -855,6 +855,11 @@ async function closeOverlay() {
 .sale-banner {
   position: relative;
   width: 100%;
+  height: 160px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 6px;
   overflow: hidden;
   background: var(--OrbitDarkBlue, #336699);
@@ -863,8 +868,7 @@ async function closeOverlay() {
 .sale-banner-img {
   display: block;
   width: 100%;
-  aspect-ratio: 16 / 5;
-  max-height: 160px;
+  height: 100%;
   object-fit: cover;
 }
 
@@ -878,6 +882,7 @@ async function closeOverlay() {
 }
 
 .sale-banner-title--fallback {
+  width: 100%;
   border-radius: 6px;
   padding: 14px 8px;
   font-size: 1.15rem;
@@ -888,6 +893,7 @@ async function closeOverlay() {
   grid-template-columns: repeat(5, 1fr);
   grid-auto-rows: var(--shortcard-height);
   gap: 4px;
+  flex-shrink: 0;
 }
 
 .sale-divider {
@@ -941,23 +947,34 @@ async function closeOverlay() {
 }
 
 /* ── cToons grid ─────────────────────────────────────────────── */
+/* .cmart-grid is just the scroll container (flex column) so the sale
+   showcase can sit above the regular-cards grid, sized to its own natural
+   content, while both still scroll away together. It used to be the grid
+   itself with the sale-showcase as a full-width spanning grid item, but
+   CSS Grid's "auto" row-track sizing badly under-measured that item's
+   actual (deeply-nested, variable-row-count) content height, which then
+   either clipped it or made it overlap the row below — a nested grid inside
+   a flex column just isn't something Grid's intrinsic sizing handles well. */
 .cmart-grid {
   flex: 1;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--OrbitLightBlue) transparent;
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  /* minmax (not a fixed value) so the full-width sale-showcase row can grow to
-     fit its content while ordinary card rows still size to --shortcard-height. */
-  grid-auto-rows: minmax(var(--shortcard-height), auto);
-  grid-auto-flow: row;
-  gap: 4px;
+  display: flex;
+  flex-direction: column;
   padding: 4px;
   box-sizing: border-box;
 }
 
-.cmart-grid :deep(.sc) {
+.cmart-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-auto-rows: var(--shortcard-height);
+  grid-auto-flow: row;
+  gap: 4px;
+}
+
+.cmart-cards-grid :deep(.sc) {
   width: 100%;
 }
 
@@ -1354,12 +1371,12 @@ async function closeOverlay() {
 }
 
 @media (max-width: 768px) {
-  .cmart-grid {
+  .cmart-cards-grid {
     grid-template-columns: repeat(3, 1fr);
     grid-auto-rows: auto;
   }
 
-  .cmart-grid :deep(.sc) {
+  .cmart-cards-grid :deep(.sc) {
     width: 100%;
     height: auto;
     aspect-ratio: 3 / 4;
@@ -1384,8 +1401,8 @@ async function closeOverlay() {
     aspect-ratio: 3 / 4;
   }
 
-  .sale-banner-img {
-    max-height: 100px;
+  .sale-banner {
+    height: 100px;
   }
 
   .sale-banner-title {

--- a/composables/useCentralTime.js
+++ b/composables/useCentralTime.js
@@ -1,0 +1,32 @@
+// Shared America/Chicago (CST/CDT) <-> UTC conversion for admin forms that
+// enter/display date-time fields in Central time (e.g. Manage Codes).
+function isoToCSTLocal(iso) {
+  if (!iso) return ''
+  const date = new Date(iso)
+  const parts = date.toLocaleString('en-US', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', hour12: false
+  }).split(', ')
+  const [m, d, y] = parts[0].split('/')
+  const time = parts[1]
+  return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}T${time}`
+}
+
+function cstLocalToISO(localStr) {
+  if (!localStr) return null
+  const approxUTC = new Date(localStr + ':00Z')
+  const cstStr = approxUTC.toLocaleString('en-US', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', hour12: false
+  }).split(', ')
+  const [m2, d2, y2] = cstStr[0].split('/')
+  const cstEquivStr = `${y2}-${m2}-${d2}T${cstStr[1]}`
+  const diffMs = new Date(localStr + ':00Z') - new Date(cstEquivStr + ':00Z')
+  return new Date(approxUTC.getTime() + diffMs).toISOString()
+}
+
+export function useCentralTime() {
+  return { isoToCSTLocal, cstLocalToISO }
+}

--- a/pages/admin/create-code.vue
+++ b/pages/admin/create-code.vue
@@ -193,11 +193,16 @@
         <!-- cToon Rewards -->
         <div>
           <label class="block font-medium mb-1">cToon Rewards</label>
+          <p class="text-sm text-gray-500 mb-2">
+            Optionally set an End Bonus Date/Time (CST) per cToon below — if set, that cToon is only
+            given out when redeemed between the code's Available At time and that cToon's End Bonus
+            Date/Time. Leave blank to give it out normally whenever the code is redeemed.
+          </p>
 
           <div
             v-for="(rc, idx) in ctoonRewards"
             :key="idx"
-            class="flex items-center space-x-2 mb-2"
+            class="border rounded p-3 mb-2 grid grid-cols-2 sm:grid-cols-[1fr_auto_5rem_auto] gap-2 sm:items-center"
           >
             <!-- per-row datalist fed by filtered options -->
             <datalist :id="`ctoon-list-${idx}`">
@@ -208,41 +213,57 @@
               />
             </datalist>
 
-            <input
-              :value="rc.ctoonName"
-              @input="e => { 
-                const val = e.target.value;
-                rc.ctoonName = val; 
-                onCtoonInput(val);
-              }"
-              :list="`ctoon-list-${idx}`"
-              type="text"
-              required
-              class="flex-1 border rounded p-2"
-              placeholder="Type 3+ characters to search"
-            />
+            <div class="col-span-2 sm:col-span-1">
+              <label class="text-xs text-gray-500 sm:hidden">cToon</label>
+              <input
+                :value="rc.ctoonName"
+                @input="e => {
+                  const val = e.target.value;
+                  rc.ctoonName = val;
+                  onCtoonInput(val);
+                }"
+                :list="`ctoon-list-${idx}`"
+                type="text"
+                required
+                class="w-full border rounded p-2 text-base"
+                placeholder="Type 3+ characters to search"
+              />
+            </div>
 
             <img
               v-if="findCtoonByInput(rc.ctoonName)"
               :src="findCtoonByInput(rc.ctoonName).assetPath"
-              class="w-8 h-8 object-cover rounded"
+              class="w-8 h-8 object-cover rounded justify-self-center"
               alt="cToon preview"
             />
 
-            <input
-              v-model.number="rc.quantity"
-              type="number"
-              min="1"
-              class="w-20 border rounded p-2"
-              placeholder="Qty"
-            />
+            <div>
+              <label class="text-xs text-gray-500 sm:hidden">Qty</label>
+              <input
+                v-model.number="rc.quantity"
+                type="number"
+                min="1"
+                class="w-full sm:w-20 border rounded p-2 text-base"
+                placeholder="Qty"
+              />
+            </div>
+
             <button
               type="button"
               @click="removeCtoonReward(idx)"
-              class="text-red-600 hover:underline"
+              class="text-red-600 hover:underline justify-self-end sm:justify-self-auto p-2 -m-2"
             >
               Remove
             </button>
+
+            <div class="col-span-2">
+              <label class="text-xs text-gray-500">End Bonus Date/Time (CST) &middot; optional</label>
+              <input
+                v-model="rc.endBonusAt"
+                type="datetime-local"
+                class="w-full border rounded p-2 text-base"
+              />
+            </div>
           </div>
 
           <button
@@ -277,6 +298,7 @@
             Save Code
           </button>
           <p v-if="error" class="mt-2 text-red-600">{{ error }}</p>
+          <p v-if="!error && warning" class="mt-2 text-amber-600">{{ warning }}</p>
         </div>
       </form>
     </div>
@@ -295,32 +317,7 @@ definePageMeta({
 })
 
 const router = useRouter()
-
-function isoToCSTLocal(iso) {
-  const date = new Date(iso)
-  const parts = date.toLocaleString('en-US', {
-    timeZone: 'America/Chicago',
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', hour12: false
-  }).split(', ')
-  const [m, d, y] = parts[0].split('/')
-  const time = parts[1]
-  return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}T${time}`
-}
-
-function cstLocalToISO(localStr) {
-  if (!localStr) return null
-  const approxUTC = new Date(localStr + ':00Z')
-  const cstStr = approxUTC.toLocaleString('en-US', {
-    timeZone: 'America/Chicago',
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', hour12: false
-  }).split(', ')
-  const [m2, d2, y2] = cstStr[0].split('/')
-  const cstEquivStr = `${y2}-${m2}-${d2}T${cstStr[1]}`
-  const diffMs = new Date(localStr + ':00Z') - new Date(cstEquivStr + ':00Z')
-  return new Date(approxUTC.getTime() + diffMs).toISOString()
-}
+const { isoToCSTLocal, cstLocalToISO } = useCentralTime()
 
 // form state
 const code = ref('')
@@ -329,9 +326,10 @@ const startsAt = ref(isoToCSTLocal(new Date().toISOString()))
 const expiresAt = ref('')        // datetime-local string, optional
 const points = ref(0)
 const ctoonRewards = ref([
-  { ctoonName: '', quantity: 1 }
+  { ctoonName: '', quantity: 1, endBonusAt: '' }
 ])
 const error = ref('')
+const warning = ref('')
 const bgOptions = ref([])
 
 const pooledEnabled   = ref(false)
@@ -463,7 +461,7 @@ onMounted(async () => {
 
 // add/remove cToon reward entries
 function addCtoonReward() {
-  ctoonRewards.value.push({ ctoonName: '', quantity: 1 })
+  ctoonRewards.value.push({ ctoonName: '', quantity: 1, endBonusAt: '' })
 }
 function removeCtoonReward(index) {
   ctoonRewards.value.splice(index, 1)
@@ -472,6 +470,7 @@ function removeCtoonReward(index) {
 // form submission
 async function submitForm() {
   error.value = ''
+  warning.value = ''
 
   // basic validation
   if (!code.value.trim()) {
@@ -568,6 +567,12 @@ async function submitForm() {
     if (poolUniqueCount.value > validPool.length) { error.value = 'Number to give out cannot exceed pool size.'; return }
     rewardBlock.pool = { uniqueCount: poolUniqueCount.value, items: validPool }
   } else {
+    const startsDateObj = startsIso ? new Date(startsIso) : null
+    const nowDate = new Date()
+    const endBonusMin = startsDateObj && startsDateObj > nowDate ? startsDateObj : nowDate
+    const expiresDateObj = expiresIso ? new Date(expiresIso) : null
+    const warnings = []
+
     const validCtoons = []
     for (const r of ctoonRewards.value) {
       const name = (r.ctoonName||'').trim()
@@ -581,9 +586,28 @@ async function submitForm() {
         }
         return
       }
-      validCtoons.push({ ctoonId: resolved.id, quantity: r.quantity })
+
+      let endBonusIso = null
+      if (r.endBonusAt) {
+        endBonusIso = cstLocalToISO(r.endBonusAt)
+        const ebDate = new Date(endBonusIso)
+        if (isNaN(ebDate.getTime())) {
+          error.value = `Invalid End Bonus Date/Time for “${name}”.`
+          return
+        }
+        if (ebDate <= endBonusMin) {
+          error.value = `End Bonus Date/Time for “${name}” must be after the code's start date/time and after now.`
+          return
+        }
+        if (expiresDateObj && ebDate > expiresDateObj) {
+          warnings.push(`“${name}”'s End Bonus Date/Time is after the code's Expires At — the code will stop working first, so this bonus window will never take effect.`)
+        }
+      }
+
+      validCtoons.push({ ctoonId: resolved.id, quantity: r.quantity, endBonusAt: endBonusIso })
     }
     rewardBlock.ctoons = validCtoons
+    warning.value = warnings.join(' ')
   }
 
   const payload = {

--- a/pages/admin/edit-code.vue
+++ b/pages/admin/edit-code.vue
@@ -107,11 +107,16 @@
           <!-- cToon Rewards -->
           <div>
             <label class="block font-medium mb-1">cToon Rewards</label>
+            <p class="text-sm text-gray-500 mb-2">
+              Optionally set an End Bonus Date/Time (CST) per cToon below — if set, that cToon is only
+              given out when redeemed between the code's Available At time and that cToon's End Bonus
+              Date/Time. Leave blank to give it out normally whenever the code is redeemed.
+            </p>
 
             <div
               v-for="(rc, idx) in ctoonRewards"
               :key="idx"
-              class="flex items-center space-x-2 mb-2"
+              class="border rounded p-3 mb-2 grid grid-cols-2 sm:grid-cols-[1fr_auto_5rem_auto] gap-2 sm:items-center"
             >
               <!-- per-row datalist, filtered by current input -->
               <datalist :id="`reward-ctoon-list-${idx}`">
@@ -122,35 +127,52 @@
                 />
               </datalist>
 
-              <input
-                v-model="rc.ctoonName"
-                :list="`reward-ctoon-list-${idx}`"
-                type="text"
-                required
-                class="flex-1 border rounded p-2"
-                placeholder="Type 3+ characters to search"
-              />
+              <div class="col-span-2 sm:col-span-1">
+                <label class="text-xs text-gray-500 sm:hidden">cToon</label>
+                <input
+                  v-model="rc.ctoonName"
+                  :list="`reward-ctoon-list-${idx}`"
+                  type="text"
+                  required
+                  class="w-full border rounded p-2 text-base"
+                  placeholder="Type 3+ characters to search"
+                />
+              </div>
 
               <img
                 v-if="findCtoon(rc.ctoonName)?.assetPath"
                 :src="findCtoon(rc.ctoonName).assetPath"
-                class="w-8 h-8 object-cover rounded"
+                class="w-8 h-8 object-cover rounded justify-self-center"
                 alt="cToon preview"
               />
-              <input
-                v-model.number="rc.quantity"
-                type="number"
-                min="1"
-                class="w-20 border rounded p-2"
-                placeholder="Qty"
-              />
+
+              <div>
+                <label class="text-xs text-gray-500 sm:hidden">Qty</label>
+                <input
+                  v-model.number="rc.quantity"
+                  type="number"
+                  min="1"
+                  class="w-full sm:w-20 border rounded p-2 text-base"
+                  placeholder="Qty"
+                />
+              </div>
+
               <button
                 type="button"
                 @click="removeCtoonReward(idx)"
-                class="text-red-600 hover:underline"
+                class="text-red-600 hover:underline justify-self-end sm:justify-self-auto p-2 -m-2"
               >
                 Remove
               </button>
+
+              <div class="col-span-2">
+                <label class="text-xs text-gray-500">End Bonus Date/Time (CST) &middot; optional</label>
+                <input
+                  v-model="rc.endBonusAt"
+                  type="datetime-local"
+                  class="w-full border rounded p-2 text-base"
+                />
+              </div>
             </div>
 
             <button
@@ -271,6 +293,7 @@
               Save Changes
             </button>
             <p v-if="error" class="text-red-600">{{ error }}</p>
+            <p v-if="!error && warning" class="text-amber-600">{{ warning }}</p>
           </div>
         </form>
       </div>
@@ -291,20 +314,7 @@ definePageMeta({
 
 const route         = useRoute()
 const router        = useRouter()
-
-function cstLocalToISO(localStr) {
-  if (!localStr) return null
-  const approxUTC = new Date(localStr + ':00Z')
-  const cstStr = approxUTC.toLocaleString('en-US', {
-    timeZone: 'America/Chicago',
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', hour12: false
-  }).split(', ')
-  const [m2, d2, y2] = cstStr[0].split('/')
-  const cstEquivStr = `${y2}-${m2}-${d2}T${cstStr[1]}`
-  const diffMs = new Date(localStr + ':00Z') - new Date(cstEquivStr + ':00Z')
-  return new Date(approxUTC.getTime() + diffMs).toISOString()
-}
+const { isoToCSTLocal, cstLocalToISO } = useCentralTime()
 
 // form state
 const code          = ref('')
@@ -318,6 +328,7 @@ const prereqPoolEnabled = ref(false)
 const prereqMinOwned    = ref(1)
 const setSearch         = ref('')
 const error         = ref('')
+const warning       = ref('')
 
 // options
 const ctoonOptions  = ref([])
@@ -346,19 +357,6 @@ function findBg(value) {
 }
 function addBgReward() { bgRewards.value.push({ bgLabel: '' }) }
 function removeBgReward(i) { bgRewards.value.splice(i,1) }
-
-// helper to format ISO to CST datetime-local
-function isoToCSTLocal(iso) {
-  const date = new Date(iso)
-  const parts = date.toLocaleString('en-US', {
-    timeZone: 'America/Chicago',
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', hour12: false
-  }).split(', ')
-  const [m,d,y] = parts[0].split('/')
-  const time    = parts[1]
-  return `${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}T${time}`
-}
 
 onMounted(async () => {
   try {
@@ -415,11 +413,11 @@ onMounted(async () => {
     ctoonRewards.value = entry.rewards.flatMap(r =>
       r.ctoons.map(rc => {
         const found = ctoonOptions.value.find(ct => ct.id === rc.ctoonId)
-        return { ctoonName: found?.name||'', quantity: rc.quantity }
+        return { ctoonName: found?.name||'', quantity: rc.quantity, endBonusAt: rc.endBonusAt ? isoToCSTLocal(rc.endBonusAt) : '' }
       })
     )
     if (ctoonRewards.value.length === 0) {
-      ctoonRewards.value = [{ ctoonName: '', quantity: 1 }]
+      ctoonRewards.value = [{ ctoonName: '', quantity: 1, endBonusAt: '' }]
     }
 
     // map existing prerequisites
@@ -440,7 +438,7 @@ onMounted(async () => {
   }
 })
 
-function addCtoonReward() { ctoonRewards.value.push({ ctoonName: '', quantity: 1 }) }
+function addCtoonReward() { ctoonRewards.value.push({ ctoonName: '', quantity: 1, endBonusAt: '' }) }
 function removeCtoonReward(i)  { ctoonRewards.value.splice(i,1) }
 function addPrereqCtoon()       { prereqCtoons.value.push({ ctoonName: '' }) }
 function removePrereqCtoon(i)   { prereqCtoons.value.splice(i,1) }
@@ -481,6 +479,7 @@ function onSetSelected() {
 
 async function submitForm() {
   error.value = ''
+  warning.value = ''
 
   if (maxClaims.value < 1) {
     error.value = 'Max Claims must be at least 1.'
@@ -556,15 +555,37 @@ async function submitForm() {
     if (poolUniqueCount.value > validPool.length) { error.value = 'Number to give out cannot exceed pool size.'; return }
     rewardBlock.pool = { uniqueCount: poolUniqueCount.value, items: validPool }
   } else {
+    const startsDateObj = startsIso ? new Date(startsIso) : null
+    const nowDate = new Date()
+    const endBonusMin = startsDateObj && startsDateObj > nowDate ? startsDateObj : nowDate
+    const expiresDateObj = expiresIso ? new Date(expiresIso) : null
+    const warnings = []
+
     const validCtoons = []
     for (const r of ctoonRewards.value) {
       const name = (r.ctoonName||'').trim()
       if (!name || r.quantity < 1) continue
       const found = ctoonOptions.value.find(ct => ct.name === name)
       if (!found) { error.value = `Unrecognized cToon: “${name}”`; return }
-      validCtoons.push({ ctoonId: found.id, quantity: r.quantity })
+
+      let endBonusIso = null
+      if (r.endBonusAt) {
+        endBonusIso = cstLocalToISO(r.endBonusAt)
+        const ebDate = new Date(endBonusIso)
+        if (isNaN(ebDate.getTime())) { error.value = `Invalid End Bonus Date/Time for “${name}”.`; return }
+        if (ebDate <= endBonusMin) {
+          error.value = `End Bonus Date/Time for “${name}” must be after the code's start date/time and after now.`
+          return
+        }
+        if (expiresDateObj && ebDate > expiresDateObj) {
+          warnings.push(`“${name}”'s End Bonus Date/Time is after the code's Expires At — the code will stop working first, so this bonus window will never take effect.`)
+        }
+      }
+
+      validCtoons.push({ ctoonId: found.id, quantity: r.quantity, endBonusAt: endBonusIso })
     }
     rewardBlock.ctoons = validCtoons
+    warning.value = warnings.join(' ')
   }
 
   const payload = {

--- a/prisma/migrations/20260710205815_add_reward_ctoon_end_bonus_at/migration.sql
+++ b/prisma/migrations/20260710205815_add_reward_ctoon_end_bonus_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "RewardCtoon" ADD COLUMN     "endBonusAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -663,10 +663,13 @@ model RewardCtoonPool {
 }
 
 model RewardCtoon {
-  id       String @id @default(uuid())
-  rewardId String
-  ctoonId  String
-  quantity Int    @default(1)
+  id         String    @id @default(uuid())
+  rewardId   String
+  ctoonId    String
+  quantity   Int       @default(1)
+  // When set, this ctoon is only awarded if redeemed at or before this UTC instant
+  // (entered/displayed as CST in the admin UI). Null = awarded normally, no bonus window.
+  endBonusAt DateTime?
 
   reward ClaimCodeReward @relation(fields: [rewardId], references: [id])
   ctoon  Ctoon           @relation(fields: [ctoonId], references: [id])

--- a/server/api/admin/codes.get.js
+++ b/server/api/admin/codes.get.js
@@ -90,6 +90,7 @@ export default defineEventHandler(async (event) => {
               select: {
                 ctoonId: true,
                 quantity: true,
+                endBonusAt: true,
                 ctoon: { select: { id: true, name: true } }
               }
             },

--- a/server/api/admin/codes.post.js
+++ b/server/api/admin/codes.post.js
@@ -29,6 +29,18 @@ export default defineEventHandler(async (event) => {
   if (!Array.isArray(rewards) || rewards.length === 0) throw createError({ statusCode: 400, statusMessage: 'At least one reward batch is required.' })
   if (prerequisites && !Array.isArray(prerequisites)) throw createError({ statusCode: 400, statusMessage: 'prerequisites must be an array.' })
 
+  // A ctoon's End Bonus Date/Time must be after both "now" and the code's own
+  // start date/time (if that start date/time is still in the future).
+  const now = new Date()
+  const endBonusMin = startsDate && startsDate > now ? startsDate : now
+  function parseEndBonusAt(raw, where) {
+    if (raw == null || raw === '') return null
+    const dt = new Date(raw)
+    if (isNaN(dt.getTime())) throw createError({ statusCode: 400, statusMessage: `Invalid endBonusAt in ${where}.` })
+    if (dt <= endBonusMin) throw createError({ statusCode: 400, statusMessage: `endBonusAt in ${where} must be after the code's start date/time and after now.` })
+    return dt
+  }
+
   const prereqCreates = (prerequisites || []).map((p, i) => {
     if (!p?.ctoonId || typeof p.ctoonId !== 'string') throw createError({ statusCode: 400, statusMessage: `Invalid ctoonId in prerequisites[${i}].` })
     return { ctoonId: p.ctoonId }
@@ -96,7 +108,8 @@ export default defineEventHandler(async (event) => {
     const ctoonCreates = r.ctoons.map((c, j) => {
       if (!c?.ctoonId || typeof c.ctoonId !== 'string') throw createError({ statusCode: 400, statusMessage: `Invalid ctoonId in rewards[${i}].ctoons[${j}].` })
       if (typeof c.quantity !== 'number' || c.quantity < 1) throw createError({ statusCode: 400, statusMessage: `Invalid quantity in rewards[${i}].ctoons[${j}].` })
-      return { ctoonId: c.ctoonId, quantity: c.quantity }
+      const endBonusAt = parseEndBonusAt(c.endBonusAt, `rewards[${i}].ctoons[${j}]`)
+      return { ctoonId: c.ctoonId, quantity: c.quantity, endBonusAt }
     })
     return {
       points: points ?? 0,

--- a/server/api/admin/codes.put.js
+++ b/server/api/admin/codes.put.js
@@ -30,6 +30,18 @@ export default defineEventHandler(async (event) => {
   if (!Array.isArray(rewards) || rewards.length === 0) throw createError({ statusCode: 400, statusMessage: 'At least one reward batch is required.' })
   if (prerequisites && !Array.isArray(prerequisites)) throw createError({ statusCode: 400, statusMessage: 'prerequisites must be an array.' })
 
+  // A ctoon's End Bonus Date/Time must be after both "now" and the code's own
+  // (newly submitted) start date/time, if that start date/time is still in the future.
+  const now = new Date()
+  const endBonusMin = startsDate && startsDate > now ? startsDate : now
+  function parseEndBonusAt(raw, where) {
+    if (raw == null || raw === '') return null
+    const dt = new Date(raw)
+    if (isNaN(dt.getTime())) throw createError({ statusCode: 400, statusMessage: `Invalid endBonusAt in ${where}.` })
+    if (dt <= endBonusMin) throw createError({ statusCode: 400, statusMessage: `endBonusAt in ${where} must be after the code's start date/time and after now.` })
+    return dt
+  }
+
   const existing = await prisma.claimCode.findUnique({
     where: { code },
     include: {
@@ -84,7 +96,8 @@ export default defineEventHandler(async (event) => {
     const fixedCreates = r.ctoons.map((c, j) => {
       if (!c?.ctoonId || typeof c.ctoonId !== 'string') throw createError({ statusCode: 400, statusMessage: `Invalid ctoonId in rewards[${i}].ctoons[${j}].` })
       if (typeof c.quantity !== 'number' || c.quantity < 1) throw createError({ statusCode: 400, statusMessage: `Invalid quantity in rewards[${i}].ctoons[${j}].` })
-      return { ctoonId: c.ctoonId, quantity: c.quantity }
+      const endBonusAt = parseEndBonusAt(c.endBonusAt, `rewards[${i}].ctoons[${j}]`)
+      return { ctoonId: c.ctoonId, quantity: c.quantity, endBonusAt }
     })
     return {
       points: points ?? 0,
@@ -134,7 +147,7 @@ export default defineEventHandler(async (event) => {
       rewards: (cc.rewards || []).map(r => ({
         points: r.points ?? 0,
         pooledUniqueCount: r.pooledUniqueCount ?? null,
-        ctoons: (r.ctoons || []).map(x => ({ ctoonId: x.ctoonId, quantity: x.quantity })),
+        ctoons: (r.ctoons || []).map(x => ({ ctoonId: x.ctoonId, quantity: x.quantity, endBonusAt: x.endBonusAt ? new Date(x.endBonusAt).toISOString() : null })),
         pool: (r.poolCtoons || []).map(x => ({ ctoonId: x.ctoonId, weight: x.weight })),
         backgrounds: (r.backgrounds || []).map(b => b.backgroundId)
       })),

--- a/server/api/redeem.post.js
+++ b/server/api/redeem.post.js
@@ -63,17 +63,26 @@ export default defineEventHandler(async (event) => {
 
   const pointsToAward = rewardDefs.reduce((s, r) => s + (r.points ?? 0), 0)
 
-  // Fixed awards
+  // Fixed awards — skip any ctoon whose bonus window has already ended.
+  const now = new Date()
   const ctoonAwards = rewardDefs.flatMap(r =>
-    r.ctoons.map(rc => ({
-      ctoonId: rc.ctoon.id,
-      name: rc.ctoon.name,
-      quantity: rc.quantity,
-      initialQuantity: rc.ctoon.initialQuantity ?? 0,
-      assetPath: rc.ctoon.assetPath,
-      rarity: rc.ctoon.rarity,
-      set: rc.ctoon.set
-    }))
+    r.ctoons
+      .filter(rc => {
+        if (!rc.endBonusAt || rc.endBonusAt >= now) return true
+        console.log('[redeem] skipped ctoon: bonus window ended', {
+          codeId: claimCode.id, ctoonId: rc.ctoon.id, userId, endBonusAt: rc.endBonusAt, redeemedAt: now
+        })
+        return false
+      })
+      .map(rc => ({
+        ctoonId: rc.ctoon.id,
+        name: rc.ctoon.name,
+        quantity: rc.quantity,
+        initialQuantity: rc.ctoon.initialQuantity ?? 0,
+        assetPath: rc.ctoon.assetPath,
+        rarity: rc.ctoon.rarity,
+        set: rc.ctoon.set
+      }))
   )
 
   // Pooled awards (unique without replacement)


### PR DESCRIPTION
- Show the sale name as a styled fallback banner only when no image is
  set or the image fails to load, instead of always stacking a caption
  under the image.
- Give the banner image a fixed aspect-ratio so its box size no longer
  depends on ambiguous width/height auto-derivation, which could cause
  it to size inconsistently across viewports.
- Extend the sale showcase's background color to the whole section
  (banner + item grid) so it matches the color behind the banner image
  instead of leaving mismatched panels.