### PR TITLE
Add Discord announcements for cZone Contest winners

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,6 +19,9 @@ DISCORD_INVITE=https://discord.gg/InviteURLFromDiscordServer
 BOT_TOKEN="Bot WhateverTokenFromDiscordDeveloperPortal"
 # OPTIONAL: dedicated bot for scheduled + achievement announcements
 DISCORD_ANNOUNCEMENTS_BOT_TOKEN="Bot WhateverTokenFromDiscordDeveloperPortal"
+# OPTIONAL: fallback announcements channel ID, used when a feature-specific channel
+# (e.g. achievements, cZone Contest) isn't set in the admin Global Settings page
+DISCORD_ANNOUNCEMENTS_CHANNEL=
 
 NUXT_PORT=3000
 SOCKET_PORT=3001

--- a/pages/admin/global-settings.vue
+++ b/pages/admin/global-settings.vue
@@ -31,6 +31,10 @@
             class="px-3 py-2 border-b-2"
             :class="activeTab==='Second Editions' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Second Editions'">Second Editions</button>
+          <button
+            class="px-3 py-2 border-b-2"
+            :class="activeTab==='Discord' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
+            @click="activeTab='Discord'">Discord</button>
         </nav>
       </div>
 
@@ -436,6 +440,37 @@
         </div>
       </section>
 
+      <!-- Discord tab -->
+      <section v-if="activeTab==='Discord'" class="space-y-6">
+        <p class="text-sm text-gray-600">
+          Configure where Discord announcements for site events are posted. More announcement
+          types may be added here over time.
+        </p>
+        <div class="max-w-md">
+          <label for="czoneContestDiscordChannelId" class="block text-sm font-medium text-gray-700">
+            cZone Contest Winner Channel ID
+          </label>
+          <input
+            id="czoneContestDiscordChannelId"
+            v-model.trim="czoneContestDiscordChannelId"
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            class="input"
+            placeholder="123456789012345678"
+          />
+          <p class="text-xs text-gray-500 mt-1">
+            When an admin distributes cZone Contest prizes, an announcement is posted here.
+            Leave blank to use the DISCORD_ANNOUNCEMENTS_CHANNEL environment variable.
+          </p>
+        </div>
+        <div>
+          <button class="btn-primary" :disabled="savingDiscord" @click="saveDiscord">
+            {{ savingDiscord ? 'Saving…' : 'Save' }}
+          </button>
+        </div>
+      </section>
+
       <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded',
                                  toast.type==='error'?'bg-red-100 text-red-700':'bg-green-100 text-green-700']">
         {{ toast.msg }}
@@ -457,6 +492,8 @@ const savingRarity = ref(false)
 const savingDuplicates = ref(false)
 const savingAuctions = ref(false)
 const savingCmart = ref(false)
+const savingDiscord = ref(false)
+const czoneContestDiscordChannelId = ref('')
 
 // cMart state
 const firstAdditionalCzoneCost      = ref(25000)
@@ -568,6 +605,7 @@ async function loadGlobal() {
     secondEditionOverlayPath.value   = g?.secondEditionOverlayPath   ?? null
     secondEditionOverlayWidth.value  = g?.secondEditionOverlayWidth  ?? null
     secondEditionOverlayHeight.value = g?.secondEditionOverlayHeight ?? null
+    czoneContestDiscordChannelId.value = g?.czoneContestDiscordChannelId ?? ''
     if (g?.timeBasedPurchaseLimits) {
       for (const r of timeBasedRarities) {
         const def = g.timeBasedPurchaseLimits[r]
@@ -730,6 +768,24 @@ async function saveCmart() {
     console.error(e); toast.value = { type: 'error', msg: e?.statusMessage || 'Save failed' }
   } finally {
     savingCmart.value = false; setTimeout(() => { toast.value = null }, 2500)
+  }
+}
+
+async function saveDiscord() {
+  savingDiscord.value = true; toast.value = null
+  try {
+    await $fetch('/api/admin/global-config', {
+      method: 'POST',
+      body: {
+        dailyPointLimit: Number(dailyPointLimit.value),
+        czoneContestDiscordChannelId: czoneContestDiscordChannelId.value
+      }
+    })
+    toast.value = { type: 'ok', msg: 'Discord settings saved.' }
+  } catch (e) {
+    console.error(e); toast.value = { type: 'error', msg: e?.statusMessage || e?.data?.statusMessage || 'Save failed' }
+  } finally {
+    savingDiscord.value = false; setTimeout(() => { toast.value = null }, 2500)
   }
 }
 

--- a/prisma/migrations/20260726213648_add_czone_contest_discord_channel_id/migration.sql
+++ b/prisma/migrations/20260726213648_add_czone_contest_discord_channel_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GlobalGameConfig" ADD COLUMN     "czoneContestDiscordChannelId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1021,6 +1021,7 @@ model GlobalGameConfig {
   dhashDuplicateThreshold        Int      @default(16)
   rarityDefaults                 Json?
   achievementDiscordChannelId    String?
+  czoneContestDiscordChannelId   String?
   // Scavenger Hunt settings
   scavengerChancePercent         Int      @default(5) // 0–100; 0 disables
   scavengerCooldownHours         Int      @default(24) // cooldown between completed hunts per user

--- a/server/api/admin/czone-contest/[id]/distribute.post.js
+++ b/server/api/admin/czone-contest/[id]/distribute.post.js
@@ -2,6 +2,7 @@
 import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { mintQueue } from '@/server/utils/queues'
+import { announceCZoneContestWinner } from '@/server/utils/discord'
 
 export default defineEventHandler(async (event) => {
   const { id } = event.context.params
@@ -115,6 +116,12 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  // Fire the Discord announcement without blocking the admin's response — Discord being
+  // slow/unreachable must never make a successful, already-committed distribution look failed.
+  // announceCZoneContestWinner never throws; this catch is just a safety net.
+  announceContestDistribution(contest, winnerUserId, winnerPrizes, participantPrizes)
+    .catch(e => console.error('cZone contest Discord announcement failed:', e?.message || e))
+
   return {
     ok: true,
     winnerId,
@@ -122,3 +129,28 @@ export default defineEventHandler(async (event) => {
     participantsAwarded: participantUserIds.length
   }
 })
+
+async function announceContestDistribution(contest, winnerUserId, winnerPrizes, participantPrizes) {
+  const ctoonIds = [
+    ...(winnerPrizes.ctoons ?? []).map(c => c.ctoonId),
+    ...(participantPrizes.ctoons ?? []).map(c => c.ctoonId)
+  ].filter(Boolean)
+
+  const ctoons = ctoonIds.length
+    ? await prisma.ctoon.findMany({ where: { id: { in: ctoonIds } }, select: { id: true, name: true } })
+    : []
+  const nameById = new Map(ctoons.map(c => [c.id, c.name]))
+
+  const withNames = (prizes) => ({
+    ...prizes,
+    ctoons: (prizes.ctoons ?? []).map(c => ({ name: nameById.get(c.ctoonId), quantity: c.qty ?? 1 }))
+  })
+
+  await announceCZoneContestWinner(prisma, {
+    contestName: contest.name,
+    winnerUserId,
+    winnerPrizeSummary: withNames(winnerPrizes),
+    participantPrizeSummary: withNames(participantPrizes),
+    participantCount: contest.submissions.length
+  })
+}

--- a/server/api/admin/global-config.post.js
+++ b/server/api/admin/global-config.post.js
@@ -42,7 +42,8 @@ export default defineEventHandler(async (event) => {
     packPriceDecayAmount,
     packPriceDecayDays,
     packPriceFloor,
-    packMaxDefaultBuysPerUser
+    packMaxDefaultBuysPerUser,
+    czoneContestDiscordChannelId
   } = body
 
   // minimally require the existing cap; other fields optional with defaults
@@ -51,6 +52,15 @@ export default defineEventHandler(async (event) => {
       statusCode: 400,
       statusMessage: 'Missing or invalid "dailyPointLimit", must be a number'
     })
+  }
+
+  let czoneContestDiscordChannelIdValue
+  if (czoneContestDiscordChannelId !== undefined) {
+    const trimmed = typeof czoneContestDiscordChannelId === 'string' ? czoneContestDiscordChannelId.trim() : ''
+    if (trimmed && !/^\d{17,20}$/.test(trimmed)) {
+      throw createError({ statusCode: 400, statusMessage: 'Discord Channel ID must be a numeric channel/snowflake ID' })
+    }
+    czoneContestDiscordChannelIdValue = trimmed || null
   }
 
   const payload = {
@@ -76,7 +86,8 @@ export default defineEventHandler(async (event) => {
     packPriceDecayAmount:      (typeof packPriceDecayAmount      === 'number') ? Math.max(0, packPriceDecayAmount)      : undefined,
     packPriceDecayDays:        (typeof packPriceDecayDays        === 'number') ? Math.max(1, packPriceDecayDays)        : undefined,
     packPriceFloor:            (typeof packPriceFloor            === 'number') ? Math.max(0, packPriceFloor)            : undefined,
-    packMaxDefaultBuysPerUser: (typeof packMaxDefaultBuysPerUser === 'number') ? Math.max(1, packMaxDefaultBuysPerUser) : undefined
+    packMaxDefaultBuysPerUser: (typeof packMaxDefaultBuysPerUser === 'number') ? Math.max(1, packMaxDefaultBuysPerUser) : undefined,
+    czoneContestDiscordChannelId: czoneContestDiscordChannelIdValue
   }
 
   // 3) Upsert the singleton global config row
@@ -109,7 +120,8 @@ export default defineEventHandler(async (event) => {
         packPriceDecayAmount:      payload.packPriceDecayAmount      ?? 100,
         packPriceDecayDays:        payload.packPriceDecayDays        ?? 7,
         packPriceFloor:            payload.packPriceFloor            ?? 700,
-        packMaxDefaultBuysPerUser: payload.packMaxDefaultBuysPerUser ?? 5
+        packMaxDefaultBuysPerUser: payload.packMaxDefaultBuysPerUser ?? 5,
+        czoneContestDiscordChannelId: payload.czoneContestDiscordChannelId ?? null
       },
       update: {
         dailyPointLimit: payload.dailyPointLimit,
@@ -130,7 +142,8 @@ export default defineEventHandler(async (event) => {
         ...(payload.packPriceDecayAmount      !== undefined ? { packPriceDecayAmount:      payload.packPriceDecayAmount }      : {}),
         ...(payload.packPriceDecayDays        !== undefined ? { packPriceDecayDays:        payload.packPriceDecayDays }        : {}),
         ...(payload.packPriceFloor            !== undefined ? { packPriceFloor:            payload.packPriceFloor }            : {}),
-        ...(payload.packMaxDefaultBuysPerUser !== undefined ? { packMaxDefaultBuysPerUser: payload.packMaxDefaultBuysPerUser } : {})
+        ...(payload.packMaxDefaultBuysPerUser !== undefined ? { packMaxDefaultBuysPerUser: payload.packMaxDefaultBuysPerUser } : {}),
+        ...(payload.czoneContestDiscordChannelId !== undefined ? { czoneContestDiscordChannelId: payload.czoneContestDiscordChannelId } : {})
       }
     })
     clearUpgradesConfigCache()
@@ -152,7 +165,8 @@ export default defineEventHandler(async (event) => {
       'packPriceDecayAmount',
       'packPriceDecayDays',
       'packPriceFloor',
-      'packMaxDefaultBuysPerUser'
+      'packMaxDefaultBuysPerUser',
+      'czoneContestDiscordChannelId'
     ]
     for (const k of fields) {
       const prevVal = before ? before[k] : undefined

--- a/server/utils/discord.js
+++ b/server/utils/discord.js
@@ -297,7 +297,11 @@ export async function sendGuildChannelMessageByName(channelName, content) {
 }
 
 // New: Send to a channel by its ID (no lookup by name)
-export async function sendGuildChannelMessageById(channelId, content, tokenOverride = null) {
+// mentionUserIds: allowlist of Discord user IDs permitted to be pinged by this message.
+// Everything else (content text, @everyone/@here, roles, other users) is blocked at the
+// API level via allowed_mentions, so message content built from user-controlled strings
+// (usernames, contest/item names, etc.) can never trigger an unintended mass-ping.
+export async function sendGuildChannelMessageById(channelId, content, tokenOverride = null, mentionUserIds = []) {
   const rawToken = tokenOverride || process.env.BOT_TOKEN
   if (!rawToken || !channelId) return false
   const authHeader = rawToken.startsWith('Bot ') ? rawToken : `Bot ${rawToken}`
@@ -308,7 +312,11 @@ export async function sendGuildChannelMessageById(channelId, content, tokenOverr
         'Authorization': authHeader,
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ content })
+      body: JSON.stringify({
+        content,
+        allowed_mentions: { parse: [], users: mentionUserIds }
+      }),
+      signal: AbortSignal.timeout(5000)
     })
     // console.log('sendGuildChannelMessageById succeeded')
     return true
@@ -365,8 +373,69 @@ export async function announceAchievement(prisma, userId, achievementTitle, rewa
     if (trimmedRole) {
       msg += ` You also received the ${trimmedRole} role.`
     }
-    await sendGuildChannelMessageById(channelId, msg, botToken)
+    await sendGuildChannelMessageById(channelId, msg, botToken, [user.discordId])
   } catch {
     // swallow in worker/cron context
+  }
+}
+
+function formatPrizeSummary(prizes) {
+  if (!prizes) return ''
+  const parts = []
+  const points = Number(prizes.points || 0)
+  if (points > 0) parts.push(`${points} points`)
+  if (Array.isArray(prizes.ctoons)) {
+    for (const ctoon of prizes.ctoons) {
+      if (!ctoon?.name || !ctoon?.quantity) continue
+      parts.push(ctoon.quantity > 1 ? `${ctoon.name} ×${ctoon.quantity}` : ctoon.name)
+    }
+  }
+  const backgroundCount = Array.isArray(prizes.backgroundIds) ? prizes.backgroundIds.length : 0
+  if (backgroundCount > 0) {
+    parts.push(backgroundCount === 1 ? '1 cZone background' : `${backgroundCount} cZone backgrounds`)
+  }
+  return formatList(parts)
+}
+
+// Announce a distributed cZone Contest to the configured Discord channel.
+// Never throws — failures are logged only, since prize distribution has already
+// succeeded by the time this is called and must not be reported as failed.
+export async function announceCZoneContestWinner(prisma, {
+  contestName,
+  winnerUserId,
+  winnerPrizeSummary,
+  participantPrizeSummary,
+  participantCount = 0
+}) {
+  try {
+    const [config, winner] = await Promise.all([
+      prisma.globalGameConfig.findUnique({
+        where: { id: 'singleton' },
+        select: { czoneContestDiscordChannelId: true }
+      }),
+      prisma.user.findUnique({
+        where: { id: winnerUserId },
+        select: { discordId: true, username: true, inGuild: true }
+      })
+    ])
+
+    const channelId = (config?.czoneContestDiscordChannelId || '').trim() || process.env.DISCORD_ANNOUNCEMENTS_CHANNEL
+    const botToken = getAnnouncementsBotToken()
+    if (!channelId || !botToken || !winner) return
+
+    const canPing = !!winner.discordId && winner.inGuild !== false
+    const winnerMention = canPing ? `<@${winner.discordId}>` : (winner.username || 'The winner')
+
+    let msg = `🏆 Congrats ${winnerMention}! You won the **${contestName}** cZone Contest!`
+    const winnerParts = formatPrizeSummary(winnerPrizeSummary)
+    if (winnerParts) msg += `\n🥇 First place prize: ${winnerParts}.`
+    const participantParts = formatPrizeSummary(participantPrizeSummary)
+    if (participantParts && participantCount > 0) {
+      msg += `\n🎁 All ${participantCount} participant${participantCount === 1 ? '' : 's'} received: ${participantParts}.`
+    }
+
+    await sendGuildChannelMessageById(channelId, msg, botToken, canPing ? [winner.discordId] : [])
+  } catch (e) {
+    console.error('announceCZoneContestWinner failed:', e?.message || e)
   }
 }


### PR DESCRIPTION
## Summary
This PR adds Discord announcement functionality for cZone Contest prize distributions. When an admin distributes prizes for a contest, an announcement is automatically posted to a configured Discord channel with details about the winner and prizes awarded.

## Key Changes

- **Enhanced Discord messaging security**: Updated `sendGuildChannelMessageById()` to support allowlisted user mentions via the `mentionUserIds` parameter, with all other mention types (roles, @everyone/@here, other users) blocked at the API level. Added 5-second timeout to Discord API calls.

- **New announcement function**: Added `announceCZoneContestWinner()` to format and post contest winner announcements, including winner mention (if eligible), prize summaries for winner and participants, and participant count.

- **Prize formatting utility**: Added `formatPrizeSummary()` helper to consistently format prize details (points, items, backgrounds) into human-readable text.

- **Admin configuration UI**: Added "Discord" tab to global settings page with input field for configuring the cZone Contest winner announcement channel ID, with validation for numeric Discord snowflake IDs.

- **Contest distribution integration**: Modified the cZone Contest prize distribution endpoint to fire the Discord announcement asynchronously after successful prize distribution, ensuring admin response isn't blocked by Discord API latency.

- **Database schema**: Added `czoneContestDiscordChannelId` field to `GlobalGameConfig` model to store the configured channel ID per environment.

- **Environment configuration**: Added `DISCORD_ANNOUNCEMENTS_CHANNEL` environment variable as a fallback channel when feature-specific channels aren't configured in admin settings.

## Implementation Details

- Discord announcements are fired asynchronously and never block the prize distribution response, ensuring Discord unavailability doesn't affect the admin experience
- User mentions are only included if the winner has a valid Discord ID and is confirmed to be in the guild
- Prize summaries intelligently format items with quantities and pluralize participant counts
- Channel ID validation enforces Discord snowflake format (17-20 digit numeric IDs)
- All error handling is non-blocking with console logging for debugging

https://claude.ai/code/session_015AWhXqVStBG96QvFvqGxxJ