### PR TITLE
Add clickable Set/Series links in cToon info card

### DIFF
--- a/components/newsite/AllCtoons.vue
+++ b/components/newsite/AllCtoons.vue
@@ -3,6 +3,17 @@
 
     <div class="ac-header">All cToons</div>
 
+    <div v-if="filter.set || filter.series" class="ac-active-filters">
+      <span v-if="filter.set" class="ac-filter-chip">
+        Set: <strong>{{ filter.set }}</strong>
+        <button class="ac-filter-chip-x" aria-label="Clear set filter" @click="filter.set = ''">✕</button>
+      </span>
+      <span v-if="filter.series" class="ac-filter-chip">
+        Series: <strong>{{ filter.series }}</strong>
+        <button class="ac-filter-chip-x" aria-label="Clear series filter" @click="filter.series = ''">✕</button>
+      </span>
+    </div>
+
     <!-- ── Pagination (top) ─────────────────────────────────────── -->
     <div class="ac-pagination">
       <button class="ac-pg-btn" :disabled="groupPage <= 1" @click="prevGroupPage">‹</button>
@@ -292,6 +303,49 @@ onMounted(async () => {
   background: var(--OrbitLightBlue);
   box-sizing: border-box;
 }
+
+.ac-active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 8px 0;
+  flex-shrink: 0;
+}
+
+.ac-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--OrbitDarkBlue);
+  color: #fff;
+  font-size: 0.68rem;
+  border-radius: 12px;
+  padding: 3px 6px 3px 10px;
+  max-width: 100%;
+}
+
+.ac-filter-chip strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+}
+
+.ac-filter-chip-x {
+  border: none;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  font-size: 0.6rem;
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+.ac-filter-chip-x:hover { background: rgba(255, 255, 255, 0.3); }
 
 .ac-scroll {
   flex: 1;

--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -119,11 +119,25 @@
               </div>
               <div class="ctic-tile">
                 <div class="ctic-label">Set</div>
-                <div class="ctic-value">{{ formatValue(ctoon.set) }}</div>
+                <NuxtLink
+                  v-if="ctoon.set"
+                  :to="{ path: '/newsite/allCtoons', query: setLinkQuery }"
+                  class="ctic-value ctic-value--link"
+                  :aria-label="`View all cToons in the ${ctoon.set} set`"
+                  @click="goToFiltered('set', ctoon.set, $event)"
+                >{{ ctoon.set }}</NuxtLink>
+                <div v-else class="ctic-value">N/A</div>
               </div>
               <div class="ctic-tile">
                 <div class="ctic-label">Series</div>
-                <div class="ctic-value">{{ formatValue(ctoon.series) }}</div>
+                <NuxtLink
+                  v-if="ctoon.series"
+                  :to="{ path: '/newsite/allCtoons', query: seriesLinkQuery }"
+                  class="ctic-value ctic-value--link"
+                  :aria-label="`View all cToons in the ${ctoon.series} series`"
+                  @click="goToFiltered('series', ctoon.series, $event)"
+                >{{ ctoon.series }}</NuxtLink>
+                <div v-else class="ctic-value">N/A</div>
               </div>
               <div class="ctic-tile">
                 <div class="ctic-label">Release Date</div>
@@ -391,6 +405,57 @@ const userCtoon = computed(() => data.value?.userCtoon || null)
 const ownedCount = computed(() => data.value?.ownedCount ?? 0)
 const hasGtoon = computed(() => !!ctoon.value?.isGtoon)
 const totalQuantityLabel = computed(() => formatQuantity(ctoon.value?.quantity))
+
+const route = useRoute()
+
+// Building the target Set/Series filter: keep Ownership/Wishlist/Sort as the
+// user left them, but drop Name/Rarity since a stale text or rarity filter
+// could hide items in the set/series the user just asked to browse.
+function buildFilterLinkTarget(type, value) {
+  const current = useAllCtoonsFilter().value
+  return {
+    name: '',
+    rarities: [],
+    owned: current.owned,
+    wishlist: current.wishlist,
+    sortField: current.sortField,
+    sortAsc: current.sortAsc,
+    set: type === 'set' ? value : '',
+    series: type === 'series' ? value : '',
+  }
+}
+
+const setLinkQuery = computed(() => (
+  ctoon.value?.set
+    ? filterToQuery(buildFilterLinkTarget('set', ctoon.value.set), 'AllSets')
+    : {}
+))
+const seriesLinkQuery = computed(() => (
+  ctoon.value?.series
+    ? filterToQuery(buildFilterLinkTarget('series', ctoon.value.series), 'AllSeries')
+    : {}
+))
+
+function goToFiltered(type, value, event) {
+  if (!value) return
+  // Let modifier/middle-clicks fall through to the browser's native
+  // "open in new tab" behavior instead of hijacking them.
+  if (event && (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)) {
+    return
+  }
+  // Already on All cToons: mutate the shared filter state directly so the
+  // grid updates immediately. Prevent NuxtLink's own navigation here so we
+  // don't fire a second, redundant router call racing the page's own
+  // filter -> URL watcher.
+  if (route.path === '/newsite/allCtoons') {
+    event?.preventDefault()
+    Object.assign(useAllCtoonsFilter().value, buildFilterLinkTarget(type, value))
+    useAllCtoonsTab().value = type === 'series' ? 'AllSeries' : 'AllSets'
+  }
+  // Otherwise let the NuxtLink's own navigation run normally; the
+  // destination page reads set/series/tab straight from the URL query.
+  close()
+}
 
 const statusImage = computed(() => {
   const totalQuantity = ctoon.value?.quantity
@@ -1047,6 +1112,36 @@ function formatDate(value) {
 .ctic-value {
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+.ctic-value--link {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: #93c5fd;
+  text-decoration: none;
+  background: rgba(147, 197, 253, 0.14);
+  border-radius: 4px;
+  padding: 5px 8px;
+  margin: -5px -8px;
+  min-height: 28px;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+.ctic-value--link::after {
+  content: '\203A';
+  font-weight: 700;
+  opacity: 0.85;
+}
+.ctic-value--link:hover,
+.ctic-value--link:active {
+  color: #bfdbfe;
+  background: rgba(147, 197, 253, 0.24);
+  text-decoration: underline;
+}
+.ctic-value--link:focus-visible {
+  outline: 2px solid var(--OrbitLightBlue);
+  outline-offset: 1px;
 }
 
 .ctic-sub {

--- a/composables/useAllCtoonsQuery.js
+++ b/composables/useAllCtoonsQuery.js
@@ -1,0 +1,15 @@
+// Serializes an All cToons filter + tab into a router query object,
+// matching the shape pages/newsite/allCtoons.vue reads back on mount.
+export function filterToQuery(filter, tab) {
+  const query = {}
+  if (filter.name)                    query.name      = filter.name
+  if (filter.rarities.length)         query.rarities  = filter.rarities.join(',')
+  if (filter.owned !== 'all')         query.owned     = filter.owned
+  if (filter.wishlist)                query.wishlist  = 'true'
+  if (filter.sortField !== 'name')    query.sortField = filter.sortField
+  if (!filter.sortAsc)                query.sortAsc   = 'false'
+  if (filter.set)                     query.set       = filter.set
+  if (filter.series)                  query.series    = filter.series
+  if (tab !== 'AllSets')              query.tab       = tab
+  return query
+}

--- a/pages/newsite/allCtoons.vue
+++ b/pages/newsite/allCtoons.vue
@@ -34,18 +34,7 @@ Object.assign(filter.value, {
 activeTab.value = q.tab === 'AllSeries' ? 'AllSeries' : 'AllSets'
 
 watch([filter, activeTab], () => {
-  const f = filter.value
-  const query = {}
-  if (f.name)                   query.name      = f.name
-  if (f.rarities.length)        query.rarities  = f.rarities.join(',')
-  if (f.owned !== 'all')        query.owned     = f.owned
-  if (f.wishlist)               query.wishlist  = 'true'
-  if (f.sortField !== 'name')   query.sortField = f.sortField
-  if (!f.sortAsc)               query.sortAsc   = 'false'
-  if (f.set)                    query.set       = f.set
-  if (f.series)                 query.series    = f.series
-  if (activeTab.value !== 'AllSets') query.tab  = activeTab.value
-  router.replace({ query })
+  router.replace({ query: filterToQuery(filter.value, activeTab.value) })
 }, { deep: true })
 </script>
 


### PR DESCRIPTION
## Summary
This PR adds interactive filtering capabilities to the cToon info card by making the Set and Series fields clickable links that navigate to the All cToons page with pre-applied filters.

## Key Changes

- **CtoonInfoCard.vue**: 
  - Converted static Set and Series values into `NuxtLink` components that navigate to `/newsite/allCtoons` with appropriate filter query parameters
  - Added `goToFiltered()` function to handle navigation with smart behavior: when already on the All cToons page, it mutates the filter state directly for immediate UI updates; otherwise it lets the link navigate normally
  - Implemented `buildFilterLinkTarget()` to construct filter objects that preserve user's current Ownership/Wishlist/Sort preferences while clearing Name/Rarity filters (which could hide items in the selected set/series)
  - Added computed properties `setLinkQuery` and `seriesLinkQuery` to generate proper query strings
  - Added styling for `.ctic-value--link` class with hover states and a decorative arrow indicator
  - Displays "N/A" when Set or Series values are empty

- **AllCtoons.vue**:
  - Added visual filter chip display at the top showing active Set/Series filters
  - Each chip includes a clear button (✕) to remove the filter
  - Styled with proper spacing, truncation for long names, and hover effects

- **useAllCtoonsQuery.js** (new):
  - Extracted filter-to-query serialization logic into a reusable `filterToQuery()` utility function
  - Handles all filter parameters and tab state with sensible defaults

- **allCtoons.vue (page)**:
  - Refactored to use the new `filterToQuery()` utility, reducing code duplication

## Notable Implementation Details

- Respects modifier keys (Ctrl/Cmd/Shift/Alt) and middle-click to allow native browser "open in new tab" behavior
- When navigating within the All cToons page, prevents redundant router calls by directly mutating shared filter state
- Clears stale Name and Rarity filters to ensure the selected set/series items are visible
- Includes proper accessibility labels and focus-visible outlines for keyboard navigation

https://claude.ai/code/session_01HzyvtmF63WbTbcuR5X94aG