### PR TITLE
Separate TKO points into their own daily pool

### DIFF
--- a/pages/admin/global-settings.vue
+++ b/pages/admin/global-settings.vue
@@ -58,7 +58,17 @@
           <div>
             <label class="block text-sm font-medium text-gray-700">Daily Game Point Cap</label>
             <input type="number" class="input" v-model.number="dailyPointLimit" />
-            <p class="text-xs text-gray-500 mt-1">Max points from games per 24h window.</p>
+            <p class="text-xs text-gray-500 mt-1">Max points from games (excluding TKO) per 24h window.</p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">TKO Daily Points Cap</label>
+            <input type="number" class="input" v-model.number="tkoDailyPointLimit" />
+            <p class="text-xs text-gray-500 mt-1">Max points from TKO wins per 24h window (separate pool, same 8pm CST reset).</p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">TKO Points Per Win</label>
+            <input type="number" min="0" class="input" v-model.number="tkoPointsPerWin" />
+            <p class="text-xs text-gray-500 mt-1">Points awarded to the winner of each TKO round.</p>
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700">Max cZone Visits Per Day</label>
@@ -472,6 +482,8 @@ const dailyLoginPoints     = ref(500)
 const dailyNewUserPoints   = ref(1000)
 const czoneVisitPoints     = ref(20)
 const dailyPointLimit      = ref(250)
+const tkoDailyPointLimit   = ref(250)
+const tkoPointsPerWin      = ref(300)
 const czoneVisitMaxPerDay  = ref(10)
 const czoneCount           = ref(3)
 const phashDuplicateThreshold = ref(14)
@@ -540,6 +552,7 @@ async function loadGlobal() {
     dailyNewUserPoints.value   = Number(g?.dailyNewUserPoints   ?? 1000)
     czoneVisitPoints.value     = Number(g?.czoneVisitPoints     ?? 20)
     dailyPointLimit.value      = Number(g?.dailyPointLimit      ?? 250)
+    tkoDailyPointLimit.value   = Number(g?.tkoDailyPointLimit   ?? 250)
     czoneVisitMaxPerDay.value  = Number(g?.czoneVisitMaxPerDay  ?? 10)
     czoneCount.value           = Number(g?.czoneCount           ?? 3)
     phashDuplicateThreshold.value = Number(g?.phashDuplicateThreshold ?? 14)
@@ -569,6 +582,12 @@ async function loadGlobal() {
   } catch (e) {
     console.error('Failed to load global config', e)
   }
+  try {
+    const tc = await $fetch('/api/admin/game-config?gameName=TKO')
+    tkoPointsPerWin.value = Number(tc?.pointsPerWin ?? 300)
+  } catch (e) {
+    console.error('Failed to load TKO config', e)
+  }
 }
 
 async function saveGlobal() {
@@ -581,8 +600,16 @@ async function saveGlobal() {
         dailyNewUserPoints:   Number(dailyNewUserPoints.value),
         czoneVisitPoints:     Number(czoneVisitPoints.value),
         dailyPointLimit:      Number(dailyPointLimit.value),
+        tkoDailyPointLimit:   Number(tkoDailyPointLimit.value),
         czoneVisitMaxPerDay:  Number(czoneVisitMaxPerDay.value),
         czoneCount:           Number(czoneCount.value)
+      }
+    })
+    await $fetch('/api/admin/game-config', {
+      method: 'POST',
+      body: {
+        gameName:     'TKO',
+        pointsPerWin: Number(tkoPointsPerWin.value)
       }
     })
     toast.value = { type: 'ok', msg: 'Global points saved.' }

--- a/prisma/migrations/20260722000000_tko_separate_points_pool/migration.sql
+++ b/prisma/migrations/20260722000000_tko_separate_points_pool/migration.sql
@@ -1,0 +1,6 @@
+-- Separate TKO points from the general daily game points pool
+ALTER TABLE "GamePointLog"
+  ADD COLUMN IF NOT EXISTS "gameName" TEXT;
+
+ALTER TABLE "GlobalGameConfig"
+  ADD COLUMN IF NOT EXISTS "tkoDailyPointLimit" INTEGER NOT NULL DEFAULT 250;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -836,6 +836,7 @@ model GamePointLog {
   id        String   @id @default(uuid())
   userId    String
   points    Int
+  gameName  String? // e.g. 'TKO'; null/other values share the general daily game pool
   createdAt DateTime @default(now())
 
   user User @relation(fields: [userId], references: [id])
@@ -1010,6 +1011,7 @@ model GameConfig {
 model GlobalGameConfig {
   id                             String   @id @default(uuid())
   dailyPointLimit                Int      @default(100)
+  tkoDailyPointLimit             Int      @default(250)
   dailyLoginPoints               Int      @default(500)
   dailyNewUserPoints             Int      @default(1000)
   czoneVisitPoints               Int      @default(20)

--- a/server/api/admin/global-config.get.js
+++ b/server/api/admin/global-config.get.js
@@ -38,6 +38,7 @@ export default defineEventHandler(async (event) => {
       data: {
         id: 'singleton',
         dailyPointLimit: 250,
+        tkoDailyPointLimit: 250,
         dailyLoginPoints: 500,
         dailyNewUserPoints: 1000,
         czoneVisitPoints: 20,

--- a/server/api/admin/global-config.post.js
+++ b/server/api/admin/global-config.post.js
@@ -26,6 +26,7 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const {
     dailyPointLimit,
+    tkoDailyPointLimit,
     dailyLoginPoints,
     dailyNewUserPoints,
     czoneVisitPoints,
@@ -55,6 +56,7 @@ export default defineEventHandler(async (event) => {
   const payload = {
     dailyPointLimit: Number(dailyPointLimit),
     // allow partial updates; coerce to number if provided else keep existing via upsert+update
+    tkoDailyPointLimit: (typeof tkoDailyPointLimit === 'number') ? Number(tkoDailyPointLimit) : undefined,
     dailyLoginPoints:   (typeof dailyLoginPoints   === 'number') ? Number(dailyLoginPoints)   : undefined,
     dailyNewUserPoints: (typeof dailyNewUserPoints === 'number') ? Number(dailyNewUserPoints) : undefined,
     czoneVisitPoints:   (typeof czoneVisitPoints   === 'number') ? Number(czoneVisitPoints)   : undefined,
@@ -85,6 +87,7 @@ export default defineEventHandler(async (event) => {
       create: {
         id: 'singleton',
         dailyPointLimit: payload.dailyPointLimit,
+        tkoDailyPointLimit: payload.tkoDailyPointLimit ?? 250,
         dailyLoginPoints:   payload.dailyLoginPoints   ?? 500,
         dailyNewUserPoints: payload.dailyNewUserPoints ?? 1000,
         czoneVisitPoints:   payload.czoneVisitPoints   ?? 20,
@@ -111,6 +114,7 @@ export default defineEventHandler(async (event) => {
       update: {
         dailyPointLimit: payload.dailyPointLimit,
         // only update fields that were provided
+        ...(payload.tkoDailyPointLimit !== undefined ? { tkoDailyPointLimit: payload.tkoDailyPointLimit } : {}),
         ...(payload.dailyLoginPoints   !== undefined ? { dailyLoginPoints:   payload.dailyLoginPoints }   : {}),
         ...(payload.dailyNewUserPoints !== undefined ? { dailyNewUserPoints: payload.dailyNewUserPoints } : {}),
         ...(payload.czoneVisitPoints    !== undefined ? { czoneVisitPoints:    payload.czoneVisitPoints }    : {}),
@@ -133,6 +137,7 @@ export default defineEventHandler(async (event) => {
     // Log field-level changes
     const fields = [
       'dailyPointLimit',
+      'tkoDailyPointLimit',
       'dailyLoginPoints',
       'dailyNewUserPoints',
       'czoneVisitPoints',

--- a/server/api/game/reorbitmatch/end.post.js
+++ b/server/api/game/reorbitmatch/end.post.js
@@ -137,7 +137,7 @@ export default defineEventHandler(async (event) => {
       try {
         await prisma.$transaction(async (tx) => {
           const agg = await tx.gamePointLog.aggregate({
-            where: { userId, createdAt: { gte: boundary } },
+            where: { userId, createdAt: { gte: boundary }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
             _sum: { points: true }
           })
           const usedToday = Number(agg._sum?.points || 0)
@@ -145,7 +145,7 @@ export default defineEventHandler(async (event) => {
           pointsAwarded = toGive
 
           if (toGive > 0) {
-            await tx.gamePointLog.create({ data: { userId, points: toGive } })
+            await tx.gamePointLog.create({ data: { userId, points: toGive, gameName: 'ReOrbitMatch' } })
             const updated = await tx.userPoints.upsert({
               where: { userId },
               create: { userId, points: toGive },

--- a/server/api/game/reorbitmemory/end.post.js
+++ b/server/api/game/reorbitmemory/end.post.js
@@ -86,7 +86,7 @@ export default defineEventHandler(async (event) => {
       try {
         await prisma.$transaction(async (tx) => {
           const agg = await tx.gamePointLog.aggregate({
-            where: { userId, createdAt: { gte: boundary } },
+            where: { userId, createdAt: { gte: boundary }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
             _sum: { points: true }
           })
           const usedToday = Number(agg._sum?.points || 0)
@@ -94,7 +94,7 @@ export default defineEventHandler(async (event) => {
           pointsAwarded = toGive
 
           if (toGive > 0) {
-            await tx.gamePointLog.create({ data: { userId, points: toGive } })
+            await tx.gamePointLog.create({ data: { userId, points: toGive, gameName: 'ReOrbitMemory' } })
             const updated = await tx.userPoints.upsert({
               where: { userId },
               create: { userId, points: toGive },

--- a/server/api/game/tower/end.post.js
+++ b/server/api/game/tower/end.post.js
@@ -131,7 +131,7 @@ export default defineEventHandler(async (event) => {
       try {
         await prisma.$transaction(async (tx) => {
           const agg = await tx.gamePointLog.aggregate({
-            where: { userId, createdAt: { gte: boundary } },
+            where: { userId, createdAt: { gte: boundary }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
             _sum: { points: true }
           })
           const usedToday = Number(agg._sum?.points || 0)
@@ -139,7 +139,7 @@ export default defineEventHandler(async (event) => {
           pointsAwarded = toGive
 
           if (toGive > 0) {
-            await tx.gamePointLog.create({ data: { userId, points: toGive } })
+            await tx.gamePointLog.create({ data: { userId, points: toGive, gameName: 'TowerStack' } })
             const updated = await tx.userPoints.upsert({
               where: { userId },
               create: { userId, points: toGive },

--- a/server/api/game/winball.post.js
+++ b/server/api/game/winball.post.js
@@ -116,7 +116,8 @@ export default defineEventHandler(async (event) => {
   // before any GamePointLog row is written.
   const { toGive, remaining } = await prisma.$transaction(async (tx) => {
     const agg = await tx.gamePointLog.aggregate({
-      where: { userId, createdAt: { gte: boundary } }, _sum: { points: true }
+      where: { userId, createdAt: { gte: boundary }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
+      _sum: { points: true }
     })
     const used = agg._sum.points || 0
     const global = await tx.globalGameConfig.findUnique({ where: { id: 'singleton' } })
@@ -125,7 +126,7 @@ export default defineEventHandler(async (event) => {
     const toGive = Math.min(award.points, remaining)
 
     if (toGive > 0) {
-      await tx.gamePointLog.create({ data: { userId, points: toGive } })
+      await tx.gamePointLog.create({ data: { userId, points: toGive, gameName: 'Winball' } })
       const updated = await tx.userPoints.upsert({
         where: { userId },
         create: { userId, points: toGive },

--- a/server/api/monsters/scan.post.js
+++ b/server/api/monsters/scan.post.js
@@ -507,7 +507,7 @@ export default defineEventHandler(async (event) => {
       if (globalConfig) {
         const cutoffUTC = getGamePointBoundaryUtc()
         const agg = await tx.gamePointLog.aggregate({
-          where: { userId, createdAt: { gte: cutoffUTC } },
+          where: { userId, createdAt: { gte: cutoffUTC }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
           _sum: { points: true }
         })
         const used = agg._sum.points || 0
@@ -517,7 +517,7 @@ export default defineEventHandler(async (event) => {
       }
 
       if (toGive > 0) {
-        await tx.gamePointLog.create({ data: { userId, points: toGive } })
+        await tx.gamePointLog.create({ data: { userId, points: toGive, gameName: 'Monsters' } })
         const updatedPoints = await tx.userPoints.upsert({
           where: { userId },
           update: { points: { increment: toGive } },

--- a/server/api/onboarding/daily.get.js
+++ b/server/api/onboarding/daily.get.js
@@ -69,7 +69,7 @@ export default defineEventHandler(async (event) => {
       where: { userId, method: 'cZone Visit', createdAt: { gte: dailyWindowStart } }
     }),
     db.gamePointLog.aggregate({
-      where: { userId, createdAt: { gte: dailyWindowStart } },
+      where: { userId, createdAt: { gte: dailyWindowStart }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
       _sum: { points: true }
     }),
     db.wheelSpinLog.count({

--- a/server/api/tko/event.post.js
+++ b/server/api/tko/event.post.js
@@ -111,11 +111,12 @@ export default defineEventHandler(async (event) => {
       }),
       tx.globalGameConfig.findUnique({
         where: { id: 'singleton' },
-        select: { dailyPointLimit: true }
+        select: { tkoDailyPointLimit: true }
       }),
       tx.gamePointLog.aggregate({
         where: {
           userId: winnerUser.id,
+          gameName: 'TKO',
           createdAt: { gte: getChicagoGameBoundary() }
         },
         _sum: { points: true }
@@ -123,13 +124,13 @@ export default defineEventHandler(async (event) => {
     ])
 
     const pointsPerWin = Number(tkoConfig?.pointsPerWin ?? 300)
-    const cap = Number(globalConfig?.dailyPointLimit ?? 250)
+    const cap = Number(globalConfig?.tkoDailyPointLimit ?? 250)
     const used = Number(usedAgg._sum.points ?? 0)
     const remaining = Math.max(0, cap - used)
     const toGive = Math.max(0, Math.min(pointsPerWin, remaining))
     if (toGive <= 0) return 0
 
-    await tx.gamePointLog.create({ data: { userId: winnerUser.id, points: toGive } })
+    await tx.gamePointLog.create({ data: { userId: winnerUser.id, points: toGive, gameName: 'TKO' } })
     const updated = await tx.userPoints.upsert({
       where: { userId: winnerUser.id },
       create: { userId: winnerUser.id, points: toGive },

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -1082,14 +1082,14 @@ async function awardClashWinPoints(userId) {
 
     toGive = await db.$transaction(async (tx) => {
       const agg = await tx.gamePointLog.aggregate({
-        where: { userId, createdAt: { gte: cutoffUTC } },
+        where: { userId, createdAt: { gte: cutoffUTC }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
         _sum:  { points: true }
       })
       const used = agg._sum.points || 0
       const remaining = Math.max(0, cap - used)
       const give = Math.min(pointsPerWin, remaining)
       if (give > 0) {
-        await tx.gamePointLog.create({ data: { userId, points: give } })
+        await tx.gamePointLog.create({ data: { userId, points: give, gameName: 'Clash' } })
         const updated = await tx.userPoints.upsert({
           where:  { userId },
           create: { userId, points: give },
@@ -1187,14 +1187,14 @@ async function endMatch(io, match, result) {
         // where two concurrent match completions both pass the cap check.
         toGive = await db.$transaction(async (tx) => {
           const agg = await tx.gamePointLog.aggregate({
-            where: { userId, createdAt: { gte: cutoffUTC } },
+            where: { userId, createdAt: { gte: cutoffUTC }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
             _sum: { points: true }
           });
           const usedSinceCutoff = agg._sum.points || 0;
           const remaining = Math.max(0, cap - usedSinceCutoff);
           const give = Math.min(pointsPerWin, remaining);
           if (give > 0) {
-            await tx.gamePointLog.create({ data: { userId, points: give } });
+            await tx.gamePointLog.create({ data: { userId, points: give, gameName: 'Clash' } });
             const updated = await tx.userPoints.upsert({
               where: { userId },
               create: { userId, points: give },


### PR DESCRIPTION
TKO wins now draw from a dedicated tkoDailyPointLimit cap instead of
sharing the general dailyPointLimit pool, using the same rolling 8pm
CST/CDT reset. GamePointLog rows are tagged with gameName so each
game's cap check can exclude/include TKO appropriately. Admins can
configure both the TKO daily cap and TKO points-per-win from the
Global Points tab, next to the existing daily game point cap.