### PR TITLE
Schedule auction close jobs when auctions are created

### DIFF
--- a/server/api/admin/remove-cheating.post.js
+++ b/server/api/admin/remove-cheating.post.js
@@ -1,5 +1,6 @@
 import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { scheduleAuctionClose } from '@/server/utils/queues'
 
 const sleep = (ms) => new Promise(res => setTimeout(res, ms))
 
@@ -235,6 +236,9 @@ export default defineEventHandler(async (event) => {
       errorSink.push({ userCtoonId: row.id, phase: 'auction', message: String(e?.message || e) })
       return null
     }
+
+    // Schedule the BullMQ job that will close this auction at endAt
+    await scheduleAuctionClose(created.auctionId, endAt)
 
     // phase 3: discord
     try {

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -799,6 +799,7 @@ async function startDueAuctions() {
 
           return {
             auctionId: created.id,
+            endAt: new Date(fresh.endsAt),
             initialBet,
             durationDays,
             ctoon: row.userCtoon.ctoon,
@@ -809,6 +810,9 @@ async function startDueAuctions() {
         })
 
         if (!result) continue
+
+        // Schedule the BullMQ job that will close this auction at endAt
+        await scheduleAuctionClose(result.auctionId, result.endAt)
 
         // Holiday flag for messaging
         const isHolidayItem = !!(await prisma.holidayEventItem.findFirst({


### PR DESCRIPTION
## Summary
This PR adds automatic scheduling of auction closure jobs using BullMQ when auctions are created through two different code paths.

## Key Changes
- Import `scheduleAuctionClose` utility function from the queues module
- **In `remove-cheating.post.js`**: Schedule auction closure job after creating an auction through the admin endpoint
- **In `sync-guild-members.js`**: Schedule auction closure job after creating an auction through the guild member sync process
- Add `endAt` field to the result object returned from `startDueAuctions()` to pass the auction end time to the scheduler

## Implementation Details
- The `scheduleAuctionClose` function is called with the auction ID and end time (`endAt`) immediately after auction creation
- This ensures that auctions created through both the admin API and the automated sync process have their closure jobs properly scheduled
- The `endAt` timestamp is extracted from the freshly created auction record to ensure accuracy

https://claude.ai/code/session_01DLLt4cpfqmdsGy5AKS1je2