### PR TITLE
Redesign sale banner to float over grid instead of taking up space

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -855,11 +855,10 @@ async function closeOverlay() {
 .sale-banner {
   position: relative;
   width: 100%;
-  height: 160px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   border-radius: 6px;
   overflow: hidden;
   background: var(--OrbitDarkBlue, #336699);
@@ -867,9 +866,9 @@ async function closeOverlay() {
 
 .sale-banner-img {
   display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  width: auto;
+  height: auto;
+  max-width: 100%;
 }
 
 .sale-banner-title {
@@ -1399,10 +1398,6 @@ async function closeOverlay() {
     width: 100%;
     height: auto;
     aspect-ratio: 3 / 4;
-  }
-
-  .sale-banner {
-    height: 100px;
   }
 
   .sale-banner-title {

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -179,7 +179,6 @@
               </template>
             </ShortCard>
         </div>
-        <div class="sale-divider">More cToons</div>
       </div>
 
       <div v-if="loading" class="cmart-cards-grid">
@@ -841,10 +840,8 @@ async function closeOverlay() {
 
 /* ── Sale showcase ───────────────────────────────────────────── */
 .sale-showcase {
-  display: flex;
-  flex-direction: column;
+  position: relative;
   flex-shrink: 0;
-  gap: 4px;
   padding: 6px;
   margin-bottom: 4px;
   border-radius: 8px;
@@ -852,23 +849,26 @@ async function closeOverlay() {
   border-bottom: 2px solid var(--OrbitLightBlue, #3399CC);
 }
 
+/* Floats over the top-right corner of the grid rather than taking up its
+   own row — the badge is sized to its own natural image dimensions. */
 .sale-banner {
-  position: relative;
-  width: 100%;
-  flex-shrink: 0;
+  position: absolute;
+  top: -10px;
+  right: -6px;
+  z-index: 2;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  border-radius: 6px;
-  overflow: hidden;
-  background: var(--OrbitDarkBlue, #336699);
+  justify-content: center;
+  transform: rotate(10deg);
+  pointer-events: none;
 }
 
 .sale-banner-img {
   display: block;
   width: auto;
   height: auto;
-  max-width: 100%;
+  max-width: 200px;
+  max-height: 160px;
 }
 
 .sale-banner-title {
@@ -881,7 +881,6 @@ async function closeOverlay() {
 }
 
 .sale-banner-title--fallback {
-  width: 100%;
   border-radius: 6px;
   padding: 14px 8px;
   font-size: 1.15rem;
@@ -893,16 +892,6 @@ async function closeOverlay() {
   grid-auto-rows: var(--shortcard-height);
   gap: 4px;
   flex-shrink: 0;
-}
-
-.sale-divider {
-  margin-top: 6px;
-  text-align: center;
-  font-size: 0.7rem;
-  font-weight: bold;
-  color: rgba(255, 255, 255, 0.6);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 .sale-price-stack {
@@ -1390,7 +1379,7 @@ async function closeOverlay() {
   }
 
   .sale-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: 1fr;
     grid-auto-rows: auto;
   }
 
@@ -1398,6 +1387,11 @@ async function closeOverlay() {
     width: 100%;
     height: auto;
     aspect-ratio: 3 / 4;
+  }
+
+  .sale-banner-img {
+    max-width: 130px;
+    max-height: 110px;
   }
 
   .sale-banner-title {


### PR DESCRIPTION
## Summary
Refactored the sale banner layout from a full-width banner taking up its own row to a floating badge positioned absolutely over the top-right corner of the product grid, reducing visual clutter and improving space efficiency.

## Key Changes
- Changed `.sale-showcase` from flex column layout to `position: relative` to serve as positioning context
- Repositioned `.sale-banner` from relative/full-width to `position: absolute` with `top: -10px; right: -6px` to float over grid corner
- Updated `.sale-banner-img` to use `width: auto; height: auto` with `max-width: 200px; max-height: 160px` constraints instead of stretching to fill container
- Added `transform: rotate(10deg)` and `pointer-events: none` to the banner for visual interest and interaction handling
- Removed `.sale-divider` element and its associated CSS (the "More cToons" text separator)
- Removed `width: 100%` from `.sale-banner-title--fallback` since banner no longer spans full width
- Updated mobile breakpoint: changed `.sale-grid` from 3-column to 1-column layout
- Adjusted `.sale-banner-img` max dimensions for mobile (`max-width: 130px; max-height: 110px`)

## Implementation Details
The banner now uses absolute positioning with `z-index: 2` to layer over the product grid while maintaining its natural image dimensions. The `pointer-events: none` ensures the rotated badge doesn't interfere with grid interactions. This approach eliminates the need for the divider text and creates a more compact, modern layout.

https://claude.ai/code/session_01DQASRWJmnSYrGJcURV3jo2