### PR TITLE
Add admin Favicon upload tab that regenerates the site's icon set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "nodemailer": "^7.0.6",
         "nuxt": "^3.17.2",
         "pg": "^8.15.6",
+        "png-to-ico": "^2.1.8",
         "sharp": "^0.33.5",
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
@@ -11348,6 +11349,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -12698,6 +12708,38 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/png-to-ico": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/png-to-ico/-/png-to-ico-2.1.8.tgz",
+      "integrity": "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.36",
+        "minimist": "^1.2.6",
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "png-to-ico": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/png-to-ico/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "nodemailer": "^7.0.6",
     "nuxt": "^3.17.2",
     "pg": "^8.15.6",
+    "png-to-ico": "^2.1.8",
     "sharp": "^0.33.5",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",

--- a/pages/admin/manage-homepage.vue
+++ b/pages/admin/manage-homepage.vue
@@ -6,28 +6,31 @@
     <div class="bg-white rounded-lg shadow-md p-6 max-w-4xl mx-auto">
       <!-- Tabs -->
       <div class="border-b mb-6">
-        <nav class="flex gap-4">
+        <nav class="flex gap-1 sm:gap-4 overflow-x-auto flex-nowrap -mb-px">
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Homepage' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Homepage'">Homepage</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Home' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Home'">Home</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Sidebar' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Sidebar'">Sidebar</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Release Settings' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Release Settings'">Release Settings</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Other' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Other'">Other</button>
-
+          <button
+            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
+            :class="activeTab==='Favicon' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
+            @click="activeTab='Favicon'">Favicon</button>
         </nav>
       </div>
 
@@ -390,6 +393,56 @@
         </div>
       </section>
 
+      <!-- Favicon tab -->
+      <section v-if="activeTab==='Favicon'" class="space-y-6">
+        <p class="text-sm text-gray-600">
+          Upload one image (PNG, JPG, or WEBP) and it will replace the site's favicon and all
+          meta/touch icons used site-wide. It will be automatically cropped to a centered square.
+          Changes may take a minute to appear everywhere due to browser caching.
+        </p>
+
+        <div class="border rounded p-4 space-y-3">
+          <h2 class="font-semibold">Master Icon Image</h2>
+          <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+            <div class="relative w-32 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
+              <img v-if="faviconPreviewUrl || faviconSourcePath" :src="faviconPreviewUrl || faviconSourcePath" alt="Favicon preview" class="max-h-full max-w-full object-contain" @load="onFaviconPreviewLoad" />
+              <span v-else class="text-gray-400 text-xs">No image</span>
+              <!-- Square crop-boundary overlay so admins can see what will be kept before saving -->
+              <div v-if="faviconPreviewUrl" class="pointer-events-none absolute inset-0 flex items-center justify-center">
+                <div class="border-2 border-dashed border-indigo-500/80" :style="cropOverlayStyle"></div>
+              </div>
+            </div>
+            <div class="space-y-2 flex-1 min-w-0">
+              <label for="favicon-file-input" class="block text-sm font-medium text-gray-700">Choose image</label>
+              <input id="favicon-file-input" type="file" accept="image/png,image/jpeg,.jpg,.jpeg,.png,image/webp,.webp"
+                @change="onFaviconFile($event)" class="block w-full text-sm" />
+              <p v-if="faviconPreviewUrl" class="text-xs text-gray-500">
+                Dashed box shows the centered square that will be used — anything outside it is cropped away.
+              </p>
+              <div v-if="faviconFile" class="text-xs text-gray-600 truncate">Selected: {{ faviconFile.name }}</div>
+            </div>
+          </div>
+
+          <!-- A handful of representative generated sizes — not all ~20, to keep this usable on mobile -->
+          <div v-if="faviconPreviewUrl" class="flex items-end gap-4 pt-2">
+            <div v-for="s in [16, 32, 96, 180]" :key="s" class="flex flex-col items-center gap-1">
+              <img :src="faviconPreviewUrl" :style="{ width: Math.min(s, 64) + 'px', height: Math.min(s, 64) + 'px' }" class="object-cover border rounded" :alt="s + 'px preview'" />
+              <span class="text-[10px] text-gray-500">{{ s }}px</span>
+            </div>
+          </div>
+
+          <div class="mt-2">
+            <button class="btn-primary inline-flex items-center gap-2" :disabled="!faviconFile || faviconSaving" @click="saveFavicon">
+              <svg v-if="faviconSaving" class="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+              </svg>
+              <span v-if="!faviconSaving">Save Favicon</span><span v-else>Generating icons… this can take a few seconds</span>
+            </button>
+          </div>
+        </div>
+      </section>
+
       <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded',
                                  toast.type==='error'?'bg-red-100 text-red-700':'bg-green-100 text-green-700']">
         {{ toast.msg }}
@@ -459,6 +512,61 @@ const middleSidebarFiles = reactive({ 1: null, 2: null, 3: null })
 
 const saving = ref(false)
 const toast  = ref(null)
+
+// Favicon tab state
+const faviconFile = ref(null)
+const faviconPreviewUrl = ref(null)
+const faviconSourcePath = ref('')
+const faviconSaving = ref(false)
+const faviconBoxPx = 128 // matches the w-32 h-32 preview box
+const cropOverlayStyle = ref({ width: `${faviconBoxPx}px`, height: `${faviconBoxPx}px` })
+
+function onFaviconPreviewLoad(e) {
+  const img = e.target
+  const nw = img.naturalWidth
+  const nh = img.naturalHeight
+  if (!nw || !nh) return
+  // Replicate object-contain's rendered size within the fixed preview box,
+  // then draw the centered square crop boundary sharp will actually keep.
+  const scale = Math.min(faviconBoxPx / nw, faviconBoxPx / nh)
+  const dispW = nw * scale
+  const dispH = nh * scale
+  const side = Math.min(dispW, dispH)
+  cropOverlayStyle.value = { width: `${side}px`, height: `${side}px` }
+}
+
+function onFaviconFile(e) {
+  const f = e.target.files?.[0] || null
+  try { if (faviconPreviewUrl.value) { URL.revokeObjectURL(faviconPreviewUrl.value); faviconPreviewUrl.value = null } } catch (e) {}
+  faviconFile.value = f
+  if (f) faviconPreviewUrl.value = URL.createObjectURL(f)
+}
+
+async function loadFaviconConfig() {
+  try {
+    const cfg = await $fetch('/api/admin/favicon')
+    faviconSourcePath.value = cfg.faviconSourcePath || ''
+  } catch {}
+}
+
+async function saveFavicon() {
+  if (!faviconFile.value) return
+  faviconSaving.value = true; toast.value = null
+  try {
+    const fd = new FormData()
+    fd.append('image', faviconFile.value)
+    const res = await $fetch('/api/admin/favicon', { method: 'POST', body: fd })
+    faviconSourcePath.value = res.faviconSourcePath || ''
+    try { if (faviconPreviewUrl.value) URL.revokeObjectURL(faviconPreviewUrl.value) } catch (e) {}
+    faviconPreviewUrl.value = null
+    faviconFile.value = null
+    toast.value = { type: 'ok', msg: 'Favicon updated. It may take a minute to appear everywhere due to browser caching.' }
+  } catch (e) {
+    console.error(e); toast.value = { type: 'error', msg: e?.data?.statusMessage || e?.statusMessage || 'Save failed' }
+  } finally {
+    faviconSaving.value = false; setTimeout(() => { toast.value = null }, 4000)
+  }
+}
 
 // Release settings state
 const releasePercent = ref(75)
@@ -603,6 +711,7 @@ onBeforeUnmount(() => {
     const u = previewUrls.value[k]
     if (u) { try { URL.revokeObjectURL(u) } catch (e) {} }
   }
+  if (faviconPreviewUrl.value) { try { URL.revokeObjectURL(faviconPreviewUrl.value) } catch (e) {} }
 })
 
 async function loadConfig() {
@@ -765,6 +874,7 @@ async function saveOther() {
 }
 
 onMounted(loadConfig)
+onMounted(loadFaviconConfig)
 
 
 onMounted(async () => {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -399,6 +399,15 @@ onBeforeUnmount(() => { clearTimeout(timer); abortCtrl.abort() })
 /* ── SEO (existing) ─────────────────────────────────────────── */
 const url = useRequestURL()
 const siteName = 'Cartoon ReOrbit'
+
+// Cache-busting for the favicon/meta-icon set: admin-uploaded icons overwrite
+// the same filenames in place, so a version query string is the only way
+// browsers pick up an update without a hard refresh.
+const { data: globalConfig } = await useAsyncData('global-config-public', () => $fetch('/api/global-config'))
+const faviconV = computed(() => globalConfig.value?.faviconVersion ? `?v=${globalConfig.value.faviconVersion}` : '')
+function iconHref(path) {
+  return `${path}${faviconV.value}`
+}
 const title = 'Cartoon ReOrbit — Free Fan-Made Cartoon Orbit Remake'
 const description = 'Collect cToons, build cZones, and trade through live auctions and mini-games. Free, community-driven remake of Cartoon Orbit. Not affiliated with Cartoon Network.'
 const ogImage = 'https://www.cartoonreorbit.com/images/atom-icon.png'
@@ -426,19 +435,20 @@ useHead({
   htmlAttrs: { lang: 'en' },
   link: [
     { rel: 'canonical', href: url.href },
-    { rel: 'apple-touch-icon', sizes: '57x57', href: '/images/apple-icon-57x57.png' },
-    { rel: 'apple-touch-icon', sizes: '60x60', href: '/images/apple-icon-60x60.png' },
-    { rel: 'apple-touch-icon', sizes: '72x72', href: '/images/apple-icon-72x72.png' },
-    { rel: 'apple-touch-icon', sizes: '76x76', href: '/images/apple-icon-76x76.png' },
-    { rel: 'apple-touch-icon', sizes: '114x114', href: '/images/apple-icon-114x114.png' },
-    { rel: 'apple-touch-icon', sizes: '120x120', href: '/images/apple-icon-120x120.png' },
-    { rel: 'apple-touch-icon', sizes: '144x144', href: '/images/apple-icon-144x144.png' },
-    { rel: 'apple-touch-icon', sizes: '152x152', href: '/images/apple-icon-152x152.png' },
-    { rel: 'apple-touch-icon', sizes: '180x180', href: '/images/apple-icon-180x180.png' },
-    { rel: 'icon', type: 'image/png', sizes: '192x192', href: '/images/android-icon-192x192.png' },
-    { rel: 'icon', type: 'image/png', sizes: '32x32',  href: '/images/favicon-32x32.png' },
-    { rel: 'icon', type: 'image/png', sizes: '96x96',  href: '/images/favicon-96x96.png' },
-    { rel: 'icon', type: 'image/png', sizes: '16x16',  href: '/images/favicon-16x16.png' },
+    { rel: 'apple-touch-icon', sizes: '57x57', href: iconHref('/images/apple-icon-57x57.png') },
+    { rel: 'apple-touch-icon', sizes: '60x60', href: iconHref('/images/apple-icon-60x60.png') },
+    { rel: 'apple-touch-icon', sizes: '72x72', href: iconHref('/images/apple-icon-72x72.png') },
+    { rel: 'apple-touch-icon', sizes: '76x76', href: iconHref('/images/apple-icon-76x76.png') },
+    { rel: 'apple-touch-icon', sizes: '114x114', href: iconHref('/images/apple-icon-114x114.png') },
+    { rel: 'apple-touch-icon', sizes: '120x120', href: iconHref('/images/apple-icon-120x120.png') },
+    { rel: 'apple-touch-icon', sizes: '144x144', href: iconHref('/images/apple-icon-144x144.png') },
+    { rel: 'apple-touch-icon', sizes: '152x152', href: iconHref('/images/apple-icon-152x152.png') },
+    { rel: 'apple-touch-icon', sizes: '180x180', href: iconHref('/images/apple-icon-180x180.png') },
+    { rel: 'icon', type: 'image/png', sizes: '192x192', href: iconHref('/images/android-icon-192x192.png') },
+    { rel: 'icon', type: 'image/png', sizes: '32x32',  href: iconHref('/images/favicon-32x32.png') },
+    { rel: 'icon', type: 'image/png', sizes: '96x96',  href: iconHref('/images/favicon-96x96.png') },
+    { rel: 'icon', type: 'image/png', sizes: '16x16',  href: iconHref('/images/favicon-16x16.png') },
+    { rel: 'shortcut icon', href: iconHref('/images/favicon.ico') },
     { rel: 'manifest', href: '/images/manifest.json' },
   ],
   meta: [
@@ -447,7 +457,7 @@ useHead({
     { name: 'viewport', content: 'width=device-width, initial-scale=1' },
     { name: 'format-detection', content: 'telephone=no' },
     { name: 'msapplication-TileColor', content: '#ffffff' },
-    { name: 'msapplication-TileImage', content: '/images/ms-icon-144x144.png' },
+    { name: 'msapplication-TileImage', content: iconHref('/images/ms-icon-144x144.png') },
     { name: 'theme-color', content: '#ffffff' },
   ],
   script: [

--- a/prisma/migrations/20260730020000_favicon_config/migration.sql
+++ b/prisma/migrations/20260730020000_favicon_config/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: site favicon/meta-icon config, uploaded from Admin > Manage Homepage > Favicon
+ALTER TABLE "GlobalGameConfig" ADD COLUMN "faviconVersion" BIGINT;
+ALTER TABLE "GlobalGameConfig" ADD COLUMN "faviconSourcePath" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1089,6 +1089,11 @@ model GlobalGameConfig {
   featuredDissolveRarities       Json     @default("[]")
   featuredDissolveSeries         Json     @default("[]")
   featuredDissolveSets           Json     @default("[]")
+  // Site favicon / meta-icon set, uploaded from Admin > Manage Homepage > Favicon.
+  // faviconVersion is bumped on every upload and appended as a cache-busting
+  // query string to every icon URL rendered in pages/index.vue's useHead.
+  faviconVersion                 BigInt?
+  faviconSourcePath              String? // original master upload, retained for re-generation/audit
   createdAt                      DateTime @default(now())
   updatedAt                      DateTime @updatedAt
 }

--- a/server/api/admin/favicon.get.js
+++ b/server/api/admin/favicon.get.js
@@ -1,0 +1,15 @@
+// server/api/admin/favicon.get.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const cfg = await db.globalGameConfig.findUnique({ where: { id: 'singleton' } })
+  return {
+    faviconVersion: cfg?.faviconVersion ? cfg.faviconVersion.toString() : null,
+    faviconSourcePath: cfg?.faviconSourcePath ?? null
+  }
+})

--- a/server/api/admin/favicon.post.js
+++ b/server/api/admin/favicon.post.js
@@ -1,0 +1,204 @@
+// server/api/admin/favicon.post.js
+// Uploads a single master image, then regenerates the full site favicon /
+// meta-icon set (used site-wide, by every visitor) from it via sharp.
+//
+// Output filenames are fixed constants only — never derived from client
+// input — because they overwrite the exact paths already referenced by
+// pages/index.vue's useHead(). Writes are atomic (temp file + rename) so a
+// concurrent visitor request never sees a half-updated icon set.
+import {
+  defineEventHandler,
+  readMultipartFormData,
+  getRequestHeader,
+  createError
+} from 'h3'
+import { mkdir, writeFile, rename, rm } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'node:crypto'
+import sharp from 'sharp'
+import pngToIco from 'png-to-ico'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const baseDir = process.env.NODE_ENV === 'production'
+  ? join(__dirname, '..', '..', '..')
+  : process.cwd()
+
+// Raster only — SVG is deliberately not accepted. Untrusted SVG rasterized by
+// librsvg (and any future path that might pass an uploaded SVG through as-is)
+// is an XXE/script-injection risk that's out of proportion for an asset
+// served to every site visitor.
+const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/webp'])
+const MAX_BYTES = 5 * 1024 * 1024 // 5MB
+const MAX_INPUT_PIXELS = 30_000_000 // guards against decompression-bomb-style crafted images
+
+// Fixed output filenames — must match pages/index.vue's useHead() exactly.
+const PNG_SIZES = [
+  { name: 'favicon-16x16.png', size: 16 },
+  { name: 'favicon-32x32.png', size: 32 },
+  { name: 'favicon-96x96.png', size: 96 },
+  { name: 'android-icon-36x36.png', size: 36 },
+  { name: 'android-icon-48x48.png', size: 48 },
+  { name: 'android-icon-72x72.png', size: 72 },
+  { name: 'android-icon-96x96.png', size: 96 },
+  { name: 'android-icon-144x144.png', size: 144 },
+  { name: 'android-icon-192x192.png', size: 192 },
+  { name: 'apple-icon-57x57.png', size: 57 },
+  { name: 'apple-icon-60x60.png', size: 60 },
+  { name: 'apple-icon-72x72.png', size: 72 },
+  { name: 'apple-icon-76x76.png', size: 76 },
+  { name: 'apple-icon-114x114.png', size: 114 },
+  { name: 'apple-icon-120x120.png', size: 120 },
+  { name: 'apple-icon-144x144.png', size: 144 },
+  { name: 'apple-icon-152x152.png', size: 152 },
+  { name: 'apple-icon-180x180.png', size: 180 },
+  { name: 'apple-icon.png', size: 180 },
+  { name: 'apple-icon-precomposed.png', size: 180 },
+  { name: 'ms-icon-70x70.png', size: 70 },
+  { name: 'ms-icon-144x144.png', size: 144 },
+  { name: 'ms-icon-150x150.png', size: 150 },
+  { name: 'ms-icon-310x310.png', size: 310 }
+]
+const ICO_SOURCE_SIZES = [16, 32, 48]
+const ICO_NAME = 'favicon.ico'
+const MASTER_PREFIX = 'favicon-master-'
+
+export default defineEventHandler(async (event) => {
+  // 1) Admin check
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  // 2) Parse multipart
+  const parts = await readMultipartFormData(event)
+  let imagePart = null
+  for (const part of parts || []) {
+    if (part.filename && part.name === 'image') imagePart = part
+  }
+  if (!imagePart) throw createError({ statusCode: 400, statusMessage: 'Image required.' })
+  if (!ALLOWED_TYPES.has(imagePart.type)) {
+    throw createError({ statusCode: 400, statusMessage: 'PNG, JPG, or WEBP only.' })
+  }
+  if (!imagePart.data || imagePart.data.length > MAX_BYTES) {
+    throw createError({ statusCode: 400, statusMessage: 'Image must be 5MB or smaller.' })
+  }
+
+  // 3) Decode + auto-orient (EXIF) up front, so downstream width/height and
+  // the crop box always match what will actually be rendered — this also
+  // fails closed on anything sharp can't parse, which rejects mismatched/
+  // spoofed Content-Type since sharp sniffs the real file header rather than
+  // trusting it.
+  let orientedBuffer, meta
+  try {
+    orientedBuffer = await sharp(imagePart.data, { limitInputPixels: MAX_INPUT_PIXELS })
+      .rotate()
+      .toBuffer()
+    meta = await sharp(orientedBuffer).metadata()
+    if (!meta.width || !meta.height) throw new Error('no dimensions')
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Could not read image — file may be corrupt, too large, or an unsupported format.' })
+  }
+
+  // 4) Center-crop to square so every generated size is a clean square icon
+  const side = Math.min(meta.width, meta.height)
+  const squareBuffer = await sharp(orientedBuffer)
+    .extract({
+      left: Math.floor((meta.width - side) / 2),
+      top: Math.floor((meta.height - side) / 2),
+      width: side,
+      height: side
+    })
+    .png()
+    .toBuffer()
+
+  // 5) Generate every fixed-size PNG variant
+  const generated = await Promise.all(
+    PNG_SIZES.map(async ({ name, size }) => ({
+      name,
+      buffer: await sharp(squareBuffer).resize(size, size).png().toBuffer()
+    }))
+  )
+
+  // 6) Encode favicon.ico from a few representative sizes
+  const icoSourceBuffers = await Promise.all(
+    ICO_SOURCE_SIZES.map((size) => sharp(squareBuffer).resize(size, size).png().toBuffer())
+  )
+  let icoBuffer
+  try {
+    icoBuffer = await pngToIco(icoSourceBuffers)
+  } catch {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to encode favicon.ico.' })
+  }
+
+  // 7) Retain the master upload (for re-generation/audit — derived variants
+  // alone give no way to redo the crop or recover the original later)
+  const masterExt = imagePart.type === 'image/png' ? '.png'
+    : imagePart.type === 'image/webp' ? '.webp'
+    : '.jpg'
+  const masterFilename = `${MASTER_PREFIX}${Date.now()}${masterExt}`
+
+  const uploadDir = process.env.NODE_ENV === 'production'
+    ? join(baseDir, 'cartoon-reorbit-images')
+    : join(baseDir, 'public', 'images')
+  await mkdir(uploadDir, { recursive: true })
+
+  // 8) Atomic writes: write every file to a temp name in the same directory,
+  // then rename() into place (atomic on the same filesystem) only once all
+  // renders succeeded — so a mid-batch failure never leaves a mismatched
+  // icon set live, and no visitor ever reads a partially-written file.
+  const allOutputs = [...generated, { name: ICO_NAME, buffer: icoBuffer }, { name: masterFilename, buffer: imagePart.data }]
+  const tmpSuffix = `.tmp-${randomUUID()}`
+  const written = []
+  try {
+    await Promise.all(allOutputs.map(async ({ name, buffer }) => {
+      const tmpPath = join(uploadDir, `${name}${tmpSuffix}`)
+      await writeFile(tmpPath, buffer)
+      written.push(tmpPath)
+    }))
+    await Promise.all(allOutputs.map(({ name }) =>
+      rename(join(uploadDir, `${name}${tmpSuffix}`), join(uploadDir, name))
+    ))
+  } catch (err) {
+    await Promise.all(written.map((p) => rm(p, { force: true }).catch(() => {})))
+    throw createError({ statusCode: 500, statusMessage: 'Failed to save favicon files.' })
+  }
+
+  const faviconVersion = BigInt(Date.now())
+  // Both prod (cartoon-reorbit-images/) and dev (public/images/) write to a
+  // directory served at the same /images/ URL prefix.
+  const masterAssetPath = `/images/${masterFilename}`
+
+  // 9) Persist + audit log
+  const before = await db.globalGameConfig.findUnique({ where: { id: 'singleton' } })
+  await db.globalGameConfig.upsert({
+    where: { id: 'singleton' },
+    create: { id: 'singleton', faviconVersion, faviconSourcePath: masterAssetPath },
+    update: { faviconVersion, faviconSourcePath: masterAssetPath }
+  })
+
+  try {
+    await logAdminChange(db, {
+      userId: me.id,
+      area: 'GlobalGameConfig',
+      key: 'faviconVersion',
+      prevValue: before?.faviconSourcePath ?? null,
+      newValue: masterAssetPath
+    })
+  } catch {}
+
+  // Best-effort cleanup of the previous master upload so these don't
+  // accumulate on disk indefinitely.
+  if (before?.faviconSourcePath?.startsWith('/images/') && before.faviconSourcePath.includes(MASTER_PREFIX)) {
+    const prevFilename = before.faviconSourcePath.slice('/images/'.length)
+    if (prevFilename !== masterFilename) {
+      await rm(join(uploadDir, prevFilename), { force: true }).catch(() => {})
+    }
+  }
+
+  return {
+    faviconVersion: faviconVersion.toString(),
+    faviconSourcePath: masterAssetPath
+  }
+})

--- a/server/api/global-config.get.js
+++ b/server/api/global-config.get.js
@@ -14,6 +14,7 @@ export default defineEventHandler(async () => {
     czoneCount: cfg?.czoneCount ?? 3,
     secondEditionOverlayPath:   cfg?.secondEditionOverlayPath   ?? null,
     secondEditionOverlayWidth:  cfg?.secondEditionOverlayWidth  ?? null,
-    secondEditionOverlayHeight: cfg?.secondEditionOverlayHeight ?? null
+    secondEditionOverlayHeight: cfg?.secondEditionOverlayHeight ?? null,
+    faviconVersion: cfg?.faviconVersion ? cfg.faviconVersion.toString() : null
   }
 })


### PR DESCRIPTION
## Summary
- Adds a "Favicon" tab to Admin > Manage Homepage where an admin uploads one master image (PNG/JPG/WEBP)
- Server center-crops it to a square and regenerates the full fixed-size favicon/apple-touch/android/ms-icon PNG set plus `favicon.ico` (via `sharp` + `png-to-ico`), atomically overwriting the same files already referenced by `pages/index.vue`'s `useHead()` (write-to-temp then rename, so visitors never see a half-updated icon set)
- A `faviconVersion` timestamp on `GlobalGameConfig` is bumped on each upload and appended as a cache-busting query string to every icon link/meta tag on the homepage
- Fixes the admin tab bar to scroll horizontally instead of overflowing on narrow viewports now that there's a 6th tab

## Security
- Raster-only input (SVG rejected, to avoid librsvg XXE/script-injection risk on an asset served to every site visitor)
- `limitInputPixels` guard against decompression-bomb-style crafted images
- EXIF auto-rotation applied before cropping so the on-screen preview matches the generated output
- Fully static output filenames, never derived from client input
- Action is audit-logged via `logAdminChange`

## Architecture notes
- New standalone endpoint (`server/api/admin/favicon.post.js` / `.get.js`) rather than reusing the existing multi-slot `/api/admin/homepage` endpoint, since favicon generation (fixed-name overwrite + ico encoding) is a fundamentally different write pattern than that endpoint's timestamped-slot uploads
- New fields live on `GlobalGameConfig` (the existing global-singleton config model), matching the precedent set by the "Second Edition overlay" feature, rather than on `HomepageConfig`

## Test plan
- [x] `npx prisma generate` succeeds against the updated schema
- [x] `nuxt build` succeeds, including the new `admin/favicon.post` / `admin/favicon.get` routes and the updated `global-config.get` route
- [ ] Manually upload a favicon in a deployed environment and confirm the site's favicon/touch icons update
- [ ] Confirm `prisma migrate deploy` applies the new migration cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WzLTGD1Ynv3Pi19z7WDz2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzLTGD1Ynv3Pi19z7WDz2F)_