### PR TITLE
Add separate daily point cap for TKO game

### DIFF
--- a/components/Onboarding.vue
+++ b/components/Onboarding.vue
@@ -290,6 +290,7 @@ const items = computed(() => {
   const czonePoints = Number(cfg.czoneVisitPoints ?? 0)
   const czoneTotal = formatNumber(czoneVisits * czonePoints)
   const dailyPointLimit = formatNumber(cfg.dailyPointLimit)
+  const tkoDailyPointLimit = formatNumber(cfg.tkoDailyPointLimit)
   const winwheelMax = Number(cfg.winwheelMaxDailySpins ?? 0)
   const lottoCountRaw = Number(cfg.lottoCountPerDay ?? 0)
   const scanLimit = Number(cfg.monsterDailyScanLimit ?? 0)
@@ -314,7 +315,12 @@ const items = computed(() => {
     {
       id: 'games',
       done: Boolean(st.gamePointsComplete),
-      text: `Play Winball, ReOrbit Match, gToons Clash, TKO, or scan for Monsters to win up to ${dailyPointLimit} points.`
+      text: `Play Winball, ReOrbit Match, gToons Clash, or scan for Monsters to win up to ${dailyPointLimit} points.`
+    },
+    {
+      id: 'tko',
+      done: Boolean(st.tkoPointsComplete),
+      text: `Play TKO to win up to ${tkoDailyPointLimit} points.`
     },
     {
       id: 'winwheel',

--- a/pages/admin/games.vue
+++ b/pages/admin/games.vue
@@ -39,6 +39,10 @@
             <label class="block text-sm font-medium text-gray-700">Daily Point Cap</label>
             <input type="number" v-model.number="globalDailyPointLimit" class="input" />
           </div>
+          <div class="mb-6">
+            <label class="block text-sm font-medium text-gray-700">Daily TKO Points Cap</label>
+            <input type="number" v-model.number="globalTkoDailyPointLimit" class="input" />
+          </div>
           <button @click="saveGlobalConfig" :disabled="loadingGlobal" class="btn-primary">
             <span v-if="!loadingGlobal">Save Global Settings</span>
             <span v-else>Saving…</span>
@@ -1074,6 +1078,7 @@ function onTabsWheel(e) {
 
 // ── Settings state ────────────────────────────
 const globalDailyPointLimit = ref(100)
+const globalTkoDailyPointLimit = ref(250)
 const loadingGlobal         = ref(false)
 const leftCupPoints         = ref(0)
 const rightCupPoints        = ref(0)
@@ -1379,6 +1384,7 @@ function clearSelection() {
 async function loadSettings() {
   const g = await $fetch('/api/admin/global-config')
   globalDailyPointLimit.value = g.dailyPointLimit
+  globalTkoDailyPointLimit.value = g.tkoDailyPointLimit
   gameTileImages.value.winball      = g.gameTileWinballImagePath      || ''
   gameTileImages.value.lotto        = g.gameTileLottoImagePath        || ''
   gameTileImages.value.winwheel     = g.gameTileWinwheelImagePath     || ''
@@ -1707,7 +1713,10 @@ async function saveGlobalConfig() {
   try {
     await $fetch('/api/admin/global-config', {
       method: 'POST',
-      body: { dailyPointLimit: globalDailyPointLimit.value }
+      body: {
+        dailyPointLimit: globalDailyPointLimit.value,
+        tkoDailyPointLimit: globalTkoDailyPointLimit.value
+      }
     })
     toastMessage.value = 'Global settings saved!'; toastType.value = 'success'
   } catch {

--- a/server/api/onboarding/daily.get.js
+++ b/server/api/onboarding/daily.get.js
@@ -33,6 +33,7 @@ export default defineEventHandler(async (event) => {
       select: {
         dailyLoginPoints: true,
         dailyPointLimit: true,
+        tkoDailyPointLimit: true,
         czoneVisitMaxPerDay: true,
         czoneVisitPoints: true
       }
@@ -59,6 +60,7 @@ export default defineEventHandler(async (event) => {
     dailyLoginCount,
     czoneVisitCount,
     gamePointAgg,
+    tkoPointAgg,
     winwheelSpins,
     lottoUser
   ] = await Promise.all([
@@ -72,6 +74,10 @@ export default defineEventHandler(async (event) => {
       where: { userId, createdAt: { gte: dailyWindowStart }, OR: [{ gameName: null }, { gameName: { not: 'TKO' } }] },
       _sum: { points: true }
     }),
+    db.gamePointLog.aggregate({
+      where: { userId, gameName: 'TKO', createdAt: { gte: dailyWindowStart } },
+      _sum: { points: true }
+    }),
     db.wheelSpinLog.count({
       where: { userId, createdAt: { gte: morningWindowStart }, status: { not: 'failed' } }
     }),
@@ -83,6 +89,7 @@ export default defineEventHandler(async (event) => {
 
   const dailyLoginPoints = Number(globalConfig?.dailyLoginPoints ?? 500)
   const dailyPointLimit = Number(globalConfig?.dailyPointLimit ?? 250)
+  const tkoDailyPointLimit = Number(globalConfig?.tkoDailyPointLimit ?? 250)
   const czoneVisitMaxPerDay = Number(globalConfig?.czoneVisitMaxPerDay ?? 10)
   const czoneVisitPoints = Number(globalConfig?.czoneVisitPoints ?? 20)
   const winwheelMaxDailySpins = Number(winwheelConfig?.maxDailySpins ?? 0)
@@ -91,6 +98,7 @@ export default defineEventHandler(async (event) => {
   const scanPoints = Number(barcodeConfig?.scanPoints ?? 0)
 
   const gamePointsUsed = Number(gamePointAgg?._sum?.points || 0)
+  const tkoPointsUsed = Number(tkoPointAgg?._sum?.points || 0)
 
   const lastResetAt = lottoUser?.lastReset ? new Date(lottoUser.lastReset) : null
   const lottoPurchasesToday = (lastResetAt && lastResetAt.getTime() >= morningWindowStart.getTime())
@@ -108,6 +116,7 @@ export default defineEventHandler(async (event) => {
     dailyLoginComplete: dailyLoginCount > 0,
     czoneVisitComplete: czoneVisitMaxPerDay > 0 && czoneVisitCount >= czoneVisitMaxPerDay,
     gamePointsComplete: dailyPointLimit > 0 && gamePointsUsed >= dailyPointLimit,
+    tkoPointsComplete: tkoDailyPointLimit > 0 && tkoPointsUsed >= tkoDailyPointLimit,
     winwheelComplete: winwheelMaxDailySpins > 0 && winwheelSpins >= winwheelMaxDailySpins,
     lottoComplete: lottoCountPerDay !== -1 && lottoCountPerDay > 0 && lottoPurchasesToday >= lottoCountPerDay,
     monsterScanComplete: monsterDailyScanLimit > 0 && monsterScans >= monsterDailyScanLimit
@@ -117,6 +126,7 @@ export default defineEventHandler(async (event) => {
     config: {
       dailyLoginPoints,
       dailyPointLimit,
+      tkoDailyPointLimit,
       czoneVisitMaxPerDay,
       czoneVisitPoints,
       winwheelMaxDailySpins,
@@ -129,6 +139,7 @@ export default defineEventHandler(async (event) => {
       dailyLoginCount,
       czoneVisitCount,
       gamePointsUsed,
+      tkoPointsUsed,
       winwheelSpins,
       lottoPurchasesToday,
       monsterScans


### PR DESCRIPTION
## Summary
This PR introduces a separate daily point cap specifically for the TKO game, allowing independent control of TKO point limits from other games.

## Key Changes
- **Admin Settings UI**: Added a new "Daily TKO Points Cap" input field in the games admin panel to configure the TKO-specific point limit
- **Global Configuration**: Extended the global config to store and manage `tkoDailyPointLimit` (defaults to 250 points)
- **Daily Onboarding API**: 
  - Added separate aggregation query to track TKO game points independently from other games
  - Added `tkoPointsUsed` calculation and `tkoPointsComplete` completion status
  - Exposed `tkoDailyPointLimit` and `tkoPointsUsed` in the API response
- **Onboarding UI**: 
  - Split the games completion item into two separate items: one for non-TKO games and one specifically for TKO
  - Updated text to clarify that TKO has its own separate point cap

## Implementation Details
- TKO points are now tracked separately by filtering `gamePointLog` entries where `gameName: 'TKO'`
- Other games (Winball, ReOrbit Match, gToons Clash, Monster Scan) continue to share the original `dailyPointLimit`
- Both limits are independently configurable and tracked in the daily onboarding completion status

https://claude.ai/code/session_01AqJYNXwHVijVP6tH1XGhmL