### PR TITLE
Use a square aspect ratio for ReOrbit Memory cards

### DIFF
--- a/pages/newsite/reorbitmemory.vue
+++ b/pages/newsite/reorbitmemory.vue
@@ -531,7 +531,7 @@ onUnmounted(() => {
 
 .card {
   position: relative;
-  aspect-ratio: 3 / 4;
+  aspect-ratio: 4 / 4;
   min-width: 0;
   min-height: 0;
   background: transparent;


### PR DESCRIPTION
## Summary
- Changed the ReOrbit Memory card `aspect-ratio` from `3 / 4` to `4 / 4` (square) so cards no longer overlap vertically in the grid.

## Test plan
- [ ] Play ReOrbit Memory and confirm cards render as squares with no vertical overlap between rows.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jrd21TWrwLNCTwFHXi6wJC)_