### PR TITLE
Make dissolve-auction "featured" rules admin-configurable

### DIFF
--- a/components/newsite/AdminManageUsers.vue
+++ b/components/newsite/AdminManageUsers.vue
@@ -481,40 +481,21 @@
                      class="flex-1 text-xs border rounded px-2 py-1" />
             </div>
 
-            <div class="rounded border border-blue-100 bg-blue-50 p-2 space-y-1.5">
-              <p class="text-xs font-medium text-blue-700">
-                Pokémon
-                <span class="ml-1 font-normal text-blue-500">
-                  ({{ dissolveCategoryCounts ? dissolveCategoryCounts.pokemon : '…' }} cToons)
-                </span>
-              </p>
-              <div class="flex items-center gap-2">
-                <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
-                <input v-model.number="dissolveSchedule.pokemonCadenceDays" type="number" min="1"
-                       class="w-24 text-xs border rounded px-2 py-1" />
-              </div>
-              <div class="flex items-center gap-2">
-                <label class="w-36 text-xs text-gray-600 shrink-0">Per cadence</label>
-                <input v-model.number="dissolveSchedule.pokemonPerCadence" type="number" min="1"
-                       class="w-24 text-xs border rounded px-2 py-1" />
-              </div>
-            </div>
-
             <div class="rounded border border-purple-100 bg-purple-50 p-2 space-y-1.5">
               <p class="text-xs font-medium text-purple-700">
-                Crazy Rare
+                Featured
                 <span class="ml-1 font-normal text-purple-500">
-                  ({{ dissolveCategoryCounts ? dissolveCategoryCounts.crazyRare : '…' }} cToons)
+                  ({{ dissolveCategoryCounts ? dissolveCategoryCounts.featured : '…' }} cToons)
                 </span>
               </p>
               <div class="flex items-center gap-2">
                 <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
-                <input v-model.number="dissolveSchedule.crazyRareCadenceDays" type="number" min="1"
+                <input v-model.number="dissolveSchedule.featuredCadenceDays" type="number" min="1"
                        class="w-24 text-xs border rounded px-2 py-1" />
               </div>
               <div class="flex items-center gap-2">
                 <label class="w-36 text-xs text-gray-600 shrink-0">Per cadence</label>
-                <input v-model.number="dissolveSchedule.crazyRarePerCadence" type="number" min="1"
+                <input v-model.number="dissolveSchedule.featuredPerCadence" type="number" min="1"
                        class="w-24 text-xs border rounded px-2 py-1" />
               </div>
             </div>
@@ -1137,13 +1118,11 @@ function defaultStartLocal() {
 
 function defaultDissolveSchedule() {
   return {
-    startAtLocal:          defaultStartLocal(),
-    pokemonCadenceDays:    7,
-    pokemonPerCadence:     2,
-    crazyRareCadenceDays:  7,
-    crazyRarePerCadence:   1,
-    otherCadenceDays:      7,
-    otherPerCadence:       10,
+    startAtLocal:        defaultStartLocal(),
+    featuredCadenceDays: 7,
+    featuredPerCadence:  2,
+    otherCadenceDays:    7,
+    otherPerCadence:     10,
   }
 }
 
@@ -1224,13 +1203,11 @@ async function confirmDissolve() {
       method: 'POST',
       body: {
         scheduleConfig: {
-          startAtUtc:            new Date(s.startAtLocal + ':00-06:00').toISOString(),
-          pokemonCadenceDays:    s.pokemonCadenceDays,
-          pokemonPerCadence:     s.pokemonPerCadence,
-          crazyRareCadenceDays:  s.crazyRareCadenceDays,
-          crazyRarePerCadence:   s.crazyRarePerCadence,
-          otherCadenceDays:      s.otherCadenceDays,
-          otherPerCadence:       s.otherPerCadence,
+          startAtUtc:          new Date(s.startAtLocal + ':00-06:00').toISOString(),
+          featuredCadenceDays: s.featuredCadenceDays,
+          featuredPerCadence:  s.featuredPerCadence,
+          otherCadenceDays:    s.otherCadenceDays,
+          otherPerCadence:     s.otherPerCadence,
         }
       }
     })

--- a/pages/admin/dissolve-queue.vue
+++ b/pages/admin/dissolve-queue.vue
@@ -5,7 +5,10 @@
     <div class="max-w-5xl mx-auto mt-6 space-y-6">
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Dissolve Queue</h1>
-        <button @click="loadData" class="text-sm text-blue-600 underline">Refresh</button>
+        <div class="flex items-center gap-4">
+          <button @click="openFeaturedModal" class="text-sm text-blue-600 underline">Edit Featured</button>
+          <button @click="loadData" class="text-sm text-blue-600 underline">Refresh</button>
+        </div>
       </div>
 
       <!-- Summary cards -->
@@ -86,8 +89,7 @@
               class="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
             >
               <option value="ALL">All Categories</option>
-              <option value="POKEMON">Pokémon</option>
-              <option value="CRAZY_RARE">Crazy Rare</option>
+              <option value="FEATURED">Featured</option>
               <option value="UNSCHEDULED">Unscheduled</option>
             </select>
             <select
@@ -228,13 +230,8 @@
                    class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
           </div>
           <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
-            <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Pokémon / cadence</label>
-            <input v-model.number="form.pokemonPerCadence" type="number" min="1"
-                   class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
-          </div>
-          <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
-            <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Crazy Rare / cadence</label>
-            <input v-model.number="form.crazyRarePerCadence" type="number" min="1"
+            <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Featured / cadence</label>
+            <input v-model.number="form.featuredPerCadence" type="number" min="1"
                    class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
           </div>
           <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
@@ -260,6 +257,90 @@
             :disabled="scheduling"
             class="w-full sm:w-auto px-4 py-2 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
           >{{ scheduling ? 'Scheduling…' : 'Apply Schedule' }}</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Edit Featured modal -->
+    <div v-if="showFeaturedModal" class="fixed inset-0 z-30 flex items-center justify-center p-3 sm:p-6 bg-black/40" @click.self="closeFeaturedModal">
+      <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+        <div class="p-4 sm:p-5 border-b">
+          <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-lg">Edit Featured</h2>
+            <button @click="closeFeaturedModal" class="text-gray-400 hover:text-gray-600 text-2xl leading-none">&times;</button>
+          </div>
+          <p class="text-xs text-gray-600 mt-2 leading-relaxed">
+            When an account is dissolved, its cToons are transferred to the official account and queued
+            for auction. Any cToon that matches a checked rarity, series, or set below is marked as a
+            <span class="font-medium">featured</span> auction when it's queued. Checking a box here does
+            not change anything already in the queue until you click Save — at that point every entry
+            currently in the dissolve queue (scheduled or not) is re-evaluated against these rules too.
+          </p>
+        </div>
+
+        <div class="p-4 sm:p-5 overflow-y-auto space-y-5 flex-1">
+          <!-- Rarities -->
+          <div>
+            <h3 class="text-sm font-semibold text-gray-700 mb-2">Rarities</h3>
+            <div class="border rounded-lg divide-y max-h-40 overflow-y-auto">
+              <label v-for="r in orderedRarityOptions" :key="r"
+                     class="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 cursor-pointer">
+                <input type="checkbox" :value="r" v-model="featuredForm.rarities" class="rounded border-gray-300" />
+                {{ r }}
+              </label>
+            </div>
+          </div>
+
+          <!-- Series -->
+          <div>
+            <h3 class="text-sm font-semibold text-gray-700 mb-2">Series</h3>
+            <input
+              v-model="seriesSearch"
+              type="text"
+              placeholder="Filter series… (3+ characters)"
+              class="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
+            />
+            <div class="border rounded-lg divide-y max-h-40 overflow-y-auto">
+              <label v-for="s in orderedSeriesOptions" :key="s"
+                     class="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 cursor-pointer">
+                <input type="checkbox" :value="s" v-model="featuredForm.series" class="rounded border-gray-300" />
+                {{ s }}
+              </label>
+              <div v-if="!orderedSeriesOptions.length" class="px-3 py-2 text-sm text-gray-400">No matches</div>
+            </div>
+          </div>
+
+          <!-- Sets -->
+          <div>
+            <h3 class="text-sm font-semibold text-gray-700 mb-2">Sets</h3>
+            <input
+              v-model="setSearch"
+              type="text"
+              placeholder="Filter sets… (3+ characters)"
+              class="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
+            />
+            <div class="border rounded-lg divide-y max-h-40 overflow-y-auto">
+              <label v-for="s in orderedSetOptions" :key="s"
+                     class="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 cursor-pointer">
+                <input type="checkbox" :value="s" v-model="featuredForm.sets" class="rounded border-gray-300" />
+                {{ s }}
+              </label>
+              <div v-if="!orderedSetOptions.length" class="px-3 py-2 text-sm text-gray-400">No matches</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-4 sm:p-5 border-t">
+          <div v-if="featuredError" class="mb-3 text-xs text-red-600">{{ featuredError }}</div>
+          <div v-if="featuredSuccess" class="mb-3 text-xs text-emerald-600">{{ featuredSuccess }}</div>
+          <div class="flex items-center justify-end gap-3">
+            <button @click="closeFeaturedModal" class="px-4 py-2 text-sm rounded-md border border-gray-300 hover:bg-gray-50">Cancel</button>
+            <button
+              @click="saveFeaturedConfig"
+              :disabled="savingFeatured"
+              class="px-4 py-2 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+            >{{ savingFeatured ? 'Saving…' : 'Save' }}</button>
+          </div>
         </div>
       </div>
     </div>
@@ -313,9 +394,8 @@ const currentPage = ref(1)
 const pageSize    = 50
 
 const categories = [
-  { key: 'POKEMON',    label: 'Pokémon' },
-  { key: 'CRAZY_RARE', label: 'Crazy Rare' },
-  { key: 'OTHER',      label: 'Other' },
+  { key: 'FEATURED', label: 'Featured' },
+  { key: 'OTHER',    label: 'Other' },
 ]
 
 // Filter across all entries (not just current page)
@@ -395,12 +475,11 @@ function defaultStartLocal() {
 }
 
 const form = ref({
-  startAtLocal:        defaultStartLocal(),
-  cadenceDays:         7,
-  pokemonPerCadence:   2,
-  crazyRarePerCadence: 1,
-  otherPerCadence:     10,
-  reschedule:          false,
+  startAtLocal:       defaultStartLocal(),
+  cadenceDays:        7,
+  featuredPerCadence: 2,
+  otherPerCadence:    10,
+  reschedule:         false,
 })
 
 const scheduling      = ref(false)
@@ -437,12 +516,11 @@ async function applySchedule() {
     const res = await $fetch('/api/admin/dissolve-queue/schedule', {
       method: 'POST',
       body: {
-        startAtUtc:          new Date(f.startAtLocal).toISOString(),
-        cadenceDays:         f.cadenceDays,
-        pokemonPerCadence:   f.pokemonPerCadence,
-        crazyRarePerCadence: f.crazyRarePerCadence,
-        otherPerCadence:     f.otherPerCadence,
-        reschedule:          f.reschedule,
+        startAtUtc:         new Date(f.startAtLocal).toISOString(),
+        cadenceDays:        f.cadenceDays,
+        featuredPerCadence: f.featuredPerCadence,
+        otherPerCadence:    f.otherPerCadence,
+        reschedule:         f.reschedule,
       }
     })
     scheduleSuccess.value = `Scheduled ${res.scheduled} entries.`
@@ -481,8 +559,95 @@ function fmtCST(iso) {
 }
 
 function categoryChip(cat) {
-  if (cat === 'POKEMON')    return 'bg-blue-100 text-blue-700'
-  if (cat === 'CRAZY_RARE') return 'bg-purple-100 text-purple-700'
+  if (cat === 'FEATURED') return 'bg-purple-100 text-purple-700'
   return 'bg-gray-100 text-gray-600'
+}
+
+// ── Edit Featured modal ────────────────────────────────────────────────────
+const showFeaturedModal = ref(false)
+const savingFeatured    = ref(false)
+const featuredError     = ref('')
+const featuredSuccess   = ref('')
+
+const seriesSearch = ref('')
+const setSearch    = ref('')
+
+const featuredForm = ref({ rarities: [], series: [], sets: [] })
+const featuredOptions = ref({ rarities: [], series: [], sets: [] })
+
+// Checked items first (alphabetical within each group), then unchecked (alphabetical).
+function orderChecked(options, checked) {
+  const checkedSet = new Set(checked)
+  const checkedItems   = options.filter(o => checkedSet.has(o)).sort((a, b) => a.localeCompare(b))
+  const uncheckedItems = options.filter(o => !checkedSet.has(o)).sort((a, b) => a.localeCompare(b))
+  return [...checkedItems, ...uncheckedItems]
+}
+
+// Checked items always stay visible even if they don't match the active filter,
+// so a selection can't silently disappear while searching.
+function filterOptions(options, checked, search) {
+  const q = search.trim().toLowerCase()
+  if (q.length < 3) return options
+  const checkedSet = new Set(checked)
+  return options.filter(o => checkedSet.has(o) || o.toLowerCase().includes(q))
+}
+
+const orderedRarityOptions = computed(() =>
+  orderChecked(featuredOptions.value.rarities, featuredForm.value.rarities)
+)
+const orderedSeriesOptions = computed(() =>
+  orderChecked(filterOptions(featuredOptions.value.series, featuredForm.value.series, seriesSearch.value), featuredForm.value.series)
+)
+const orderedSetOptions = computed(() =>
+  orderChecked(filterOptions(featuredOptions.value.sets, featuredForm.value.sets, setSearch.value), featuredForm.value.sets)
+)
+
+async function openFeaturedModal() {
+  featuredError.value   = ''
+  featuredSuccess.value = ''
+  seriesSearch.value    = ''
+  setSearch.value       = ''
+  showFeaturedModal.value = true
+  try {
+    const data = await $fetch('/api/admin/dissolve-featured-config', { headers })
+    featuredForm.value = {
+      rarities: [...(data.selected?.rarities || [])],
+      series:   [...(data.selected?.series   || [])],
+      sets:     [...(data.selected?.sets     || [])],
+    }
+    featuredOptions.value = {
+      rarities: data.options?.rarities || [],
+      series:   data.options?.series   || [],
+      sets:     data.options?.sets     || [],
+    }
+  } catch (e) {
+    featuredError.value = e?.data?.statusMessage || 'Failed to load featured config.'
+  }
+}
+
+function closeFeaturedModal() {
+  showFeaturedModal.value = false
+}
+
+async function saveFeaturedConfig() {
+  savingFeatured.value = true
+  featuredError.value   = ''
+  featuredSuccess.value = ''
+  try {
+    const res = await $fetch('/api/admin/dissolve-featured-config', {
+      method: 'POST',
+      body: {
+        rarities: featuredForm.value.rarities,
+        series:   featuredForm.value.series,
+        sets:     featuredForm.value.sets,
+      }
+    })
+    featuredSuccess.value = `Saved. ${res.updated} queue ${res.updated === 1 ? 'entry' : 'entries'} updated.`
+    await loadData()
+  } catch (e) {
+    featuredError.value = e?.data?.statusMessage || 'Failed to save featured config.'
+  } finally {
+    savingFeatured.value = false
+  }
 }
 </script>

--- a/pages/admin/users.vue
+++ b/pages/admin/users.vue
@@ -427,42 +427,22 @@
                    class="flex-1 text-xs border rounded px-2 py-1" />
           </div>
 
-          <!-- Pokémon category -->
-          <div class="rounded border border-blue-100 bg-blue-50 p-2 space-y-1.5">
-            <p class="text-xs font-medium text-blue-700">
-              Pokémon
-              <span class="ml-1 font-normal text-blue-500">
-                ({{ dissolveCategoryCounts ? dissolveCategoryCounts.pokemon : '…' }} cToons)
-              </span>
-            </p>
-            <div class="flex items-center gap-2">
-              <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
-              <input v-model.number="dissolveSchedule.pokemonCadenceDays" type="number" min="1"
-                     class="w-24 text-xs border rounded px-2 py-1" />
-            </div>
-            <div class="flex items-center gap-2">
-              <label class="w-36 text-xs text-gray-600 shrink-0">Per cadence</label>
-              <input v-model.number="dissolveSchedule.pokemonPerCadence" type="number" min="1"
-                     class="w-24 text-xs border rounded px-2 py-1" />
-            </div>
-          </div>
-
-          <!-- Crazy Rare category -->
+          <!-- Featured category -->
           <div class="rounded border border-purple-100 bg-purple-50 p-2 space-y-1.5">
             <p class="text-xs font-medium text-purple-700">
-              Crazy Rare
+              Featured
               <span class="ml-1 font-normal text-purple-500">
-                ({{ dissolveCategoryCounts ? dissolveCategoryCounts.crazyRare : '…' }} cToons)
+                ({{ dissolveCategoryCounts ? dissolveCategoryCounts.featured : '…' }} cToons)
               </span>
             </p>
             <div class="flex items-center gap-2">
               <label class="w-36 text-xs text-gray-600 shrink-0">Cadence (days)</label>
-              <input v-model.number="dissolveSchedule.crazyRareCadenceDays" type="number" min="1"
+              <input v-model.number="dissolveSchedule.featuredCadenceDays" type="number" min="1"
                      class="w-24 text-xs border rounded px-2 py-1" />
             </div>
             <div class="flex items-center gap-2">
               <label class="w-36 text-xs text-gray-600 shrink-0">Per cadence</label>
-              <input v-model.number="dissolveSchedule.crazyRarePerCadence" type="number" min="1"
+              <input v-model.number="dissolveSchedule.featuredPerCadence" type="number" min="1"
                      class="w-24 text-xs border rounded px-2 py-1" />
             </div>
           </div>
@@ -1100,13 +1080,11 @@ function defaultStartLocal() {
 
 function defaultDissolveSchedule() {
   return {
-    startAtLocal:          defaultStartLocal(),
-    pokemonCadenceDays:    7,
-    pokemonPerCadence:     2,
-    crazyRareCadenceDays:  7,
-    crazyRarePerCadence:   1,
-    otherCadenceDays:      7,
-    otherPerCadence:       10,
+    startAtLocal:        defaultStartLocal(),
+    featuredCadenceDays: 7,
+    featuredPerCadence:  2,
+    otherCadenceDays:    7,
+    otherPerCadence:     10,
   }
 }
 
@@ -1192,13 +1170,11 @@ async function confirmDissolve() {
       method: 'POST',
       body: {
         scheduleConfig: {
-          startAtUtc:            new Date(s.startAtLocal + ':00-06:00').toISOString(),
-          pokemonCadenceDays:    s.pokemonCadenceDays,
-          pokemonPerCadence:     s.pokemonPerCadence,
-          crazyRareCadenceDays:  s.crazyRareCadenceDays,
-          crazyRarePerCadence:   s.crazyRarePerCadence,
-          otherCadenceDays:      s.otherCadenceDays,
-          otherPerCadence:       s.otherPerCadence,
+          startAtUtc:          new Date(s.startAtLocal + ':00-06:00').toISOString(),
+          featuredCadenceDays: s.featuredCadenceDays,
+          featuredPerCadence:  s.featuredPerCadence,
+          otherCadenceDays:    s.otherCadenceDays,
+          otherPerCadence:     s.otherPerCadence,
         }
       }
     })

--- a/prisma/migrations/20260720000000_dissolve_featured_config/migration.sql
+++ b/prisma/migrations/20260720000000_dissolve_featured_config/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "GlobalGameConfig"
+  ADD COLUMN "featuredDissolveRarities" JSONB NOT NULL DEFAULT '[]',
+  ADD COLUMN "featuredDissolveSeries" JSONB NOT NULL DEFAULT '[]',
+  ADD COLUMN "featuredDissolveSets" JSONB NOT NULL DEFAULT '[]';
+
+-- Backfill: preserve current hardcoded behavior (Pokemon series + Crazy Rare
+-- rarity were the only two "featured" triggers before this migration).
+UPDATE "GlobalGameConfig"
+SET "featuredDissolveRarities" = '["Crazy Rare"]',
+    "featuredDissolveSeries" = '["Pokemon"]'
+WHERE "id" = 'singleton';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1038,6 +1038,13 @@ model GlobalGameConfig {
   gameTileTkoImagePath          String?
   gameTileReorbitmatchImagePath String?
   gameTileTowerImagePath        String?
+  // Account-dissolve "featured auction" rules: cToons matching any of these
+  // rarities/series/sets are marked isFeatured when an account is dissolved.
+  // Each is a JSON array of strings, edited via the "Edit Featured" modal on
+  // /admin/dissolve-queue.
+  featuredDissolveRarities Json     @default("[]")
+  featuredDissolveSeries   Json     @default("[]")
+  featuredDissolveSets     Json     @default("[]")
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 }
@@ -1648,7 +1655,7 @@ model AuctionOnly {
 model DissolveAuctionQueue {
   id           String    @id @default(uuid())
   userCtoonId  String    @unique
-  category     String    @default("OTHER")  // "POKEMON" | "CRAZY_RARE" | "OTHER"
+  category     String    @default("OTHER")  // "FEATURED" | "OTHER"
   isFeatured   Boolean   @default(false)
   scheduledFor DateTime?                     // UTC; null = not yet scheduled
   createdAt    DateTime  @default(now())

--- a/server/api/admin/dissolve-featured-config.get.js
+++ b/server/api/admin/dissolve-featured-config.get.js
@@ -1,0 +1,36 @@
+// server/api/admin/dissolve-featured-config.get.js
+// Powers the "Edit Featured" modal on /admin/dissolve-queue: returns the
+// currently-selected rarities/series/sets plus the full option lists to
+// render as checkboxes.
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { getFeaturedDissolveConfig } from '@/server/utils/featuredDissolveConfig'
+
+// Matches the static rarity list used elsewhere in admin (addCtoon.vue, auctions.vue, etc).
+const RARITY_OPTIONS = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare', 'Prize Only', 'Code Only', 'Auction Only']
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const [selected, seriesRows, setRows] = await Promise.all([
+    getFeaturedDissolveConfig(),
+    prisma.ctoon.findMany({ where: { series: { not: null } }, distinct: ['series'], select: { series: true }, orderBy: { series: 'asc' } }),
+    prisma.ctoon.findMany({ where: { set: { not: null } }, distinct: ['set'], select: { set: true }, orderBy: { set: 'asc' } }),
+  ])
+
+  return {
+    selected,
+    options: {
+      rarities: RARITY_OPTIONS,
+      series: seriesRows.map(r => r.series).filter(Boolean),
+      sets: setRows.map(r => r.set).filter(Boolean),
+    }
+  }
+})

--- a/server/api/admin/dissolve-featured-config.post.js
+++ b/server/api/admin/dissolve-featured-config.post.js
@@ -1,0 +1,91 @@
+// server/api/admin/dissolve-featured-config.post.js
+// Saves the "Edit Featured" rule set (rarities/series/sets that make a
+// dissolved cToon featured) and retroactively re-evaluates every entry
+// currently sitting in the dissolve queue — scheduled or not — since none of
+// them are live auctions yet.
+import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { isCtoonFeatured } from '@/server/utils/featuredDissolveConfig'
+
+function sanitizeList(input) {
+  if (!Array.isArray(input)) return []
+  const seen = new Set()
+  const out = []
+  for (const raw of input) {
+    if (typeof raw !== 'string') continue
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    const key = trimmed.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(trimmed)
+  }
+  return out
+}
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const body = await readBody(event) || {}
+  const rarities = sanitizeList(body.rarities)
+  const series   = sanitizeList(body.series)
+  const sets     = sanitizeList(body.sets)
+
+  const before = await prisma.globalGameConfig.findUnique({
+    where: { id: 'singleton' },
+    select: { featuredDissolveRarities: true, featuredDissolveSeries: true, featuredDissolveSets: true }
+  })
+
+  const result = await prisma.globalGameConfig.upsert({
+    where: { id: 'singleton' },
+    create: { id: 'singleton', featuredDissolveRarities: rarities, featuredDissolveSeries: series, featuredDissolveSets: sets },
+    update: { featuredDissolveRarities: rarities, featuredDissolveSeries: series, featuredDissolveSets: sets },
+  })
+
+  for (const [key, prevVal, nextVal] of [
+    ['featuredDissolveRarities', before?.featuredDissolveRarities, result.featuredDissolveRarities],
+    ['featuredDissolveSeries',   before?.featuredDissolveSeries,   result.featuredDissolveSeries],
+    ['featuredDissolveSets',     before?.featuredDissolveSets,     result.featuredDissolveSets],
+  ]) {
+    if (JSON.stringify(prevVal ?? []) !== JSON.stringify(nextVal ?? [])) {
+      await logAdminChange(prisma, { userId: me.id, area: 'GlobalGameConfig', key, prevValue: prevVal, newValue: nextVal })
+    }
+  }
+
+  // Retroactively re-evaluate every queue entry (scheduled or not — neither
+  // is a live auction yet) against the new rule set.
+  const config = { rarities, series, sets }
+  const entries = await prisma.dissolveAuctionQueue.findMany({
+    select: {
+      id: true,
+      category: true,
+      isFeatured: true,
+      userCtoon: { select: { ctoon: { select: { rarity: true, series: true, set: true } } } }
+    }
+  })
+
+  let updated = 0
+  for (const entry of entries) {
+    const nextFeatured = isCtoonFeatured(entry.userCtoon?.ctoon, config)
+    const nextCategory = nextFeatured ? 'FEATURED' : 'OTHER'
+    if (nextFeatured === entry.isFeatured && nextCategory === entry.category) continue
+
+    // Race-safe: a matching `id` in the where-clause means this no-ops
+    // instead of throwing if the launch worker deleted the row concurrently.
+    const { count } = await prisma.dissolveAuctionQueue.updateMany({
+      where: { id: entry.id },
+      data:  { isFeatured: nextFeatured, category: nextCategory }
+    })
+    updated += count
+  }
+
+  return { rarities, series, sets, reevaluated: entries.length, updated }
+})

--- a/server/api/admin/dissolve-queue/index.get.js
+++ b/server/api/admin/dissolve-queue/index.get.js
@@ -26,9 +26,8 @@ export default defineEventHandler(async (event) => {
   })
 
   const byCategory = {
-    POKEMON:    { total: 0, scheduled: 0, unscheduled: 0 },
-    CRAZY_RARE: { total: 0, scheduled: 0, unscheduled: 0 },
-    OTHER:      { total: 0, scheduled: 0, unscheduled: 0 },
+    FEATURED: { total: 0, scheduled: 0, unscheduled: 0 },
+    OTHER:    { total: 0, scheduled: 0, unscheduled: 0 },
   }
 
   for (const e of allEntries) {

--- a/server/api/admin/dissolve-queue/schedule.post.js
+++ b/server/api/admin/dissolve-queue/schedule.post.js
@@ -18,8 +18,7 @@ export default defineEventHandler(async (event) => {
   const {
     startAtUtc,
     cadenceDays,
-    pokemonPerCadence,
-    crazyRarePerCadence,
+    featuredPerCadence,
     otherPerCadence,
     reschedule = false,
   } = body
@@ -30,9 +29,8 @@ export default defineEventHandler(async (event) => {
   if (!cadenceDays || Number(cadenceDays) < 1) throw createError({ statusCode: 400, statusMessage: 'cadenceDays must be >= 1' })
 
   const perCategory = {
-    POKEMON:    Number(pokemonPerCadence)   || 0,
-    CRAZY_RARE: Number(crazyRarePerCadence) || 0,
-    OTHER:      Number(otherPerCadence)     || 0,
+    FEATURED: Number(featuredPerCadence) || 0,
+    OTHER:    Number(otherPerCadence)    || 0,
   }
 
   // Fetch entries to schedule
@@ -54,7 +52,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Group by category
-  const grouped = { POKEMON: [], CRAZY_RARE: [], OTHER: [] }
+  const grouped = { FEATURED: [], OTHER: [] }
   for (const e of entries) grouped[e.category]?.push(e.id)
 
   let scheduled = 0

--- a/server/api/admin/users/[id]/ctoon-categories.get.js
+++ b/server/api/admin/users/[id]/ctoon-categories.get.js
@@ -1,6 +1,7 @@
 // server/api/admin/users/[id]/ctoon-categories.get.js
 import { defineEventHandler, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { getFeaturedDissolveConfig, isCtoonFeatured } from '@/server/utils/featuredDissolveConfig'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -20,19 +21,18 @@ export default defineEventHandler(async (event) => {
   const ctoons = await prisma.userCtoon.findMany({
     where: { userId: id, burnedAt: null },
     select: {
-      ctoon: { select: { series: true, rarity: true } }
+      ctoon: { select: { series: true, rarity: true, set: true } }
     }
   })
 
-  let pokemon = 0, crazyRare = 0, other = 0
+  const featuredConfig = await getFeaturedDissolveConfig()
+
+  let featured = 0, other = 0
 
   for (const uc of ctoons) {
-    const isPokemon   = (uc.ctoon?.series || '').toLowerCase() === 'pokemon'
-    const isCrazyRare = (uc.ctoon?.rarity || '').toLowerCase() === 'crazy rare'
-    if (isPokemon)        pokemon++
-    else if (isCrazyRare) crazyRare++
-    else                  other++
+    if (isCtoonFeatured(uc.ctoon, featuredConfig)) featured++
+    else other++
   }
 
-  return { pokemon, crazyRare, other, total: ctoons.length }
+  return { featured, other, total: ctoons.length }
 })

--- a/server/utils/featuredDissolveConfig.js
+++ b/server/utils/featuredDissolveConfig.js
@@ -1,0 +1,45 @@
+// server/utils/featuredDissolveConfig.js
+// Shared logic for determining which cToons are "featured" when an account is
+// dissolved. Admins configure the qualifying rarities/series/sets via the
+// "Edit Featured" modal on /admin/dissolve-queue; this module reads that config
+// and applies it to a given cToon.
+import { prisma } from '../prisma.js'
+
+function toArray(json) {
+  return Array.isArray(json) ? json.filter(v => typeof v === 'string' && v.trim()) : []
+}
+
+// Loads the admin-configured featured rule set. Falls back to empty rules
+// (nothing featured) if no GlobalGameConfig row exists yet.
+export async function getFeaturedDissolveConfig() {
+  const config = await prisma.globalGameConfig.findUnique({
+    where: { id: 'singleton' },
+    select: {
+      featuredDissolveRarities: true,
+      featuredDissolveSeries: true,
+      featuredDissolveSets: true,
+    }
+  })
+
+  return {
+    rarities: toArray(config?.featuredDissolveRarities),
+    series:   toArray(config?.featuredDissolveSeries),
+    sets:     toArray(config?.featuredDissolveSets),
+  }
+}
+
+// Case-insensitive membership check against a config list.
+function matches(value, list) {
+  if (!value) return false
+  const v = value.trim().toLowerCase()
+  return list.some(entry => entry.trim().toLowerCase() === v)
+}
+
+// ctoon: { rarity, series, set }, config: result of getFeaturedDissolveConfig()
+export function isCtoonFeatured(ctoon, config) {
+  return (
+    matches(ctoon?.rarity, config.rarities) ||
+    matches(ctoon?.series, config.series) ||
+    matches(ctoon?.set, config.sets)
+  )
+}

--- a/server/workers/dissolve.worker.js
+++ b/server/workers/dissolve.worker.js
@@ -2,6 +2,7 @@ import { Worker } from 'bullmq'
 import { prisma } from '../prisma.js'
 import { logAdminChange } from '../utils/adminChangeLog.js'
 import { scheduleDissolveAuctionLaunch } from '../utils/queues.js'
+import { getFeaturedDissolveConfig, isCtoonFeatured } from '../utils/featuredDissolveConfig.js'
 
 const QUEUE_NAME = process.env.DISSOLVE_QUEUE_KEY || 'dissolveQueue'
 
@@ -82,9 +83,11 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
   // ── Step 2: cToons ───────────────────────────────────────────────────────
   const userCtoons = await prisma.userCtoon.findMany({
     where: { userId, burnedAt: null },
-    select: { id: true, ctoon: { select: { id: true, rarity: true, series: true } }, mintNumber: true }
+    select: { id: true, ctoon: { select: { id: true, rarity: true, series: true, set: true } }, mintNumber: true }
   })
   const total = userCtoons.length
+
+  const featuredConfig = await getFeaturedDissolveConfig()
 
   const queuedEntries = []  // { id, category } — tracked for Step 9 scheduling
 
@@ -117,10 +120,8 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
       })
       ctoonsTransferred++
 
-      const isPokemon   = (uc.ctoon?.series || '').toLowerCase() === 'pokemon'
-      const isCrazyRare = (uc.ctoon?.rarity || '').toLowerCase() === 'crazy rare'
-      const category    = isPokemon ? 'POKEMON' : (isCrazyRare ? 'CRAZY_RARE' : 'OTHER')
-      const isFeatured  = isPokemon || isCrazyRare
+      const isFeatured = isCtoonFeatured(uc.ctoon, featuredConfig)
+      const category   = isFeatured ? 'FEATURED' : 'OTHER'
 
       const queueEntry = await prisma.dissolveAuctionQueue.upsert({
         where:  { userCtoonId: uc.id },
@@ -305,25 +306,22 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
   if (scheduleConfig && queuedEntries.length) {
     const {
       startAtUtc,
-      pokemonCadenceDays,   pokemonPerCadence,
-      crazyRareCadenceDays, crazyRarePerCadence,
-      otherCadenceDays,     otherPerCadence,
+      featuredCadenceDays, featuredPerCadence,
+      otherCadenceDays,    otherPerCadence,
     } = scheduleConfig
     const startMs = new Date(startAtUtc).getTime()
 
     const perCategory = {
-      POKEMON:    Number(pokemonPerCadence)   || 0,
-      CRAZY_RARE: Number(crazyRarePerCadence) || 0,
-      OTHER:      Number(otherPerCadence)     || 0,
+      FEATURED: Number(featuredPerCadence) || 0,
+      OTHER:    Number(otherPerCadence)    || 0,
     }
 
     const cadenceDaysPerCategory = {
-      POKEMON:    Number(pokemonCadenceDays)   || 0,
-      CRAZY_RARE: Number(crazyRareCadenceDays) || 0,
-      OTHER:      Number(otherCadenceDays)     || 0,
+      FEATURED: Number(featuredCadenceDays) || 0,
+      OTHER:    Number(otherCadenceDays)    || 0,
     }
 
-    const grouped = { POKEMON: [], CRAZY_RARE: [], OTHER: [] }
+    const grouped = { FEATURED: [], OTHER: [] }
     for (const e of queuedEntries) grouped[e.category].push(e.id)
 
     for (const [cat, ids] of Object.entries(grouped)) {


### PR DESCRIPTION
## Summary
- Adds an "Edit Featured" button/modal to `/admin/dissolve-queue` where admins pick which rarities, series, and sets make a dissolved cToon "featured" — replacing the previous hardcoded Pokémon-series / Crazy-Rare-rarity check.
- Saving the config re-evaluates every entry currently sitting in the dissolve queue (scheduled or unscheduled — neither is a live auction yet), so the change applies retroactively, not just to future dissolves.
- Collapses the old 3-way `POKEMON` / `CRAZY_RARE` / `OTHER` dissolve-queue category into `FEATURED` / `OTHER` across the worker, the scheduling API, and both admin UIs (`pages/admin/users.vue` and `components/newsite/AdminManageUsers.vue`), since featuring is now driven by configurable rules instead of two fixed cases.

## Details
- **Schema**: `GlobalGameConfig` gains `featuredDissolveRarities` / `featuredDissolveSeries` / `featuredDissolveSets` (JSON string arrays). Migration backfills the singleton row with `["Crazy Rare"]` / `["Pokemon"]` to preserve current behavior until an admin edits it.
- **New endpoints**: `GET/POST /api/admin/dissolve-featured-config` — GET returns selected + full option lists (rarities = static list used elsewhere in admin; series/sets = distinct `Ctoon` values); POST validates/dedupes and saves, then re-evaluates all `DissolveAuctionQueue` rows.
- **Shared logic**: `server/utils/featuredDissolveConfig.js` centralizes the case-insensitive rarity/series/set matching, used by the dissolve worker, the new config endpoints, and the dissolve-confirmation preview counts (`ctoon-categories.get.js`).
- **UI**: modal has three checkbox sections (Rarities, Series, Sets); Series and Sets get a 3+ character filter; checked items are pinned to the top of each list and stay visible even while a filter is active, so a selection can't be lost mid-search.

## Test plan
- [ ] Open `/admin/dissolve-queue`, click "Edit Featured", verify current selections load and the explanatory text renders
- [ ] Check/uncheck a rarity, series, and set; verify checked items move to the top of each section
- [ ] Type a 3-char+ filter in Series/Sets; verify list narrows but checked items stay visible
- [ ] Save and verify existing queue entries' `category`/`isFeatured` update accordingly (both scheduled and unscheduled)
- [ ] Dissolve a test account and confirm cToons matching the configured rules are queued with `category: FEATURED`
- [ ] Verify the Reschedule All form and the per-user dissolve schedule forms (users.vue + newsite AdminManageUsers.vue) all use the single "Featured / cadence" input correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wkiEBN3kwBUDFpTN7DdTG

---
_Generated by [Claude Code](https://claude.ai/code/session_014wkiEBN3kwBUDFpTN7DdTG)_