### PR TITLE
Add price filter and official winner exclusion to auction logs

### DIFF
--- a/components/newsite/AdminAuctionLogs.vue
+++ b/components/newsite/AdminAuctionLogs.vue
@@ -129,6 +129,18 @@
             Showing only CLOSED auctions with a winner; Status &amp; Has Bidder filters are disabled.
           </div>
         </div>
+
+        <div class="flex items-end">
+          <label class="flex items-center gap-1.5 text-[11px] text-gray-700">
+            <input
+              id="excludeOfficialWinner"
+              v-model="excludeOfficialWinner"
+              type="checkbox"
+              class="rounded border-gray-300 focus:ring-indigo-500"
+            />
+            Hide official account wins
+          </label>
+        </div>
       </div>
 
       <div class="mb-2 text-[11px] text-gray-600">
@@ -229,6 +241,7 @@ const selectedStatus = ref('')
 const selectedHasBidder = ref('')
 const priceOp = ref('')
 const priceValue = ref('')
+const excludeOfficialWinner = ref(false)
 
 const statusOptions = ['ACTIVE', 'CLOSED', 'CANCELLED']
 const rarityOptions = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare', 'Prize Only', 'Code Only', 'Auction Only']
@@ -258,7 +271,8 @@ async function fetchAuctions() {
       status: selectedStatus.value || undefined,
       hasBidder: selectedHasBidder.value || undefined,
       priceOp: isPriceFilterActive.value ? priceOp.value : undefined,
-      priceValue: isPriceFilterActive.value ? priceValue.value.trim() : undefined
+      priceValue: isPriceFilterActive.value ? priceValue.value.trim() : undefined,
+      excludeOfficialWinner: excludeOfficialWinner.value ? '1' : undefined
     }
   })
   auctions.value = res.items || []
@@ -340,6 +354,16 @@ watch(isPriceFilterActive, (active) => {
 
 watch([priceOp, priceValue], () => {
   scheduleFilterFetch()
+})
+
+watch(excludeOfficialWinner, async () => {
+  if (page.value !== 1) {
+    page.value = 1
+    return
+  }
+  await fetchAuctions()
+  await nextTick()
+  scrollTop()
 })
 
 watch(page, async () => {

--- a/components/newsite/AdminAuctionLogs.vue
+++ b/components/newsite/AdminAuctionLogs.vue
@@ -79,7 +79,8 @@
           <select
             id="statusFilter"
             v-model="selectedStatus"
-            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            :disabled="isPriceFilterActive"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100 disabled:text-gray-400"
           >
             <option value="">All</option>
             <option v-for="status in statusOptions" :key="status" :value="status">{{ status }}</option>
@@ -91,12 +92,42 @@
           <select
             id="bidderFilter"
             v-model="selectedHasBidder"
-            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            :disabled="isPriceFilterActive"
+            class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100 disabled:text-gray-400"
           >
             <option v-for="opt in hasBidderOptions" :key="opt.value" :value="opt.value">
               {{ opt.label }}
             </option>
           </select>
+        </div>
+
+        <div class="col-span-2">
+          <label for="priceValue" class="block text-[10px] font-medium text-gray-700 mb-0.5">
+            Sold Price (ended &amp; sold auctions only)
+          </label>
+          <div class="flex gap-1">
+            <select
+              id="priceOp"
+              v-model="priceOp"
+              class="border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            >
+              <option value="">—</option>
+              <option value="gt">More than</option>
+              <option value="lt">Less than</option>
+            </select>
+            <input
+              id="priceValue"
+              v-model="priceValue"
+              type="text"
+              inputmode="numeric"
+              pattern="[0-9]*"
+              placeholder="e.g. 3000"
+              class="w-full border rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+          <div v-if="isPriceFilterActive" class="mt-0.5 text-[10px] text-gray-500">
+            Showing only CLOSED auctions with a winner; Status &amp; Has Bidder filters are disabled.
+          </div>
         </div>
       </div>
 
@@ -196,6 +227,8 @@ const winnerSuggestions = ref([])
 const selectedRarity = ref('')
 const selectedStatus = ref('')
 const selectedHasBidder = ref('')
+const priceOp = ref('')
+const priceValue = ref('')
 
 const statusOptions = ['ACTIVE', 'CLOSED', 'CANCELLED']
 const rarityOptions = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Crazy Rare', 'Prize Only', 'Code Only', 'Auction Only']
@@ -206,6 +239,7 @@ const hasBidderOptions = [
 ]
 
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+const isPriceFilterActive = computed(() => priceOp.value !== '' && priceValue.value.trim() !== '')
 
 function scrollTop() {
   if (process.client) window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -222,7 +256,9 @@ async function fetchAuctions() {
       characters: characterQuery.value.trim() || undefined,
       rarity: selectedRarity.value || undefined,
       status: selectedStatus.value || undefined,
-      hasBidder: selectedHasBidder.value || undefined
+      hasBidder: selectedHasBidder.value || undefined,
+      priceOp: isPriceFilterActive.value ? priceOp.value : undefined,
+      priceValue: isPriceFilterActive.value ? priceValue.value.trim() : undefined
     }
   })
   auctions.value = res.items || []
@@ -285,6 +321,25 @@ watch([selectedStatus, selectedHasBidder, selectedRarity], async () => {
   await fetchAuctions()
   await nextTick()
   scrollTop()
+})
+
+// Numeric-only input: strip any non-digit characters as the user types.
+watch(priceValue, (val) => {
+  const digitsOnly = val.replace(/\D/g, '')
+  if (digitsOnly !== val) priceValue.value = digitsOnly
+})
+
+// While the price filter is active, Status & Has Bidder are disabled and
+// forced back to "All" so the UI never shows a stale, conflicting selection.
+watch(isPriceFilterActive, (active) => {
+  if (active) {
+    selectedStatus.value = ''
+    selectedHasBidder.value = ''
+  }
+})
+
+watch([priceOp, priceValue], () => {
+  scheduleFilterFetch()
 })
 
 watch(page, async () => {

--- a/prisma/migrations/20260730000000_auction_status_winner_highestbid_idx/migration.sql
+++ b/prisma/migrations/20260730000000_auction_status_winner_highestbid_idx/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "Auction_status_winnerId_idx";
+
+-- CreateIndex
+CREATE INDEX "Auction_status_winnerId_highestBid_idx" ON "Auction"("status", "winnerId", "highestBid");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1203,7 +1203,7 @@ model Auction {
   autoBids AuctionAutoBid[]
 
   @@index([userCtoonId, status])
-  @@index([status, winnerId])
+  @@index([status, winnerId, highestBid])
   @@index([isFeatured, status, highestBidderId])
 }
 

--- a/server/api/admin/auctions.get.js
+++ b/server/api/admin/auctions.get.js
@@ -23,7 +23,8 @@ export default defineEventHandler(async (event) => {
     characters = '',
     rarity = '',
     priceOp = '',
-    priceValue = ''
+    priceValue = '',
+    excludeOfficialWinner = ''
   } = getQuery(event)
   const pageNum = Math.max(1, parseInt(String(page), 10) || 1)
   const take = Math.min(500, Math.max(1, parseInt(String(limit), 10) || 100))
@@ -41,6 +42,9 @@ export default defineEventHandler(async (event) => {
   if (hasBidder === 'has') where.highestBidderId = { not: null }
   if (hasBidder === 'none') where.highestBidderId = null
 
+  // winnerId conditions accumulate across filters below (AND'd together).
+  const winnerIdFilter = {}
+
   // Sold-price filter: only meaningful for ended auctions that actually sold.
   // A valid price filter takes precedence over status/hasBidder above, since
   // "ended & sold" is a stricter, well-defined scope.
@@ -54,9 +58,21 @@ export default defineEventHandler(async (event) => {
     parsedPriceValue <= 2147483647
   if (isValidPriceFilter) {
     where.status = 'CLOSED'
-    where.winnerId = { not: null }
+    winnerIdFilter.not = null
     where.highestBid = { [priceOp]: parsedPriceValue }
   }
+
+  // Exclude auctions won by the official account (e.g. auto-bid safety-net wins).
+  if (excludeOfficialWinner === '1' || excludeOfficialWinner === 'true') {
+    const officialUsername = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
+    const official = await prisma.user.findUnique({
+      where: { username: officialUsername },
+      select: { id: true }
+    })
+    if (official) winnerIdFilter.notIn = [official.id]
+  }
+
+  if (Object.keys(winnerIdFilter).length) where.winnerId = winnerIdFilter
 
   const ctoonFilters = {}
   if (ctoonName) {

--- a/server/api/admin/auctions.get.js
+++ b/server/api/admin/auctions.get.js
@@ -21,7 +21,9 @@ export default defineEventHandler(async (event) => {
     hasBidder = '',
     ctoonName = '',
     characters = '',
-    rarity = ''
+    rarity = '',
+    priceOp = '',
+    priceValue = ''
   } = getQuery(event)
   const pageNum = Math.max(1, parseInt(String(page), 10) || 1)
   const take = Math.min(500, Math.max(1, parseInt(String(limit), 10) || 100))
@@ -38,6 +40,23 @@ export default defineEventHandler(async (event) => {
   }
   if (hasBidder === 'has') where.highestBidderId = { not: null }
   if (hasBidder === 'none') where.highestBidderId = null
+
+  // Sold-price filter: only meaningful for ended auctions that actually sold.
+  // A valid price filter takes precedence over status/hasBidder above, since
+  // "ended & sold" is a stricter, well-defined scope.
+  const priceValueStr = String(priceValue).trim()
+  const parsedPriceValue = Number(priceValueStr)
+  const isValidPriceFilter =
+    (priceOp === 'gt' || priceOp === 'lt') &&
+    /^\d+$/.test(priceValueStr) &&
+    Number.isInteger(parsedPriceValue) &&
+    parsedPriceValue >= 0 &&
+    parsedPriceValue <= 2147483647
+  if (isValidPriceFilter) {
+    where.status = 'CLOSED'
+    where.winnerId = { not: null }
+    where.highestBid = { [priceOp]: parsedPriceValue }
+  }
 
   const ctoonFilters = {}
   if (ctoonName) {


### PR DESCRIPTION
## Summary
Enhanced the AdminAuctionLogs component with advanced filtering capabilities, allowing admins to filter auctions by sold price and optionally exclude official account wins.

## Key Changes

- **Price Filter**: Added a new filter section that allows filtering auctions by sold price with "More than" or "Less than" operators. This filter only applies to closed auctions with winners.
  - Includes numeric-only input validation that strips non-digit characters as the user types
  - When active, automatically disables and resets the Status and Has Bidder filters to prevent conflicting selections
  - Displays a helper message explaining the filter's scope

- **Official Winner Exclusion**: Added a checkbox to hide auctions won by the official account (configurable via `OFFICIAL_USERNAME` env var, defaults to 'CartoonReOrbitOfficial')

- **Filter State Management**: 
  - Status and Bidder filters are now disabled when a price filter is active
  - Applied visual styling (gray background and text) to disabled filter controls
  - Price filter changes trigger automatic data fetching via `scheduleFilterFetch()`

- **Backend API Updates**: Extended the `/admin/auctions` endpoint to accept and process `priceOp`, `priceValue`, and `excludeOfficialWinner` query parameters
  - Price filter validation ensures only valid integer values within safe bounds (0-2147483647) are processed
  - Official winner lookup is performed only when the exclusion filter is active

- **Database Optimization**: Updated the Auction model index from `[status, winnerId]` to `[status, winnerId, highestBid]` to efficiently support the new price-based filtering queries

## Implementation Details

- The price filter takes precedence over status/hasBidder filters when active, enforcing a stricter "closed & sold" scope
- Winner ID filtering uses Prisma's `not` and `notIn` operators to handle both the "has winner" requirement and official account exclusion
- Input validation occurs both client-side (numeric pattern) and server-side (integer range checks)

https://claude.ai/code/session_01QioXbcqmUYH91jRYhgi9Cv