### PR TITLE
Fix "???" quantity on time-based mint cToons after mint end date

### DIFF
--- a/server/api/cmart/open-pack.get.js
+++ b/server/api/cmart/open-pack.get.js
@@ -52,9 +52,20 @@ export default defineEventHandler(async (event) => {
   if (userPack.opened) throw createError({ statusCode: 400, statusMessage: 'Pack already opened' })
 
   /* ── 1. Build pools & choose cToons ─────────────────────── */
+  const TIME_BASED_CAP = 999999999
+
   const poolByRarity = {}
   for (const opt of userPack.pack.ctoonOptions) {
     const c = opt.ctoon
+
+    // Time-based mint window guard: once mintEndDate has passed, treat the
+    // cToon as depleted even if the finalize job hasn't written the real
+    // quantity yet (still the TIME_BASED_CAP sentinel) — same logic buy.post.js
+    // uses, so packs can't keep minting a cToon whose window already closed.
+    if (c.mintLimitType === 'timeBased' && c.mintEndDate && new Date(c.mintEndDate) <= new Date()) {
+      if (c.quantity === TIME_BASED_CAP) continue
+    }
+
     if (c.quantity !== null) {
       const minted = await db.userCtoon.count({ where: { ctoonId: c.id } })
       if (minted >= c.quantity) continue

--- a/server/api/collection/[username].get.js
+++ b/server/api/collection/[username].get.js
@@ -56,7 +56,21 @@ export default defineEventHandler(async (event) => {
     return mA - mB
   })
 
-  return rows.map(uc => ({
+  const TIME_BASED_CAP = 999999999
+  const now = new Date()
+
+  return rows.map(uc => {
+    // If a time-based cToon's mint window has closed but the finalization job
+    // hasn't written the real quantity yet (sentinel still in place), substitute
+    // totalMinted so the collection displays the actual count instead of "???".
+    const effectiveQuantity = (
+      uc.ctoon.mintLimitType === 'timeBased' &&
+      uc.ctoon.mintEndDate &&
+      new Date(uc.ctoon.mintEndDate) <= now &&
+      uc.ctoon.quantity === TIME_BASED_CAP
+    ) ? uc.ctoon.totalMinted : uc.ctoon.quantity
+
+    return {
     id: encodeUserCtoonId(uc.userId, uc.ctoonId, uc.mintNumber),
     ctoonId: uc.ctoonId,
     assetPath: uc.ctoon.assetPath,
@@ -68,7 +82,7 @@ export default defineEventHandler(async (event) => {
     cost: uc.ctoon.cost,
     power: uc.ctoon.power,
     mintNumber: uc.mintNumber,
-    quantity: uc.ctoon.quantity,
+    quantity: effectiveQuantity,
     isFirstEdition: uc.isFirstEdition,
     isHolidayItem: holidaySet.has(uc.ctoonId),
     inPendingTrade: pendingTradeSet.has(uc.id),
@@ -76,5 +90,6 @@ export default defineEventHandler(async (event) => {
     secondEditionOverlayX: uc.ctoon.secondEditionOverlayX,
     secondEditionOverlayY: uc.ctoon.secondEditionOverlayY,
     secondEditionOverlaySize: uc.ctoon.secondEditionOverlaySize
-  }))
+    }
+  })
 })

--- a/server/api/collections.get.js
+++ b/server/api/collections.get.js
@@ -61,7 +61,21 @@ export default defineEventHandler(async (event) => {
   const holidaySet = new Set(holidayRows.map(r => r.ctoonId))
 
   // shape response
-  return filtered.map(uc => ({
+  const TIME_BASED_CAP = 999999999
+  const now = new Date()
+
+  return filtered.map(uc => {
+    // If a time-based cToon's mint window has closed but the finalization job
+    // hasn't written the real quantity yet (sentinel still in place), substitute
+    // totalMinted so the collection displays the actual count instead of "???".
+    const effectiveQuantity = (
+      uc.ctoon.mintLimitType === 'timeBased' &&
+      uc.ctoon.mintEndDate &&
+      new Date(uc.ctoon.mintEndDate) <= now &&
+      uc.ctoon.quantity === TIME_BASED_CAP
+    ) ? uc.ctoon.totalMinted : uc.ctoon.quantity
+
+    return {
     id: uc.id,
     userId: uc.userId,
     ctoonId: uc.ctoonId,
@@ -76,7 +90,7 @@ export default defineEventHandler(async (event) => {
     cost: uc.ctoon.cost,
     power: uc.ctoon.power,
     mintNumber: uc.mintNumber,
-    quantity: uc.ctoon.quantity,
+    quantity: effectiveQuantity,
     isFirstEdition: uc.isFirstEdition,
     acquiredAt: uc.createdAt,
     auctions: uc.auctions || [],
@@ -85,5 +99,6 @@ export default defineEventHandler(async (event) => {
     secondEditionOverlayX: uc.ctoon.secondEditionOverlayX,
     secondEditionOverlayY: uc.ctoon.secondEditionOverlayY,
     secondEditionOverlaySize: uc.ctoon.secondEditionOverlaySize
-  }))
+    }
+  })
 })

--- a/server/api/ctoon/modal.get.js
+++ b/server/api/ctoon/modal.get.js
@@ -69,6 +69,17 @@ export default defineEventHandler(async (event) => {
   })
   const highestMint = mintAgg._max.mintNumber ?? ctoon.totalMinted ?? 0
 
+  // If a time-based cToon's mint window has closed but the finalization job
+  // hasn't written the real quantity yet (sentinel still in place), substitute
+  // totalMinted so the modal displays the actual count instead of "???".
+  const TIME_BASED_CAP = 999999999
+  const effectiveQuantity = (
+    ctoon.mintLimitType === 'timeBased' &&
+    ctoon.mintEndDate &&
+    new Date(ctoon.mintEndDate) <= new Date() &&
+    ctoon.quantity === TIME_BASED_CAP
+  ) ? ctoon.totalMinted : ctoon.quantity
+
   const activeSale = await getActiveSale()
   const activeSaleItem = activeSale?.items?.find(item => item.ctoon.id === ctoon.id) || null
   const saleImagePath = activeSaleItem ? (activeSale.imagePath || null) : null
@@ -163,7 +174,7 @@ export default defineEventHandler(async (event) => {
       characters: ctoon.characters,
       releaseDate: ctoon.releaseDate,
       highestMint,
-      quantity: ctoon.quantity,
+      quantity: effectiveQuantity,
       inCmart: ctoon.inCmart,
       price: ctoon.price,
       soundPath: ctoon.soundPath ?? null,

--- a/server/api/czone/[username].get.js
+++ b/server/api/czone/[username].get.js
@@ -100,11 +100,23 @@ export default defineEventHandler(async (event) => {
   const ownedSet = new Set(ownedUserCtoons.map((uc) => uc.id))
 
   // Helper: Enrich a single userCtoon ID with metadata
+  const TIME_BASED_CAP = 999999999
+  const now = new Date()
   const ctoonMeta = {}
   for (const uc of ownedUserCtoons) {
+    // If a time-based cToon's mint window has closed but the finalization job
+    // hasn't written the real quantity yet (sentinel still in place), substitute
+    // totalMinted so the cZone displays the actual count instead of "???".
+    const effectiveQuantity = (
+      uc.ctoon.mintLimitType === 'timeBased' &&
+      uc.ctoon.mintEndDate &&
+      new Date(uc.ctoon.mintEndDate) <= now &&
+      uc.ctoon.quantity === TIME_BASED_CAP
+    ) ? uc.ctoon.totalMinted : uc.ctoon.quantity
+
     ctoonMeta[uc.id] = {
       mintNumber: uc.mintNumber,
-      quantity: uc.ctoon.quantity,
+      quantity: effectiveQuantity,
       series: uc.ctoon.series,
       rarity: uc.ctoon.rarity,
       isFirstEdition: uc.isFirstEdition,


### PR DESCRIPTION
The cMart grid endpoint already substituted totalMinted for the
999999999 sentinel once a time-based mint window closed, but the
cToon detail modal, My Collection, cZone, and username collection
endpoints still returned the raw sentinel value until the async
mint-end worker finished writing the final quantity, so those views
kept showing "???" even after the mint end date/time had passed.