### PR TITLE
Fix cMart sale banner image display and background

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -857,8 +857,9 @@ async function closeOverlay() {
    (which scrolls out of view inside .cmart-grid) — the badge is sized to
    its own natural image dimensions. Positioned relative to .cmart. */
 .sale-banner {
+  --sale-banner-top: 5px;
   position: absolute;
-  top: -18px;
+  top: var(--sale-banner-top);
   right: -6px;
   z-index: 3;
   display: flex;
@@ -1392,6 +1393,10 @@ async function closeOverlay() {
     width: 100%;
     height: auto;
     aspect-ratio: 3 / 4;
+  }
+
+  .sale-banner {
+    --sale-banner-top: 41px;
   }
 
   .sale-banner-img {


### PR DESCRIPTION
- Show the sale name as a styled fallback banner only when no image is
  set or the image fails to load, instead of always stacking a caption
  under the image.
- Give the banner image a fixed aspect-ratio so its box size no longer
  depends on ambiguous width/height auto-derivation, which could cause
  it to size inconsistently across viewports.
- Extend the sale showcase's background color to the whole section
  (banner + item grid) so it matches the color behind the banner image
  instead of leaving mismatched panels.