### PR TITLE
Track how each cToon was acquired in the ownership log

### DIFF
--- a/components/newsite/AdminCtoonOwnerLogs.vue
+++ b/components/newsite/AdminCtoonOwnerLogs.vue
@@ -180,6 +180,7 @@
                 <div><span class="font-medium">User:</span> {{ selected?.user?.username || 'Unknown' }}</div>
                 <div><span class="font-medium">cToon:</span> {{ selected?.ctoon?.name || 'Unknown' }} <span class="text-gray-500">({{ selected?.ctoon?.rarity || '-' }})</span></div>
                 <div><span class="font-medium">Mint #:</span> {{ selected?.mintNumber ?? '—' }}</div>
+                <div><span class="font-medium">How Obtained:</span> {{ describeMethod(selected) }}</div>
                 <div><span class="font-medium">UserCtoonId:</span> <span class="font-mono break-all">{{ selected?.userCtoonId }}</span></div>
                 <div class="text-[10px] text-gray-500"><span class="font-medium">cToon ID:</span> <span class="font-mono break-all">{{ selected?.ctoonId }}</span></div>
                 <div class="text-[10px] text-gray-500"><span class="font-medium">User ID:</span> <span class="font-mono break-all">{{ selected?.userId }}</span></div>
@@ -229,6 +230,35 @@ function openModal(log) { selected.value = log; showModal.value = true }
 function closeModal() { showModal.value = false }
 
 function shorten(id) { return !id ? '' : (id.length > 12 ? `${id.slice(0,6)}…${id.slice(-4)}` : id) }
+
+const METHOD_LABELS = {
+  CMART: 'cMart',
+  PACK: 'Pack',
+  TRADE: 'Trade',
+  AUCTION: 'Auction',
+  WINBALL: 'Winball',
+  WINWHEEL: 'Win Wheel',
+  CZONE_CONTEST: 'cZone Contest',
+  CZONE_SEARCH: 'cZone Search',
+  HOLIDAY: 'Holiday Event',
+  STARTER_SET: 'Starter Set',
+  CODE_REDEEM: 'Redeemed Code',
+  LOTTERY: 'Lottery',
+  ACHIEVEMENT: 'Achievement Reward',
+  SCAVENGER_HUNT: 'Scavenger Hunt',
+  ADMIN_GRANT: 'Admin Grant',
+  ADMIN_CORRECTION: 'Admin Correction',
+  DISSOLVE: 'Inactivity Reclaim'
+}
+function describeMethod(log) {
+  if (!log?.method) return 'Unknown'
+  const label = METHOD_LABELS[log.method] || log.method
+  const counterpartyName = log.counterparty?.username || log.counterpartyUsername
+  if ((log.method === 'TRADE' || log.method === 'AUCTION') && counterpartyName) {
+    return `${label} with ${counterpartyName}`
+  }
+  return label
+}
 function formatTs(ts) { try { return new Date(ts).toLocaleString() } catch { return String(ts || '') } }
 function img(p) { return !p ? '' : (p.startsWith('http') ? p : p) }
 async function copy(text) { if (text) try { await navigator.clipboard.writeText(text) } catch {} }

--- a/components/newsite/AdminCtoonOwnerLogs.vue
+++ b/components/newsite/AdminCtoonOwnerLogs.vue
@@ -180,12 +180,58 @@
                 <div><span class="font-medium">User:</span> {{ selected?.user?.username || 'Unknown' }}</div>
                 <div><span class="font-medium">cToon:</span> {{ selected?.ctoon?.name || 'Unknown' }} <span class="text-gray-500">({{ selected?.ctoon?.rarity || '-' }})</span></div>
                 <div><span class="font-medium">Mint #:</span> {{ selected?.mintNumber ?? '—' }}</div>
-                <div><span class="font-medium">How Obtained:</span> {{ describeMethod(selected) }}</div>
-                <div><span class="font-medium">UserCtoonId:</span> <span class="font-mono break-all">{{ selected?.userCtoonId }}</span></div>
+                <div class="flex items-center gap-1.5">
+                  <span class="font-medium">How Obtained:</span> {{ describeMethod(selected) }}
+                  <button
+                    v-if="!selected?.method"
+                    class="text-blue-600 underline"
+                    :disabled="investigateLoading"
+                    @click="investigate(selected)"
+                  >
+                    {{ investigateLoading ? 'Searching…' : 'Investigate' }}
+                  </button>
+                </div>
+                <div class="text-[10px] text-gray-500"><span class="font-medium">UserCtoonId:</span> <span class="font-mono break-all">{{ selected?.userCtoonId }}</span></div>
                 <div class="text-[10px] text-gray-500"><span class="font-medium">cToon ID:</span> <span class="font-mono break-all">{{ selected?.ctoonId }}</span></div>
                 <div class="text-[10px] text-gray-500"><span class="font-medium">User ID:</span> <span class="font-mono break-all">{{ selected?.userId }}</span></div>
               </div>
             </div>
+
+            <!-- Investigation results -->
+            <div v-if="investigateResult" class="mt-3 border-t pt-2">
+              <h3 class="font-semibold mb-1.5">Nearby records (±{{ investigateResult.windowSeconds }}s of acquisition time)</h3>
+              <div v-if="!investigateResult.candidates.length" class="text-gray-500 mb-2">
+                No matching records found in that window. Try widening the window below.
+              </div>
+              <ul v-else class="space-y-1.5 mb-2">
+                <li
+                  v-for="(c, i) in investigateResult.candidates"
+                  :key="i"
+                  class="border rounded p-1.5"
+                  :class="i === 0 ? 'border-blue-400 bg-blue-50' : ''"
+                >
+                  <div class="font-medium">
+                    {{ c.label }}
+                    <span v-if="c.counterpartyUsername"> with {{ c.counterpartyUsername }}</span>
+                    <span class="text-gray-500 font-normal">({{ c.deltaSeconds >= 0 ? '+' : '' }}{{ c.deltaSeconds }}s)</span>
+                  </div>
+                  <div class="text-gray-600">{{ c.detail }}</div>
+                  <div class="text-gray-400 text-[10px]">{{ formatTs(c.at) }}</div>
+                </li>
+              </ul>
+              <div v-if="investigateResult.activity.length" class="text-[10px] text-gray-500 mb-2">
+                <div class="font-medium mb-1">Other nearby points activity:</div>
+                <div v-for="(a, i) in investigateResult.activity" :key="i">
+                  {{ a.method || 'Unknown' }} ({{ a.direction }} {{ a.points }}) — {{ a.deltaSeconds >= 0 ? '+' : '' }}{{ a.deltaSeconds }}s
+                </div>
+              </div>
+              <div class="flex items-center gap-1.5">
+                <label>Window (seconds):</label>
+                <input v-model.number="investigateWindow" type="number" min="10" max="3600" class="border rounded px-1.5 py-0.5 w-20" />
+                <button class="border px-1.5 py-0.5 rounded" @click="investigate(selected)">Re-search</button>
+              </div>
+            </div>
+
             <div class="mt-3 flex gap-1 flex-wrap">
               <button class="border px-2 py-0.5 rounded text-[11px]" @click="copy(selected?.userCtoonId)">Copy UserCtoonId</button>
               <button class="border px-2 py-0.5 rounded text-[11px]" @click="copy(selected?.ctoonId)">Copy cToonId</button>
@@ -226,8 +272,31 @@ const showingRange = computed(() => {
 
 const showModal = ref(false)
 const selected = ref(null)
-function openModal(log) { selected.value = log; showModal.value = true }
+const investigateResult = ref(null)
+const investigateLoading = ref(false)
+const investigateWindow = ref(300)
+function openModal(log) {
+  selected.value = log
+  investigateResult.value = null
+  investigateWindow.value = 300
+  showModal.value = true
+}
 function closeModal() { showModal.value = false }
+
+async function investigate(log) {
+  if (!log?.id || investigateLoading.value) return
+  investigateLoading.value = true
+  try {
+    const res = await $fetch('/api/admin/ctoonOwnerLogs/investigate', {
+      params: { id: log.id, windowSeconds: investigateWindow.value }
+    })
+    investigateResult.value = res
+  } catch {
+    investigateResult.value = { windowSeconds: investigateWindow.value, candidates: [], activity: [] }
+  } finally {
+    investigateLoading.value = false
+  }
+}
 
 function shorten(id) { return !id ? '' : (id.length > 12 ? `${id.slice(0,6)}…${id.slice(-4)}` : id) }
 

--- a/pages/admin/ctoonOwnerLogs.vue
+++ b/pages/admin/ctoonOwnerLogs.vue
@@ -186,6 +186,7 @@
               <div><span class="font-medium">User:</span> {{ selected?.user?.username || 'Unknown' }}</div>
               <div><span class="font-medium">cToon:</span> {{ selected?.ctoon?.name || 'Unknown' }} <span class="text-gray-500">({{ selected?.ctoon?.rarity || '-' }})</span></div>
               <div><span class="font-medium">Mint #:</span> {{ selected?.mintNumber ?? '—' }}</div>
+              <div><span class="font-medium">How Obtained:</span> {{ describeMethod(selected) }}</div>
               <div><span class="font-medium">UserCtoonId:</span> <span class="font-mono break-all">{{ selected?.userCtoonId }}</span></div>
               <div class="text-sm text-gray-500"><span class="font-medium">cToon ID:</span> <span class="font-mono break-all">{{ selected?.ctoonId }}</span></div>
               <div class="text-sm text-gray-500"><span class="font-medium">User ID:</span> <span class="font-mono break-all">{{ selected?.userId }}</span></div>
@@ -242,6 +243,35 @@ function closeModal() { showModal.value = false }
 
 // Helpers
 function shorten(id) { return !id ? '' : (id.length > 12 ? `${id.slice(0,6)}…${id.slice(-4)}` : id) }
+
+const METHOD_LABELS = {
+  CMART: 'cMart',
+  PACK: 'Pack',
+  TRADE: 'Trade',
+  AUCTION: 'Auction',
+  WINBALL: 'Winball',
+  WINWHEEL: 'Win Wheel',
+  CZONE_CONTEST: 'cZone Contest',
+  CZONE_SEARCH: 'cZone Search',
+  HOLIDAY: 'Holiday Event',
+  STARTER_SET: 'Starter Set',
+  CODE_REDEEM: 'Redeemed Code',
+  LOTTERY: 'Lottery',
+  ACHIEVEMENT: 'Achievement Reward',
+  SCAVENGER_HUNT: 'Scavenger Hunt',
+  ADMIN_GRANT: 'Admin Grant',
+  ADMIN_CORRECTION: 'Admin Correction',
+  DISSOLVE: 'Inactivity Reclaim'
+}
+function describeMethod(log) {
+  if (!log?.method) return 'Unknown'
+  const label = METHOD_LABELS[log.method] || log.method
+  const counterpartyName = log.counterparty?.username || log.counterpartyUsername
+  if ((log.method === 'TRADE' || log.method === 'AUCTION') && counterpartyName) {
+    return `${label} with ${counterpartyName}`
+  }
+  return label
+}
 function formatTs(ts) { try { return new Date(ts).toLocaleString() } catch { return String(ts || '') } }
 function img(p) { return !p ? '' : (p.startsWith('http') ? p : p) }
 async function copy(text) { if (text) try { await navigator.clipboard.writeText(text) } catch {} }

--- a/pages/admin/ctoonOwnerLogs.vue
+++ b/pages/admin/ctoonOwnerLogs.vue
@@ -186,12 +186,58 @@
               <div><span class="font-medium">User:</span> {{ selected?.user?.username || 'Unknown' }}</div>
               <div><span class="font-medium">cToon:</span> {{ selected?.ctoon?.name || 'Unknown' }} <span class="text-gray-500">({{ selected?.ctoon?.rarity || '-' }})</span></div>
               <div><span class="font-medium">Mint #:</span> {{ selected?.mintNumber ?? '—' }}</div>
-              <div><span class="font-medium">How Obtained:</span> {{ describeMethod(selected) }}</div>
-              <div><span class="font-medium">UserCtoonId:</span> <span class="font-mono break-all">{{ selected?.userCtoonId }}</span></div>
+              <div class="flex items-center gap-2">
+                <span class="font-medium">How Obtained:</span> {{ describeMethod(selected) }}
+                <button
+                  v-if="!selected?.method"
+                  class="text-blue-600 underline text-sm"
+                  :disabled="investigateLoading"
+                  @click="investigate(selected)"
+                >
+                  {{ investigateLoading ? 'Searching…' : 'Investigate' }}
+                </button>
+              </div>
+              <div class="text-sm text-gray-500"><span class="font-medium">UserCtoonId:</span> <span class="font-mono break-all">{{ selected?.userCtoonId }}</span></div>
               <div class="text-sm text-gray-500"><span class="font-medium">cToon ID:</span> <span class="font-mono break-all">{{ selected?.ctoonId }}</span></div>
               <div class="text-sm text-gray-500"><span class="font-medium">User ID:</span> <span class="font-mono break-all">{{ selected?.userId }}</span></div>
             </div>
           </div>
+
+          <!-- Investigation results -->
+          <div v-if="investigateResult" class="mt-6 border-t pt-4">
+            <h3 class="font-semibold mb-2">Nearby records (±{{ investigateResult.windowSeconds }}s of acquisition time)</h3>
+            <div v-if="!investigateResult.candidates.length" class="text-sm text-gray-500 mb-3">
+              No matching records found in that window. Try widening the window below.
+            </div>
+            <ul v-else class="space-y-2 mb-3">
+              <li
+                v-for="(c, i) in investigateResult.candidates"
+                :key="i"
+                class="border rounded p-2 text-sm"
+                :class="i === 0 ? 'border-blue-400 bg-blue-50' : ''"
+              >
+                <div class="font-medium">
+                  {{ c.label }}
+                  <span v-if="c.counterpartyUsername"> with {{ c.counterpartyUsername }}</span>
+                  <span class="text-gray-500 font-normal">({{ c.deltaSeconds >= 0 ? '+' : '' }}{{ c.deltaSeconds }}s)</span>
+                </div>
+                <div class="text-gray-600">{{ c.detail }}</div>
+                <div class="text-gray-400 text-xs">{{ formatTs(c.at) }}</div>
+              </li>
+            </ul>
+            <div v-if="investigateResult.activity.length" class="text-xs text-gray-500 mb-3">
+              <div class="font-medium mb-1">Other nearby points activity:</div>
+              <div v-for="(a, i) in investigateResult.activity" :key="i">
+                {{ a.method || 'Unknown' }} ({{ a.direction }} {{ a.points }}) — {{ a.deltaSeconds >= 0 ? '+' : '' }}{{ a.deltaSeconds }}s
+              </div>
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="text-sm">Window (seconds):</label>
+              <input v-model.number="investigateWindow" type="number" min="10" max="3600" class="border rounded px-2 py-1 w-24 text-sm" />
+              <button class="border px-2 py-1 rounded text-sm" @click="investigate(selected)">Re-search</button>
+            </div>
+          </div>
+
           <div class="mt-6 flex gap-2">
             <button class="border px-3 py-1 rounded" @click="copy(selected?.userCtoonId)">Copy UserCtoonId</button>
             <button class="border px-3 py-1 rounded" @click="copy(selected?.ctoonId)">Copy cToonId</button>
@@ -238,8 +284,31 @@ const showingRange = computed(() => {
 // Modal
 const showModal = ref(false)
 const selected = ref(null)
-function openModal(log) { selected.value = log; showModal.value = true }
+const investigateResult = ref(null)
+const investigateLoading = ref(false)
+const investigateWindow = ref(300)
+function openModal(log) {
+  selected.value = log
+  investigateResult.value = null
+  investigateWindow.value = 300
+  showModal.value = true
+}
 function closeModal() { showModal.value = false }
+
+async function investigate(log) {
+  if (!log?.id || investigateLoading.value) return
+  investigateLoading.value = true
+  try {
+    const res = await $fetch('/api/admin/ctoonOwnerLogs/investigate', {
+      params: { id: log.id, windowSeconds: investigateWindow.value }
+    })
+    investigateResult.value = res
+  } catch {
+    investigateResult.value = { windowSeconds: investigateWindow.value, candidates: [], activity: [] }
+  } finally {
+    investigateLoading.value = false
+  }
+}
 
 // Helpers
 function shorten(id) { return !id ? '' : (id.length > 12 ? `${id.slice(0,6)}…${id.slice(-4)}` : id) }

--- a/prisma/migrations/20260712000000_add_ctoon_owner_log_method/migration.sql
+++ b/prisma/migrations/20260712000000_add_ctoon_owner_log_method/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "CtoonOwnerLog" ADD COLUMN     "method" TEXT,
+ADD COLUMN     "counterpartyUserId" TEXT,
+ADD COLUMN     "counterpartyUsername" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "CtoonOwnerLog" ADD CONSTRAINT "CtoonOwnerLog_counterpartyUserId_fkey" FOREIGN KEY ("counterpartyUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -441,6 +441,7 @@ model User {
   backgroundsCreated       Background[]                @relation("BackgroundCreatedBy")
   ownedBackgrounds         UserBackground[]            @relation("User_UserBackgrounds")
   ownerLogs                CtoonOwnerLog[]
+  ownerLogsAsCounterparty  CtoonOwnerLog[]             @relation("CtoonOwnerLogCounterparty")
   holidayRedemptions       HolidayRedemption[]
   auctionsOnlyCreated      AuctionOnly[]               @relation("AuctionOnlyCreatedBy")
   adImagesCreated          AdImage[]                   @relation("AdImagesCreatedBy")
@@ -1536,16 +1537,20 @@ model AuctionAutoBid {
 }
 
 model CtoonOwnerLog {
-  id          String   @id @default(uuid())
-  userId      String?
-  ctoonId     String?
-  userCtoonId String?
-  mintNumber  Int? // snapshot at the time of ownership
-  createdAt   DateTime @default(now())
+  id                   String   @id @default(uuid())
+  userId               String?
+  ctoonId              String?
+  userCtoonId          String?
+  mintNumber           Int? // snapshot at the time of ownership
+  method               String? // e.g. CMART, PACK, TRADE, AUCTION, WINBALL, WINWHEEL, CZONE_CONTEST, CZONE_SEARCH, HOLIDAY, STARTER_SET, CODE_REDEEM, LOTTERY, ADMIN_GRANT
+  counterpartyUserId   String? // other party for TRADE/AUCTION transfers
+  counterpartyUsername String? // snapshot, survives counterparty account deletion
+  createdAt            DateTime @default(now())
 
-  user      User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
-  ctoon     Ctoon?     @relation(fields: [ctoonId], references: [id], onDelete: SetNull)
-  userCtoon UserCtoon? @relation(fields: [userCtoonId], references: [id], onDelete: SetNull)
+  user        User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
+  ctoon       Ctoon?     @relation(fields: [ctoonId], references: [id], onDelete: SetNull)
+  userCtoon   UserCtoon? @relation(fields: [userCtoonId], references: [id], onDelete: SetNull)
+  counterparty User?     @relation("CtoonOwnerLogCounterparty", fields: [counterpartyUserId], references: [id], onDelete: SetNull)
 
   @@index([userCtoonId, createdAt])
   @@index([ctoonId, createdAt])

--- a/server/api/admin/auction-only/index.post.js
+++ b/server/api/admin/auction-only/index.post.js
@@ -154,7 +154,7 @@ export default defineEventHandler(async (event) => {
           select: { id: true, mintNumber: true, createdAt: true }
         })
         await tx.ctoonOwnerLog.create({
-          data: { userId: owner.id, ctoonId, userCtoonId: uc.id, mintNumber: uc.mintNumber }
+          data: { userId: owner.id, ctoonId, userCtoonId: uc.id, mintNumber: uc.mintNumber, method: 'ADMIN_GRANT' }
         })
         pool.push(uc)
         minted++

--- a/server/api/admin/cheating-tool-apply-stream.post.js
+++ b/server/api/admin/cheating-tool-apply-stream.post.js
@@ -252,7 +252,7 @@ export default defineEventHandler(async (event) => {
               where: { userCtoonId: uc.id, userId: { not: officialId } }
             })
             await tx.ctoonOwnerLog.create({
-              data: { userId: officialId, ctoonId: uc.ctoonId, userCtoonId: uc.id, mintNumber: uc.mintNumber ?? null }
+              data: { userId: officialId, ctoonId: uc.ctoonId, userCtoonId: uc.id, mintNumber: uc.mintNumber ?? null, method: 'ADMIN_CORRECTION' }
             })
           })
           ctoonsTransferred++

--- a/server/api/admin/cheating-tool-apply.post.js
+++ b/server/api/admin/cheating-tool-apply.post.js
@@ -243,7 +243,8 @@ export default defineEventHandler(async (event) => {
             userId: officialId,
             ctoonId: uc.ctoonId,
             userCtoonId: uc.id,
-            mintNumber: uc.mintNumber ?? null
+            mintNumber: uc.mintNumber ?? null,
+            method: 'ADMIN_CORRECTION'
           }
         })
       })

--- a/server/api/admin/ctoonOwnerLogs.get.js
+++ b/server/api/admin/ctoonOwnerLogs.get.js
@@ -65,6 +65,7 @@ export default defineEventHandler(async (event) => {
       include: {
         user:  { select: { id: true, username: true } },
         ctoon: { select: { id: true, name: true, rarity: true, assetPath: true } },
+        counterparty: { select: { id: true, username: true } },
       },
       orderBy: { createdAt: 'desc' },
       skip,

--- a/server/api/admin/ctoonOwnerLogs/investigate.get.js
+++ b/server/api/admin/ctoonOwnerLogs/investigate.get.js
@@ -1,0 +1,186 @@
+// server/api/admin/ctoonOwnerLogs/investigate.get.js
+// Cross-references a CtoonOwnerLog row's user/ctoon/timestamp against other
+// tables to surface likely acquisition methods for historical (pre-tracking)
+// rows where `method` is null.
+import { defineEventHandler, getRequestHeader, getQuery, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+const DEFAULT_WINDOW_SECONDS = 300
+const MIN_WINDOW_SECONDS = 10
+const MAX_WINDOW_SECONDS = 3600
+
+export default defineEventHandler(async (event) => {
+  // AuthZ: admin only
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+
+  const q = getQuery(event)
+  const logId = q.id ? String(q.id) : null
+  if (!logId) throw createError({ statusCode: 400, statusMessage: 'Missing id' })
+
+  const windowSeconds = Math.min(
+    Math.max(parseInt(q.windowSeconds || String(DEFAULT_WINDOW_SECONDS), 10) || DEFAULT_WINDOW_SECONDS, MIN_WINDOW_SECONDS),
+    MAX_WINDOW_SECONDS
+  )
+
+  const log = await prisma.ctoonOwnerLog.findUnique({
+    where: { id: logId },
+    select: {
+      id: true,
+      userId: true,
+      ctoonId: true,
+      userCtoonId: true,
+      mintNumber: true,
+      method: true,
+      createdAt: true,
+      user:  { select: { id: true, username: true } },
+      ctoon: { select: { id: true, name: true } },
+    }
+  })
+  if (!log) throw createError({ statusCode: 404, statusMessage: 'Log not found' })
+  if (!log.userId || !log.ctoonId) {
+    return { log, windowSeconds, candidates: [], activity: [] }
+  }
+
+  const { userId, ctoonId } = log
+  const at = new Date(log.createdAt)
+  const start = new Date(at.getTime() - windowSeconds * 1000)
+  const end = new Date(at.getTime() + windowSeconds * 1000)
+  const within = { gte: start, lte: end }
+
+  const [
+    cmartPurchases,
+    packs,
+    tradeOffers,
+    auctions,
+    wheelSpins,
+    czoneCaptures,
+    holidayRedemptions,
+    lottoLogs,
+    claims,
+    achievements,
+    scavengerSessions,
+    czoneContestSubs,
+    pointsLogs,
+  ] = await Promise.all([
+    prisma.cmartPurchaseLog.findMany({
+      where: { userId, ctoonId, createdAt: within },
+      select: { id: true, createdAt: true, saleId: true }
+    }),
+    prisma.userPack.findMany({
+      where: {
+        userId,
+        mintedCtoons: { some: { ctoonId } },
+        OR: [{ openedAt: within }, { createdAt: within }]
+      },
+      select: { id: true, createdAt: true, openedAt: true, pack: { select: { name: true } } }
+    }),
+    prisma.tradeOffer.findMany({
+      where: {
+        status: 'ACCEPTED',
+        OR: [{ initiatorId: userId }, { recipientId: userId }],
+        ctoons: { some: { userCtoon: { ctoonId } } },
+        updatedAt: within
+      },
+      select: {
+        id: true, updatedAt: true, initiatorId: true, recipientId: true,
+        initiator: { select: { username: true } },
+        recipient: { select: { username: true } }
+      }
+    }),
+    prisma.auction.findMany({
+      where: { winnerId: userId, winnerAt: within, userCtoon: { ctoonId } },
+      select: { id: true, winnerAt: true, highestBid: true, creator: { select: { username: true } } }
+    }),
+    prisma.wheelSpinLog.findMany({
+      where: { userId, ctoonId, createdAt: within },
+      select: { id: true, createdAt: true, result: true }
+    }),
+    prisma.cZoneSearchCapture.findMany({
+      where: { userId, ctoonId, createdAt: within },
+      select: { id: true, createdAt: true }
+    }),
+    prisma.holidayRedemption.findMany({
+      where: { userId, resultCtoonId: ctoonId, redeemedAt: within },
+      select: { id: true, redeemedAt: true, event: { select: { name: true } } }
+    }),
+    log.userCtoonId
+      ? prisma.lottoLog.findMany({
+          where: { userId, userCtoonId: log.userCtoonId, createdAt: within },
+          select: { id: true, createdAt: true, outcome: true }
+        })
+      : Promise.resolve([]),
+    prisma.claim.findMany({
+      where: { userId, claimedAt: within },
+      select: { id: true, claimedAt: true, code: { select: { code: true } } }
+    }),
+    prisma.achievementUser.findMany({
+      where: { userId, achievedAt: within },
+      select: { id: true, achievedAt: true, achievement: { select: { title: true } } }
+    }),
+    prisma.scavengerSession.findMany({
+      where: { userId, ctoonIdAwarded: ctoonId, createdAt: within },
+      select: { id: true, createdAt: true, story: { select: { title: true } } }
+    }),
+    prisma.cZoneContestSubmission.findMany({
+      where: { userId, contest: { distributedAt: within } },
+      select: { id: true, contest: { select: { id: true, name: true, distributedAt: true, winnerId: true } } }
+    }),
+    prisma.pointsLog.findMany({
+      where: { userId, createdAt: within },
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, createdAt: true, method: true, points: true, direction: true }
+    }),
+  ])
+
+  const candidates = []
+  const push = (method, label, ts, detail, counterpartyUsername = null) => {
+    candidates.push({
+      method,
+      label,
+      at: ts,
+      deltaSeconds: Math.round((new Date(ts).getTime() - at.getTime()) / 1000),
+      detail,
+      counterpartyUsername
+    })
+  }
+
+  for (const r of cmartPurchases) push('CMART', 'cMart Purchase', r.createdAt, r.saleId ? 'Purchased during a Sale' : 'Purchased at cMart')
+  for (const r of packs) push('PACK', 'Pack Opening', r.openedAt || r.createdAt, `Pack: ${r.pack?.name || 'Unknown pack'}`)
+  for (const r of tradeOffers) {
+    const counterpartyUsername = r.initiatorId === userId ? r.recipient?.username : r.initiator?.username
+    push('TRADE', 'Trade', r.updatedAt, 'Accepted trade offer', counterpartyUsername)
+  }
+  for (const r of auctions) push('AUCTION', 'Auction Win', r.winnerAt, `Winning bid: ${r.highestBid}`, r.creator?.username || null)
+  for (const r of wheelSpins) push('WINWHEEL', 'Win Wheel', r.createdAt, `Spin result: ${r.result}`)
+  for (const r of czoneCaptures) push('CZONE_SEARCH', 'cZone Search', r.createdAt, 'Captured via cZone Search')
+  for (const r of holidayRedemptions) push('HOLIDAY', 'Holiday Event', r.redeemedAt, `Event: ${r.event?.name || 'Unknown'}`)
+  for (const r of lottoLogs) push('LOTTERY', 'Lottery', r.createdAt, `Outcome: ${r.outcome}`)
+  for (const r of claims) push('CODE_REDEEM', 'Redeemed Code', r.claimedAt, `Code: ${r.code?.code || 'Unknown'}`)
+  for (const r of achievements) push('ACHIEVEMENT', 'Achievement Reward', r.achievedAt, `Achievement: ${r.achievement?.title || 'Unknown'}`)
+  for (const r of scavengerSessions) push('SCAVENGER_HUNT', 'Scavenger Hunt', r.createdAt, `Story: ${r.story?.title || 'Unknown'}`)
+  for (const r of czoneContestSubs) {
+    const isWinner = r.contest?.winnerId === r.id
+    push('CZONE_CONTEST', 'cZone Contest', r.contest?.distributedAt, `Contest: ${r.contest?.name || 'Unknown'}${isWinner ? ' (winner)' : ' (participant)'}`)
+  }
+
+  candidates.sort((a, b) => Math.abs(a.deltaSeconds) - Math.abs(b.deltaSeconds))
+
+  const activity = pointsLogs.map(p => ({
+    at: p.createdAt,
+    deltaSeconds: Math.round((new Date(p.createdAt).getTime() - at.getTime()) / 1000),
+    method: p.method,
+    points: p.points,
+    direction: p.direction
+  })).sort((a, b) => Math.abs(a.deltaSeconds) - Math.abs(b.deltaSeconds))
+
+  return { log, windowSeconds, candidates, activity }
+})

--- a/server/api/admin/czone-contest/[id]/distribute.post.js
+++ b/server/api/admin/czone-contest/[id]/distribute.post.js
@@ -93,7 +93,7 @@ export default defineEventHandler(async (event) => {
   for (const { ctoonId, qty } of winnerCtoons) {
     const quantity = qty ?? 1
     for (let i = 0; i < quantity; i++) {
-      await mintQueue.add('mintCtoon', { userId: winnerUserId, ctoonId, isSpecial: true })
+      await mintQueue.add('mintCtoon', { userId: winnerUserId, ctoonId, isSpecial: true, method: 'CZONE_CONTEST' })
     }
   }
 
@@ -102,7 +102,7 @@ export default defineEventHandler(async (event) => {
   for (const { ctoonId, qty } of participantCtoons) {
     const quantity = qty ?? 1
     for (let i = 0; i < quantity; i++) {
-      await mintQueue.add('mintCtoon', { userId: winnerUserId, ctoonId, isSpecial: true })
+      await mintQueue.add('mintCtoon', { userId: winnerUserId, ctoonId, isSpecial: true, method: 'CZONE_CONTEST' })
     }
   }
 
@@ -110,7 +110,7 @@ export default defineEventHandler(async (event) => {
     for (const { ctoonId, qty } of participantCtoons) {
       const quantity = qty ?? 1
       for (let i = 0; i < quantity; i++) {
-        await mintQueue.add('mintCtoon', { userId, ctoonId, isSpecial: true })
+        await mintQueue.add('mintCtoon', { userId, ctoonId, isSpecial: true, method: 'CZONE_CONTEST' })
       }
     }
   }

--- a/server/api/admin/remove-cheating.post.js
+++ b/server/api/admin/remove-cheating.post.js
@@ -207,7 +207,7 @@ export default defineEventHandler(async (event) => {
         })
 
         await tx.ctoonOwnerLog.create({
-          data: { userId: officialId, userCtoonId: row.id, ctoonId: row.ctoon?.id ?? null, mintNumber: row.mintNumber ?? null }
+          data: { userId: officialId, userCtoonId: row.id, ctoonId: row.ctoon?.id ?? null, mintNumber: row.mintNumber ?? null, method: 'ADMIN_CORRECTION' }
         })
       })
       transferredCount++ // caller will override to sourceTransferredCount when needed

--- a/server/api/czone/searches/capture.post.js
+++ b/server/api/czone/searches/capture.post.js
@@ -126,7 +126,7 @@ export default defineEventHandler(async (event) => {
 
   let qe
   try {
-    const job = await mintQueue.add('mintCtoon', { userId, ctoonId: appearance.ctoonId, isSpecial: true })
+    const job = await mintQueue.add('mintCtoon', { userId, ctoonId: appearance.ctoonId, isSpecial: true, method: 'CZONE_SEARCH' })
     qe = new QueueEvents(mintQueue.name, { connection: redisConnection })
     await qe.waitUntilReady()
     await job.waitUntilFinished(qe)

--- a/server/api/game/winball.post.js
+++ b/server/api/game/winball.post.js
@@ -168,7 +168,7 @@ export default defineEventHandler(async (event) => {
       if (!existing) {
         await mintQueue.add(
           'mintCtoon',
-          { userId, ctoonId: gpCtoon.id, isSpecial: true },
+          { userId, ctoonId: gpCtoon.id, isSpecial: true, method: 'WINBALL' },
           { jobId: `winball-gp-${userId}-${gpCtoon.id}` }
         )
         grandPrizeCtoonName = gpCtoon.name

--- a/server/api/game/winwheel/spin.post.js
+++ b/server/api/game/winwheel/spin.post.js
@@ -199,7 +199,8 @@ export default defineEventHandler(async (event) => {
         const job = await mintQueue.add('mintCtoon', {
           userId,
           ctoonId: ctoonIdToMint,
-          isSpecial: true
+          isSpecial: true,
+          method: 'WINWHEEL'
         })
         // Second arg to waitUntilFinished is the client-side wait TTL in ms.
         // The `timeout` field on add() options does not exist in BullMQ v5.

--- a/server/api/holiday/redeem.post.js
+++ b/server/api/holiday/redeem.post.js
@@ -276,7 +276,8 @@ export default defineEventHandler(async (event) => {
       userId,
       ctoonId: resultCtoonId,
       isSpecial: true,
-      bypassHolidayWindowCheck: true
+      bypassHolidayWindowCheck: true,
+      method: 'HOLIDAY'
     })
 
     // Wait for worker to finish

--- a/server/api/lottery.post.js
+++ b/server/api/lottery.post.js
@@ -133,7 +133,8 @@ export default defineEventHandler(async (event) => {
             userId: me.id,
             ctoonId: awardedCtoon.id,
             userCtoonId: newUserCtoon.id,
-            mintNumber
+            mintNumber,
+            method: 'LOTTERY'
           }
         })
       })

--- a/server/api/redeem.post.js
+++ b/server/api/redeem.post.js
@@ -145,7 +145,7 @@ export default defineEventHandler(async (event) => {
     for (const award of ctoonAwards) {
       for (let i = 0; i < award.quantity; i++) {
         const { ctoonId, name } = award
-        const job = await mintQueue.add('mintCtoon', { userId, ctoonId, isSpecial: true })
+        const job = await mintQueue.add('mintCtoon', { userId, ctoonId, isSpecial: true, method: 'CODE_REDEEM' })
         await job.waitUntilFinished(qe)
         const minted = await prisma.userCtoon.findFirst({
           where: { userId, ctoonId },

--- a/server/api/scavenger/choose.post.js
+++ b/server/api/scavenger/choose.post.js
@@ -121,7 +121,7 @@ export default defineEventHandler(async (event) => {
       if (available.length) {
         const pick = available[Math.floor(Math.random() * available.length)].id
         // Mint and wait
-        const job = await mintQueue.add('mintCtoon', { userId, ctoonId: pick, isSpecial: true })
+        const job = await mintQueue.add('mintCtoon', { userId, ctoonId: pick, isSpecial: true, method: 'SCAVENGER_HUNT' })
         const qe = new QueueEvents(mintQueue.name, { connection: redisConnection })
         await qe.waitUntilReady()
         try { await job.waitUntilFinished(qe); ctoonId = pick } finally { await qe.close() }

--- a/server/api/starter-sets.post.js
+++ b/server/api/starter-sets.post.js
@@ -81,7 +81,7 @@ export default defineEventHandler(async (event) => {
   // 6) Enqueue mints
   await Promise.all(
     toMint.map(ctoonId =>
-      mintQueue.add('mintCtoon', { userId, ctoonId, isSpecial: true })
+      mintQueue.add('mintCtoon', { userId, ctoonId, isSpecial: true, method: 'STARTER_SET' })
     )
   )
 

--- a/server/api/trade/offers/[id]/accept.post.js
+++ b/server/api/trade/offers/[id]/accept.post.js
@@ -143,6 +143,12 @@ export default defineEventHandler(async (event) => {
       const newOwner = tc.role === 'OFFERED'
         ? offer.recipientId
         : offer.initiatorId
+      const counterpartyUserId = tc.role === 'OFFERED'
+        ? offer.initiatorId
+        : offer.recipientId
+      const counterpartyUsername = tc.role === 'OFFERED'
+        ? initiator.username
+        : me.username
 
       const updatedUC = await tx.userCtoon.update({
         where: { id: tc.userCtoonId },
@@ -161,7 +167,10 @@ export default defineEventHandler(async (event) => {
           userId:      newOwner,
           ctoonId:     updatedUC.ctoonId,
           userCtoonId: updatedUC.id,
-          mintNumber:  updatedUC.mintNumber
+          mintNumber:  updatedUC.mintNumber,
+          method:      'TRADE',
+          counterpartyUserId,
+          counterpartyUsername
         }
       })
     }

--- a/server/api/wishlist/accept/[id].post.js
+++ b/server/api/wishlist/accept/[id].post.js
@@ -121,7 +121,15 @@ export default defineEventHandler(async (event) => {
       where: { userCtoonId: uc.id, userId: { not: initiatorId } }
     })
     await tx.ctoonOwnerLog.create({
-      data: { userId: initiatorId, ctoonId: transferred.ctoonId, userCtoonId: transferred.id, mintNumber: transferred.mintNumber }
+      data: {
+        userId: initiatorId,
+        ctoonId: transferred.ctoonId,
+        userCtoonId: transferred.id,
+        mintNumber: transferred.mintNumber,
+        method: 'TRADE',
+        counterpartyUserId: recipientId,
+        counterpartyUsername: me.username
+      }
     })
 
     // record the traded cToon on the offer as REQUESTED (initiator requested it)

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -2905,6 +2905,14 @@ async function performAuctionClose(auctionId) {
     })
     resolvedCreatorId = official?.id || null
   }
+  let resolvedCreatorUsername = null
+  if (resolvedCreatorId) {
+    const seller = await db.user.findUnique({
+      where: { id: resolvedCreatorId },
+      select: { username: true }
+    })
+    resolvedCreatorUsername = seller?.username || null
+  }
 
   // Highest bid placed before auction end; earliest timestamp breaks ties
   const winningBid = await db.bid.findFirst({
@@ -2962,7 +2970,10 @@ async function performAuctionClose(auctionId) {
           userId:      winningBid.userId,
           ctoonId:     uc.ctoonId,
           userCtoonId: uc.id,
-          mintNumber:  uc.mintNumber
+          mintNumber:  uc.mintNumber,
+          method:      'AUCTION',
+          counterpartyUserId: resolvedCreatorId,
+          counterpartyUsername: resolvedCreatorUsername
         }
       })
 

--- a/server/utils/achievements.js
+++ b/server/utils/achievements.js
@@ -240,7 +240,7 @@ export async function awardAchievementToUser(client, userId, achievement) {
       const lim = rc?.ctoon?.quantity
       let canGive = lim == null ? qty : Math.max(0, Math.min(qty, lim - minted))
       for (let i = 0; i < canGive; i++) {
-        await mintQueue.add('mintCtoon', { userId, ctoonId: rc.ctoonId, isSpecial: true })
+        await mintQueue.add('mintCtoon', { userId, ctoonId: rc.ctoonId, isSpecial: true, method: 'ACHIEVEMENT' })
       }
       if (canGive > 0) {
         awardSummary.ctoons.push({

--- a/server/workers/dissolve.worker.js
+++ b/server/workers/dissolve.worker.js
@@ -111,7 +111,8 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
           userId: officialId,
           userCtoonId: uc.id,
           ctoonId: uc.ctoon?.id ?? null,
-          mintNumber: uc.mintNumber ?? null
+          mintNumber: uc.mintNumber ?? null,
+          method: 'DISSOLVE'
         }
       })
       ctoonsTransferred++

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -10,7 +10,8 @@ const connection = {
 
 // Create a BullMQ worker to process mint jobs
 const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
-    const { userId, ctoonId, isSpecial = false, effectivePrice, userPackId = null } = job.data
+    const { userId, ctoonId, isSpecial = false, effectivePrice, userPackId = null, method = null } = job.data
+    const resolvedMethod = method || (userPackId ? 'PACK' : (isSpecial ? null : 'CMART'))
 
     const TIME_BASED_CAP = 999999999
 
@@ -304,7 +305,8 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
           userId,
           ctoonId,
           userCtoonId: uc.id,
-          mintNumber: uc.mintNumber
+          mintNumber: uc.mintNumber,
+          method: resolvedMethod
         }
       })
 


### PR DESCRIPTION
Add method/counterparty fields to CtoonOwnerLog and thread the
acquisition source through every mint and transfer path (cMart,
packs, trades, auctions, Winball, Win Wheel, cZone search/contest,
holiday events, starter sets, code redemption, lottery, achievements,
scavenger hunt, and admin corrections). The admin Ownership Log
modal now shows "How Obtained", including the counterparty username
for trades and auctions.