### PR TITLE
Refactor active sale logic and improve sale banner positioning

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -1379,7 +1379,7 @@ async function closeOverlay() {
   }
 
   .sale-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(3, 1fr);
     grid-auto-rows: auto;
   }
 

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -112,21 +112,25 @@
     <div class="cmart-header">Cartoon ReOrbit cMart</div>
     <div v-if="cmartHalfPriceEnabled" class="cmart-sale-banner">🏷️ 50% Off Sale! All prices are half price.</div>
 
+    <!-- ── Active Sale banner — floats over the top-right corner of the
+         whole panel (overlapping the header), positioned here (rather than
+         inside .cmart-grid) so it isn't clipped by that scroll container ── -->
+    <div v-if="cmartTab === 'ctoons' && !loading && activeSale" class="sale-banner">
+      <img
+        v-if="activeSale.imagePath && !saleImageFailed"
+        :src="activeSale.imagePath"
+        :alt="activeSale.name"
+        class="sale-banner-img"
+        @error="saleImageFailed = true"
+      />
+      <div v-else class="sale-banner-title sale-banner-title--fallback">🔥 {{ activeSale.name }}</div>
+    </div>
+
     <!-- ── cToons grid ───────────────────────────────────────────── -->
     <div v-if="cmartTab === 'ctoons'" class="cmart-grid">
       <!-- ── Active Sale showcase (sits above the cards grid, sized to its
            own content — not a grid item, see .cmart-grid CSS note) ────── -->
       <div v-if="!loading && activeSale" class="sale-showcase">
-        <div class="sale-banner">
-          <img
-            v-if="activeSale.imagePath && !saleImageFailed"
-            :src="activeSale.imagePath"
-            :alt="activeSale.name"
-            class="sale-banner-img"
-            @error="saleImageFailed = true"
-          />
-          <div v-else class="sale-banner-title sale-banner-title--fallback">🔥 {{ activeSale.name }}</div>
-        </div>
         <div class="sale-grid">
             <ShortCard
               v-for="item in activeSale.items"
@@ -840,7 +844,6 @@ async function closeOverlay() {
 
 /* ── Sale showcase ───────────────────────────────────────────── */
 .sale-showcase {
-  position: relative;
   flex-shrink: 0;
   padding: 6px;
   margin-bottom: 4px;
@@ -849,13 +852,15 @@ async function closeOverlay() {
   border-bottom: 2px solid var(--OrbitLightBlue, #3399CC);
 }
 
-/* Floats over the top-right corner of the grid rather than taking up its
-   own row — the badge is sized to its own natural image dimensions. */
+/* Floats over the top-right corner of the whole panel, overlapping the
+   header bar, rather than being scoped to the sale showcase box below it
+   (which scrolls out of view inside .cmart-grid) — the badge is sized to
+   its own natural image dimensions. Positioned relative to .cmart. */
 .sale-banner {
   position: absolute;
-  top: -10px;
+  top: -18px;
   right: -6px;
-  z-index: 2;
+  z-index: 3;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -403,6 +403,8 @@ const statusImage = computed(() => {
 
   if (isSoldOut) return '/images/soldout.png'
 
+  if (ctoon.value?.saleImagePath) return ctoon.value.saleImagePath
+
   const releaseDate = ctoon.value?.releaseDate
   if (releaseDate) {
     const releaseTime = new Date(releaseDate).getTime()
@@ -427,7 +429,9 @@ const statusImageAlt = computed(() => {
     case '/images/new.png': return 'New release'
     case '/images/goingfast.png': return 'Going fast'
     case '/images/soldout.png': return 'Sold out'
-    default: return 'cToon status'
+    default: return ctoon.value?.saleImagePath && statusImage.value === ctoon.value.saleImagePath
+      ? 'On sale'
+      : 'cToon status'
   }
 })
 

--- a/server/api/cmart/active-sale.get.js
+++ b/server/api/cmart/active-sale.get.js
@@ -5,48 +5,8 @@
 // usually no active sale.
 
 import { defineEventHandler } from 'h3'
-import { prisma } from '@/server/prisma'
-import { getActiveSaleCache, setActiveSaleCache } from '@/server/utils/activeSaleCache'
+import { getActiveSale } from '@/server/utils/activeSaleCache'
 
 export default defineEventHandler(async () => {
-  const cached = getActiveSaleCache()
-  if (cached !== undefined) return cached
-
-  const now = new Date()
-  const sale = await prisma.sale.findFirst({
-    where: { startAt: { lte: now }, endAt: { gte: now } },
-    orderBy: { startAt: 'asc' },
-    select: {
-      id: true,
-      name: true,
-      imagePath: true,
-      endAt: true,
-      items: {
-        select: {
-          price: true,
-          perDayLimit: true,
-          ctoon: {
-            select: {
-              id: true,
-              name: true,
-              assetPath: true,
-              rarity: true,
-              price: true,
-              isGtoon: true,
-              quantity: true,
-              totalMinted: true,
-              isSecondEdition: true,
-              secondEditionOverlayX: true,
-              secondEditionOverlayY: true,
-              secondEditionOverlaySize: true
-            }
-          }
-        }
-      }
-    }
-  })
-
-  const result = sale || null
-  setActiveSaleCache(result)
-  return result
+  return await getActiveSale()
 })

--- a/server/api/ctoon/modal.get.js
+++ b/server/api/ctoon/modal.get.js
@@ -1,6 +1,7 @@
 import { defineEventHandler, getQuery, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { isSyntheticUserCtoonId, resolveUserCtoonId, encodeUserCtoonId } from '@/server/utils/userCtoonId'
+import { getActiveSale } from '@/server/utils/activeSaleCache'
 
 function asString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null
@@ -67,6 +68,10 @@ export default defineEventHandler(async (event) => {
     _max: { mintNumber: true }
   })
   const highestMint = mintAgg._max.mintNumber ?? ctoon.totalMinted ?? 0
+
+  const activeSale = await getActiveSale()
+  const activeSaleItem = activeSale?.items?.find(item => item.ctoon.id === ctoon.id) || null
+  const saleImagePath = activeSaleItem ? (activeSale.imagePath || null) : null
 
   const [highestSale, lowestSale, overallTradeCount, overallStats, ownedCount] = await Promise.all([
     prisma.auction.findFirst({
@@ -184,7 +189,8 @@ export default defineEventHandler(async (event) => {
       secondEditionOverlayY: ctoon.secondEditionOverlayY,
       secondEditionOverlaySize: ctoon.secondEditionOverlaySize,
       relatedFirstEdition: ctoon.relatedFirstEdition ?? null,
-      relatedSecondEdition: ctoon.relatedSecondEdition ?? null
+      relatedSecondEdition: ctoon.relatedSecondEdition ?? null,
+      saleImagePath
     },
     userCtoon: userStats,
     ownedCount

--- a/server/utils/activeSaleCache.js
+++ b/server/utils/activeSaleCache.js
@@ -4,6 +4,8 @@
 // create/update/delete routes so changes show up promptly; otherwise expires
 // on its own so a sale's start/end boundary is never more than TTL stale.
 
+import { prisma } from '@/server/prisma'
+
 export const CACHE_TTL_MS = 30 * 1000 // 30 seconds
 
 let _cache = null
@@ -24,4 +26,51 @@ export function getActiveSaleCache() {
     return _cache
   }
   return undefined
+}
+
+// Fetches the currently active Sale (with items), using the short-lived
+// cache above. Shared by the public cMart showcase endpoint and anywhere
+// else (e.g. the cToon info modal) that needs to know if a given cToon is
+// currently on sale.
+export async function getActiveSale() {
+  const cached = getActiveSaleCache()
+  if (cached !== undefined) return cached
+
+  const now = new Date()
+  const sale = await prisma.sale.findFirst({
+    where: { startAt: { lte: now }, endAt: { gte: now } },
+    orderBy: { startAt: 'asc' },
+    select: {
+      id: true,
+      name: true,
+      imagePath: true,
+      endAt: true,
+      items: {
+        select: {
+          price: true,
+          perDayLimit: true,
+          ctoon: {
+            select: {
+              id: true,
+              name: true,
+              assetPath: true,
+              rarity: true,
+              price: true,
+              isGtoon: true,
+              quantity: true,
+              totalMinted: true,
+              isSecondEdition: true,
+              secondEditionOverlayX: true,
+              secondEditionOverlayY: true,
+              secondEditionOverlaySize: true
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const result = sale || null
+  setActiveSaleCache(result)
+  return result
 }


### PR DESCRIPTION
## Summary
This PR refactors the active sale fetching logic into a reusable utility function and improves the sale banner UI by repositioning it to float over the cMart header rather than being contained within the scrollable grid. It also adds sale indicators to individual cToon info cards.

## Key Changes

- **Extracted `getActiveSale()` utility function** in `activeSaleCache.js` that encapsulates the database query and caching logic previously duplicated in the API endpoint
- **Simplified the active-sale API endpoint** to use the new `getActiveSale()` function, reducing code duplication
- **Repositioned sale banner** in Cmart.vue to float absolutely over the top-right corner of the entire panel (overlapping the header) instead of being contained within the scrollable `.cmart-grid`, ensuring it remains visible when scrolling
- **Added sale indicators to cToon info cards** by:
  - Fetching the active sale in the ctoon modal endpoint
  - Detecting if the cToon is part of the active sale
  - Passing the sale image path to the frontend
  - Displaying the sale image as a status badge on individual cToon cards
- **Adjusted responsive layout** for the sale grid on mobile (3 columns instead of 1)
- **Updated z-index and positioning values** to properly layer the banner over the header

## Implementation Details

- The `getActiveSale()` function queries for sales where the current time falls between `startAt` and `endAt`, orders by start time, and caches the result with the existing TTL mechanism
- Sale banner positioning changed from `top: -10px` to `top: -18px` and z-index from `2` to `3` to properly overlay the header
- The `.sale-showcase` container no longer needs `position: relative` since the banner is now positioned relative to the parent `.cmart` container
- Sale image path is conditionally included in cToon modal responses only when the cToon is actively on sale

https://claude.ai/code/session_014HAWLjngAP6rSn18XBSzf3