### PR TITLE
Fix Games Home layout and ReOrbit Memory card images

### DIFF
--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -79,22 +79,12 @@ const tiles = computed(() => tileData.value ?? {})
 .gameshome {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: repeat(4, 1fr) 0.85fr;
+  grid-template-rows: repeat(4, 1fr);
   width: 100%;
   flex: 1;
   gap: 6px;
   padding: 6px;
   box-sizing: border-box;
-}
-
-/* Tower Stack spans both columns on its own row */
-.quadrant--tower {
-  grid-column: 1 / -1;
-}
-
-/* ReOrbit Memory gets its own (shorter) full-width row below Tower Stack */
-.quadrant--reorbitmemory {
-  grid-column: 1 / -1;
 }
 
 .quadrant {
@@ -147,11 +137,6 @@ const tiles = computed(() => tileData.value ?? {})
     grid-template-columns: 1fr;
     grid-template-rows: repeat(8, minmax(70px, 1fr));
     height: max(300px, calc(100dvh - 276px));
-  }
-
-  .quadrant--tower,
-  .quadrant--reorbitmemory {
-    grid-column: auto;
   }
 }
 </style>

--- a/pages/newsite/reorbitmemory.vue
+++ b/pages/newsite/reorbitmemory.vue
@@ -570,7 +570,7 @@ onUnmounted(() => {
 .card-face img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   pointer-events: none;
 }
 .card-face--back {


### PR DESCRIPTION
## Summary
- Tower Stack and ReOrbit Memory now sit side by side on desktop in the normal 2-column Games Home grid, instead of each spanning a full row.
- ReOrbit Memory card fronts now use `object-fit: contain` at 100% width/height so cToon images display fully without being cropped, while staying sized inside the card without vertical overlap.

## Test plan
- [ ] Visually verify Games Home desktop layout shows Tower Stack and ReOrbit Memory as a side-by-side pair.
- [ ] Play ReOrbit Memory and confirm card fronts show the full cToon image with no cropping and no overlap between rows.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jrd21TWrwLNCTwFHXi6wJC)_