### PR TITLE
Limit users to one active featured-auction lead per cToon

### DIFF
--- a/components/newsite/AuctionDetails.vue
+++ b/components/newsite/AuctionDetails.vue
@@ -61,7 +61,7 @@
           <!-- Featured notice -->
           <div v-if="auction.isFeatured" class="adet-featured-notice">
             ⭐ Featured — you can't bid if you already own 2+<template v-if="auction.ctoon.isSecondEdition"> (1st + 2nd edition combined)</template>
-            or have received 2+ in the last 30 days.
+            or have received 2+ in the last 30 days. You also can't lead more than one active featured auction for this cToon at the same time.
           </div>
 
           <!-- ── Place bid ── -->
@@ -74,6 +74,7 @@
               {{ hasBids ? `Raise to ${nextBidAmount} pts` : `Bid ${nextBidAmount} pts` }}
             </button>
             <div v-if="isTopBidder" class="adet-hint">You are the highest bidder.</div>
+            <div v-else-if="blockedByFeaturedLead" class="adet-hint warn">You're already leading another active featured auction for this cToon — you can only lead one at a time.</div>
             <div v-else-if="!canBid" class="adet-hint warn">Need {{ Math.max(0, nextBidAmount - userPoints) }} more pts (have {{ userPoints }}).</div>
           </div>
 
@@ -87,6 +88,7 @@
                 v-model.number="autoBidInput"
                 :placeholder="`> ${displayedBid} pts`"
                 min="0"
+                :disabled="blockedByFeaturedLead"
               />
               <button class="adet-autobid-set" :disabled="!canSaveAutoBid" @click="saveAutoBid">
                 {{ myAutoBid ? 'Update' : 'Set' }}
@@ -97,6 +99,7 @@
               Max: {{ myAutoBid.maxAmount }} pts
               <span v-if="!myAutoBid.isActive" class="adet-dim"> (inactive)</span>
             </div>
+            <div v-if="blockedByFeaturedLead" class="adet-hint warn">Auto-Bid disabled — you're already leading another active featured auction for this cToon.</div>
           </div>
         </div>
       </div>
@@ -151,7 +154,8 @@ const autoBidInput = ref(null)
 const currentTopBidder = ref(null)
 const toast = reactive({ message: '', type: 'success' })
 const now   = ref(new Date())
-let timer, socket
+const blockedByFeaturedLead = ref(false)
+let timer, featuredLeadTimer, socket
 
 // ── Computed ─────────────────────────────────────────────────────
 const ended = computed(() => auction.value.endAt && new Date(auction.value.endAt) <= now.value)
@@ -178,10 +182,10 @@ const isTopBidder = computed(() =>
   user.value?.username && currentTopBidder.value === user.value.username
 )
 const canBid = computed(() =>
-  !ended.value && !isTopBidder.value && userPoints.value >= nextBidAmount.value
+  !ended.value && !isTopBidder.value && !blockedByFeaturedLead.value && userPoints.value >= nextBidAmount.value
 )
 const canSaveAutoBid = computed(() => {
-  if (ended.value) return false
+  if (ended.value || blockedByFeaturedLead.value) return false
   const v = Number(autoBidInput.value)
   return Number.isFinite(v) && v > displayedBid.value && v <= userPoints.value
 })
@@ -221,12 +225,24 @@ async function loadAuction() {
   auction.value.highestBid = data.highestBid ?? data.currentBid ?? 0
   bids.value       = data.bids || []
   userPoints.value = pts.points
+  blockedByFeaturedLead.value = !!data.blockedByFeaturedLead
   currentTopBidder.value = topBidderFromHistory.value ?? data.highestBidderUsername ?? null
   recentSales.value = await $fetch(`/api/auction/${props.auctionId}/getRecentAuctions`)
   try {
     const ab = await $fetch(`/api/auction/${props.auctionId}/autobid`)
     myAutoBid.value    = ab || null
     autoBidInput.value = ab?.maxAmount ?? null
+  } catch {}
+}
+
+// The lead-conflict flag can go stale (e.g. the user gets outbid on the
+// other featured auction while sitting on this page), so re-check it
+// periodically rather than only at initial load.
+async function refreshFeaturedLead() {
+  if (!auction.value?.isFeatured || ended.value) return
+  try {
+    const data = await $fetch(`/api/auction/${props.auctionId}`)
+    blockedByFeaturedLead.value = !!data.blockedByFeaturedLead
   } catch {}
 }
 
@@ -323,11 +339,15 @@ onMounted(async () => {
   await loadAuction()
   loading.value = false
   timer = setInterval(() => { now.value = new Date() }, 1000)
+  if (auction.value.isFeatured) {
+    featuredLeadTimer = setInterval(refreshFeaturedLead, 30_000)
+  }
   connectSocket()
 })
 
 onUnmounted(() => {
   clearInterval(timer)
+  clearInterval(featuredLeadTimer)
   if (socket) {
     socket.emit('leave-auction', { auctionId: props.auctionId })
     socket.disconnect()

--- a/prisma/migrations/20260718000000_add_auction_featured_lead_index/migration.sql
+++ b/prisma/migrations/20260718000000_add_auction_featured_lead_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Auction_isFeatured_status_highestBidderId_idx" ON "Auction"("isFeatured", "status", "highestBidderId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1180,6 +1180,7 @@ model Auction {
 
   @@index([userCtoonId, status])
   @@index([status, winnerId])
+  @@index([isFeatured, status, highestBidderId])
 }
 
 model Bid {

--- a/server/api/auction/[id].get.js
+++ b/server/api/auction/[id].get.js
@@ -1,6 +1,7 @@
 import { defineEventHandler, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { encodeUserCtoonId } from '@/server/utils/userCtoonId'
+import { findConcurrentFeaturedLead } from '@/server/utils/featuredEligibility'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -42,9 +43,25 @@ export default defineEventHandler(async (event) => {
     ? Math.max(...bids.map((b) => b.amount))
     : auction.initialBet
 
+  // Featured auctions: a user can't hold the lead on more than one active
+  // featured auction for the same cToon (1st/2nd edition combined) at a time.
+  let blockedByFeaturedLead = false
+  if (auction.isFeatured) {
+    const conflict = await findConcurrentFeaturedLead(prisma, userId, {
+      excludeAuctionId: auction.id,
+      ctoon: {
+        ctoonId: auction.userCtoon.ctoonId,
+        isSecondEdition: auction.userCtoon.ctoon.isSecondEdition,
+        relatedFirstEditionId: auction.userCtoon.ctoon.relatedFirstEditionId
+      }
+    })
+    blockedByFeaturedLead = !!conflict
+  }
+
   return {
     id: auction.id,
     isFeatured: auction.isFeatured,
+    blockedByFeaturedLead,
     ctoon: {
       id:         auction.userCtoon.ctoonId,
       userCtoonId: encodeUserCtoonId(auction.userCtoon.userId, auction.userCtoon.ctoonId, auction.userCtoon.mintNumber),

--- a/server/api/auction/[id]/autobid.post.js
+++ b/server/api/auction/[id]/autobid.post.js
@@ -5,7 +5,7 @@ import { useRuntimeConfig } from '#imports'
 import { prisma as db } from '@/server/prisma'
 import { applyProxyAutoBids } from '@/server/utils/autoBid'
 import { scheduleAuctionClose } from '@/server/utils/queues'
-import { assertFeaturedEligibility } from '@/server/utils/featuredEligibility'
+import { assertFeaturedEligibility, assertNoConcurrentFeaturedLead } from '@/server/utils/featuredEligibility'
 
 const ANTI_SNIPE_MS = 60_000
 
@@ -63,6 +63,18 @@ export default defineEventHandler(async (event) => {
   // This check must happen before the upsert so an ineligible user's auto-bid is never saved.
   await assertFeaturedEligibility(db, userId, {
     isFeatured: auc.isFeatured,
+    ctoon: {
+      ctoonId: auc.userCtoon?.ctoonId,
+      isSecondEdition: auc.userCtoon?.ctoon?.isSecondEdition,
+      relatedFirstEditionId: auc.userCtoon?.ctoon?.relatedFirstEditionId
+    }
+  })
+
+  // A user can't hold the lead on more than one active featured auction for
+  // the same cToon (1st/2nd edition combined) at a time.
+  await assertNoConcurrentFeaturedLead(db, userId, {
+    isFeatured: auc.isFeatured,
+    excludeAuctionId: auctionId,
     ctoon: {
       ctoonId: auc.userCtoon?.ctoonId,
       isSecondEdition: auc.userCtoon?.ctoon?.isSecondEdition,
@@ -158,6 +170,17 @@ export default defineEventHandler(async (event) => {
     // cToons this counts copies across both editions.
     await assertFeaturedEligibility(tx, userId, {
       isFeatured: fresh.isFeatured,
+      ctoon: {
+        ctoonId: fresh.userCtoon?.ctoonId,
+        isSecondEdition: fresh.userCtoon?.ctoon?.isSecondEdition,
+        relatedFirstEditionId: fresh.userCtoon?.ctoon?.relatedFirstEditionId
+      }
+    })
+
+    // Re-check the concurrent-featured-lead rule inside txn to avoid races
+    await assertNoConcurrentFeaturedLead(tx, userId, {
+      isFeatured: fresh.isFeatured,
+      excludeAuctionId: auctionId,
       ctoon: {
         ctoonId: fresh.userCtoon?.ctoonId,
         isSecondEdition: fresh.userCtoon?.ctoon?.isSecondEdition,

--- a/server/api/auction/[id]/bid.post.js
+++ b/server/api/auction/[id]/bid.post.js
@@ -5,7 +5,7 @@ import { useRuntimeConfig } from '#imports'
 import { prisma as db } from '@/server/prisma'
 import { applyProxyAutoBids, incrementFor } from '@/server/utils/autoBid'
 import { scheduleAuctionClose } from '@/server/utils/queues'
-import { assertFeaturedEligibility } from '@/server/utils/featuredEligibility'
+import { assertFeaturedEligibility, assertNoConcurrentFeaturedLead } from '@/server/utils/featuredEligibility'
 
 const ANTI_SNIPE_MS = 60_000
 
@@ -91,6 +91,18 @@ export default defineEventHandler(async (event) => {
     // across both editions (see server/utils/featuredEligibility.js).
     await assertFeaturedEligibility(tx, userId, {
       isFeatured: fresh.isFeatured,
+      ctoon: {
+        ctoonId: fresh.userCtoon?.ctoonId,
+        isSecondEdition: fresh.userCtoon?.ctoon?.isSecondEdition,
+        relatedFirstEditionId: fresh.userCtoon?.ctoon?.relatedFirstEditionId
+      }
+    })
+
+    // A user can't hold the lead on more than one active featured auction for
+    // the same cToon (1st/2nd edition combined) at a time.
+    await assertNoConcurrentFeaturedLead(tx, userId, {
+      isFeatured: fresh.isFeatured,
+      excludeAuctionId: auctionId,
       ctoon: {
         ctoonId: fresh.userCtoon?.ctoonId,
         isSecondEdition: fresh.userCtoon?.ctoon?.isSecondEdition,

--- a/server/utils/featuredEligibility.js
+++ b/server/utils/featuredEligibility.js
@@ -86,3 +86,50 @@ export async function assertFeaturedEligibility(client, userId, { isFeatured, ct
     })
   }
 }
+
+/**
+ * A user may not hold the lead on more than one ACTIVE featured auction for
+ * the same cToon (1st/2nd edition combined) at a time. Finds another active
+ * featured auction, other than `excludeAuctionId`, where the user is
+ * currently the highest bidder for the same counted cToon set.
+ *
+ * @param {import('@prisma/client').PrismaClient} client  prisma or a tx client
+ * @param {string} userId
+ * @param {{ excludeAuctionId: string, ctoon: { ctoonId?: string|null, isSecondEdition?: boolean|null, relatedFirstEditionId?: string|null } }} opts
+ * @returns {Promise<{ id: string }|null>}
+ */
+export async function findConcurrentFeaturedLead(client, userId, { excludeAuctionId, ctoon }) {
+  const ctoonIds = resolveFeaturedCtoonIds(ctoon)
+  if (!ctoonIds.length) return null
+
+  return client.auction.findFirst({
+    where: {
+      id: { not: excludeAuctionId },
+      isFeatured: true,
+      status: 'ACTIVE',
+      endAt: { gt: new Date() },
+      highestBidderId: userId,
+      userCtoon: { ctoonId: { in: ctoonIds } }
+    },
+    select: { id: true }
+  })
+}
+
+/**
+ * Throwing guard for the manual-bid / set-autobid endpoints. No-op when the
+ * auction is not featured.
+ *
+ * @param {import('@prisma/client').PrismaClient} client
+ * @param {string} userId
+ * @param {{ isFeatured?: boolean|null, excludeAuctionId: string, ctoon: object }} opts
+ */
+export async function assertNoConcurrentFeaturedLead(client, userId, { isFeatured, excludeAuctionId, ctoon }) {
+  if (!isFeatured) return
+  const conflict = await findConcurrentFeaturedLead(client, userId, { excludeAuctionId, ctoon })
+  if (conflict) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: 'You are already the leading bidder on another active featured auction for this cToon'
+    })
+  }
+}


### PR DESCRIPTION
A user can no longer hold the highest bid on more than one active
featured auction for the same cToon (1st/2nd edition combined) at a
time. Manual bids and auto-bid submissions are blocked server-side
(pre-check plus in-transaction re-check, mirroring the existing
featured-eligibility guard), and the featured-auction panel now
disables the bid/auto-bid controls with an explanatory message when
this applies, with the instructional notice updated to describe the
rule.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QWZK6ByHoi94w9pwWnibfc