### PR TITLE
Add ReOrbit Memory card-matching game

### DIFF
--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -40,6 +40,10 @@
         <img v-if="tiles.tower" :src="tiles.tower" alt="Tower Stack" class="tile-img" />
         <span v-else>Tower Stack</span>
       </NuxtLink>
+      <NuxtLink to="/newsite/reorbitmemory" class="quadrant quadrant--reorbitmemory">
+        <img v-if="tiles.reorbitmemory" :src="tiles.reorbitmemory" alt="ReOrbit Memory" class="tile-img" />
+        <span v-else>ReOrbit Memory</span>
+      </NuxtLink>
     </div>
   </div>
 </template>
@@ -75,7 +79,7 @@ const tiles = computed(() => tileData.value ?? {})
 .gameshome {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: repeat(4, 1fr);
+  grid-template-rows: repeat(4, 1fr) 0.85fr;
   width: 100%;
   flex: 1;
   gap: 6px;
@@ -83,8 +87,13 @@ const tiles = computed(() => tileData.value ?? {})
   box-sizing: border-box;
 }
 
-/* 7th tile spans both columns on its own row */
+/* Tower Stack spans both columns on its own row */
 .quadrant--tower {
+  grid-column: 1 / -1;
+}
+
+/* ReOrbit Memory gets its own (shorter) full-width row below Tower Stack */
+.quadrant--reorbitmemory {
   grid-column: 1 / -1;
 }
 
@@ -131,15 +140,17 @@ const tiles = computed(() => tileData.value ?? {})
 .quadrant--tko        { background: #8a1a32; }
 .quadrant--reorbit    { background: #1a6a8a; }
 .quadrant--tower      { background: #5a2a8a; }
+.quadrant--reorbitmemory { background: #2a7a5a; }
 
 @media (max-width: 768px) {
   .gameshome {
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(7, minmax(70px, 1fr));
+    grid-template-rows: repeat(8, minmax(70px, 1fr));
     height: max(300px, calc(100dvh - 276px));
   }
 
-  .quadrant--tower {
+  .quadrant--tower,
+  .quadrant--reorbitmemory {
     grid-column: auto;
   }
 }

--- a/components/newsite/Leaderboards.vue
+++ b/components/newsite/Leaderboards.vue
@@ -91,7 +91,8 @@ const { data: totalData, pending: totalPending } = useFetch('/api/leaderboard/to
 // Users tab (the default) never pulls either game's leaderboard data.
 const gameOptions = [
   { key: 'reorbitmatch', label: 'ReOrbit Match', endpoint: '/api/game/reorbitmatch/leaderboard' },
-  { key: 'tower',        label: 'Tower Stack',   endpoint: '/api/game/tower/leaderboard' }
+  { key: 'tower',        label: 'Tower Stack',   endpoint: '/api/game/tower/leaderboard' },
+  { key: 'reorbitmemory', label: 'ReOrbit Memory', endpoint: '/api/game/reorbitmemory/leaderboard', lowerIsBetter: true }
 ]
 const selectedGame = ref('reorbitmatch')
 const gameDataCache = ref({})
@@ -150,21 +151,30 @@ const usersBoards = computed(() => [
   },
 ])
 
+// ReOrbit Memory's "score" column holds moves taken (lower is better), so its rows are
+// labeled "moves" instead of formatted like a points total.
+const gameValueLabel = computed(() => {
+  const opt = gameOptions.find(g => g.key === selectedGame.value)
+  return opt?.lowerIsBetter
+    ? row => `${Number(row.score).toLocaleString()} move${row.score === 1 ? '' : 's'}`
+    : row => Number(row.score).toLocaleString()
+})
+
 const gamesBoards = computed(() => [
   {
     key: 'alltime', title: 'All Time', headerClass: 'lb-card-header--alltime',
     rows: gameData.value?.allTime, pending: gamePending.value,
-    formatValue: row => Number(row.score).toLocaleString()
+    formatValue: gameValueLabel.value
   },
   {
     key: 'monthly', title: 'This Month', headerClass: 'lb-card-header--monthly',
     rows: gameData.value?.monthly, pending: gamePending.value,
-    formatValue: row => Number(row.score).toLocaleString()
+    formatValue: gameValueLabel.value
   },
   {
     key: 'weekly', title: 'This Week', headerClass: 'lb-card-header--weekly',
     rows: gameData.value?.weekly, pending: gamePending.value,
-    formatValue: row => Number(row.score).toLocaleString()
+    formatValue: gameValueLabel.value
   },
 ])
 </script>

--- a/pages/admin/games.vue
+++ b/pages/admin/games.vue
@@ -840,6 +840,77 @@
           </button>
         </section>
 
+        <!-- ReOrbit Memory -->
+        <section v-if="activeTab === 'ReOrbitMemory'" role="tabpanel" aria-label="ReOrbit Memory Settings">
+          <h2 class="text-2xl font-semibold mb-4">ReOrbit Memory Settings</h2>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Plays Per Period</label>
+              <p class="text-xs text-gray-400 mb-1">Number of games per 24-hour period (resets 8 PM CT)</p>
+              <input type="number" v-model.number="reorbitMemoryPlaysPerPeriod" min="1" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-400 mb-1">Points awarded toward daily cap on game completion</p>
+              <input type="number" v-model.number="reorbitMemoryPointsPerGame" min="0" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Number of Pairs</label>
+              <p class="text-xs text-gray-400 mb-1">Board size — kept small enough to stay tappable on phones</p>
+              <select v-model.number="reorbitMemoryPairs" class="input">
+                <option :value="6">6 pairs (3×4 — 12 cards)</option>
+                <option :value="8">8 pairs (4×4 — 16 cards)</option>
+                <option :value="10">10 pairs (4×5 — 20 cards)</option>
+                <option :value="12">12 pairs (4×6 — 24 cards)</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Time Per Game (seconds)</label>
+              <p class="text-xs text-gray-400 mb-1">Leave empty for unlimited time</p>
+              <input type="number" v-model="reorbitMemoryTimeSecondsInput" min="30" placeholder="Unlimited" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Flip-back Delay (ms)</label>
+              <p class="text-xs text-gray-400 mb-1">How long a mismatched pair stays face up before flipping back (300–3000)</p>
+              <input type="number" v-model.number="reorbitMemoryFlipBackDelayMs" min="300" max="3000" step="100" class="input" />
+            </div>
+          </div>
+
+          <div class="mb-6 border rounded-lg p-4">
+            <h3 class="text-lg font-semibold mb-1">Card Back Image</h3>
+            <p class="text-xs text-gray-500 mb-3">Shown on the back of every face-down card. Card fronts are random cToon images, chosen automatically each game.</p>
+            <div class="w-24 h-32 bg-gray-100 border rounded overflow-hidden flex items-center justify-center mb-2">
+              <img
+                v-if="reorbitMemoryCardBackImage"
+                :src="reorbitMemoryCardBackImage"
+                alt="Card back"
+                class="w-full h-full object-cover"
+              />
+              <span v-else class="text-gray-400 text-xs px-1 text-center">No image</span>
+            </div>
+            <input
+              type="file"
+              accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
+              @change="onReorbitMemoryCardBackFile"
+              class="block w-full text-xs mb-2"
+            />
+            <button
+              class="btn-primary text-sm py-1 px-3"
+              @click="uploadReorbitMemoryCardBack"
+              :disabled="!reorbitMemoryCardBackFile || uploadingReorbitMemoryCardBack"
+            >
+              <span v-if="!uploadingReorbitMemoryCardBack">Upload</span>
+              <span v-else>Uploading…</span>
+            </button>
+          </div>
+
+          <button @click="saveReorbitMemoryConfig" :disabled="loadingReorbitMemory" class="btn-primary">
+            <span v-if="!loadingReorbitMemory">Save ReOrbit Memory Settings</span>
+            <span v-else>Saving…</span>
+          </button>
+        </section>
+
         <!-- TKO -->
         <section v-if="activeTab === 'TKO'" role="tabpanel" aria-label="TKO Events">
           <h2 class="text-2xl font-semibold mb-4">TKO Events</h2>
@@ -982,7 +1053,8 @@ const tabs = [
   { key: 'Winwheel',     label: 'Win Wheel' },
   { key: 'TKO',          label: 'TKO' },
   { key: 'ReOrbitMatch', label: 'ReOrbit Match' },
-  { key: 'TowerStack',   label: 'Tower Stack' }
+  { key: 'TowerStack',   label: 'Tower Stack' },
+  { key: 'ReOrbitMemory', label: 'ReOrbit Memory' }
 ]
 const activeTab = ref('Global')
 async function switchTab(k) {
@@ -1314,6 +1386,7 @@ async function loadSettings() {
   gameTileImages.value.tko          = g.gameTileTkoImagePath          || ''
   gameTileImages.value.reorbitmatch = g.gameTileReorbitmatchImagePath || ''
   gameTileImages.value.tower        = g.gameTileTowerImagePath        || ''
+  gameTileImages.value.reorbitmemory = g.gameTileReorbitmemoryImagePath || ''
 
   const wb = await $fetch('/api/admin/game-config?gameName=Winball')
   leftCupPoints.value  = wb.leftCupPoints
@@ -1400,6 +1473,14 @@ async function loadSettings() {
   towerMaxSpeedMultiplier.value  = tw.towerMaxSpeedMultiplier ?? 2.5
   towerPerfectEpsilon.value      = tw.towerPerfectEpsilon ?? 4
   towerMaxLayers.value           = tw.towerMaxLayers ?? 800
+
+  const rm = await $fetch('/api/admin/game-config?gameName=ReOrbitMemory')
+  reorbitMemoryPlaysPerPeriod.value    = rm.reorbitMemoryPlaysPerPeriod ?? 3
+  reorbitMemoryPointsPerGame.value     = rm.reorbitMemoryPointsPerGame ?? 50
+  reorbitMemoryPairs.value             = rm.reorbitMemoryPairs ?? 8
+  reorbitMemoryTimeSecondsInput.value  = rm.reorbitMemoryTimeSeconds != null ? String(rm.reorbitMemoryTimeSeconds) : ''
+  reorbitMemoryFlipBackDelayMs.value   = rm.reorbitMemoryFlipBackDelayMs ?? 800
+  reorbitMemoryCardBackImage.value     = rm.reorbitMemoryCardBackImagePath || ''
 }
 
 // Win Wheel state
@@ -1739,11 +1820,12 @@ const gameTileSlots = [
   { slot: 'clash',        label: 'gToons Clash' },
   { slot: 'tko',          label: 'TKO' },
   { slot: 'reorbitmatch', label: 'ReOrbit Match' },
-  { slot: 'tower',        label: 'Tower Stack' }
+  { slot: 'tower',        label: 'Tower Stack' },
+  { slot: 'reorbitmemory', label: 'ReOrbit Memory' }
 ]
-const gameTileImages = ref({ winball: '', lotto: '', winwheel: '', clash: '', tko: '', reorbitmatch: '', tower: '' })
-const gameTileFiles  = ref({ winball: null, lotto: null, winwheel: null, clash: null, tko: null, reorbitmatch: null, tower: null })
-const uploadingGameTile = ref({ winball: false, lotto: false, winwheel: false, clash: false, tko: false, reorbitmatch: false, tower: false })
+const gameTileImages = ref({ winball: '', lotto: '', winwheel: '', clash: '', tko: '', reorbitmatch: '', tower: '', reorbitmemory: '' })
+const gameTileFiles  = ref({ winball: null, lotto: null, winwheel: null, clash: null, tko: null, reorbitmatch: null, tower: null, reorbitmemory: null })
+const uploadingGameTile = ref({ winball: false, lotto: false, winwheel: false, clash: false, tko: false, reorbitmatch: false, tower: false, reorbitmemory: false })
 
 function onGameTileFile(slot, e) {
   gameTileFiles.value[slot] = e.target.files?.[0] || null
@@ -1805,6 +1887,64 @@ const towerMaxSpeedMultiplier  = ref(2.5)
 const towerPerfectEpsilon      = ref(4)
 const towerMaxLayers           = ref(800)
 const loadingTower              = ref(false)
+
+// ── ReOrbit Memory ────────────────────────────
+const reorbitMemoryPlaysPerPeriod  = ref(3)
+const reorbitMemoryPointsPerGame   = ref(50)
+const reorbitMemoryPairs           = ref(8)
+const reorbitMemoryTimeSecondsInput = ref('')  // '' = unlimited (null)
+const reorbitMemoryFlipBackDelayMs = ref(800)
+const reorbitMemoryCardBackImage   = ref('')
+const reorbitMemoryCardBackFile    = ref(null)
+const uploadingReorbitMemoryCardBack = ref(false)
+const loadingReorbitMemory         = ref(false)
+
+function onReorbitMemoryCardBackFile(e) {
+  reorbitMemoryCardBackFile.value = e.target.files?.[0] || null
+}
+
+async function uploadReorbitMemoryCardBack() {
+  const file = reorbitMemoryCardBackFile.value
+  if (!file) return
+  uploadingReorbitMemoryCardBack.value = true; toastMessage.value = ''
+  try {
+    const fd = new FormData()
+    fd.append('image', file)
+    const res = await $fetch('/api/admin/reorbitmemory-cardback-image', { method: 'POST', body: fd })
+    reorbitMemoryCardBackImage.value = res.assetPath
+    reorbitMemoryCardBackFile.value = null
+    toastMessage.value = 'Card back image uploaded.'; toastType.value = 'success'
+  } catch (err) {
+    console.error(err)
+    toastMessage.value = 'Upload failed'; toastType.value = 'error'
+  } finally {
+    uploadingReorbitMemoryCardBack.value = false
+  }
+}
+
+async function saveReorbitMemoryConfig() {
+  loadingReorbitMemory.value = true; toastMessage.value = ''
+  try {
+    await $fetch('/api/admin/game-config', {
+      method: 'POST',
+      body: {
+        gameName:                      'ReOrbitMemory',
+        reorbitMemoryPlaysPerPeriod:   reorbitMemoryPlaysPerPeriod.value,
+        reorbitMemoryPointsPerGame:    reorbitMemoryPointsPerGame.value,
+        reorbitMemoryPairs:            reorbitMemoryPairs.value,
+        reorbitMemoryTimeSeconds:      reorbitMemoryTimeSecondsInput.value !== '' ? Number(reorbitMemoryTimeSecondsInput.value) : null,
+        reorbitMemoryFlipBackDelayMs:  reorbitMemoryFlipBackDelayMs.value,
+        reorbitMemoryCardBackImagePath: reorbitMemoryCardBackImage.value || null
+      }
+    })
+    toastMessage.value = 'ReOrbit Memory settings saved!'; toastType.value = 'success'
+  } catch (err) {
+    console.error(err)
+    toastMessage.value = 'Error saving ReOrbit Memory settings'; toastType.value = 'error'
+  } finally {
+    loadingReorbitMemory.value = false
+  }
+}
 
 function addReorbitEmoji() {
   const e = reorbitEmojiInput.value.trim()

--- a/pages/newsite/reorbitmemory.vue
+++ b/pages/newsite/reorbitmemory.vue
@@ -1,0 +1,751 @@
+<template>
+  <div>
+    <NuxtLayout name="newsite-template" :show-adbar="true" :show-nav="true">
+      <div class="memory-wrapper">
+        <!-- Loading state -->
+        <div v-if="uiState === 'loading'" class="center-content">
+          <div class="spinner" aria-label="Loading game…"></div>
+        </div>
+
+        <!-- No plays left -->
+        <div v-else-if="uiState === 'noplays'" class="center-content">
+          <div class="start-card">
+            <h1 class="game-title">ReOrbit Memory</h1>
+            <p class="no-plays-text">No plays left today.</p>
+            <p class="reset-text">Resets {{ resetLabel }}</p>
+          </div>
+        </div>
+
+        <!-- Start screen -->
+        <div v-else-if="uiState === 'start'" class="center-content">
+          <div class="start-card">
+            <h1 class="game-title">ReOrbit Memory</h1>
+            <p class="start-sub">Flip two cards at a time. Find every matching pair in as few moves as possible!</p>
+            <div class="plays-info">
+              <span class="plays-badge">{{ playsLeft }} play{{ playsLeft !== 1 ? 's' : '' }} left</span>
+              <span class="reset-text">· Resets {{ resetLabel }}</span>
+            </div>
+            <button class="btn-start" @click="startGame" :disabled="starting">
+              {{ starting ? 'Shuffling…' : 'Play' }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Active game -->
+        <div v-else-if="uiState === 'playing'" class="game-area" role="main" aria-label="ReOrbit Memory game board">
+          <div class="hud" role="status" aria-live="polite" aria-atomic="true">
+            <div class="hud-row">
+              <div class="hud-item">
+                <span class="hud-label">Moves</span>
+                <span class="hud-value">{{ moves }}</span>
+              </div>
+              <div v-if="timeSeconds" class="hud-item" :class="{ 'hud-item--warning': timeLeft <= 10 }">
+                <span class="hud-label">Time</span>
+                <span class="hud-value">{{ timeLeft }}s</span>
+              </div>
+              <div class="hud-item">
+                <span class="hud-label">Plays Left</span>
+                <span class="hud-value">{{ playsLeft }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div
+            class="card-grid"
+            :style="{ '--cols': cols }"
+          >
+            <button
+              v-for="(card, i) in cards"
+              :key="i"
+              type="button"
+              class="card"
+              :class="{ 'card--flipped': card.state !== 'down', 'card--matched': card.state === 'matched' }"
+              :disabled="card.state !== 'down' || busy"
+              :aria-label="card.state === 'matched' ? 'Matched card' : 'Face-down card'"
+              @click="onCardTap(i)"
+            >
+              <div class="card-inner">
+                <div class="card-face card-face--back">
+                  <img v-if="cardBackImagePath" :src="cardBackImagePath" alt="" draggable="false" />
+                  <div v-else class="card-face--placeholder"></div>
+                </div>
+                <div class="card-face card-face--front">
+                  <img v-if="card.src" :src="card.src" alt="" draggable="false" />
+                  <div v-else class="card-face--loading"></div>
+                </div>
+              </div>
+            </button>
+          </div>
+
+          <p class="sr-only" aria-live="polite">{{ announce }}</p>
+        </div>
+      </div>
+    </NuxtLayout>
+
+    <!-- Game Over Modal -->
+    <Teleport to="body">
+      <div v-if="uiState === 'gameover'" class="modal-backdrop" @click.self="uiState = 'start'">
+        <div class="modal-card" role="dialog" aria-modal="true" aria-label="Game Over">
+          <button class="modal-close" type="button" @click="goToGamesHome" aria-label="Close and return to Games Home">&times;</button>
+          <h2 class="modal-title">{{ finalCompleted ? 'Solved!' : "Time's Up" }}</h2>
+          <div class="modal-score-row">
+            <span class="modal-score-label">{{ finalCompleted ? 'Your Moves' : 'Board Not Finished' }}</span>
+            <span v-if="finalCompleted" class="modal-score-value">{{ finalMoves }}</span>
+          </div>
+          <template v-if="finalCompleted">
+            <div class="modal-divider"></div>
+            <div class="modal-leaderboard">
+              <div class="modal-lb-row">
+                <span class="modal-lb-label">This Week's Best</span>
+                <span class="modal-lb-value">{{ weekBest != null ? weekBest : '—' }}</span>
+              </div>
+              <div class="modal-lb-row">
+                <span class="modal-lb-label">Your All-Time Best</span>
+                <span class="modal-lb-value">{{ allTimeBest != null ? allTimeBest : '—' }}</span>
+              </div>
+            </div>
+            <div class="modal-points-notice" :class="{ 'modal-points-notice--zero': pointsAwarded === 0 }">
+              <template v-if="pointsAwarded > 0">+{{ pointsAwarded }} game points earned!</template>
+              <template v-else>No game points earned (daily limit reached)</template>
+            </div>
+          </template>
+          <div class="modal-actions">
+            <button v-if="playsLeft > 0" class="btn-start" @click="startGame">
+              Play Again ({{ playsLeft }} left)
+            </button>
+            <button v-else class="btn-secondary" @click="uiState = 'noplays'">
+              No Plays Left
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({ ssr: false })
+
+const uiState    = ref('loading') // loading | start | playing | gameover | noplays
+const starting   = ref(false)
+const moves      = ref(0)
+const timeLeft   = ref(null)
+const playsLeft  = ref(0)
+const resetLabel = ref('')
+const announce   = ref('')
+const busy       = ref(false) // true while a flip request is in flight — blocks further taps
+
+const cols = ref(4)
+const rows = ref(4)
+const timeSeconds = ref(null)
+const flipBackDelayMs = ref(800)
+const cardBackImagePath = ref(null)
+
+const finalMoves     = ref(0)
+const finalCompleted = ref(true)
+const weekBest       = ref(null)
+const allTimeBest    = ref(null)
+const pointsAwarded  = ref(0)
+
+// cards[i] = { state: 'down' | 'up' | 'matched', src: string|null }
+const cards = ref([])
+
+let timerStart    = null
+let timerId       = null
+let ending        = false
+
+function vibrate(pattern) { try { navigator.vibrate?.(pattern) } catch {} }
+// Warm the browser cache for every card-front image right after /start, before the player's
+// first tap, so flips render instantly instead of popping in over the network.
+function preloadImages(paths) {
+  for (const src of paths || []) {
+    const img = new Image()
+    img.src = src
+  }
+}
+function onImgLoad() {} // hook kept for future use; images are small enough not to need a skeleton swap
+
+function goToGamesHome() {
+  navigateTo('/newsite/games')
+}
+
+function formatReset(isoString) {
+  if (!isoString) return ''
+  const d = new Date(isoString)
+  return new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' }).format(d)
+}
+
+async function fetchStatus() {
+  try {
+    const data = await $fetch('/api/game/reorbitmemory/status', { credentials: 'include' })
+    playsLeft.value  = data.playsLeft
+    weekBest.value   = data.weekBest
+    allTimeBest.value = data.allTimeBest
+    cols.value       = data.config.cols
+    rows.value       = data.config.rows
+    cardBackImagePath.value = data.config.cardBackImagePath
+    resetLabel.value = formatReset(data.playsResetAt)
+    uiState.value = data.playsLeft > 0 ? 'start' : 'noplays'
+  } catch {
+    uiState.value = 'start'
+  }
+}
+
+async function startGame() {
+  if (starting.value) return
+  starting.value = true
+  try {
+    const data = await $fetch('/api/game/reorbitmemory/start', { method: 'POST', credentials: 'include' })
+    cols.value = data.cols
+    rows.value = data.rows
+    cardBackImagePath.value = data.cardBackImagePath
+    timeSeconds.value = data.timeSeconds
+    flipBackDelayMs.value = data.flipBackDelayMs ?? 800
+
+    const total = data.pairs * 2
+    cards.value = Array.from({ length: total }, () => ({ state: 'down', src: null }))
+    preloadImages(data.frontImages)
+    moves.value = 0
+    ending = false
+    announce.value = ''
+    busy.value = false
+
+    await fetchStatus() // refresh plays left
+    playsLeft.value = Math.max(0, playsLeft.value - 1) // optimistic
+
+    uiState.value = 'playing'
+    timerStart = Date.now()
+    if (timeSeconds.value) {
+      timeLeft.value = timeSeconds.value
+      timerId = setInterval(() => {
+        const elapsed = (Date.now() - timerStart) / 1000
+        timeLeft.value = Math.max(0, Math.ceil(timeSeconds.value - elapsed))
+        if (timeLeft.value === 0) endGame()
+      }, 250)
+    } else {
+      timeLeft.value = null
+    }
+  } catch (err) {
+    const msg = err?.data?.statusMessage || err?.message || 'Failed to start game'
+    alert(msg)
+  } finally {
+    starting.value = false
+  }
+}
+
+function wait(ms) { return new Promise(r => setTimeout(r, ms)) }
+
+async function onCardTap(i) {
+  if (uiState.value !== 'playing' || busy.value) return
+  const card = cards.value[i]
+  if (!card || card.state !== 'down') return
+
+  busy.value = true
+  vibrate(8)
+  try {
+    const result = await $fetch('/api/game/reorbitmemory/flip', {
+      method: 'POST',
+      credentials: 'include',
+      body: { index: i }
+    })
+
+    if (result.firstFlip) {
+      cards.value[i] = { state: 'up', src: result.assetPath }
+      moves.value = result.moves
+      busy.value = false
+      return
+    }
+
+    // Second flip — server has already evaluated the pair.
+    cards.value[i] = { state: 'up', src: result.assetPath }
+    if (result.firstIndex != null && cards.value[result.firstIndex]) {
+      cards.value[result.firstIndex] = { state: 'up', src: result.firstAssetPath }
+    }
+    moves.value = result.moves
+
+    if (result.matched) {
+      vibrate([10, 30, 10])
+      announce.value = 'Match!'
+      cards.value[i].state = 'matched'
+      if (result.firstIndex != null && cards.value[result.firstIndex]) {
+        cards.value[result.firstIndex].state = 'matched'
+      }
+      if (result.gameOver) {
+        await wait(350) // let the flip settle before the modal appears
+        endGame()
+        return
+      }
+    } else {
+      announce.value = 'No match'
+      await wait(flipBackDelayMs.value)
+      // Only revert if the card hasn't been re-flipped/matched in the meantime.
+      if (cards.value[i]?.state === 'up') cards.value[i] = { state: 'down', src: null }
+      if (result.firstIndex != null && cards.value[result.firstIndex]?.state === 'up') {
+        cards.value[result.firstIndex] = { state: 'down', src: null }
+      }
+    }
+  } catch {
+    // Stale/invalid tap (e.g. a race with the server) — just drop it, no visual change needed
+    // since the card never left the 'down' state on screen.
+  } finally {
+    busy.value = false
+  }
+}
+
+async function endGame() {
+  if (ending) return
+  ending = true
+  if (timerId) { clearInterval(timerId); timerId = null }
+
+  finalMoves.value = moves.value
+
+  try {
+    const result = await $fetch('/api/game/reorbitmemory/end', { method: 'POST', credentials: 'include' })
+    finalCompleted.value = result.completed
+    finalMoves.value = result.moves
+    pointsAwarded.value = result.pointsAwarded ?? 0
+    if (result.completed) {
+      const status = await $fetch('/api/game/reorbitmemory/status', { credentials: 'include' })
+      weekBest.value    = status.weekBest
+      allTimeBest.value = status.allTimeBest
+      playsLeft.value   = status.playsLeft
+    }
+  } catch {
+    finalCompleted.value = false
+    pointsAwarded.value = 0
+  }
+
+  uiState.value = 'gameover'
+}
+
+onMounted(async () => {
+  await fetchStatus()
+})
+
+onUnmounted(() => {
+  if (timerId) { clearInterval(timerId); timerId = null }
+})
+</script>
+
+<style scoped>
+.memory-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  position: relative;
+  background: #001230;
+}
+
+.center-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 300px;
+}
+
+.start-card {
+  background: rgba(10, 25, 55, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 2rem 2.5rem;
+  text-align: center;
+  max-width: 340px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.game-title {
+  font-size: clamp(1.4rem, 5vw, 2rem);
+  font-weight: 800;
+  color: #fff;
+  margin: 0 0 0.5rem;
+  background: linear-gradient(135deg, #2adf9c, #fff 50%, #ffd700);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.start-sub {
+  color: rgba(255,255,255,0.65);
+  font-size: 0.875rem;
+  margin: 0 0 1.25rem;
+}
+
+.plays-info {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.plays-badge {
+  background: rgba(42, 223, 156, 0.15);
+  border: 1px solid rgba(42, 223, 156, 0.4);
+  color: #2adf9c;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+}
+
+.reset-text {
+  color: rgba(255,255,255,0.4);
+  font-size: 0.75rem;
+}
+
+.no-plays-text {
+  color: rgba(255,255,255,0.7);
+  font-size: 1rem;
+  margin: 0 0 0.5rem;
+}
+
+.btn-start {
+  background: linear-gradient(135deg, #1a6e3c, #3399cc);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 2.5rem;
+  cursor: pointer;
+  transition: filter 0.15s, transform 0.1s;
+  min-width: 140px;
+}
+.btn-start:hover { filter: brightness(1.15); }
+.btn-start:active { transform: scale(0.97); }
+.btn-start:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-secondary {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7);
+  font-weight: 600;
+  font-size: 0.9rem;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 10px;
+  padding: 0.65rem 2rem;
+  cursor: pointer;
+}
+
+.spinner {
+  width: 40px; height: 40px;
+  border: 3px solid rgba(255,255,255,0.1);
+  border-top-color: #2adf9c;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.game-area {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  gap: 0;
+  background: #001230;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+}
+
+.hud {
+  display: flex;
+  justify-content: center;
+  padding: 6px 8px;
+  background: rgba(0, 10, 30, 0.8);
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  flex-shrink: 0;
+}
+
+.hud-row {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+
+.hud-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 8px;
+  padding: 4px 10px;
+  min-width: 64px;
+}
+
+.hud-item--warning {
+  border-color: rgba(255, 80, 80, 0.5);
+  background: rgba(255, 80, 80, 0.1);
+  animation: pulse-warn 1s ease-in-out infinite;
+}
+@keyframes pulse-warn {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.6; }
+}
+
+.hud-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.45);
+  line-height: 1;
+}
+
+.hud-value {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.2;
+}
+
+/* Card grid */
+.card-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(var(--cols), minmax(0, 1fr));
+  grid-auto-rows: auto;
+  gap: clamp(4px, 1.5vw, 10px);
+  padding: clamp(6px, 2vw, 14px);
+  align-content: center;
+  justify-content: center;
+  align-items: start;
+  min-height: 0;
+  overflow-y: auto;
+  max-width: 560px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.card {
+  position: relative;
+  aspect-ratio: 3 / 4;
+  min-width: 0;
+  min-height: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  perspective: 800px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+.card:disabled { cursor: default; }
+
+.card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 0.32s cubic-bezier(0.4, 0.2, 0.2, 1);
+}
+.card--flipped .card-inner {
+  transform: rotateY(180deg);
+}
+
+.card-face {
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+}
+.card-face img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+}
+.card-face--back {
+  background: linear-gradient(135deg, #1a3a8f, #1a6a8a);
+}
+.card-face--placeholder {
+  width: 60%;
+  height: 60%;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.15);
+}
+.card-face--front {
+  background: #0a1937;
+  transform: rotateY(180deg);
+}
+.card-face--loading {
+  width: 40%;
+  height: 40%;
+  border-radius: 50%;
+  border: 3px solid rgba(255,255,255,0.15);
+  border-top-color: #2adf9c;
+  animation: spin 0.7s linear infinite;
+}
+
+.card--matched .card-face--front {
+  outline: 2px solid #ffd700;
+  outline-offset: -2px;
+}
+.card--matched {
+  opacity: 0.92;
+}
+
+/* No 3D transform support / reduced motion: crossfade instead of a flip */
+@media (prefers-reduced-motion: reduce) {
+  .card-inner { transition: none; }
+  .card-face { transition: opacity 0.15s linear; backface-visibility: visible; -webkit-backface-visibility: visible; }
+  .card-face--front { transform: none; opacity: 0; }
+  .card--flipped .card-inner { transform: none; }
+  .card--flipped .card-face--back { opacity: 0; }
+  .card--flipped .card-face--front { opacity: 1; }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Modal */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  backdrop-filter: blur(4px);
+}
+
+.modal-card {
+  position: relative;
+  background: rgba(10, 25, 55, 0.97);
+  border: 1px solid rgba(255,255,255,0.14);
+  border-radius: 20px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 360px;
+  max-height: min(90dvh, 520px);
+  overflow-y: auto;
+  box-shadow: 0 16px 48px rgba(0,0,0,0.7);
+  text-align: center;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.08);
+  color: rgba(255,255,255,0.7);
+  font-size: 1.4rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.modal-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #fff;
+  margin: 0 0 1.25rem;
+  background: linear-gradient(135deg, #ffd700, #fff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.modal-score-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 1.25rem;
+}
+
+.modal-score-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.5);
+}
+
+.modal-score-value {
+  font-size: 3rem;
+  font-weight: 900;
+  color: #ffd700;
+  line-height: 1;
+}
+
+.modal-divider {
+  height: 1px;
+  background: rgba(255,255,255,0.1);
+  margin: 0 0 1.25rem;
+}
+
+.modal-leaderboard { margin-bottom: 1rem; }
+
+.modal-lb-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.modal-lb-row:last-child { border-bottom: none; }
+
+.modal-lb-label {
+  font-size: 0.8rem;
+  color: rgba(255,255,255,0.6);
+}
+
+.modal-lb-value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.modal-points-notice {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #66cc00;
+  background: rgba(102, 204, 0, 0.1);
+  border: 1px solid rgba(102, 204, 0, 0.25);
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1.25rem;
+}
+.modal-points-notice--zero {
+  color: rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.modal-actions { display: flex; justify-content: center; }
+</style>

--- a/prisma/migrations/20260720000001_add_reorbit_memory/migration.sql
+++ b/prisma/migrations/20260720000001_add_reorbit_memory/migration.sql
@@ -1,0 +1,42 @@
+-- AddField: ReOrbit Memory settings on GameConfig
+ALTER TABLE "GameConfig"
+  ADD COLUMN IF NOT EXISTS "reorbitMemoryPlaysPerPeriod"    INTEGER NOT NULL DEFAULT 3,
+  ADD COLUMN IF NOT EXISTS "reorbitMemoryPointsPerGame"     INTEGER NOT NULL DEFAULT 50,
+  ADD COLUMN IF NOT EXISTS "reorbitMemoryPairs"             INTEGER NOT NULL DEFAULT 8,
+  ADD COLUMN IF NOT EXISTS "reorbitMemoryTimeSeconds"       INTEGER,
+  ADD COLUMN IF NOT EXISTS "reorbitMemoryFlipBackDelayMs"   INTEGER NOT NULL DEFAULT 800,
+  ADD COLUMN IF NOT EXISTS "reorbitMemoryCardBackImagePath" TEXT;
+
+-- AddField: ReOrbit Memory tile image on GlobalGameConfig
+ALTER TABLE "GlobalGameConfig"
+  ADD COLUMN IF NOT EXISTS "gameTileReorbitmemoryImagePath" TEXT;
+
+-- CreateTable: ReOrbitMemoryScore
+CREATE TABLE IF NOT EXISTS "ReOrbitMemoryScore" (
+  "id"        TEXT         NOT NULL,
+  "userId"    TEXT         NOT NULL,
+  "moves"     INTEGER      NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ReOrbitMemoryScore_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: ReOrbitMemoryPlay
+CREATE TABLE IF NOT EXISTS "ReOrbitMemoryPlay" (
+  "id"        TEXT         NOT NULL,
+  "userId"    TEXT         NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ReOrbitMemoryPlay_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "ReOrbitMemoryScore_userId_moves_idx"     ON "ReOrbitMemoryScore"("userId", "moves");
+CREATE INDEX IF NOT EXISTS "ReOrbitMemoryScore_createdAt_idx"         ON "ReOrbitMemoryScore"("createdAt");
+CREATE INDEX IF NOT EXISTS "ReOrbitMemoryScore_userId_createdAt_idx"  ON "ReOrbitMemoryScore"("userId", "createdAt");
+CREATE INDEX IF NOT EXISTS "ReOrbitMemoryPlay_userId_createdAt_idx"   ON "ReOrbitMemoryPlay"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ReOrbitMemoryScore" ADD CONSTRAINT "ReOrbitMemoryScore_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "ReOrbitMemoryPlay" ADD CONSTRAINT "ReOrbitMemoryPlay_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,22 +109,22 @@ model CZone {
 }
 
 model CZoneSearch {
-  id                     String                    @id @default(uuid())
-  name                   String                    @default("")
-  startAt                DateTime
-  endAt                  DateTime
-  appearanceRatePercent  Float                     @default(0)
-  cooldownHours          Int                       @default(0)
-  resetType              CZoneSearchResetType      @default(COOLDOWN_HOURS)
-  dailyCollectLimit      Int?
-  collectionType         CZoneSearchCollectionType @default(MULTIPLE)
-  linkInOnboarding       Boolean                   @default(false)
-  createdAt              DateTime                  @default(now())
-  updatedAt              DateTime                  @updatedAt
+  id                    String                    @id @default(uuid())
+  name                  String                    @default("")
+  startAt               DateTime
+  endAt                 DateTime
+  appearanceRatePercent Float                     @default(0)
+  cooldownHours         Int                       @default(0)
+  resetType             CZoneSearchResetType      @default(COOLDOWN_HOURS)
+  dailyCollectLimit     Int?
+  collectionType        CZoneSearchCollectionType @default(MULTIPLE)
+  linkInOnboarding      Boolean                   @default(false)
+  createdAt             DateTime                  @default(now())
+  updatedAt             DateTime                  @updatedAt
 
-  prizePool    CZoneSearchPrize[]
-  appearances  CZoneSearchAppearance[]
-  captures     CZoneSearchCapture[]
+  prizePool   CZoneSearchPrize[]
+  appearances CZoneSearchAppearance[]
+  captures    CZoneSearchCapture[]
 
   @@index([startAt])
   @@index([endAt])
@@ -132,37 +132,37 @@ model CZoneSearch {
 }
 
 model CZoneSearchPrize {
-  id          String       @id @default(uuid())
-  cZoneSearchId String
-  ctoonId     String
-  chancePercent Float      @default(0)
-  maxCaptures Int?
-  conditionDateEnabled Boolean @default(false)
-  conditionDateStart   String?
-  conditionDateEnd     String?
-  conditionTimeEnabled Boolean @default(false)
-  conditionTimeOfDay   CZoneSearchTimeOfDay?
-  conditionBackgroundEnabled Boolean @default(false)
-  conditionBackgrounds String[] @default([])
-  conditionCtoonInZoneEnabled Boolean @default(false)
-  conditionCtoonInZoneId String?
-  conditionUserOwnsEnabled Boolean @default(false)
-  conditionUserOwns Json?
-  conditionUserPointsEnabled Boolean @default(false)
-  conditionUserPointsMin Int?
-  conditionUserTotalCountEnabled Boolean @default(false)
-  conditionUserTotalCountMin Int?
-  conditionUserUniqueCountEnabled Boolean @default(false)
-  conditionUserUniqueCountMin Int?
-  conditionSetUniqueCountEnabled Boolean @default(false)
-  conditionSetUniqueCountMin Int?
-  conditionSetUniqueCountSet String?
-  conditionSetTotalCountEnabled Boolean @default(false)
-  conditionSetTotalCountMin Int?
-  conditionSetTotalCountSet String?
-  conditionOwnsLessThanEnabled Boolean @default(false)
-  conditionOwnsLessThanCount   Int?
-  glitchEffect                 Boolean @default(false)
+  id                              String                @id @default(uuid())
+  cZoneSearchId                   String
+  ctoonId                         String
+  chancePercent                   Float                 @default(0)
+  maxCaptures                     Int?
+  conditionDateEnabled            Boolean               @default(false)
+  conditionDateStart              String?
+  conditionDateEnd                String?
+  conditionTimeEnabled            Boolean               @default(false)
+  conditionTimeOfDay              CZoneSearchTimeOfDay?
+  conditionBackgroundEnabled      Boolean               @default(false)
+  conditionBackgrounds            String[]              @default([])
+  conditionCtoonInZoneEnabled     Boolean               @default(false)
+  conditionCtoonInZoneId          String?
+  conditionUserOwnsEnabled        Boolean               @default(false)
+  conditionUserOwns               Json?
+  conditionUserPointsEnabled      Boolean               @default(false)
+  conditionUserPointsMin          Int?
+  conditionUserTotalCountEnabled  Boolean               @default(false)
+  conditionUserTotalCountMin      Int?
+  conditionUserUniqueCountEnabled Boolean               @default(false)
+  conditionUserUniqueCountMin     Int?
+  conditionSetUniqueCountEnabled  Boolean               @default(false)
+  conditionSetUniqueCountMin      Int?
+  conditionSetUniqueCountSet      String?
+  conditionSetTotalCountEnabled   Boolean               @default(false)
+  conditionSetTotalCountMin       Int?
+  conditionSetTotalCountSet       String?
+  conditionOwnsLessThanEnabled    Boolean               @default(false)
+  conditionOwnsLessThanCount      Int?
+  glitchEffect                    Boolean               @default(false)
 
   cZoneSearch CZoneSearch @relation(fields: [cZoneSearchId], references: [id], onDelete: Cascade)
   ctoon       Ctoon       @relation(fields: [ctoonId], references: [id], onDelete: Cascade)
@@ -184,7 +184,7 @@ model CZoneSearchAppearance {
   ctoon       Ctoon       @relation(fields: [ctoonId], references: [id], onDelete: Cascade)
   zoneOwner   User?       @relation("CZoneSearchZoneOwner", fields: [zoneOwnerId], references: [id], onDelete: SetNull)
 
-  capture     CZoneSearchCapture?
+  capture CZoneSearchCapture?
 
   @@index([userId, cZoneSearchId, createdAt])
   @@index([cZoneSearchId, createdAt])
@@ -231,18 +231,18 @@ model Ctoon {
   totalMinted     Int       @default(0)
 
   // Mint limit mode: "defined" (fixed quantity) or "timeBased" (unlimited until deadline)
-  mintLimitType   String    @default("defined")
-  mintEndDate     DateTime?
+  mintLimitType String    @default("defined")
+  mintEndDate   DateTime?
 
   // Two-phase release (advisory fields; availability driven by global settings)
-  initialReleaseAt DateTime?
-  finalReleaseAt   DateTime?
+  initialReleaseAt  DateTime?
+  finalReleaseAt    DateTime?
   initialReleaseQty Int?
   finalReleaseQty   Int?
 
   // Time-based release purchase limit overrides (null = use rarity defaults from GlobalGameConfig)
-  timeBasedLimitCount      Int?      // max purchases per user; null = use rarity default
-  timeBasedLimitWindowDays Int?      // rolling window in days; null = use rarity default (falls back to full release duration)
+  timeBasedLimitCount      Int? // max purchases per user; null = use rarity default
+  timeBasedLimitWindowDays Int? // rolling window in days; null = use rarity default (falls back to full release duration)
 
   // gToon fields
   isGtoon     Boolean @default(false)
@@ -253,14 +253,14 @@ model Ctoon {
   abilityData Json?
 
   // Second Edition fields
-  isSecondEdition        Boolean  @default(false)
-  relatedFirstEditionId  String?  @unique
+  isSecondEdition          Boolean @default(false)
+  relatedFirstEditionId    String? @unique
   secondEditionOverlayX    Float? // % offset of overlay's left edge within the cToon image (0-100)
   secondEditionOverlayY    Float? // % offset of overlay's top edge within the cToon image (0-100)
   secondEditionOverlaySize Float? // % scale of overlay relative to its natural size (100 = natural size)
 
-  relatedFirstEdition  Ctoon?  @relation("EditionPair", fields: [relatedFirstEditionId], references: [id])
-  relatedSecondEdition Ctoon?  @relation("EditionPair")
+  relatedFirstEdition  Ctoon? @relation("EditionPair", fields: [relatedFirstEditionId], references: [id])
+  relatedSecondEdition Ctoon? @relation("EditionPair")
 
   owners                     UserCtoon[]
   deckCards                  ClashDeckCard[]
@@ -284,18 +284,18 @@ model Ctoon {
   userSuggestions            CtoonUserSuggestion[]
 
   // Scavenger Hunt relations
-  scavengerExclusivePoolRows ScavengerExclusiveCtoon[] @relation("ScavengerExclusivePool")
-  scavengerAwardedSessions   ScavengerSession[]        @relation("ScavengerAwardedCtoon")
+  scavengerExclusivePoolRows ScavengerExclusiveCtoon[]  @relation("ScavengerExclusivePool")
+  scavengerAwardedSessions   ScavengerSession[]         @relation("ScavengerAwardedCtoon")
   // Achievements back‑relations
   achievementRewardCtoons    AchievementRewardCtoon[]
   achievementRequiredCtoons  AchievementRequiredCtoon[]
 
-  cZoneSearchPrizeRows  CZoneSearchPrize[]
+  cZoneSearchPrizeRows   CZoneSearchPrize[]
   cZoneSearchAppearances CZoneSearchAppearance[]
-  cZoneSearchCaptures   CZoneSearchCapture[]
-  cmartPurchaseLogs     CmartPurchaseLog[]
-  saleItems             SaleCtoon[]
-  saleDailyPurchases    SaleDailyPurchase[]
+  cZoneSearchCaptures    CZoneSearchCapture[]
+  cmartPurchaseLogs      CmartPurchaseLog[]
+  saleItems              SaleCtoon[]
+  saleDailyPurchases     SaleDailyPurchase[]
 
   @@index([isSecondEdition])
   @@index([name])
@@ -329,7 +329,7 @@ model UserCtoon {
   createdAt      DateTime  @default(now())
   burnedAt       DateTime?
   userPackId     String?
-  pricePaid      Int?      // Points charged at purchase time; null for pack-origin, trade, reward, etc.
+  pricePaid      Int? // Points charged at purchase time; null for pack-origin, trade, reward, etc.
 
   user     User      @relation(fields: [userId], references: [id])
   ctoon    Ctoon     @relation(fields: [ctoonId], references: [id])
@@ -339,7 +339,7 @@ model UserCtoon {
   tradeOfferCtoons          TradeOfferCtoon[]
   auctions                  Auction[]
   ownerLogs                 CtoonOwnerLog[]
-  holidayRedemptionAsSource HolidayRedemption? @relation("HolidaySourceUserCtoon")
+  holidayRedemptionAsSource HolidayRedemption?    @relation("HolidaySourceUserCtoon")
   auctionOnlyListings       AuctionOnly[]
   tradeListItems            UserTradeListItem[]
   dissolveAuctionQueue      DissolveAuctionQueue?
@@ -396,70 +396,70 @@ model User {
   usernameChangedAt                 DateTime?
   vpnDetected                       Boolean   @default(false)
 
-  cZones                   CZone[]
-  clashDecks               ClashDeck[]
-  logins                   LoginLog[]
-  deviceFingerprintLogs    DeviceFingerprintLog[]
-  gamePointLogs            GamePointLog[]
-  pointsLogs               PointsLog[]
-  lockedPoints             LockedPoints[]
-  claims                   Claim[]
-  visits                   Visit[]
-  points                   UserPoints?
-  ctoons                   UserCtoon[]
-  friends                  Friend[]                    @relation("UserFriends")
-  friendedBy               Friend[]                    @relation("UserFriendOf")
-  traderARooms             TradeRoom[]                 @relation("TraderA")
-  traderBRooms             TradeRoom[]                 @relation("TraderB")
-  trades                   Trade[]
-  tradeSpectators          TradeSpectator[]
-  ips                      UserIP[]
-  packs                    UserPack[]
-  wishlistItems            WishlistItem[]
-  tradeListItems           UserTradeListItem[]
-  tradeOffersInitiated     TradeOffer[]                @relation("OfferInitiator")
-  tradeOffersReceived      TradeOffer[]                @relation("OfferRecipient")
-  auctionsAsHighestBid     Auction[]                   @relation("HighestBidder")
-  auctionsAsWinner         Auction[]                   @relation("AuctionWinner")
-  bids                     Bid[]
-  autoBids                 AuctionAutoBid[]
-  auctionsCreated          Auction[]                   @relation("AuctionsCreated")
-  clashGamesAsPlayer1      ClashGame[]                 @relation("ClashGamePlayer1")
-  clashGamesAsPlayer2      ClashGame[]                 @relation("ClashGamePlayer2")
-  clashGamesWhoLeft        ClashGame[]                 @relation("ClashGameWhoLeft")
-  clashGamesAsWinner       ClashGame[]                 @relation("ClashGameWinner")
-  gtoonTournamentsWon      GtoonTournament[]           @relation("GtoonTournamentWinner")
-  gtoonTournamentOptIns    GtoonTournamentOptIn[]
-  gtoonTournamentMatchesAsA GtoonTournamentMatch[]     @relation("GtoonTournamentMatchPlayerA")
-  gtoonTournamentMatchesAsB GtoonTournamentMatch[]     @relation("GtoonTournamentMatchPlayerB")
-  gtoonTournamentMatchesWon GtoonTournamentMatch[]     @relation("GtoonTournamentMatchWinner")
-  gtoonTournamentRecords   GtoonTournamentPlayerRecord[]
-  monsterBattlesAsPlayer1  MonsterBattle[]             @relation("MonsterBattlePlayer1")
-  monsterBattlesAsPlayer2  MonsterBattle[]             @relation("MonsterBattlePlayer2")
-  monsterBattlesAsWinner   MonsterBattle[]             @relation("MonsterBattleWinner")
-  wheelSpinLogs            WheelSpinLog[]              @relation("WheelSpinLogToUser")
-  backgroundsCreated       Background[]                @relation("BackgroundCreatedBy")
-  ownedBackgrounds         UserBackground[]            @relation("User_UserBackgrounds")
-  ownerLogs                CtoonOwnerLog[]
-  ownerLogsAsCounterparty  CtoonOwnerLog[]             @relation("CtoonOwnerLogCounterparty")
-  holidayRedemptions       HolidayRedemption[]
-  auctionsOnlyCreated      AuctionOnly[]               @relation("AuctionOnlyCreatedBy")
-  adImagesCreated          AdImage[]                   @relation("AdImagesCreatedBy")
-  winballGrandPrizeCreated WinballGrandPrizeSchedule[] @relation("WinballGrandPrizeCreatedBy")
-  announcementsCreated     Announcement[]              @relation("AnnouncementsCreatedBy")
-  salesCreated             Sale[]                      @relation("SaleCreatedBy")
-  saleDailyPurchases       SaleDailyPurchase[]
+  cZones                    CZone[]
+  clashDecks                ClashDeck[]
+  logins                    LoginLog[]
+  deviceFingerprintLogs     DeviceFingerprintLog[]
+  gamePointLogs             GamePointLog[]
+  pointsLogs                PointsLog[]
+  lockedPoints              LockedPoints[]
+  claims                    Claim[]
+  visits                    Visit[]
+  points                    UserPoints?
+  ctoons                    UserCtoon[]
+  friends                   Friend[]                      @relation("UserFriends")
+  friendedBy                Friend[]                      @relation("UserFriendOf")
+  traderARooms              TradeRoom[]                   @relation("TraderA")
+  traderBRooms              TradeRoom[]                   @relation("TraderB")
+  trades                    Trade[]
+  tradeSpectators           TradeSpectator[]
+  ips                       UserIP[]
+  packs                     UserPack[]
+  wishlistItems             WishlistItem[]
+  tradeListItems            UserTradeListItem[]
+  tradeOffersInitiated      TradeOffer[]                  @relation("OfferInitiator")
+  tradeOffersReceived       TradeOffer[]                  @relation("OfferRecipient")
+  auctionsAsHighestBid      Auction[]                     @relation("HighestBidder")
+  auctionsAsWinner          Auction[]                     @relation("AuctionWinner")
+  bids                      Bid[]
+  autoBids                  AuctionAutoBid[]
+  auctionsCreated           Auction[]                     @relation("AuctionsCreated")
+  clashGamesAsPlayer1       ClashGame[]                   @relation("ClashGamePlayer1")
+  clashGamesAsPlayer2       ClashGame[]                   @relation("ClashGamePlayer2")
+  clashGamesWhoLeft         ClashGame[]                   @relation("ClashGameWhoLeft")
+  clashGamesAsWinner        ClashGame[]                   @relation("ClashGameWinner")
+  gtoonTournamentsWon       GtoonTournament[]             @relation("GtoonTournamentWinner")
+  gtoonTournamentOptIns     GtoonTournamentOptIn[]
+  gtoonTournamentMatchesAsA GtoonTournamentMatch[]        @relation("GtoonTournamentMatchPlayerA")
+  gtoonTournamentMatchesAsB GtoonTournamentMatch[]        @relation("GtoonTournamentMatchPlayerB")
+  gtoonTournamentMatchesWon GtoonTournamentMatch[]        @relation("GtoonTournamentMatchWinner")
+  gtoonTournamentRecords    GtoonTournamentPlayerRecord[]
+  monsterBattlesAsPlayer1   MonsterBattle[]               @relation("MonsterBattlePlayer1")
+  monsterBattlesAsPlayer2   MonsterBattle[]               @relation("MonsterBattlePlayer2")
+  monsterBattlesAsWinner    MonsterBattle[]               @relation("MonsterBattleWinner")
+  wheelSpinLogs             WheelSpinLog[]                @relation("WheelSpinLogToUser")
+  backgroundsCreated        Background[]                  @relation("BackgroundCreatedBy")
+  ownedBackgrounds          UserBackground[]              @relation("User_UserBackgrounds")
+  ownerLogs                 CtoonOwnerLog[]
+  ownerLogsAsCounterparty   CtoonOwnerLog[]               @relation("CtoonOwnerLogCounterparty")
+  holidayRedemptions        HolidayRedemption[]
+  auctionsOnlyCreated       AuctionOnly[]                 @relation("AuctionOnlyCreatedBy")
+  adImagesCreated           AdImage[]                     @relation("AdImagesCreatedBy")
+  winballGrandPrizeCreated  WinballGrandPrizeSchedule[]   @relation("WinballGrandPrizeCreatedBy")
+  announcementsCreated      Announcement[]                @relation("AnnouncementsCreatedBy")
+  salesCreated              Sale[]                        @relation("SaleCreatedBy")
+  saleDailyPurchases        SaleDailyPurchase[]
   // Ban notes relations
-  banNotes                 UserBanNote[]               @relation("BanNoteUser")
-  banNotesAuthored         UserBanNote[]               @relation("BanNoteAdmin")
+  banNotes                  UserBanNote[]                 @relation("BanNoteUser")
+  banNotesAuthored          UserBanNote[]                 @relation("BanNoteAdmin")
 
   // Scavenger Hunt relations
   scavengerSessions    ScavengerSession[]
   scavengerTriggerLogs ScavengerTriggerLog[]
 
-  cZoneSearchAppearances     CZoneSearchAppearance[]
+  cZoneSearchAppearances          CZoneSearchAppearance[]
   cZoneSearchZoneOwnerAppearances CZoneSearchAppearance[] @relation("CZoneSearchZoneOwner")
-  cZoneSearchCaptures        CZoneSearchCapture[]
+  cZoneSearchCaptures             CZoneSearchCapture[]
 
   // Admin change logs (inverse)
   adminChangeLogs AdminChangeLog[]
@@ -471,8 +471,8 @@ model User {
 
   ctoonSuggestions CtoonUserSuggestion[]
 
-  submittedCtoons         SubmittedCtoon[]       @relation("SubmittedCtoonByUser")
-  reviewedSubmissions     SubmittedCtoon[]       @relation("SubmittedCtoonReviewedBy")
+  submittedCtoons     SubmittedCtoon[] @relation("SubmittedCtoonByUser")
+  reviewedSubmissions SubmittedCtoon[] @relation("SubmittedCtoonReviewedBy")
 
   czoneContestSubmissions CZoneContestSubmission[]
   czoneContestVotes       CZoneContestVote[]
@@ -509,19 +509,23 @@ model User {
   towerStackScores TowerStackScore[]
   towerStackPlays  TowerStackPlay[]
 
+  // ReOrbit Memory
+  reOrbitMemoryScores ReOrbitMemoryScore[]
+  reOrbitMemoryPlays  ReOrbitMemoryPlay[]
+
   @@unique([discordId, active]) // at most one active user per Discord ID
 }
 
 model CtoonUserSuggestion {
-  id        String                @id @default(uuid())
-  ctoonId   String
-  userId    String
-  status    CtoonSuggestionStatus @default(IN_REVIEW)
-  oldValues Json
-  newValues Json
+  id              String                @id @default(uuid())
+  ctoonId         String
+  userId          String
+  status          CtoonSuggestionStatus @default(IN_REVIEW)
+  oldValues       Json
+  newValues       Json
   rejectionReason String?
-  createdAt DateTime              @default(now())
-  updatedAt DateTime              @updatedAt
+  createdAt       DateTime              @default(now())
+  updatedAt       DateTime              @updatedAt
 
   ctoon Ctoon @relation(fields: [ctoonId], references: [id])
   user  User  @relation(fields: [userId], references: [id])
@@ -742,20 +746,20 @@ model TradeSpectator {
 }
 
 model Pack {
-  id                 String   @id @default(uuid())
+  id                 String              @id @default(uuid())
   name               String
   description        String?
-  price              Int      @default(0)
+  price              Int                 @default(0)
   imagePath          String?
-  inCmart            Boolean  @default(false)
+  inCmart            Boolean             @default(false)
   scheduledAt        DateTime?
   sentAt             DateTime?
   scheduledOffAt     DateTime?
   sellOutBehavior    PackSellOutBehavior @default(REMOVE_ON_ANY_RARITY_EMPTY)
   dailyPurchaseLimit Int?
   maxBuysPerUser     Int?
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
 
   rarityConfigs PackRarityConfig[]
   ctoonOptions  PackCtoonOption[]
@@ -794,10 +798,10 @@ model UserPack {
   opened    Boolean   @default(false)
   openedAt  DateTime?
   createdAt DateTime  @default(now())
-  pricePaid Int?      // Effective points charged at purchase time; null for legacy records
+  pricePaid Int? // Effective points charged at purchase time; null for legacy records
 
-  user         User       @relation(fields: [userId], references: [id])
-  pack         Pack       @relation(fields: [packId], references: [id])
+  user         User        @relation(fields: [userId], references: [id])
+  pack         Pack        @relation(fields: [packId], references: [id])
   mintedCtoons UserCtoon[]
 }
 
@@ -870,26 +874,26 @@ model GameConfig {
   winballPlungerForce        Float? @default(500)
 
   // — Winball color settings —
-  winballColorBackground String? @default("#ffffff")
-  winballColorBackboard  String? @default("#F0E6FF")
-  winballColorWalls      String? @default("#4b4b4b")
-  winballColorBall       String? @default("#ff0000")
-  winballColorBumpers    String? @default("#8c8cff")
-  winballColorLeftCup    String? @default("#8c8cff")
-  winballColorRightCup   String? @default("#8c8cff")
-  winballColorGoldCup    String? @default("#FFD700")
-  winballColorCap        String? @default("#ffd000")
-  winballColorTransform  String? @default("#ffffff")
-  winballColorTransformIntensity Float? @default(0)
-  winballOverlayColor    String? @default("#ffffff")
-  winballOverlayAlpha    Float?  @default(0)
-  winballImageWidthPercent Float? @default(100)
-  winballImageOffsetXPercent Float? @default(0)
-  winballImageOffsetYPercent Float? @default(0)
-  winballBackboardImagePath String?
-  winballBumper1ImagePath   String?
-  winballBumper2ImagePath   String?
-  winballBumper3ImagePath   String?
+  winballColorBackground         String? @default("#ffffff")
+  winballColorBackboard          String? @default("#F0E6FF")
+  winballColorWalls              String? @default("#4b4b4b")
+  winballColorBall               String? @default("#ff0000")
+  winballColorBumpers            String? @default("#8c8cff")
+  winballColorLeftCup            String? @default("#8c8cff")
+  winballColorRightCup           String? @default("#8c8cff")
+  winballColorGoldCup            String? @default("#FFD700")
+  winballColorCap                String? @default("#ffd000")
+  winballColorTransform          String? @default("#ffffff")
+  winballColorTransformIntensity Float?  @default(0)
+  winballOverlayColor            String? @default("#ffffff")
+  winballOverlayAlpha            Float?  @default(0)
+  winballImageWidthPercent       Float?  @default(100)
+  winballImageOffsetXPercent     Float?  @default(0)
+  winballImageOffsetYPercent     Float?  @default(0)
+  winballBackboardImagePath      String?
+  winballBumper1ImagePath        String?
+  winballBumper2ImagePath        String?
+  winballBumper3ImagePath        String?
 
   // — Winball bumper geometry —
   winballBumper1Radius Float? @default(6)
@@ -975,12 +979,12 @@ model GameConfig {
   winWheelSoundMode String?
 
   // — ReOrbit Match settings —
-  reorbitPlaysPerPeriod Int     @default(3)
-  reorbitPointsPerGame  Int     @default(50)
+  reorbitPlaysPerPeriod Int      @default(3)
+  reorbitPointsPerGame  Int      @default(50)
   reorbitTimeSeconds    Int?
   reorbitEmojis         String[] @default([])
-  reorbitGridSize       Int     @default(8)
-  reorbitComboMs        Int     @default(3500)
+  reorbitGridSize       Int      @default(8)
+  reorbitComboMs        Int      @default(3500)
 
   // — Tower Stack settings —
   towerPlaysPerPeriod      Int   @default(3)
@@ -991,62 +995,71 @@ model GameConfig {
   towerPerfectEpsilon      Float @default(4)
   towerMaxLayers           Int   @default(800)
 
+  // — ReOrbit Memory settings —
+  reorbitMemoryPlaysPerPeriod    Int     @default(3)
+  reorbitMemoryPointsPerGame     Int     @default(50)
+  reorbitMemoryPairs             Int     @default(8)
+  reorbitMemoryTimeSeconds       Int?
+  reorbitMemoryFlipBackDelayMs   Int     @default(800)
+  reorbitMemoryCardBackImagePath String?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 }
 
 model GlobalGameConfig {
-  id                     String   @id @default(uuid())
-  dailyPointLimit        Int      @default(100)
-  dailyLoginPoints       Int      @default(500)
-  dailyNewUserPoints     Int      @default(1000)
-  czoneVisitPoints       Int      @default(20)
-  czoneVisitMaxPerDay    Int      @default(10)
-  czoneCount             Int      @default(3)
-  phashDuplicateThreshold Int     @default(14)
-  dhashDuplicateThreshold Int     @default(16)
-  rarityDefaults         Json?
-  achievementDiscordChannelId String?
+  id                             String   @id @default(uuid())
+  dailyPointLimit                Int      @default(100)
+  dailyLoginPoints               Int      @default(500)
+  dailyNewUserPoints             Int      @default(1000)
+  czoneVisitPoints               Int      @default(20)
+  czoneVisitMaxPerDay            Int      @default(10)
+  czoneCount                     Int      @default(3)
+  phashDuplicateThreshold        Int      @default(14)
+  dhashDuplicateThreshold        Int      @default(16)
+  rarityDefaults                 Json?
+  achievementDiscordChannelId    String?
   // Scavenger Hunt settings
-  scavengerChancePercent Int      @default(5) // 0–100; 0 disables
-  scavengerCooldownHours Int      @default(24) // cooldown between completed hunts per user
+  scavengerChancePercent         Int      @default(5) // 0–100; 0 disables
+  scavengerCooldownHours         Int      @default(24) // cooldown between completed hunts per user
   // cToon release settings
-  initialReleasePercent  Int      @default(75)
-  finalReleaseDelayHours Int      @default(12)
-  featuredAuctionHours         Json     @default("[]")  // int[] of hours 0–23 CST to fire
-  featuredAuctionIntervalDays  Int      @default(1)      // fire every N days
-  featuredAuctionsPerSlot      Int      @default(1)      // auctions created per slot
-  featuredAuctionLastFiredSlot String?                   // idempotency key e.g. "2026-03-30-08"
-  cmartHalfPriceEnabled        Boolean  @default(false)   // halves cToon and pack prices in cMart
+  initialReleasePercent          Int      @default(75)
+  finalReleaseDelayHours         Int      @default(12)
+  featuredAuctionHours           Json     @default("[]") // int[] of hours 0–23 CST to fire
+  featuredAuctionIntervalDays    Int      @default(1) // fire every N days
+  featuredAuctionsPerSlot        Int      @default(1) // auctions created per slot
+  featuredAuctionLastFiredSlot   String? // idempotency key e.g. "2026-03-30-08"
+  cmartHalfPriceEnabled          Boolean  @default(false) // halves cToon and pack prices in cMart
   // Pack price decay settings
-  packPriceDecayAmount         Int      @default(100)     // points to drop per decay period
-  packPriceDecayDays           Int      @default(7)       // days between each price drop
-  packPriceFloor               Int      @default(700)     // minimum price after decay
-  packMaxDefaultBuysPerUser    Int      @default(5)       // default maxBuysPerUser set on new packs
+  packPriceDecayAmount           Int      @default(100) // points to drop per decay period
+  packPriceDecayDays             Int      @default(7) // days between each price drop
+  packPriceFloor                 Int      @default(700) // minimum price after decay
+  packMaxDefaultBuysPerUser      Int      @default(5) // default maxBuysPerUser set on new packs
   // Per-rarity time-based purchase limits: { "Common": { "count": 5, "windowDays": null }, ... }
   // windowDays null = full release window (releaseDate → mintEndDate)
-  timeBasedPurchaseLimits      Json?
+  timeBasedPurchaseLimits        Json?
   // Second Edition overlay icon, shown over every Second Edition cToon's image
-  secondEditionOverlayPath   String?
-  secondEditionOverlayWidth  Int?     // natural pixel width of the uploaded overlay image
-  secondEditionOverlayHeight Int?     // natural pixel height of the uploaded overlay image
+  secondEditionOverlayPath       String?
+  secondEditionOverlayWidth      Int? // natural pixel width of the uploaded overlay image
+  secondEditionOverlayHeight     Int? // natural pixel height of the uploaded overlay image
   // Game tile images shown on the Games page
-  gameTileWinballImagePath      String?
-  gameTileLottoImagePath        String?
-  gameTileWinwheelImagePath     String?
-  gameTileClashImagePath        String?
-  gameTileTkoImagePath          String?
-  gameTileReorbitmatchImagePath String?
-  gameTileTowerImagePath        String?
+  gameTileWinballImagePath       String?
+  gameTileLottoImagePath         String?
+  gameTileWinwheelImagePath      String?
+  gameTileClashImagePath         String?
+  gameTileTkoImagePath           String?
+  gameTileReorbitmatchImagePath  String?
+  gameTileTowerImagePath         String?
+  gameTileReorbitmemoryImagePath String?
   // Account-dissolve "featured auction" rules: cToons matching any of these
   // rarities/series/sets are marked isFeatured when an account is dissolved.
   // Each is a JSON array of strings, edited via the "Edit Featured" modal on
   // /admin/dissolve-queue.
-  featuredDissolveRarities Json     @default("[]")
-  featuredDissolveSeries   Json     @default("[]")
-  featuredDissolveSets     Json     @default("[]")
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  featuredDissolveRarities       Json     @default("[]")
+  featuredDissolveSeries         Json     @default("[]")
+  featuredDissolveSets           Json     @default("[]")
+  createdAt                      DateTime @default(now())
+  updatedAt                      DateTime @updatedAt
 }
 
 model WishlistItem {
@@ -1202,14 +1215,14 @@ model Bid {
 }
 
 model ClashGame {
-  id            String  @id @default(uuid())
-  player1UserId String
-  player2UserId String? // null for AI
-  player1Points Int     @default(0) // staked by P1
-  player2Points Int     @default(0) // staked by P2
+  id                  String  @id @default(uuid())
+  player1UserId       String
+  player2UserId       String? // null for AI
+  player1Points       Int     @default(0) // staked by P1
+  player2Points       Int     @default(0) // staked by P2
   player1DeckSnapshot Json?
   player2DeckSnapshot Json?
-  isTournament Boolean @default(false)
+  isTournament        Boolean @default(false)
 
   winnerUserId  String? // null if AI won or tie
   outcome       String? // 'player' | 'ai' | 'tie' | 'incomplete'
@@ -1224,10 +1237,10 @@ model ClashGame {
 }
 
 model MonsterBattle {
-  id                String                 @id @default(uuid())
+  id                String                  @id @default(uuid())
   player1UserId     String
   player2UserId     String?
-  player2IsAi       Boolean                @default(false)
+  player2IsAi       Boolean                 @default(false)
   player1MonsterId  String
   player2MonsterId  String?
   player1StartStats Json
@@ -1235,10 +1248,10 @@ model MonsterBattle {
   player1FinalHp    Int?
   player2FinalHp    Int?
   winnerUserId      String?
-  winnerIsAi        Boolean                @default(false)
+  winnerIsAi        Boolean                 @default(false)
   endReason         MonsterBattleEndReason?
   turnLog           Json?
-  startedAt         DateTime               @default(now())
+  startedAt         DateTime                @default(now())
   endedAt           DateTime?
 
   player1        User         @relation("MonsterBattlePlayer1", fields: [player1UserId], references: [id])
@@ -1315,26 +1328,26 @@ model ClashDeckCard {
 }
 
 model GtoonTournament {
-  id       String               @id @default(uuid())
-  name     String
-  status   GtoonTournamentStatus @default(DRAFT)
-  optInStartAt DateTime
-  optInEndAt   DateTime
-  format       GtoonTournamentFormat?
-  swissRounds  Int               @default(4)
-  bestOf       Int               @default(3)
-  maxSuddenDeathGames Int         @default(10)
-  createdAt    DateTime          @default(now())
-  updatedAt    DateTime          @updatedAt
+  id                  String                 @id @default(uuid())
+  name                String
+  status              GtoonTournamentStatus  @default(DRAFT)
+  optInStartAt        DateTime
+  optInEndAt          DateTime
+  format              GtoonTournamentFormat?
+  swissRounds         Int                    @default(4)
+  bestOf              Int                    @default(3)
+  maxSuddenDeathGames Int                    @default(10)
+  createdAt           DateTime               @default(now())
+  updatedAt           DateTime               @updatedAt
 
-  announcementChannelId String
-  lastAnnouncementAt DateTime?
-  nextAnnouncementAt DateTime?
-  finalOptInMidnightAnnouncementSent Boolean @default(false)
+  announcementChannelId              String
+  lastAnnouncementAt                 DateTime?
+  nextAnnouncementAt                 DateTime?
+  finalOptInMidnightAnnouncementSent Boolean   @default(false)
 
-  finalizedAt DateTime?
-  finalPlacementsJson Json?
-  winnerUserId String?
+  finalizedAt           DateTime?
+  finalPlacementsJson   Json?
+  winnerUserId          String?
   tournamentCompletedAt DateTime?
 
   winner User? @relation("GtoonTournamentWinner", fields: [winnerUserId], references: [id])
@@ -1357,7 +1370,7 @@ model GtoonTournamentOptIn {
   isActive     Boolean  @default(true)
 
   tournament GtoonTournament @relation(fields: [tournamentId], references: [id])
-  user       User           @relation(fields: [userId], references: [id])
+  user       User            @relation(fields: [userId], references: [id])
 
   @@unique([tournamentId, userId])
   @@index([tournamentId, isActive])
@@ -1370,7 +1383,7 @@ model GtoonTournamentRound {
   roundNumber  Int
   createdAt    DateTime             @default(now())
 
-  tournament GtoonTournament @relation(fields: [tournamentId], references: [id])
+  tournament GtoonTournament        @relation(fields: [tournamentId], references: [id])
   matches    GtoonTournamentMatch[]
 
   @@unique([tournamentId, stage, roundNumber])
@@ -1378,43 +1391,43 @@ model GtoonTournamentRound {
 }
 
 model GtoonTournamentMatch {
-  id           String               @id @default(uuid())
-  tournamentId String
-  roundId      String
-  stage        GtoonTournamentStage
-  roundNumber  Int
-  tableNumber  Int?
+  id            String               @id @default(uuid())
+  tournamentId  String
+  roundId       String
+  stage         GtoonTournamentStage
+  roundNumber   Int
+  tableNumber   Int?
   playerAUserId String
   playerBUserId String
 
-  status       GtoonTournamentMatchStatus @default(PENDING)
-  bestOf       Int                        @default(3)
-  winsA        Int                        @default(0)
-  winsB        Int                        @default(0)
-  ties         Int                        @default(0)
-  gamesCounted Int                        @default(0)
+  status       GtoonTournamentMatchStatus   @default(PENDING)
+  bestOf       Int                          @default(3)
+  winsA        Int                          @default(0)
+  winsB        Int                          @default(0)
+  ties         Int                          @default(0)
+  gamesCounted Int                          @default(0)
   outcome      GtoonTournamentMatchOutcome?
   winnerUserId String?
 
-  pairedAt     DateTime                  @default(now())
-  lockedAt     DateTime?
-  completedAt  DateTime?
+  pairedAt    DateTime  @default(now())
+  lockedAt    DateTime?
+  completedAt DateTime?
 
-  sourceBattleIdsJson Json?
-  resolutionPolicy    GtoonTournamentResolutionPolicy @default(FIRST_GAMES_AFTER_PAIRING)
-  requiresWinner      Boolean                        @default(false)
-  tiebreakMethod      GtoonTournamentTiebreakMethod?
-  tiebreakResolvedAt  DateTime?
-  tiebreakNotes       String?
-  suddenDeathGamesCounted Int                         @default(0)
-  seedA Int?
-  seedB Int?
+  sourceBattleIdsJson     Json?
+  resolutionPolicy        GtoonTournamentResolutionPolicy @default(FIRST_GAMES_AFTER_PAIRING)
+  requiresWinner          Boolean                         @default(false)
+  tiebreakMethod          GtoonTournamentTiebreakMethod?
+  tiebreakResolvedAt      DateTime?
+  tiebreakNotes           String?
+  suddenDeathGamesCounted Int                             @default(0)
+  seedA                   Int?
+  seedB                   Int?
 
-  tournament GtoonTournament @relation(fields: [tournamentId], references: [id])
+  tournament GtoonTournament      @relation(fields: [tournamentId], references: [id])
   round      GtoonTournamentRound @relation(fields: [roundId], references: [id])
-  playerA    User @relation("GtoonTournamentMatchPlayerA", fields: [playerAUserId], references: [id])
-  playerB    User @relation("GtoonTournamentMatchPlayerB", fields: [playerBUserId], references: [id])
-  winner     User? @relation("GtoonTournamentMatchWinner", fields: [winnerUserId], references: [id])
+  playerA    User                 @relation("GtoonTournamentMatchPlayerA", fields: [playerAUserId], references: [id])
+  playerB    User                 @relation("GtoonTournamentMatchPlayerB", fields: [playerBUserId], references: [id])
+  winner     User?                @relation("GtoonTournamentMatchWinner", fields: [winnerUserId], references: [id])
 
   @@index([tournamentId, stage, roundNumber])
   @@index([tournamentId, status])
@@ -1424,25 +1437,25 @@ model GtoonTournamentMatch {
 }
 
 model GtoonTournamentPlayerRecord {
-  id              String   @id @default(uuid())
-  tournamentId    String
-  userId          String
-  swissWins       Int      @default(0)
-  swissLosses     Int      @default(0)
-  swissTies       Int      @default(0)
-  swissByes       Int      @default(0)
-  bracketWins     Int      @default(0)
-  bracketLosses   Int      @default(0)
-  points          Int      @default(0)
-  swissGameWins   Int      @default(0)
-  swissGameLosses Int      @default(0)
-  swissGameTies   Int      @default(0)
-  opponentMatchWinPct Float @default(0)
-  gameWinPct      Float    @default(0)
-  lastUpdatedAt   DateTime @default(now())
+  id                  String   @id @default(uuid())
+  tournamentId        String
+  userId              String
+  swissWins           Int      @default(0)
+  swissLosses         Int      @default(0)
+  swissTies           Int      @default(0)
+  swissByes           Int      @default(0)
+  bracketWins         Int      @default(0)
+  bracketLosses       Int      @default(0)
+  points              Int      @default(0)
+  swissGameWins       Int      @default(0)
+  swissGameLosses     Int      @default(0)
+  swissGameTies       Int      @default(0)
+  opponentMatchWinPct Float    @default(0)
+  gameWinPct          Float    @default(0)
+  lastUpdatedAt       DateTime @default(now())
 
   tournament GtoonTournament @relation(fields: [tournamentId], references: [id])
-  user       User           @relation(fields: [userId], references: [id])
+  user       User            @relation(fields: [userId], references: [id])
 
   @@unique([tournamentId, userId])
   @@index([tournamentId, points])
@@ -1555,10 +1568,10 @@ model CtoonOwnerLog {
   counterpartyUsername String? // snapshot, survives counterparty account deletion
   createdAt            DateTime @default(now())
 
-  user        User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
-  ctoon       Ctoon?     @relation(fields: [ctoonId], references: [id], onDelete: SetNull)
-  userCtoon   UserCtoon? @relation(fields: [userCtoonId], references: [id], onDelete: SetNull)
-  counterparty User?     @relation("CtoonOwnerLogCounterparty", fields: [counterpartyUserId], references: [id], onDelete: SetNull)
+  user         User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
+  ctoon        Ctoon?     @relation(fields: [ctoonId], references: [id], onDelete: SetNull)
+  userCtoon    UserCtoon? @relation(fields: [userCtoonId], references: [id], onDelete: SetNull)
+  counterparty User?      @relation("CtoonOwnerLogCounterparty", fields: [counterpartyUserId], references: [id], onDelete: SetNull)
 
   @@index([userCtoonId, createdAt])
   @@index([ctoonId, createdAt])
@@ -1655,9 +1668,9 @@ model AuctionOnly {
 model DissolveAuctionQueue {
   id           String    @id @default(uuid())
   userCtoonId  String    @unique
-  category     String    @default("OTHER")  // "FEATURED" | "OTHER"
+  category     String    @default("OTHER") // "FEATURED" | "OTHER"
   isFeatured   Boolean   @default(false)
-  scheduledFor DateTime?                     // UTC; null = not yet scheduled
+  scheduledFor DateTime? // UTC; null = not yet scheduled
   createdAt    DateTime  @default(now())
 
   userCtoon UserCtoon @relation(fields: [userCtoonId], references: [id])
@@ -1668,32 +1681,32 @@ model DissolveAuctionQueue {
 }
 
 model HomepageConfig {
-  id                   String   @id
-  topLeftImagePath     String?
-  bottomLeftImagePath  String?
-  topRightImagePath    String?
-  bottomRightImagePath String?
-  bottomRightLink      String?
-  showcaseImagePath    String?
-  homeImage1Path       String?
-  homeImage1Link       String?
-  homeImage2Path       String?
-  homeImage2Link       String?
-  homeImage3Path       String?
-  homeImage3Link       String?
-  homeImage4Path           String?
-  homeImage4Link           String?
-  middleSidebar1ImagePath  String?
-  middleSidebar1Link       String?
-  middleSidebar2ImagePath  String?
-  middleSidebar2Link       String?
-  middleSidebar3ImagePath  String?
-  middleSidebar3Link       String?
-  newsImagePath            String?
-  earnPointsImagePath      String?
-  labelImagePath           String?
-  createdAt                DateTime @default(now())
-  updatedAt                DateTime @updatedAt
+  id                      String   @id
+  topLeftImagePath        String?
+  bottomLeftImagePath     String?
+  topRightImagePath       String?
+  bottomRightImagePath    String?
+  bottomRightLink         String?
+  showcaseImagePath       String?
+  homeImage1Path          String?
+  homeImage1Link          String?
+  homeImage2Path          String?
+  homeImage2Link          String?
+  homeImage3Path          String?
+  homeImage3Link          String?
+  homeImage4Path          String?
+  homeImage4Link          String?
+  middleSidebar1ImagePath String?
+  middleSidebar1Link      String?
+  middleSidebar2ImagePath String?
+  middleSidebar2Link      String?
+  middleSidebar3ImagePath String?
+  middleSidebar3Link      String?
+  newsImagePath           String?
+  earnPointsImagePath     String?
+  labelImagePath          String?
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
 }
 
 model AdImage {
@@ -1711,25 +1724,25 @@ model AdImage {
 }
 
 model Announcement {
-  id            String   @id @default(uuid())
-  message       String
-  pingOption    String?
-  imagePath     String?
-  imageFilename String?
+  id             String    @id @default(uuid())
+  message        String
+  pingOption     String?
+  imagePath      String?
+  imageFilename  String?
   imagePath2     String?
   imageFilename2 String?
   imagePath3     String?
   imageFilename3 String?
-  scheduledAt   DateTime
-  sentAt        DateTime?
-  sendingAt     DateTime?
-  sendError     String?
-  sendErrorAt   DateTime?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  scheduledAt    DateTime
+  sentAt         DateTime?
+  sendingAt      DateTime?
+  sendError      String?
+  sendErrorAt    DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   createdById String?
-  createdBy   User? @relation("AnnouncementsCreatedBy", fields: [createdById], references: [id])
+  createdBy   User?   @relation("AnnouncementsCreatedBy", fields: [createdById], references: [id])
 
   @@index([scheduledAt])
   @@index([sentAt])
@@ -1935,30 +1948,30 @@ model LottoPoolCtoon {
 
 // ── Achievements ─────────────────────────────────────────────────────────────
 model Achievement {
-  id              String   @id @default(uuid())
-  slug            String   @unique
-  title           String
-  description     String?
-  imagePath       String?
-  isActive        Boolean  @default(true)
-  notifyDiscord   Boolean  @default(false)
+  id                          String    @id @default(uuid())
+  slug                        String    @unique
+  title                       String
+  description                 String?
+  imagePath                   String?
+  isActive                    Boolean   @default(true)
+  notifyDiscord               Boolean   @default(false)
   // Criteria (all ANDed when present)
-  pointsGte       Int?
-  totalCtoonsGte  Int?
-  uniqueCtoonsGte Int?
-  auctionsWonGte  Int?
-  auctionsCreatedGte Int?
-  tradesAcceptedGte Int?
+  pointsGte                   Int?
+  totalCtoonsGte              Int?
+  uniqueCtoonsGte             Int?
+  auctionsWonGte              Int?
+  auctionsCreatedGte          Int?
+  tradesAcceptedGte           Int?
   ctoonSuggestionsAcceptedGte Int?
-  cumulativeActiveDaysGte Int?
-  tkoWinsGte      Int?
-  wordleWinsGte   Int?     // total lifetime crown wins in Wordle
-  wordleCurrentStreakGte Int? // current consecutive-day crown streak
-  setsRequired    String[] // complete ALL sets in this array
-  userCreatedBefore DateTime? // user must have signed up before this date (strictly earlier)
-  discordRoleName String?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  cumulativeActiveDaysGte     Int?
+  tkoWinsGte                  Int?
+  wordleWinsGte               Int? // total lifetime crown wins in Wordle
+  wordleCurrentStreakGte      Int? // current consecutive-day crown streak
+  setsRequired                String[] // complete ALL sets in this array
+  userCreatedBefore           DateTime? // user must have signed up before this date (strictly earlier)
+  discordRoleName             String?
+  createdAt                   DateTime  @default(now())
+  updatedAt                   DateTime  @updatedAt
 
   rewards        AchievementReward[]
   users          AchievementUser[]
@@ -1996,7 +2009,7 @@ model WordleResult {
   userId    String
   date      DateTime // puzzle date stored as UTC midnight
   isWinner  Boolean  @default(false) // true = held the crown (best score that day)
-  score     String?  // e.g. "3/6"
+  score     String? // e.g. "3/6"
   createdAt DateTime @default(now())
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -2081,10 +2094,10 @@ enum MonsterRarity {
 }
 
 // Renamed to avoid collision with your existing GameConfig model
-  model BarcodeGameConfig {
-    id        String  @id @default(uuid())
-    version   String  @unique
-    isActive  Boolean @default(false)
+model BarcodeGameConfig {
+  id       String  @id @default(uuid())
+  version  String  @unique
+  isActive Boolean @default(false)
 
   // Roll odds for NEW barcodes (admin-editable)
   oddsNothing Float @default(0.20)
@@ -2092,10 +2105,10 @@ enum MonsterRarity {
   oddsMonster Float @default(0.50)
   oddsBattle  Float @default(0.00)
 
-    // Admin-editable rarity weights (normalized in code)
-    monsterRarityChances Json
-    // Admin-editable item rarity weights (normalized in code)
-    itemRarityChances    Json @default("{}")
+  // Admin-editable rarity weights (normalized in code)
+  monsterRarityChances Json
+  // Admin-editable item rarity weights (normalized in code)
+  itemRarityChances    Json @default("{}")
 
   // % variability applied to species base stats per owned instance (e.g. 0.12 = ±12%)
   monsterStatVariancePct Float @default(0.12)
@@ -2127,7 +2140,7 @@ enum MonsterRarity {
 }
 
 model ItemDefinition {
-  id       String           @id @default(cuid())
+  id       String            @id @default(cuid())
   configId String
   config   BarcodeGameConfig @relation(fields: [configId], references: [id], onDelete: Cascade)
 
@@ -2169,9 +2182,9 @@ model SpeciesBaseStats {
   baseDef Int
 
   // Images for UI/animations
-  walkingImagePath      String?
+  walkingImagePath       String?
   standingStillImagePath String?
-  jumpingImagePath      String?
+  jumpingImagePath       String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -2181,10 +2194,10 @@ model SpeciesBaseStats {
 }
 
 model AiMonster {
-  id      String        @id @default(uuid())
-  name    String
-  type    String
-  rarity  MonsterRarity
+  id     String        @id @default(uuid())
+  name   String
+  type   String
+  rarity MonsterRarity
 
   baseHp  Int
   baseAtk Int
@@ -2202,7 +2215,7 @@ model AiMonster {
 }
 
 model BarcodeMapping {
-  id         String           @id @default(uuid())
+  id         String            @id @default(uuid())
   barcodeKey String
   configId   String
   config     BarcodeGameConfig @relation(fields: [configId], references: [id], onDelete: Cascade)
@@ -2243,10 +2256,10 @@ model UserMonster {
   // Seed used to roll this instance's stats
   seed String
 
-  hp  Int
+  hp        Int
   maxHealth Int
-  atk Int
-  def Int
+  atk       Int
+  def       Int
 
   lastInteractionAt DateTime?
 
@@ -2267,18 +2280,18 @@ model UserMonster {
 
 // Each row represents one item owned by a user (from barcode scans or future grants)
 model UserMonsterItem {
-  id       String @id @default(uuid())
+  id String @id @default(uuid())
 
-  userId   String
-  user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   configId String
   config   BarcodeGameConfig @relation(fields: [configId], references: [id], onDelete: Cascade)
 
-  itemId   String
-  item     ItemDefinition @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  itemId String
+  item   ItemDefinition @relation(fields: [itemId], references: [id], onDelete: Cascade)
 
-  isUsed   Boolean @default(false)
+  isUsed Boolean @default(false)
 
   createdAt DateTime @default(now())
 
@@ -2301,7 +2314,7 @@ model UserBarcodeScan {
   configId String
   config   BarcodeGameConfig @relation(fields: [configId], references: [id], onDelete: Cascade)
 
-  lastScannedAt   DateTime @default(now())
+  lastScannedAt   DateTime  @default(now())
   nextAvailableAt DateTime?
 
   createdAt DateTime @default(now())
@@ -2328,7 +2341,7 @@ model UserScan {
   config   BarcodeGameConfig @relation(fields: [configId], references: [id], onDelete: Cascade)
 
   outcome   ScanOutcome
-  scannedAt DateTime @default(now())
+  scannedAt DateTime    @default(now())
 
   @@index([userId])
   @@index([mappingId])
@@ -2342,20 +2355,20 @@ model UserScan {
 model CZoneContestAutomationConfig {
   id                     String   @id @default("singleton")
   enabled                Boolean  @default(false)
-  startDayOfWeek         Int      @default(6)   // 0=Sun … 6=Sat; default Saturday
-  startHour              Int      @default(8)   // CST hour (0–23); default 8am
+  startDayOfWeek         Int      @default(6) // 0=Sun … 6=Sat; default Saturday
+  startHour              Int      @default(8) // CST hour (0–23); default 8am
   startMinute            Int      @default(0)
-  submissionEndDayOfWeek Int      @default(1)   // default Monday
-  submissionEndHour      Int      @default(20)  // default 8pm CST
+  submissionEndDayOfWeek Int      @default(1) // default Monday
+  submissionEndHour      Int      @default(20) // default 8pm CST
   submissionEndMinute    Int      @default(0)
-  votingEndDayOfWeek     Int      @default(3)   // default Wednesday
-  votingEndHour          Int      @default(8)   // default 8am CST
+  votingEndDayOfWeek     Int      @default(3) // default Wednesday
+  votingEndHour          Int      @default(8) // default 8am CST
   votingEndMinute        Int      @default(0)
   winnerPoints           Int      @default(1000)
   participantPoints      Int      @default(250)
   titleTemplate          String   @default("Weekly cZone Contest {startDate}")
   maxVotesPerUser        Int      @default(5)
-  lastCreatedFor         String?  // CST date "YYYY-MM-DD" of the week we last auto-created for
+  lastCreatedFor         String? // CST date "YYYY-MM-DD" of the week we last auto-created for
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 }
@@ -2369,7 +2382,7 @@ model CZoneContest {
   maxVotesPerUser   Int       @default(5)
   winnerPrizes      Json      @default("{\"ctoons\":[],\"backgroundIds\":[],\"points\":0}")
   participantPrizes Json      @default("{\"ctoons\":[],\"backgroundIds\":[],\"points\":0}")
-  winnerId          String?   // FK to the winning CZoneContestSubmission.id
+  winnerId          String? // FK to the winning CZoneContestSubmission.id
   distributedAt     DateTime?
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
@@ -2378,12 +2391,12 @@ model CZoneContest {
 }
 
 model CZoneContestSubmission {
-  id         String   @id @default(uuid())
-  contestId  String
-  userId     String
-  zoneIndex  Int
-  imageUrl   String
-  createdAt  DateTime @default(now())
+  id        String   @id @default(uuid())
+  contestId String
+  userId    String
+  zoneIndex Int
+  imageUrl  String
+  createdAt DateTime @default(now())
 
   contest CZoneContest       @relation(fields: [contestId], references: [id], onDelete: Cascade)
   user    User               @relation(fields: [userId], references: [id])
@@ -2417,16 +2430,16 @@ model ServerHeartbeat {
 // ── TKO Game Integration ──────────────────────────────────────────────────────
 
 model TkoMatch {
-  id             String   @id @default(uuid())
-  externalMatchId String  @unique
-  roomId         Int?
-  battleCode     String?
-  mode           String
-  isTraining     Boolean  @default(false)
-  isChallenge    Boolean  @default(false)
-  isPrivate      Boolean  @default(false)
-  startedAt      DateTime?
-  createdAt      DateTime @default(now())
+  id              String    @id @default(uuid())
+  externalMatchId String    @unique
+  roomId          Int?
+  battleCode      String?
+  mode            String
+  isTraining      Boolean   @default(false)
+  isChallenge     Boolean   @default(false)
+  isPrivate       Boolean   @default(false)
+  startedAt       DateTime?
+  createdAt       DateTime  @default(now())
 
   rounds TkoRound[]
 
@@ -2435,11 +2448,11 @@ model TkoMatch {
 }
 
 model TkoRound {
-  id          String   @id @default(uuid())
-  eventId     String   @unique
-  eventType   String
-  matchId     String
-  match       TkoMatch @relation(fields: [matchId], references: [id])
+  id        String   @id @default(uuid())
+  eventId   String   @unique
+  eventType String
+  matchId   String
+  match     TkoMatch @relation(fields: [matchId], references: [id])
 
   roundNumber Int
   bestOf      Int
@@ -2480,17 +2493,17 @@ model TkoRound {
 // ── Suspicious Activity Monitor ───────────────────────────────────────────────
 
 model SuspiciousActivityRule {
-  id             String   @id @default(uuid())
+  id             String                        @id @default(uuid())
   name           String
-  description    String   @default("")
-  isActive       Boolean  @default(true)
-  timeWindowDays Int?     // null = all time
-  conditionLogic String   @default("AND") // "AND" or "OR"
+  description    String                        @default("")
+  isActive       Boolean                       @default(true)
+  timeWindowDays Int? // null = all time
+  conditionLogic String                        @default("AND") // "AND" or "OR"
   conditions     SuspiciousActivityCondition[]
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  createdAt      DateTime                      @default(now())
+  updatedAt      DateTime                      @updatedAt
   createdById    String
-  createdBy      User     @relation("RuleCreatedBy", fields: [createdById], references: [id])
+  createdBy      User                          @relation("RuleCreatedBy", fields: [createdById], references: [id])
 
   @@index([isActive])
   @@index([createdAt])
@@ -2501,9 +2514,9 @@ model SuspiciousActivityCondition {
   ruleId    String
   rule      SuspiciousActivityRule @relation(fields: [ruleId], references: [id], onDelete: Cascade)
   metric    String
-  operator  String   // 'lt' | 'lte' | 'gt' | 'gte' | 'eq'
+  operator  String // 'lt' | 'lte' | 'gt' | 'gte' | 'eq'
   threshold Float
-  order     Int      @default(0)
+  order     Int                    @default(0)
 
   @@index([ruleId])
 }
@@ -2596,13 +2609,13 @@ model SaleDailyPurchase {
 // ── Survey Answers (identity signal + 3000-point reward) ──────────────────────
 
 model SurveyAnswers {
-  userId           String   @id
-  user             User     @relation(fields: [userId], references: [id])
+  userId String @id
+  user   User   @relation(fields: [userId], references: [id])
 
   // Raw text answers
-  whyJoin          String   @db.Text
-  howFound         String   @db.Text
-  favoriteShows    String   @db.Text
+  whyJoin       String @db.Text
+  howFound      String @db.Text
+  favoriteShows String @db.Text
 
   // Character lengths (for validation audit)
   whyJoinLen       Int
@@ -2616,20 +2629,20 @@ model SurveyAnswers {
   favoriteShowsVec Json?
 
   // Combined stylometric feature blob (set by worker)
-  stylometric      Json?
+  stylometric Json?
 
   // MinHash signature for near-duplicate detection (set by worker)
-  minhashSig       Bytes?
+  minhashSig Bytes?
 
   // AI-generation likelihood per answer (set by worker, 0-1)
-  aiScoreWhy       Float?
-  aiScoreFound     Float?
-  aiScoreShows     Float?
+  aiScoreWhy   Float?
+  aiScoreFound Float?
+  aiScoreShows Float?
 
   // Whether the 3000-point award was issued
-  pointsAwarded    Boolean  @default(false)
+  pointsAwarded Boolean @default(false)
 
-  createdAt        DateTime @default(now())
+  createdAt DateTime @default(now())
 
   @@index([createdAt])
 }
@@ -2675,6 +2688,33 @@ model TowerStackScore {
 }
 
 model TowerStackPlay {
+  id        String   @id @default(uuid())
+  userId    String
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId, createdAt])
+}
+
+// ── ReOrbit Memory ─────────────────────────────────────────────────────────────
+// `moves` is the number of pairs attempted to complete the board — LOWER is better,
+// unlike every other game's `score` field. The leaderboard sorts this column ascending.
+
+model ReOrbitMemoryScore {
+  id        String   @id @default(uuid())
+  userId    String
+  moves     Int
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId, moves])
+  @@index([createdAt])
+  @@index([userId, createdAt])
+}
+
+model ReOrbitMemoryPlay {
   id        String   @id @default(uuid())
   userId    String
   createdAt DateTime @default(now())

--- a/server/api/admin/game-config.get.js
+++ b/server/api/admin/game-config.get.js
@@ -153,6 +153,18 @@ export default defineEventHandler(async (event) => {
             towerMaxLayers: 800
           }
         })
+      } else if (gameName === 'ReOrbitMemory') {
+        config = await db.gameConfig.create({
+          data: {
+            gameName,
+            reorbitMemoryPlaysPerPeriod: 3,
+            reorbitMemoryPointsPerGame: 50,
+            reorbitMemoryPairs: 8,
+            reorbitMemoryTimeSeconds: null,
+            reorbitMemoryFlipBackDelayMs: 800,
+            reorbitMemoryCardBackImagePath: null
+          }
+        })
       } else {
         throw createError({
           statusCode: 400,

--- a/server/api/admin/game-config.post.js
+++ b/server/api/admin/game-config.post.js
@@ -147,6 +147,26 @@ function validatePayload(payload) {
     if (payload.towerMaxLayers == null || typeof payload.towerMaxLayers !== 'number' || payload.towerMaxLayers < 10 || payload.towerMaxLayers > 2000) {
       throw createError({ statusCode: 400, statusMessage: '"towerMaxLayers" must be between 10 and 2000' })
     }
+  } else if (payload.gameName === 'ReOrbitMemory') {
+    if (payload.reorbitMemoryPlaysPerPeriod == null || typeof payload.reorbitMemoryPlaysPerPeriod !== 'number' || payload.reorbitMemoryPlaysPerPeriod < 1) {
+      throw createError({ statusCode: 400, statusMessage: '"reorbitMemoryPlaysPerPeriod" must be a positive number' })
+    }
+    if (payload.reorbitMemoryPointsPerGame == null || typeof payload.reorbitMemoryPointsPerGame !== 'number' || payload.reorbitMemoryPointsPerGame < 0) {
+      throw createError({ statusCode: 400, statusMessage: '"reorbitMemoryPointsPerGame" must be a non-negative number' })
+    }
+    const validPairs = [6, 8, 10, 12]
+    if (payload.reorbitMemoryPairs == null || !validPairs.includes(payload.reorbitMemoryPairs)) {
+      throw createError({ statusCode: 400, statusMessage: `"reorbitMemoryPairs" must be one of ${validPairs.join(', ')}` })
+    }
+    if (payload.reorbitMemoryTimeSeconds != null && (typeof payload.reorbitMemoryTimeSeconds !== 'number' || payload.reorbitMemoryTimeSeconds < 30)) {
+      throw createError({ statusCode: 400, statusMessage: '"reorbitMemoryTimeSeconds" must be null or a number >= 30' })
+    }
+    if (payload.reorbitMemoryFlipBackDelayMs == null || typeof payload.reorbitMemoryFlipBackDelayMs !== 'number' || payload.reorbitMemoryFlipBackDelayMs < 300 || payload.reorbitMemoryFlipBackDelayMs > 3000) {
+      throw createError({ statusCode: 400, statusMessage: '"reorbitMemoryFlipBackDelayMs" must be between 300 and 3000' })
+    }
+    if (payload.reorbitMemoryCardBackImagePath != null && typeof payload.reorbitMemoryCardBackImagePath !== 'string') {
+      throw createError({ statusCode: 400, statusMessage: '"reorbitMemoryCardBackImagePath" must be a string or null' })
+    }
   } else {
     throw createError({ statusCode: 400, statusMessage: `Unknown gameName "${payload.gameName}"` })
   }
@@ -186,6 +206,13 @@ export default defineEventHandler(async (event) => {
     towerMaxSpeedMultiplier,
     towerPerfectEpsilon,
     towerMaxLayers,
+    // ReOrbitMemory fields
+    reorbitMemoryPlaysPerPeriod,
+    reorbitMemoryPointsPerGame,
+    reorbitMemoryPairs,
+    reorbitMemoryTimeSeconds = null,
+    reorbitMemoryFlipBackDelayMs,
+    reorbitMemoryCardBackImagePath = null,
     // Winball fields
     leftCupPoints,
     rightCupPoints,
@@ -379,6 +406,17 @@ export default defineEventHandler(async (event) => {
         }
         createData = { ...createData, ...towerData }
         updateData = { ...updateData, ...towerData }
+      } else if (gameName === 'ReOrbitMemory') {
+        const memoryData = {
+          reorbitMemoryPlaysPerPeriod,
+          reorbitMemoryPointsPerGame,
+          reorbitMemoryPairs,
+          reorbitMemoryTimeSeconds: reorbitMemoryTimeSeconds || null,
+          reorbitMemoryFlipBackDelayMs,
+          reorbitMemoryCardBackImagePath: reorbitMemoryCardBackImagePath || null
+        }
+        createData = { ...createData, ...memoryData }
+        updateData = { ...updateData, ...memoryData }
       } else if (gameName === 'Clash' || gameName === 'TKO') {
         createData = { ...createData, pointsPerWin }
         updateData = { ...updateData, pointsPerWin }
@@ -562,6 +600,20 @@ export default defineEventHandler(async (event) => {
           for (const [key, prev, next] of changes) {
             if (prev !== next) {
               await logAdminChange(tx, { userId: me.id, area: 'GameConfig:TowerStack', key, prevValue: prev, newValue: next })
+            }
+          }
+        } else if (gameName === 'ReOrbitMemory') {
+          const changes = [
+            ['reorbitMemoryPlaysPerPeriod', before?.reorbitMemoryPlaysPerPeriod, reorbitMemoryPlaysPerPeriod],
+            ['reorbitMemoryPointsPerGame', before?.reorbitMemoryPointsPerGame, reorbitMemoryPointsPerGame],
+            ['reorbitMemoryPairs', before?.reorbitMemoryPairs, reorbitMemoryPairs],
+            ['reorbitMemoryTimeSeconds', before?.reorbitMemoryTimeSeconds ?? null, reorbitMemoryTimeSeconds || null],
+            ['reorbitMemoryFlipBackDelayMs', before?.reorbitMemoryFlipBackDelayMs, reorbitMemoryFlipBackDelayMs],
+            ['reorbitMemoryCardBackImagePath', before?.reorbitMemoryCardBackImagePath || null, reorbitMemoryCardBackImagePath || null]
+          ]
+          for (const [key, prev, next] of changes) {
+            if (prev !== next) {
+              await logAdminChange(tx, { userId: me.id, area: 'GameConfig:ReOrbitMemory', key, prevValue: prev, newValue: next })
             }
           }
         } else if (gameName === 'Clash' || gameName === 'TKO') {

--- a/server/api/admin/game-tile-image.delete.js
+++ b/server/api/admin/game-tile-image.delete.js
@@ -9,7 +9,8 @@ const SLOT_FIELD = {
   clash:        'gameTileClashImagePath',
   tko:          'gameTileTkoImagePath',
   reorbitmatch: 'gameTileReorbitmatchImagePath',
-  tower:        'gameTileTowerImagePath'
+  tower:        'gameTileTowerImagePath',
+  reorbitmemory: 'gameTileReorbitmemoryImagePath'
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/admin/reorbitmemory-cardback-image.post.js
+++ b/server/api/admin/reorbitmemory-cardback-image.post.js
@@ -17,17 +17,6 @@ const baseDir = process.env.NODE_ENV === 'production'
 
 const ALLOWED = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/svg+xml', 'image/gif'])
 
-const SLOT_FIELD = {
-  winball:      'gameTileWinballImagePath',
-  lotto:        'gameTileLottoImagePath',
-  winwheel:     'gameTileWinwheelImagePath',
-  clash:        'gameTileClashImagePath',
-  tko:          'gameTileTkoImagePath',
-  reorbitmatch: 'gameTileReorbitmatchImagePath',
-  tower:        'gameTileTowerImagePath',
-  reorbitmemory: 'gameTileReorbitmemoryImagePath'
-}
-
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
   const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
@@ -36,16 +25,9 @@ export default defineEventHandler(async (event) => {
   const parts = await readMultipartFormData(event)
   if (!parts?.length) throw createError({ statusCode: 400, statusMessage: 'No form data' })
 
-  let filePart = null
-  let slot = ''
-  for (const p of parts) {
-    if (p.filename) filePart = p
-    else if (p.name === 'slot') slot = Buffer.isBuffer(p.data) ? p.data.toString('utf-8').trim() : String(p.data ?? '').trim()
-  }
-
+  const filePart = parts.find(p => p.filename)
   if (!filePart) throw createError({ statusCode: 400, statusMessage: 'Missing image file' })
   if (!ALLOWED.has(filePart.type)) throw createError({ statusCode: 400, statusMessage: 'Only PNG, JPG, SVG, or GIF allowed' })
-  if (!SLOT_FIELD[slot]) throw createError({ statusCode: 400, statusMessage: `Invalid slot "${slot}"` })
 
   const uploadDir = process.env.NODE_ENV === 'production'
     ? join(baseDir, 'cartoon-reorbit-images', 'game-tiles')
@@ -58,30 +40,29 @@ export default defineEventHandler(async (event) => {
     : filePart.type === 'image/gif' ? '.gif'
     : '.jpg'
   )
-  const filename = `${slot}-${Date.now()}${safeExt}`
+  const filename = `reorbitmemory-cardback-${Date.now()}${safeExt}`
   await writeFile(join(uploadDir, filename), filePart.data)
 
   const assetPath = process.env.NODE_ENV === 'production'
     ? `/images/game-tiles/${filename}`
     : `/game-tiles/${filename}`
 
-  const field = SLOT_FIELD[slot]
-  const before = await db.globalGameConfig.findUnique({ where: { id: 'singleton' } })
-  await db.globalGameConfig.upsert({
-    where: { id: 'singleton' },
-    create: { id: 'singleton', dailyPointLimit: 100, [field]: assetPath },
-    update: { [field]: assetPath, updatedAt: new Date() }
+  const before = await db.gameConfig.findUnique({ where: { gameName: 'ReOrbitMemory' } })
+  await db.gameConfig.upsert({
+    where: { gameName: 'ReOrbitMemory' },
+    create: { gameName: 'ReOrbitMemory', reorbitMemoryCardBackImagePath: assetPath },
+    update: { reorbitMemoryCardBackImagePath: assetPath, updatedAt: new Date() }
   })
 
-  if ((before?.[field] ?? null) !== assetPath) {
+  if ((before?.reorbitMemoryCardBackImagePath ?? null) !== assetPath) {
     await logAdminChange(db, {
       userId: me.id,
-      area: 'GlobalGameConfig',
-      key: field,
-      prevValue: before?.[field] ?? null,
+      area: 'GameConfig:ReOrbitMemory',
+      key: 'reorbitMemoryCardBackImagePath',
+      prevValue: before?.reorbitMemoryCardBackImagePath ?? null,
       newValue: assetPath
     }).catch(() => {})
   }
 
-  return { assetPath, slot }
+  return { assetPath }
 })

--- a/server/api/game-tile-images.get.js
+++ b/server/api/game-tile-images.get.js
@@ -11,7 +11,8 @@ export default defineEventHandler(async () => {
       gameTileClashImagePath:        true,
       gameTileTkoImagePath:          true,
       gameTileReorbitmatchImagePath: true,
-      gameTileTowerImagePath:        true
+      gameTileTowerImagePath:        true,
+      gameTileReorbitmemoryImagePath: true
     }
   })
 
@@ -22,6 +23,7 @@ export default defineEventHandler(async () => {
     clash:        cfg?.gameTileClashImagePath        ?? null,
     tko:          cfg?.gameTileTkoImagePath          ?? null,
     reorbitmatch: cfg?.gameTileReorbitmatchImagePath ?? null,
-    tower:        cfg?.gameTileTowerImagePath        ?? null
+    tower:        cfg?.gameTileTowerImagePath        ?? null,
+    reorbitmemory: cfg?.gameTileReorbitmemoryImagePath ?? null
   }
 })

--- a/server/api/game/reorbitmemory/end.post.js
+++ b/server/api/game/reorbitmemory/end.post.js
@@ -1,0 +1,120 @@
+import { defineEventHandler, createError } from 'h3'
+import { DateTime } from 'luxon'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { MIN_FLIP_INTERVAL_MS } from '@/server/utils/reorbitMemoryEngine'
+
+const LOCK_TTL_MS = 15_000
+
+function lockKey(userId) { return `reorbitmemory:lock:${userId}` }
+function sessionKey(userId) { return `reorbitmemory:session:${userId}` }
+
+function getDailyBoundary() {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  let b = chicagoNow.set({ hour: 20, minute: 0, second: 0, millisecond: 0 })
+  if (chicagoNow < b) b = b.minus({ days: 1 })
+  return b.toUTC().toJSDate()
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  // Per-user lock (same key as /start — serializes with concurrent start requests too)
+  const lockToken = crypto.randomUUID()
+  let lockAcquired = false
+  try {
+    const r = await redis.set(lockKey(userId), lockToken, 'NX', 'PX', LOCK_TTL_MS)
+    lockAcquired = r === 'OK'
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+  if (!lockAcquired) throw createError({ statusCode: 429, statusMessage: 'Request already in progress' })
+
+  const casRelease = `if redis.call("get",KEYS[1])==ARGV[1] then return redis.call("del",KEYS[1]) else return 0 end`
+
+  try {
+    // Banned check
+    const user = await prisma.user.findUnique({ where: { id: userId }, select: { banned: true } })
+    if (user?.banned) throw createError({ statusCode: 403, statusMessage: 'Account suspended' })
+
+    // Atomically consume session — prevents replay / double-claim
+    const raw = await redis.getdel(sessionKey(userId))
+    if (!raw) throw createError({ statusCode: 409, statusMessage: 'Game session not found or expired. Start a new game.' })
+
+    const session = JSON.parse(raw)
+    const { pairs, matched, moves, startedAt } = session
+    const completed = Array.isArray(matched) && matched.length === pairs * 2 && matched.every(m => m === 1)
+
+    // Only a fully-matched board yields a leaderboard score / points. Ending early (tab
+    // closed, "give up", time ran out) just discards the session — moves is authoritative
+    // and server-tracked either way, but an incomplete game must never be scoreable, or
+    // calling /end at move 0 would be the best possible "score" on the board.
+    if (!completed) {
+      return { completed: false, moves, pointsAwarded: 0 }
+    }
+
+    const elapsedMs = Date.now() - startedAt
+    // Defense-in-depth: the per-flip minimum interval is already enforced atomically inside
+    // the flip script, but re-derive a wall-clock floor here too, mirroring the other games'
+    // belt-and-suspenders timestamp checks at /end.
+    const minPossibleMs = Math.max(0, moves * 2 - 1) * MIN_FLIP_INTERVAL_MS
+    if (elapsedMs < minPossibleMs) {
+      throw createError({ statusCode: 400, statusMessage: 'Move pacing exceeds theoretical maximum' })
+    }
+
+    // Load config for points-per-game
+    const config = await prisma.gameConfig.findUnique({
+      where: { gameName: 'ReOrbitMemory' },
+      select: { reorbitMemoryPointsPerGame: true }
+    })
+    const basePointsPerGame = config?.reorbitMemoryPointsPerGame ?? 50
+
+    // Sanity-check pointsPerGame against daily limit
+    const globalConfig = await prisma.globalGameConfig.findUnique({
+      where: { id: 'singleton' },
+      select: { dailyPointLimit: true }
+    })
+    const dailyLimit = globalConfig?.dailyPointLimit ?? 100
+    const pointsPerGame = Math.min(basePointsPerGame, dailyLimit)
+
+    // Award points within daily cap (same shared pattern as every other game)
+    const boundary = getDailyBoundary()
+    let pointsAwarded = 0
+
+    if (pointsPerGame > 0) {
+      try {
+        await prisma.$transaction(async (tx) => {
+          const agg = await tx.gamePointLog.aggregate({
+            where: { userId, createdAt: { gte: boundary } },
+            _sum: { points: true }
+          })
+          const usedToday = Number(agg._sum?.points || 0)
+          const toGive = Math.min(pointsPerGame, Math.max(0, dailyLimit - usedToday))
+          pointsAwarded = toGive
+
+          if (toGive > 0) {
+            await tx.gamePointLog.create({ data: { userId, points: toGive } })
+            const updated = await tx.userPoints.upsert({
+              where: { userId },
+              create: { userId, points: toGive },
+              update: { points: { increment: toGive } }
+            })
+            await tx.pointsLog.create({
+              data: { userId, direction: 'increase', points: toGive, total: updated.points, method: 'Game - ReOrbit Memory' }
+            })
+          }
+        })
+      } catch {
+        // Points award failure is non-fatal — score is still recorded
+      }
+    }
+
+    // Save score record (moves — lower is better)
+    await prisma.reOrbitMemoryScore.create({ data: { userId, moves } })
+
+    return { completed: true, moves, pointsAwarded }
+  } finally {
+    try { await redis.eval(casRelease, 1, lockKey(userId), lockToken) } catch {}
+  }
+})

--- a/server/api/game/reorbitmemory/flip.post.js
+++ b/server/api/game/reorbitmemory/flip.post.js
@@ -1,0 +1,76 @@
+import { defineEventHandler, readBody, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { FLIP_SCRIPT, MIN_FLIP_INTERVAL_MS } from '@/server/utils/reorbitMemoryEngine'
+
+const MAX_BODY_BYTES = 1024 // tiny payload — just a card index
+
+function sessionKey(userId) { return `reorbitmemory:session:${userId}` }
+
+const ERROR_STATUS = {
+  no_session: [409, 'Game session not found or expired. Start a new game.'],
+  bad_index: [400, 'Invalid card index'],
+  too_fast: [429, 'Flips submitted too fast'],
+  already_matched: [400, 'That card is already matched'],
+  already_pending: [400, 'That card is already face up']
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const contentLength = Number(event.node.req.headers['content-length'] || 0)
+  if (contentLength > MAX_BODY_BYTES) {
+    throw createError({ statusCode: 413, statusMessage: 'Request too large' })
+  }
+
+  const body = await readBody(event)
+  const index = Number(body?.index)
+  if (!Number.isInteger(index) || index < 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid request body' })
+  }
+
+  // No per-request lock here — FLIP_SCRIPT is a single atomic Lua script (one Redis round
+  // trip), so Redis's own single-threaded execution IS the lock. An app-level lock would
+  // only add latency to every tap without closing any race the script doesn't already close.
+  let raw
+  try {
+    raw = await redis.eval(FLIP_SCRIPT, 1, sessionKey(userId), String(index), String(MIN_FLIP_INTERVAL_MS))
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+
+  let result
+  try {
+    result = JSON.parse(raw)
+  } catch {
+    throw createError({ statusCode: 500, statusMessage: 'Unexpected game state' })
+  }
+
+  if (result.error) {
+    const [statusCode, statusMessage] = ERROR_STATUS[result.error] || [400, 'Invalid flip']
+    throw createError({ statusCode, statusMessage })
+  }
+
+  // Field-limited response — only what this flip revealed, never the rest of the board.
+  if (result.firstFlip) {
+    return {
+      firstFlip: true,
+      index: result.index,
+      assetPath: result.assetPath,
+      moves: result.moves,
+      gameOver: false
+    }
+  }
+
+  return {
+    firstFlip: false,
+    index: result.index,
+    assetPath: result.assetPath,
+    firstIndex: result.firstIndex,
+    firstAssetPath: result.firstAssetPath,
+    matched: result.matched,
+    moves: result.moves,
+    gameOver: result.gameOver
+  }
+})

--- a/server/api/game/reorbitmemory/leaderboard.get.js
+++ b/server/api/game/reorbitmemory/leaderboard.get.js
@@ -1,0 +1,92 @@
+import { defineEventHandler } from 'h3'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { mergeViewerRow } from '@/server/utils/leaderboardRank'
+
+const CACHE_KEY  = 'reorbitmemory:leaderboard:v1'
+const CACHE_TTL  = 1800  // 30 minutes
+const EXCLUDE_ID = '4f0e8b3b-7d0b-466b-99e7-8996c91d7eb3'
+
+const PERIOD_FILTERS = {
+  allTime: '',
+  monthly: `AND s."createdAt" >= NOW() - INTERVAL '30 days'`,
+  weekly:  `AND s."createdAt" >= NOW() - INTERVAL '7 days'`,
+}
+
+// Lower moves is better here, so ranking sorts MIN(moves) ascending — the opposite of every
+// other game's leaderboard.
+function rankedTop11(period) {
+  const dateFilter = PERIOD_FILTERS[period]
+  return prisma.$queryRawUnsafe(`
+    SELECT u."id" AS "userId", u."username", u."avatar", MIN(s."moves")::int AS "score",
+           (ROW_NUMBER() OVER (ORDER BY MIN(s."moves") ASC, u."username" ASC))::int AS rank
+    FROM "ReOrbitMemoryScore" s
+    JOIN "User" u ON u."id" = s."userId"
+    WHERE u."active" = true
+      AND COALESCE(u."banned", false) = false
+      AND s."userId" <> '${EXCLUDE_ID}'
+      ${dateFilter}
+    GROUP BY u."id", u."username", u."avatar"
+    ORDER BY rank
+    LIMIT 11;
+  `)
+}
+
+function rankedViewer(period, userId) {
+  const dateFilter = PERIOD_FILTERS[period]
+  return prisma.$queryRawUnsafe(`
+    WITH ranked AS (
+      SELECT u."id" AS "userId", u."username", u."avatar", MIN(s."moves")::int AS "score",
+             (ROW_NUMBER() OVER (ORDER BY MIN(s."moves") ASC, u."username" ASC))::int AS rank
+      FROM "ReOrbitMemoryScore" s
+      JOIN "User" u ON u."id" = s."userId"
+      WHERE u."active" = true
+        AND COALESCE(u."banned", false) = false
+        AND s."userId" <> '${EXCLUDE_ID}'
+        ${dateFilter}
+      GROUP BY u."id", u."username", u."avatar"
+    )
+    SELECT * FROM ranked WHERE "userId" = $1;
+  `, userId)
+}
+
+async function fetchTop11() {
+  const [allTime, monthly, weekly] = await Promise.all([
+    rankedTop11('allTime'),
+    rankedTop11('monthly'),
+    rankedTop11('weekly'),
+  ])
+  return { allTime, monthly, weekly }
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId || null
+
+  let top11
+  try {
+    const cached = await redis.get(CACHE_KEY)
+    if (cached) top11 = JSON.parse(cached)
+  } catch {}
+
+  if (!top11) {
+    top11 = await fetchTop11()
+    try {
+      await redis.set(CACHE_KEY, JSON.stringify(top11), 'EX', CACHE_TTL)
+    } catch {}
+  }
+
+  const result = {}
+  for (const p of ['allTime', 'monthly', 'weekly']) {
+    const rows = top11[p]
+    let viewerRow = null
+    if (userId && !rows.some(r => r.userId === userId)) {
+      try {
+        const res = await rankedViewer(p, userId)
+        viewerRow = res[0] || null
+      } catch {}
+    }
+    result[p] = mergeViewerRow(rows, viewerRow, userId)
+  }
+
+  return result
+})

--- a/server/api/game/reorbitmemory/start.post.js
+++ b/server/api/game/reorbitmemory/start.post.js
@@ -1,0 +1,104 @@
+import { defineEventHandler, createError } from 'h3'
+import { DateTime } from 'luxon'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { gridDimsForPairs, buildPositions, DEFAULT_PAIRS } from '@/server/utils/reorbitMemoryEngine'
+
+const LOCK_TTL_MS = 10_000
+
+function lockKey(userId) { return `reorbitmemory:lock:${userId}` }
+function sessionKey(userId) { return `reorbitmemory:session:${userId}` }
+
+function getDailyBoundary() {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  let b = chicagoNow.set({ hour: 20, minute: 0, second: 0, millisecond: 0 })
+  if (chicagoNow < b) b = b.minus({ days: 1 })
+  return b.toUTC().toJSDate()
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  // Banned-user check
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { banned: true } })
+  if (user?.banned) throw createError({ statusCode: 403, statusMessage: 'Account suspended' })
+
+  // Per-user lock prevents concurrent /start requests (play-limit TOCTOU)
+  const lockToken = crypto.randomUUID()
+  let lockAcquired = false
+  try {
+    const r = await redis.set(lockKey(userId), lockToken, 'NX', 'PX', LOCK_TTL_MS)
+    lockAcquired = r === 'OK'
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+  if (!lockAcquired) throw createError({ statusCode: 429, statusMessage: 'Request already in progress' })
+
+  const casRelease = `if redis.call("get",KEYS[1])==ARGV[1] then return redis.call("del",KEYS[1]) else return 0 end`
+
+  try {
+    const config = await prisma.gameConfig.findUnique({ where: { gameName: 'ReOrbitMemory' } })
+    const pairs = config?.reorbitMemoryPairs ?? DEFAULT_PAIRS
+    const playsPerPeriod = config?.reorbitMemoryPlaysPerPeriod ?? 3
+    const timeSeconds = config?.reorbitMemoryTimeSeconds ?? null
+    const flipBackDelayMs = config?.reorbitMemoryFlipBackDelayMs ?? 800
+    const cardBackImagePath = config?.reorbitMemoryCardBackImagePath ?? null
+
+    // Check play limit
+    const boundary = getDailyBoundary()
+    const playsToday = await prisma.reOrbitMemoryPlay.count({
+      where: { userId, createdAt: { gte: boundary } }
+    })
+    if (playsToday >= playsPerPeriod) {
+      const nextReset = new Date(boundary.getTime() + 24 * 60 * 60 * 1000)
+      throw createError({
+        statusCode: 429,
+        statusMessage: 'Daily play limit reached',
+        data: { nextReset: nextReset.toISOString() }
+      })
+    }
+
+    // Pick `pairs` random, currently-released cToons directly in SQL — cheap regardless of
+    // catalog size, unlike fetching the whole table and shuffling in Node.
+    const candidates = await prisma.$queryRaw`
+      SELECT "id", "assetPath" FROM "Ctoon"
+      WHERE "releaseDate" IS NOT NULL AND "releaseDate" <= NOW()
+      ORDER BY random()
+      LIMIT ${pairs};
+    `
+    if (!candidates || candidates.length < pairs) {
+      throw createError({ statusCode: 503, statusMessage: 'Not enough cToons available to start a game' })
+    }
+
+    const { cols, rows } = gridDimsForPairs(pairs)
+    const seedHex = crypto.randomUUID().replace(/-/g, '')
+    const positions = buildPositions(candidates.map(c => c.id), seedHex)
+    const assetByCtoon = {}
+    for (const c of candidates) assetByCtoon[c.id] = c.assetPath
+
+    const ttlSeconds = timeSeconds ? timeSeconds + 120 : 900
+    await redis.set(sessionKey(userId), JSON.stringify({
+      pairs,
+      positions,
+      assetByCtoon,
+      matched: new Array(pairs * 2).fill(0),
+      pendingIndex: -1,
+      moves: 0,
+      startedAt: Date.now(),
+      lastFlipAt: 0
+    }), 'EX', ttlSeconds)
+
+    // Record the play (inside the lock to prevent TOCTOU)
+    await prisma.reOrbitMemoryPlay.create({ data: { userId } })
+
+    // Safe to reveal: which images are in play this round, but not where — position is
+    // exactly the information a flip has to pay for, so this doesn't shortcut gameplay.
+    // Lets the client prefetch every card-front image before the player's first tap.
+    const frontImages = candidates.map(c => c.assetPath)
+
+    return { pairs, cols, rows, cardBackImagePath, timeSeconds, flipBackDelayMs, frontImages }
+  } finally {
+    try { await redis.eval(casRelease, 1, lockKey(userId), lockToken) } catch {}
+  }
+})

--- a/server/api/game/reorbitmemory/status.get.js
+++ b/server/api/game/reorbitmemory/status.get.js
@@ -1,0 +1,64 @@
+import { defineEventHandler, createError } from 'h3'
+import { DateTime } from 'luxon'
+import { prisma } from '@/server/prisma'
+import { DEFAULT_PAIRS, gridDimsForPairs } from '@/server/utils/reorbitMemoryEngine'
+
+function getDailyBoundary() {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  let b = chicagoNow.set({ hour: 20, minute: 0, second: 0, millisecond: 0 })
+  if (chicagoNow < b) b = b.minus({ days: 1 })
+  return b.toUTC().toJSDate()
+}
+
+function getWeekBoundary() {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  const dow = chicagoNow.weekday % 7 // luxon: Mon=1…Sun=7; we want Mon=0
+  const monday = chicagoNow.minus({ days: dow === 0 ? 6 : dow - 1 }).set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+  return monday.toUTC().toJSDate()
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const config = await prisma.gameConfig.findUnique({ where: { gameName: 'ReOrbitMemory' } })
+
+  const pairs = config?.reorbitMemoryPairs ?? DEFAULT_PAIRS
+  const playsPerPeriod = config?.reorbitMemoryPlaysPerPeriod ?? 3
+  const { cols, rows } = gridDimsForPairs(pairs)
+
+  const boundary = getDailyBoundary()
+  const weekBoundary = getWeekBoundary()
+  const nextReset = new Date(boundary.getTime() + 24 * 60 * 60 * 1000)
+
+  const [playsToday, allTimeBest, weekBest] = await Promise.all([
+    prisma.reOrbitMemoryPlay.count({
+      where: { userId, createdAt: { gte: boundary } }
+    }),
+    prisma.reOrbitMemoryScore.aggregate({
+      where: { userId },
+      _min: { moves: true }
+    }),
+    prisma.reOrbitMemoryScore.aggregate({
+      where: { createdAt: { gte: weekBoundary } },
+      _min: { moves: true }
+    })
+  ])
+
+  return {
+    config: {
+      pairs,
+      cols,
+      rows,
+      playsPerPeriod,
+      pointsPerGame: config?.reorbitMemoryPointsPerGame ?? 50,
+      timeSeconds: config?.reorbitMemoryTimeSeconds ?? null,
+      flipBackDelayMs: config?.reorbitMemoryFlipBackDelayMs ?? 800,
+      cardBackImagePath: config?.reorbitMemoryCardBackImagePath ?? null
+    },
+    playsLeft: Math.max(0, playsPerPeriod - playsToday),
+    playsResetAt: nextReset.toISOString(),
+    allTimeBest: allTimeBest._min.moves ?? null,
+    weekBest: weekBest._min.moves ?? null
+  }
+})

--- a/server/utils/reorbitMemoryEngine.js
+++ b/server/utils/reorbitMemoryEngine.js
@@ -1,0 +1,166 @@
+// Server-only ReOrbit Memory game engine. Never import this from pages/ or components/.
+//
+// Game model: classic face-down card matching. Unlike ReOrbit Match / Tower Stack, every
+// flip necessarily reveals ground truth to the client, so this game cannot use the
+// "replay a client move-log against a server-generated board" pattern. Instead the server
+// holds the full board (card → cToon) in a Redis session and reveals exactly the card(s)
+// touched by each validated /flip call. `moves` (a pair evaluated, match or not) is
+// incremented ONLY inside the atomic flip script below — never accepted from the client.
+//
+// Anti-cheat: FLIP_SCRIPT below is a single atomic Redis Lua script (one round trip, no
+// app-level lock needed) that enforces the whole state machine — bounds checking, at most
+// one pending face-up card, no re-flipping an already-matched/pending card, and a minimum
+// interval between flips — so a race of parallel requests can't desync the "one pending
+// card" invariant or let a client peek at cards without ever completing (and paying for) a
+// pair.
+
+// Grid presets are capped at 4 columns so the smallest phones (~360px wide) keep card
+// touch-targets above the ~44px accessibility minimum, even at the largest pair count.
+const GRID_PRESETS = {
+  6: { cols: 3, rows: 4 },
+  8: { cols: 4, rows: 4 },
+  10: { cols: 4, rows: 5 },
+  12: { cols: 4, rows: 6 }
+}
+const DEFAULT_PAIRS = 8
+const MIN_FLIP_INTERVAL_MS = 150 // no human flips two cards faster than this
+
+function gridDimsForPairs(pairs) {
+  return GRID_PRESETS[pairs] || GRID_PRESETS[DEFAULT_PAIRS]
+}
+
+// splitmix32 seeded PRNG — identical construction to reorbitMatchEngine's makePRNG.
+function makePRNG(seedHex) {
+  const hi = parseInt(seedHex.slice(0, 8), 16) >>> 0
+  const lo = parseInt(seedHex.slice(8, 16), 16) >>> 0
+  let s0 = hi >>> 0
+  let s1 = lo >>> 0
+  return function () {
+    s0 = (s0 + 0x9e3779b9) >>> 0
+    let z = s0
+    z = Math.imul(z ^ (z >>> 16), 0x85ebca6b) >>> 0
+    z = Math.imul(z ^ (z >>> 13), 0xc2b2ae35) >>> 0
+    z = (z ^ (z >>> 16)) >>> 0
+    s1 = (s1 + 0x6c62272e) >>> 0
+    let w = s1
+    w = Math.imul(w ^ (w >>> 16), 0x85ebca6b) >>> 0
+    w = Math.imul(w ^ (w >>> 13), 0xc2b2ae35) >>> 0
+    w = (w ^ (w >>> 16)) >>> 0
+    return ((z ^ w) >>> 0) / 4294967296
+  }
+}
+
+// Fisher–Yates using the seeded PRNG so the shuffle is reproducible from the secret token
+// (not that reproducibility matters here — the board never leaves the server — but it keeps
+// the RNG usage consistent with the other two games' engines).
+function shuffle(arr, rng) {
+  const a = arr.slice()
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
+// Build the shuffled board: an array of cToon IDs, each appearing exactly twice.
+function buildPositions(ctoonIds, seedHex) {
+  const rng = makePRNG(seedHex)
+  const doubled = [...ctoonIds, ...ctoonIds]
+  return shuffle(doubled, rng)
+}
+
+// Atomic flip: KEYS[1] = session key. ARGV[1] = card index. ARGV[2] = min flip interval (ms).
+// Returns a JSON string (decoded by the caller) describing either an error or the reveal.
+const FLIP_SCRIPT = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return cjson.encode({error='no_session'}) end
+
+local session = cjson.decode(raw)
+local idx = tonumber(ARGV[1])
+local minInterval = tonumber(ARGV[2])
+local n = session.pairs * 2
+
+if idx == nil or idx < 0 or idx >= n then
+  return cjson.encode({error='bad_index'})
+end
+
+local t = redis.call('TIME')
+local now = (tonumber(t[1]) * 1000) + math.floor(tonumber(t[2]) / 1000)
+
+if session.lastFlipAt and session.lastFlipAt > 0 and (now - session.lastFlipAt) < minInterval then
+  return cjson.encode({error='too_fast'})
+end
+
+local matched = session.matched
+if matched[idx + 1] == 1 then
+  return cjson.encode({error='already_matched'})
+end
+
+local pendingIdx = session.pendingIndex
+if pendingIdx == idx then
+  return cjson.encode({error='already_pending'})
+end
+
+local positions = session.positions
+local assets = session.assetByCtoon
+local result
+
+if pendingIdx == -1 then
+  session.pendingIndex = idx
+  session.lastFlipAt = now
+  local ctoonId = positions[idx + 1]
+  result = {
+    firstFlip = true,
+    index = idx,
+    ctoonId = ctoonId,
+    assetPath = assets[ctoonId],
+    moves = session.moves,
+    gameOver = false
+  }
+else
+  local firstIdx = pendingIdx
+  local ctoonId = positions[idx + 1]
+  local firstCtoonId = positions[firstIdx + 1]
+  local isMatch = (ctoonId == firstCtoonId)
+
+  session.moves = session.moves + 1
+  session.lastFlipAt = now
+  session.pendingIndex = -1
+
+  if isMatch then
+    matched[idx + 1] = 1
+    matched[firstIdx + 1] = 1
+    session.matched = matched
+  end
+
+  local allMatched = true
+  for i = 1, n do
+    if matched[i] ~= 1 then allMatched = false break end
+  end
+
+  result = {
+    firstFlip = false,
+    index = idx,
+    ctoonId = ctoonId,
+    assetPath = assets[ctoonId],
+    firstIndex = firstIdx,
+    firstCtoonId = firstCtoonId,
+    firstAssetPath = assets[firstCtoonId],
+    matched = isMatch,
+    moves = session.moves,
+    gameOver = allMatched
+  }
+end
+
+redis.call('SET', KEYS[1], cjson.encode(session), 'KEEPTTL')
+return cjson.encode(result)
+`
+
+export {
+  GRID_PRESETS,
+  DEFAULT_PAIRS,
+  MIN_FLIP_INTERVAL_MS,
+  gridDimsForPairs,
+  buildPositions,
+  FLIP_SCRIPT
+}


### PR DESCRIPTION
New memory-match game following the Tower Stack/ReOrbit Match architecture:
face-down cards flip to reveal random cToon art, matched pairs stay up,
mismatches flip back, and moves are tracked toward a lowest-moves-wins
leaderboard. Card identities are never trusted from the client — an atomic
Redis Lua script owns the whole flip state machine (matching, move counting,
pacing) server-side, mirroring the anti-cheat posture of the other games.

- New Prisma models (ReOrbitMemoryScore/Play) and GameConfig/GlobalGameConfig
  fields, plus a hand-written migration
- Admin "ReOrbit Memory" tab in Manage Games (plays/period, points/game,
  pairs preset, optional time limit, flip-back delay, card-back image)
- Server routes: start/flip/end/status/leaderboard, reusing the shared
  daily play-limit and GamePointLog points-cap patterns
- Mobile-friendly CSS Grid + flip-animation frontend (capped at 4 columns,
  image preloading, reduced-motion fallback) wired into Games Home and
  the Leaderboards page

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014KF8PxWNdpkjTZY1QTTUiB