### PR TITLE
Add 24h lookahead for featured sale countdown in cMart

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -172,8 +172,15 @@
                 </span>
               </template>
               <template #footer-right>
+                <button
+                  v-if="!isSaleItemSoldOut(item) && saleIsUpcoming"
+                  class="card-countdown"
+                  disabled
+                >
+                  {{ formatSaleCountdown() }}
+                </button>
                 <GreenButton
-                  v-if="!isSaleItemSoldOut(item)"
+                  v-else-if="!isSaleItemSoldOut(item)"
                   class="card-buy"
                   :disabled="buyingIds.includes(item.ctoon.id)"
                   @click="buy(item.ctoon, item.price)"
@@ -430,11 +437,51 @@ function isSaleItemSoldOut(item) {
   return c.quantity != null && c.totalMinted >= c.quantity
 }
 
+// True while the featured sale hasn't started yet (server sends it up to 24h
+// ahead of startAt so the showcase can display a countdown instead of Buy).
+const saleIsUpcoming = computed(() => {
+  if (!activeSale.value?.startAt) return false
+  return new Date(activeSale.value.startAt).getTime() > nowTs.value
+})
+
+function formatSaleCountdown() {
+  if (!activeSale.value?.startAt) return ''
+  const ms = new Date(activeSale.value.startAt).getTime() - nowTs.value
+  if (ms <= 0) return ''
+
+  const totalSec = Math.floor(ms / 1000)
+  if (ms >= 60 * 60 * 1000) {
+    const h = Math.floor(totalSec / 3600)
+    const m = Math.floor((totalSec % 3600) / 60)
+    return `${h}h ${m}m`
+  }
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}m ${s}s`
+}
+
+// Fires a one-off refresh right as the featured sale's startAt passes, so the
+// countdown button swaps to Buy promptly instead of waiting on the 60s poll.
+let _saleTransitionTimer = null
+function scheduleSaleTransition() {
+  if (_saleTransitionTimer) clearTimeout(_saleTransitionTimer)
+  const startTs = activeSale.value?.startAt ? new Date(activeSale.value.startAt).getTime() : null
+  if (!startTs || startTs <= Date.now()) return
+
+  _saleTransitionTimer = setTimeout(async () => {
+    await loadActiveSale()
+    try {
+      allCtoons.value = await $fetch('/api/cmart')
+    } catch {}
+  }, Math.max(startTs - Date.now() + 1000, 1000))
+}
+
 async function loadActiveSale() {
   try {
     const sale = await $fetch('/api/cmart/active-sale')
     if (sale?.id !== activeSale.value?.id) saleImageFailed.value = false
     activeSale.value = sale
+    scheduleSaleTransition()
   } catch (err) {
     console.error('Cmart: failed to load active sale', err)
   }
@@ -659,6 +706,7 @@ onUnmounted(() => {
   if (_tick) clearInterval(_tick)
   if (_refreshTimer) clearTimeout(_refreshTimer)
   if (_saleRefreshTimer) clearInterval(_saleRefreshTimer)
+  if (_saleTransitionTimer) clearTimeout(_saleTransitionTimer)
 })
 
 function describePurchaseError(err, kind = 'cToon') {

--- a/server/api/cmart.get.js
+++ b/server/api/cmart.get.js
@@ -11,9 +11,12 @@ function computeInitialCap(totalQty, percent, overrideQty) {
   return Math.max(1, raw)
 }
 
+const SALE_FEATURED_LOOKAHEAD_MS = 24 * 60 * 60 * 1000 // 24 hours — keep in sync with activeSaleCache.js
+
 export default defineEventHandler(async () => {
   const now = new Date()
   const twoWeeksAhead = new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000)
+  const saleLookaheadEnd = new Date(now.getTime() + SALE_FEATURED_LOOKAHEAD_MS)
 
   // Load global release settings (with safe defaults)
   let initialPercent = 75
@@ -30,9 +33,10 @@ export default defineEventHandler(async () => {
     where: {
       inCmart: true,
       releaseDate: { lte: twoWeeksAhead },
-      // cToons in an active Sale are shown only in the Sale showcase section
-      // (see /api/cmart/active-sale), not duplicated in this normal grid.
-      saleItems: { none: { sale: { startAt: { lte: now }, endAt: { gte: now } } } }
+      // cToons in an active Sale, or one starting within the next 24h, are
+      // shown only in the Sale showcase section (see /api/cmart/active-sale),
+      // not duplicated in this normal grid.
+      saleItems: { none: { sale: { startAt: { lte: saleLookaheadEnd }, endAt: { gte: now } } } }
     },
     orderBy: { releaseDate: 'desc' },
     select: {

--- a/server/api/cmart/active-sale.get.js
+++ b/server/api/cmart/active-sale.get.js
@@ -1,12 +1,14 @@
 // GET /api/cmart/active-sale
-// Public endpoint. Returns the currently active Sale (if any) with its items,
-// for the cMart showcase section. Cached briefly (mirrors upgradesConfigCache.js)
-// since this is fetched on every cMart page load and refresh cycle, and there's
-// usually no active sale.
+// Public endpoint. Returns the Sale to feature in the cMart showcase — either
+// currently active, or starting within the next 24h (so the UI can show a
+// countdown before it goes live) — with its items. Cached briefly (mirrors
+// upgradesConfigCache.js) since this is fetched on every cMart page load and
+// refresh cycle, and there's usually no active/upcoming sale. This is
+// display-only; purchasability is always re-checked strictly server-side.
 
 import { defineEventHandler } from 'h3'
-import { getActiveSale } from '@/server/utils/activeSaleCache'
+import { getFeaturedSale } from '@/server/utils/activeSaleCache'
 
 export default defineEventHandler(async () => {
-  return await getActiveSale()
+  return await getFeaturedSale()
 })

--- a/server/utils/activeSaleCache.js
+++ b/server/utils/activeSaleCache.js
@@ -8,12 +8,21 @@ import { prisma } from '@/server/prisma'
 
 export const CACHE_TTL_MS = 30 * 1000 // 30 seconds
 
+// Lookahead window for the "featured" sale (active OR starting soon) shown
+// in the cMart showcase, so shoppers see a countdown before it goes live.
+export const FEATURED_LOOKAHEAD_MS = 24 * 60 * 60 * 1000 // 24 hours
+
 let _cache = null
 let _cacheAt = 0
+
+let _featuredCache = null
+let _featuredCacheAt = 0
 
 export function clearActiveSaleCache() {
   _cache = null
   _cacheAt = 0
+  _featuredCache = null
+  _featuredCacheAt = 0
 }
 
 export function setActiveSaleCache(value) {
@@ -24,6 +33,18 @@ export function setActiveSaleCache(value) {
 export function getActiveSaleCache() {
   if (_cache !== null && Date.now() - _cacheAt < CACHE_TTL_MS) {
     return _cache
+  }
+  return undefined
+}
+
+function setFeaturedSaleCache(value) {
+  _featuredCache = value
+  _featuredCacheAt = Date.now()
+}
+
+function getFeaturedSaleCache() {
+  if (_featuredCache !== null && Date.now() - _featuredCacheAt < CACHE_TTL_MS) {
+    return _featuredCache
   }
   return undefined
 }
@@ -72,5 +93,60 @@ export async function getActiveSale() {
 
   const result = sale || null
   setActiveSaleCache(result)
+  return result
+}
+
+// Fetches the Sale to feature in the cMart showcase: either the currently
+// active one, or (if none) one starting within the next 24h, so shoppers see
+// a countdown before it goes live. A single range query ordered by startAt
+// asc naturally prefers an active sale over an upcoming one, since an active
+// sale's startAt is always <= now, which sorts before any upcoming sale's
+// startAt (necessarily > now).
+//
+// This is display-only: it must never be used to decide whether a purchase
+// is allowed (see buy.post.js / mint.worker.js, which always re-derive the
+// strictly-active sale themselves).
+export async function getFeaturedSale() {
+  const cached = getFeaturedSaleCache()
+  if (cached !== undefined) return cached
+
+  const now = new Date()
+  const lookaheadEnd = new Date(now.getTime() + FEATURED_LOOKAHEAD_MS)
+  const sale = await prisma.sale.findFirst({
+    where: { startAt: { lte: lookaheadEnd }, endAt: { gte: now } },
+    orderBy: { startAt: 'asc' },
+    select: {
+      id: true,
+      name: true,
+      imagePath: true,
+      startAt: true,
+      endAt: true,
+      items: {
+        select: {
+          price: true,
+          perDayLimit: true,
+          ctoon: {
+            select: {
+              id: true,
+              name: true,
+              assetPath: true,
+              rarity: true,
+              price: true,
+              isGtoon: true,
+              quantity: true,
+              totalMinted: true,
+              isSecondEdition: true,
+              secondEditionOverlayX: true,
+              secondEditionOverlayY: true,
+              secondEditionOverlaySize: true
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const result = sale || null
+  setFeaturedSaleCache(result)
   return result
 }

--- a/server/utils/centralTime.js
+++ b/server/utils/centralTime.js
@@ -90,3 +90,18 @@ export function getDailyWindowStart(now = new Date()) {
   const offsetMs = zonalMs - utcGuessMs
   return new Date(utcGuessMs - offsetMs)
 }
+
+/**
+ * Returns the start of the current rolling 24h purchase window for a Sale,
+ * anchored to the Sale's own startAt rather than the global 8pm CST reset
+ * used elsewhere. Windows are [startAt, startAt+24h), [startAt+24h,
+ * startAt+48h), etc. Pure elapsed-ms arithmetic (not wall-clock based), so
+ * DST transitions don't affect it the way they would a Chicago-local calc.
+ */
+export function getSaleDailyWindowStart(saleStartAt, now = new Date()) {
+  const startMs = new Date(saleStartAt).getTime()
+  const dayMs = 24 * 60 * 60 * 1000
+  const elapsedMs = now.getTime() - startMs
+  const bucketIndex = Math.max(0, Math.floor(elapsedMs / dayMs))
+  return new Date(startMs + bucketIndex * dayMs)
+}

--- a/server/workers/mint.worker.js
+++ b/server/workers/mint.worker.js
@@ -1,6 +1,6 @@
 import { Worker } from 'bullmq'
 import { prisma } from '../prisma.js'
-import { getDailyWindowStart } from '../utils/centralTime.js'
+import { getSaleDailyWindowStart } from '../utils/centralTime.js'
 
 const connection = {
   host: process.env.REDIS_HOST,
@@ -28,7 +28,7 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
             ctoonId,
             sale: { startAt: { lte: new Date() }, endAt: { gte: new Date() } }
           },
-          select: { saleId: true, price: true, perDayLimit: true },
+          select: { saleId: true, price: true, perDayLimit: true, sale: { select: { startAt: true } } },
           orderBy: { createdAt: 'asc' }
         })
       : null
@@ -255,8 +255,11 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
       // 1b) Sale per-day limit — atomic increment-then-check on a single counter row
       // (same pattern as the totalMinted increment above) so the row lock serializes
       // concurrent buyers instead of racing on a count() read.
+      // The window is a rolling 24h period anchored to the Sale's own startAt
+      // (not the global 8pm CST reset), so the limit always resets exactly
+      // 24h after the sale began, regardless of when a user happens to buy.
       if (activeSale) {
-        const windowStart = getDailyWindowStart()
+        const windowStart = getSaleDailyWindowStart(activeSale.sale.startAt)
         const counter = await tx.saleDailyPurchase.upsert({
           where: {
             userId_ctoonId_saleId_windowStart: {
@@ -268,7 +271,7 @@ const worker = new Worker(process.env.MINT_QUEUE_KEY, async job => {
           select: { count: true }
         })
         if (counter.count > activeSale.perDayLimit) {
-          throw new Error(`Daily limit reached — you can buy ${activeSale.perDayLimit} of this cToon per day during this sale (resets at 8pm CST)`)
+          throw new Error(`Daily limit reached — you can buy ${activeSale.perDayLimit} of this cToon per 24-hour period during this sale`)
         }
       }
 


### PR DESCRIPTION
## Summary
This PR extends the cMart showcase to display upcoming sales with a countdown timer, allowing shoppers to see when a sale will go live up to 24 hours in advance. The featured sale display now shows either the currently active sale or one starting within the next 24 hours, whichever comes first.

## Key Changes

- **Featured Sale Lookahead**: Added `getFeaturedSale()` function that queries for sales starting within the next 24 hours, with a new `FEATURED_LOOKAHEAD_MS` constant to control the window
- **Dual Caching**: Implemented separate cache for featured sales (`_featuredCache`) alongside the existing active sale cache, both with 30-second TTL
- **Countdown UI**: Added countdown button in the cMart showcase that displays time until sale start (formatted as "Xh Ym" or "Xm Ys"), replacing the Buy button for upcoming sales
- **Smart Transition**: Implemented `scheduleSaleTransition()` to refresh the sale and cToons list exactly when a featured sale's start time arrives, so the countdown button swaps to Buy promptly without waiting for the next poll cycle
- **Sale-Anchored Daily Limits**: Added `getSaleDailyWindowStart()` utility that calculates rolling 24-hour purchase windows anchored to each sale's `startAt` time (not the global 8pm CST reset), ensuring limits reset exactly 24 hours after a sale begins
- **Updated Error Messages**: Changed daily limit error message to reflect the new sale-anchored window behavior
- **Grid Exclusion**: Modified the main cMart grid query to exclude cToons in active or upcoming sales (within 24h lookahead), preventing duplication in the showcase section

## Implementation Details

- The featured sale query uses a single range query ordered by `startAt` ascending, which naturally prefers active sales over upcoming ones since active sales have `startAt <= now`
- The countdown display is display-only and never affects purchase validation; purchasability is always re-checked strictly server-side
- The sale transition timer uses `Math.max(..., 1000)` to ensure a minimum 1-second delay, preventing race conditions when the transition time is very close to now
- All timers are properly cleaned up on component unmount to prevent memory leaks

https://claude.ai/code/session_01FKeaVEFXVyQBrKBEr8rykS