### PR TITLE
Economy page follow-ups: fix avg points and empty price data, add inflation metrics

### DIFF
--- a/components/newsite/Economy.vue
+++ b/components/newsite/Economy.vue
@@ -42,10 +42,29 @@
     <section class="economy-section">
       <h2 class="section-title">Net Points Issued</h2>
       <p class="section-sub">Daily points earned minus spent, last 30 days (dashed line = 7-day average)</p>
-      <div v-if="netPoints?.length" class="chart-container">
+      <div v-if="netSeries.length" class="chart-container">
         <canvas ref="netCanvas"></canvas>
       </div>
       <p v-else class="empty-note">No points activity recorded yet.</p>
+      <p class="chart-note">
+        A net of 0 means no point inflation. Positive net means inflation; negative net means deflation.
+      </p>
+
+      <div v-if="inflation" class="inflation-row">
+        <div class="inflation-card">
+          <div class="stat-label">Inflation — Year to Date</div>
+          <div class="stat-value">{{ formatPercent(inflation.ytdPct) }}</div>
+          <div class="stat-foot">{{ inflationWord(inflation.ytdPct) }} since Jan 1</div>
+        </div>
+        <div class="inflation-card">
+          <div class="stat-label">Inflation — Last 30 Days</div>
+          <div class="stat-value">{{ formatPercent(inflation.last30Pct) }}</div>
+          <div class="stat-foot">{{ inflationWord(inflation.last30Pct) }} over 30 days</div>
+        </div>
+      </div>
+      <p v-if="inflation" class="chart-note">
+        Measured as the change in the circulating player point supply over each period.
+      </p>
     </section>
 
     <!-- Trending -->
@@ -181,9 +200,11 @@ const { data: trending, refresh: refreshTrending } = useFetch('/api/economy/tren
 
 watch(windowValue, () => refreshTrending())
 
-// Net points issued (last 30 days) — not window-dependent, so it isn't
-// refetched when the window toggle changes.
+// Net points issued (last 30 days) + inflation rates — not window-dependent,
+// so it isn't refetched when the window toggle changes.
 const { data: netPoints } = useFetch('/api/economy/net-points', { headers })
+const netSeries = computed(() => netPoints.value?.series || [])
+const inflation = computed(() => netPoints.value?.inflation || null)
 
 const netPointsClass = computed(() => {
   const v = summary.value?.netPoints7d
@@ -195,7 +216,7 @@ const netCanvas = ref(null)
 let netChart = null
 
 async function renderNetChart() {
-  if (!netPoints.value?.length) return
+  if (!netSeries.value.length) return
   await nextTick()
   if (!netCanvas.value) return
   if (netChart) netChart.destroy()
@@ -203,11 +224,11 @@ async function renderNetChart() {
   netChart = new Chart(netCanvas.value.getContext('2d'), {
     type: 'line',
     data: {
-      labels: netPoints.value.map(p => p.period.slice(5)), // MM-DD
+      labels: netSeries.value.map(p => p.period.slice(5)), // MM-DD
       datasets: [
         {
           label: 'Net points',
-          data: netPoints.value.map(p => p.net),
+          data: netSeries.value.map(p => p.net),
           borderColor: '#66CC00',
           backgroundColor: '#66CC00',
           borderWidth: 2,
@@ -216,7 +237,7 @@ async function renderNetChart() {
         },
         {
           label: '7-day avg',
-          data: netPoints.value.map(p => p.movingAvg7Day),
+          data: netSeries.value.map(p => p.movingAvg7Day),
           borderColor: '#FFB000',
           backgroundColor: '#FFB000',
           borderWidth: 2,
@@ -309,6 +330,19 @@ function formatSigned(n) {
   if (n == null) return '—'
   const v = Number(n)
   return `${v >= 0 ? '+' : '−'}${Math.abs(v).toLocaleString()}`
+}
+
+function formatPercent(n) {
+  if (n == null) return 'N/A'
+  const v = Number(n)
+  return `${v >= 0 ? '+' : '−'}${Math.abs(v).toFixed(2)}%`
+}
+
+function inflationWord(n) {
+  if (n == null) return 'Not enough data'
+  if (n > 0) return 'Inflation'
+  if (n < 0) return 'Deflation'
+  return 'Flat'
 }
 
 function formatPrice(n) {
@@ -413,6 +447,29 @@ function formatPrice(n) {
   position: relative;
   height: 220px;
   padding: 4px;
+}
+
+.chart-note {
+  margin: 8px 0 0;
+  font-size: 0.72rem;
+  opacity: 0.6;
+  line-height: 1.35;
+}
+
+.inflation-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.inflation-card {
+  flex: 1 1 160px;
+  min-width: 0;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  padding: 10px 14px;
 }
 
 .economy-section {

--- a/components/newsite/Economy.vue
+++ b/components/newsite/Economy.vue
@@ -18,7 +18,15 @@
     <div class="stat-row">
       <div class="stat-card">
         <div class="stat-label">Avg Points / Player</div>
-        <div class="stat-value">{{ summary ? formatNumber(summary.avgPointsPerPlayer) : '—' }}</div>
+        <div class="stat-value">{{ summary ? formatNumber(summary.avgPointsPerPlayer, 0) : '—' }}</div>
+        <div v-if="summary" class="stat-foot">Median {{ formatNumber(summary.medianPointsPerPlayer) }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Net Points (7d)</div>
+        <div class="stat-value" :class="netPointsClass">
+          {{ summary ? formatSigned(summary.netPoints7d) : '—' }}
+        </div>
+        <div v-if="summary" class="stat-foot">Issued minus spent</div>
       </div>
       <div class="stat-card">
         <div class="stat-label">Total Trades</div>
@@ -29,6 +37,16 @@
         <div class="stat-value">{{ summary ? formatNumber(summary.totalAuctionVolume) : '—' }}</div>
       </div>
     </div>
+
+    <!-- Net points issued -->
+    <section class="economy-section">
+      <h2 class="section-title">Net Points Issued</h2>
+      <p class="section-sub">Daily points earned minus spent, last 30 days (dashed line = 7-day average)</p>
+      <div v-if="netPoints?.length" class="chart-container">
+        <canvas ref="netCanvas"></canvas>
+      </div>
+      <p v-else class="empty-note">No points activity recorded yet.</p>
+    </section>
 
     <!-- Trending -->
     <section class="economy-section">
@@ -118,8 +136,14 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import { useRequestHeaders } from '#app'
+import {
+  Chart, LineController, LineElement, PointElement,
+  LinearScale, CategoryScale, Tooltip, Legend
+} from 'chart.js'
+
+Chart.register(LineController, LineElement, PointElement, LinearScale, CategoryScale, Tooltip, Legend)
 
 const headers = process.server ? useRequestHeaders(['cookie']) : undefined
 
@@ -157,8 +181,78 @@ const { data: trending, refresh: refreshTrending } = useFetch('/api/economy/tren
 
 watch(windowValue, () => refreshTrending())
 
+// Net points issued (last 30 days) — not window-dependent, so it isn't
+// refetched when the window toggle changes.
+const { data: netPoints } = useFetch('/api/economy/net-points', { headers })
+
+const netPointsClass = computed(() => {
+  const v = summary.value?.netPoints7d
+  if (v == null) return ''
+  return v >= 0 ? 'stat-value--pos' : 'stat-value--neg'
+})
+
+const netCanvas = ref(null)
+let netChart = null
+
+async function renderNetChart() {
+  if (!netPoints.value?.length) return
+  await nextTick()
+  if (!netCanvas.value) return
+  if (netChart) netChart.destroy()
+
+  netChart = new Chart(netCanvas.value.getContext('2d'), {
+    type: 'line',
+    data: {
+      labels: netPoints.value.map(p => p.period.slice(5)), // MM-DD
+      datasets: [
+        {
+          label: 'Net points',
+          data: netPoints.value.map(p => p.net),
+          borderColor: '#66CC00',
+          backgroundColor: '#66CC00',
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0.15
+        },
+        {
+          label: '7-day avg',
+          data: netPoints.value.map(p => p.movingAvg7Day),
+          borderColor: '#FFB000',
+          backgroundColor: '#FFB000',
+          borderWidth: 2,
+          borderDash: [5, 5],
+          pointRadius: 0,
+          tension: 0.15
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: { position: 'top', labels: { color: '#fff', boxWidth: 12 } },
+        tooltip: { mode: 'index', intersect: false }
+      },
+      scales: {
+        x: {
+          ticks: { color: '#fff', maxTicksLimit: 6, autoSkip: true },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        },
+        y: {
+          ticks: { color: '#fff', maxTicksLimit: 6 },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        }
+      }
+    }
+  })
+}
+
+watch(netPoints, renderNetChart)
+
 let pollHandle = null
 onMounted(() => {
+  renderNetChart()
   pollHandle = setInterval(() => {
     if (anyModalOpen.value) return
     refreshSummary()
@@ -167,6 +261,7 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   if (pollHandle) clearInterval(pollHandle)
+  if (netChart) netChart.destroy()
 })
 
 // Browse all cToons
@@ -205,9 +300,15 @@ async function loadBrowse() {
 
 watch([debouncedQuery, browsePage], loadBrowse, { immediate: true })
 
-function formatNumber(n) {
+function formatNumber(n, maximumFractionDigits = 0) {
   if (n == null) return '—'
-  return Number(n).toLocaleString()
+  return Number(n).toLocaleString(undefined, { maximumFractionDigits })
+}
+
+function formatSigned(n) {
+  if (n == null) return '—'
+  const v = Number(n)
+  return `${v >= 0 ? '+' : '−'}${Math.abs(v).toLocaleString()}`
 }
 
 function formatPrice(n) {
@@ -292,6 +393,26 @@ function formatPrice(n) {
 .stat-value {
   font-size: 1.3rem;
   font-weight: 800;
+}
+
+.stat-value--pos {
+  color: #8CE046;
+}
+
+.stat-value--neg {
+  color: #FF8A7A;
+}
+
+.stat-foot {
+  margin-top: 2px;
+  font-size: 0.68rem;
+  opacity: 0.6;
+}
+
+.chart-container {
+  position: relative;
+  height: 220px;
+  padding: 4px;
 }
 
 .economy-section {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "achievements": "node server/workers/achievements.worker.js",
     "content-analyzer": "node server/workers/content-analyzer.worker.js",
     "guildchecker": "node ./server/cron/sync-guild-members.js",
+    "economy:aggregate": "node ./server/cron/economy-aggregate-run.js",
     "build": "nuxt build",
     "start": "nuxt start",
     "lint": "eslint .",

--- a/prisma/migrations/20260730040000_pointslog_createdat_idx/migration.sql
+++ b/prisma/migrations/20260730040000_pointslog_createdat_idx/migration.sql
@@ -1,0 +1,3 @@
+-- Supports the date-ranged aggregate scans over PointsLog used by the Economy
+-- page (net points issued, inflation rates) and the admin analytics charts.
+CREATE INDEX IF NOT EXISTS "PointsLog_createdAt_idx" ON "PointsLog"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -881,6 +881,8 @@ model PointsLog {
   createdAt DateTime @default(now())
 
   user User @relation(fields: [userId], references: [id])
+
+  @@index([createdAt])
 }
 
 model GameConfig {

--- a/server/api/economy/net-points.get.js
+++ b/server/api/economy/net-points.get.js
@@ -1,14 +1,16 @@
 // GET /api/economy/net-points
 // Daily net points issued (earned - spent) for the last 30 days, with the same
-// 7-day moving average the admin analytics chart uses. Same query shape as
-// server/api/admin/net-points-issues.get.js (daily branch), but fixed to a
-// 30-day window and readable by any logged-in player — the series is a pure
+// 7-day moving average the admin analytics chart uses, plus year-to-date and
+// trailing-30-day inflation rates. Series query matches
+// server/api/admin/net-points-issues.get.js (daily branch), fixed to a 30-day
+// window and readable by any logged-in player — everything here is an
 // economy-wide aggregate with no per-user data in it.
 import { defineEventHandler, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { redis } from '@/server/utils/redis'
+import { EXCLUDED_SYSTEM_USER_ID } from '@/server/utils/economyValuation'
 
-const CACHE_KEY = 'economy:net-points:30d:v1'
+const CACHE_KEY = 'economy:net-points:30d:v2'
 const CACHE_TTL = 300 // 5 min — PointsLog changes constantly but this is a 30-day trend
 
 async function computeSeries() {
@@ -62,6 +64,65 @@ async function computeSeries() {
   }))
 }
 
+// Point inflation = growth of the circulating player point supply over a
+// period, as a percentage of what the supply was at the start of it.
+// Supply at the start is derived by subtracting the period's net issuance
+// from today's supply, so no historical snapshot table is needed.
+//
+// The official/system account is excluded from both the supply and the net:
+// its balance is a static house hoard, not circulating player wealth, and
+// leaving it in the denominator would flatten every rate to ~0%.
+async function computeInflation() {
+  const rows = await prisma.$queryRaw`
+    WITH players AS (
+      SELECT u.id
+      FROM "User" u
+      WHERE u."active" = true
+        AND COALESCE(u."banned", false) = false
+        AND u."id" <> ${EXCLUDED_SYSTEM_USER_ID}
+    ),
+    supply AS (
+      SELECT COALESCE(SUM(up."points"), 0)::bigint AS total
+      FROM "UserPoints" up
+      JOIN players p ON p.id = up."userId"
+    ),
+    ytd AS (
+      SELECT COALESCE(SUM(CASE WHEN pl."direction" = 'increase' THEN pl."points" ELSE -pl."points" END), 0)::bigint AS net
+      FROM "PointsLog" pl
+      JOIN players p ON p.id = pl."userId"
+      WHERE pl."createdAt" >= date_trunc('year', now())
+    ),
+    last30 AS (
+      SELECT COALESCE(SUM(CASE WHEN pl."direction" = 'increase' THEN pl."points" ELSE -pl."points" END), 0)::bigint AS net
+      FROM "PointsLog" pl
+      JOIN players p ON p.id = pl."userId"
+      WHERE pl."createdAt" >= now() - INTERVAL '30 days'
+    )
+    SELECT supply.total AS "supply", ytd.net AS "netYtd", last30.net AS "net30d"
+    FROM supply, ytd, last30
+  `
+
+  const row = rows[0] || {}
+  const supply = Number(row.supply || 0)
+  const netYtd = Number(row.netYtd || 0)
+  const net30d = Number(row.net30d || 0)
+
+  // A rate is only meaningful if there was a positive supply to grow from.
+  const rate = (net) => {
+    const startingSupply = supply - net
+    if (!Number.isFinite(startingSupply) || startingSupply <= 0) return null
+    return Math.round((net / startingSupply) * 10000) / 100
+  }
+
+  return {
+    currentSupply: supply,
+    netYtd,
+    net30d,
+    ytdPct: rate(netYtd),
+    last30Pct: rate(net30d)
+  }
+}
+
 export default defineEventHandler(async (event) => {
   if (!event.context.userId) {
     throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
@@ -72,10 +133,12 @@ export default defineEventHandler(async (event) => {
     if (cached) return JSON.parse(cached)
   } catch {}
 
-  const series = await computeSeries()
+  const [series, inflation] = await Promise.all([computeSeries(), computeInflation()])
+  const payload = { series, inflation }
+
   try {
-    await redis.set(CACHE_KEY, JSON.stringify(series), 'EX', CACHE_TTL)
+    await redis.set(CACHE_KEY, JSON.stringify(payload), 'EX', CACHE_TTL)
   } catch {}
 
-  return series
+  return payload
 })

--- a/server/api/economy/net-points.get.js
+++ b/server/api/economy/net-points.get.js
@@ -1,0 +1,81 @@
+// GET /api/economy/net-points
+// Daily net points issued (earned - spent) for the last 30 days, with the same
+// 7-day moving average the admin analytics chart uses. Same query shape as
+// server/api/admin/net-points-issues.get.js (daily branch), but fixed to a
+// 30-day window and readable by any logged-in player — the series is a pure
+// economy-wide aggregate with no per-user data in it.
+import { defineEventHandler, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+
+const CACHE_KEY = 'economy:net-points:30d:v1'
+const CACHE_TTL = 300 // 5 min — PointsLog changes constantly but this is a 30-day trend
+
+async function computeSeries() {
+  // The moving average needs 6 days of lead-in before the window starts,
+  // otherwise the first points of the chart average over a short window.
+  const rows = await prisma.$queryRaw`
+    WITH
+      bounds AS (
+        SELECT (now() - INTERVAL '36 days')::date AS start_day,
+               now()::date                        AS end_day
+      ),
+      day_series AS (
+        SELECT generate_series((SELECT start_day FROM bounds),
+                               (SELECT end_day   FROM bounds),
+                               '1 day')::date AS period
+      ),
+      agg AS (
+        SELECT
+          date_trunc('day', "createdAt")::date AS period,
+          SUM(CASE WHEN "direction" = 'increase' THEN "points" ELSE 0 END)::bigint AS earned,
+          SUM(CASE WHEN "direction" = 'decrease' THEN "points" ELSE 0 END)::bigint AS spent
+        FROM "PointsLog"
+        WHERE "createdAt" >= (SELECT start_day FROM bounds)
+          AND "createdAt" <  (SELECT end_day FROM bounds) + INTERVAL '1 day'
+        GROUP BY 1
+      ),
+      joined AS (
+        SELECT ds.period,
+               COALESCE(a.earned, 0) AS earned,
+               COALESCE(a.spent, 0)  AS spent
+        FROM day_series ds
+        LEFT JOIN agg a ON a.period = ds.period
+      )
+    SELECT
+      period,
+      earned,
+      spent,
+      (earned - spent) AS net,
+      ROUND(AVG(earned - spent) OVER (ORDER BY period ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)::numeric, 2) AS net_ma7
+    FROM joined
+    ORDER BY period;
+  `
+
+  // Drop the moving-average lead-in so the chart shows exactly 30 days.
+  return rows.slice(-30).map(r => ({
+    period: r.period instanceof Date ? r.period.toISOString().slice(0, 10) : String(r.period),
+    earned: Number(r.earned),
+    spent: Number(r.spent),
+    net: Number(r.net),
+    movingAvg7Day: Number(r.net_ma7)
+  }))
+}
+
+export default defineEventHandler(async (event) => {
+  if (!event.context.userId) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  try {
+    const cached = await redis.get(CACHE_KEY)
+    if (cached) return JSON.parse(cached)
+  } catch {}
+
+  const series = await computeSeries()
+  try {
+    await redis.set(CACHE_KEY, JSON.stringify(series), 'EX', CACHE_TTL)
+  } catch {}
+
+  return series
+})

--- a/server/api/economy/summary.get.js
+++ b/server/api/economy/summary.get.js
@@ -1,29 +1,48 @@
 // GET /api/economy/summary
-// Top-of-page stat tiles for the Economy page: average points per player and
-// overall trade/auction volume (all-time counts, not filtered by window).
+// Top-of-page stat tiles for the Economy page: average points per player,
+// overall trade/auction volume, and net points issued over the last 7 days.
 import { defineEventHandler, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { redis } from '@/server/utils/redis'
+import { EXCLUDED_SYSTEM_USER_ID } from '@/server/utils/economyValuation'
 
-const CACHE_KEY = 'economy:summary:v1'
+const CACHE_KEY = 'economy:summary:v2'
 const CACHE_TTL = 60 // seconds — matches the page's polling interval, no point hitting Postgres more often
 
 async function computeSummary() {
-  const [pointsAgg, totalTradeVolume, totalAuctionVolume] = await Promise.all([
+  const [pointsAgg, totalTradeVolume, totalAuctionVolume, netPointsAgg] = await Promise.all([
+    // Median alongside the mean: point balances are heavily right-skewed, so the
+    // mean alone overstates what a typical player actually holds.
     prisma.$queryRaw`
-      SELECT AVG(up."points")::float AS "avgPoints"
+      SELECT
+        AVG(up."points")::float AS "avgPoints",
+        (PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY up."points"))::float AS "medianPoints"
       FROM "UserPoints" up
       JOIN "User" u ON u.id = up."userId"
-      WHERE u."active" = true AND COALESCE(u."banned", false) = false
+      WHERE u."active" = true
+        AND COALESCE(u."banned", false) = false
+        AND u."id" <> ${EXCLUDED_SYSTEM_USER_ID}
     `,
     prisma.tradeOffer.count({ where: { status: 'ACCEPTED' } }),
-    prisma.auction.count({ where: { status: 'CLOSED', winnerId: { not: null } } })
+    prisma.auction.count({ where: { status: 'CLOSED', winnerId: { not: null } } }),
+    prisma.$queryRaw`
+      SELECT
+        SUM(CASE WHEN "direction" = 'increase' THEN "points" ELSE 0 END)::bigint AS "earned",
+        SUM(CASE WHEN "direction" = 'decrease' THEN "points" ELSE 0 END)::bigint AS "spent"
+      FROM "PointsLog"
+      WHERE "createdAt" >= NOW() - INTERVAL '7 days'
+    `
   ])
+
+  const earned = Number(netPointsAgg[0]?.earned || 0)
+  const spent = Number(netPointsAgg[0]?.spent || 0)
 
   return {
     avgPointsPerPlayer: Math.round((pointsAgg[0]?.avgPoints || 0) * 100) / 100,
+    medianPointsPerPlayer: Math.round(pointsAgg[0]?.medianPoints || 0),
     totalTradeVolume,
-    totalAuctionVolume
+    totalAuctionVolume,
+    netPoints7d: earned - spent
   }
 }
 

--- a/server/cron/economy-aggregate-run.js
+++ b/server/cron/economy-aggregate-run.js
@@ -1,0 +1,34 @@
+// server/cron/economy-aggregate-run.js
+// One-off runner for the Economy page aggregation, so the first backfill
+// doesn't have to wait for the 4:10am cron.
+//
+//   npm run economy:aggregate            # incremental (only days with new activity)
+//   npm run economy:aggregate -- --full  # reset the cursor and rebuild all history
+import 'dotenv/config'
+import { prisma } from '../prisma.js'
+import { runEconomyAggregate, resetEconomyCursor } from './economy-aggregate.js'
+
+const full = process.argv.includes('--full')
+
+async function main() {
+  if (full) {
+    console.log('[economy-aggregate] --full: resetting cursor, rebuilding all history')
+    await resetEconomyCursor()
+  }
+  await runEconomyAggregate()
+
+  const [auctionRows, tradeRows] = await Promise.all([
+    prisma.ctoonPriceDaily.count({ where: { source: 'AUCTION' } }),
+    prisma.ctoonPriceDaily.count({ where: { source: 'TRADE' } })
+  ])
+  console.log(`[economy-aggregate] CtoonPriceDaily now holds ${auctionRows} auction row(s), ${tradeRows} trade row(s)`)
+}
+
+main()
+  .catch((err) => {
+    console.error('[economy-aggregate] fatal:', err)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/server/cron/economy-aggregate.js
+++ b/server/cron/economy-aggregate.js
@@ -2,7 +2,8 @@
 // Daily aggregation for the Economy page: turns raw Auction/TradeOffer
 // activity into per-cToon-per-day price/volume rows (CtoonPriceDaily),
 // which server/api/economy/* reads live. Scheduled from
-// server/cron/sync-guild-members.js.
+// server/cron/sync-guild-members.js; can also be run on demand with
+// `npm run economy:aggregate` (useful for the first backfill).
 //
 // AUCTION rows come straight from closed+won Auctions (real prices).
 // TRADE rows don't have a native per-cToon price — trades swap cToons (and
@@ -18,14 +19,25 @@
 // not a historical snapshot as of the trade's date — acceptable for a
 // trend-level economy view, but means a full backfill re-prices old trades
 // using today's averages rather than what was known at the time.
+//
+// Incremental runs find which *days* saw new activity since the cursor, then
+// recompute those days in full. Recomputing only the new rows would corrupt
+// the average for a day that was already partially aggregated.
 import { prisma } from '../prisma.js'
 import { getAuctionReferenceValues, getCmartPrices, pickReferenceValue } from '../utils/economyValuation.js'
 
 const LOCK_KEY = 847362910 // arbitrary constant unique to this job, for pg_try_advisory_lock
 const SAFETY_BUFFER_MS = 5 * 60 * 1000 // re-scan a trailing window each run to catch stragglers
+const INSERT_CHUNK = 2000
+
+function chunk(arr, size) {
+  const out = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
 
 async function withAdvisoryLock(fn) {
-  const [{ locked }] = await prisma.$queryRaw`SELECT pg_try_advisory_lock(${LOCK_KEY}) AS locked`
+  const [{ locked }] = await prisma.$queryRaw`SELECT pg_try_advisory_lock(${LOCK_KEY}::bigint) AS locked`
   if (!locked) {
     console.log('[economy-aggregate] another run already holds the lock, skipping')
     return
@@ -33,7 +45,7 @@ async function withAdvisoryLock(fn) {
   try {
     await fn()
   } finally {
-    await prisma.$queryRaw`SELECT pg_advisory_unlock(${LOCK_KEY})`
+    await prisma.$queryRaw`SELECT pg_advisory_unlock(${LOCK_KEY}::bigint)`
   }
 }
 
@@ -45,93 +57,139 @@ async function getCursor() {
   })
 }
 
-async function aggregateAuctionDays(sinceDate) {
-  const days = await prisma.$queryRaw`
-    SELECT DISTINCT date_trunc('day', a."winnerAt") AS day
-    FROM "Auction" a
-    WHERE a.status = 'CLOSED' AND a."winnerId" IS NOT NULL AND a."winnerAt" > ${sinceDate}
-  `
-  for (const { day } of days) {
-    const rows = await prisma.$queryRaw`
-      SELECT uc."ctoonId" AS "ctoonId", AVG(a."highestBid")::float AS "avgPrice", COUNT(*)::int AS "volume"
-      FROM "Auction" a
-      JOIN "UserCtoon" uc ON a."userCtoonId" = uc.id
-      WHERE a.status = 'CLOSED' AND a."winnerId" IS NOT NULL
-        AND date_trunc('day', a."winnerAt") = ${day}
-      GROUP BY uc."ctoonId"
-    `
-    for (const row of rows) {
-      await prisma.ctoonPriceDaily.upsert({
-        where: { ctoonId_source_date: { ctoonId: row.ctoonId, source: 'AUCTION', date: day } },
-        create: { ctoonId: row.ctoonId, source: 'AUCTION', date: day, avgPrice: row.avgPrice, volume: row.volume },
-        update: { avgPrice: row.avgPrice, volume: row.volume }
-      })
-    }
-  }
-  return days.length
+// Replace every row for the affected days in one shot. Delete-then-insert is
+// correct here because each affected day is recomputed in full above.
+async function replaceDays(source, dates, rows) {
+  if (!dates.length) return
+  await prisma.$transaction([
+    prisma.ctoonPriceDaily.deleteMany({ where: { source, date: { in: dates } } }),
+    ...chunk(rows, INSERT_CHUNK).map(batch =>
+      prisma.ctoonPriceDaily.createMany({ data: batch, skipDuplicates: true })
+    )
+  ])
 }
 
-async function aggregateTradeDays(sinceDate) {
-  const days = await prisma.$queryRaw`
-    SELECT DISTINCT date_trunc('day', "updatedAt") AS day
+async function aggregateAuctions(sinceDate) {
+  // COALESCE to endAt because winnerAt was only added in the
+  // 20250611235321_auction_bids_and_winner migration — every auction closed
+  // before then has winnerAt NULL (the old closedAt column was dropped), and
+  // keying on winnerAt alone silently skips all of that history.
+  const rows = await prisma.$queryRaw`
+    WITH touched AS (
+      SELECT DISTINCT date_trunc('day', COALESCE(a."winnerAt", a."endAt")) AS d
+      FROM "Auction" a
+      WHERE a.status = 'CLOSED'
+        AND a."winnerId" IS NOT NULL
+        AND COALESCE(a."winnerAt", a."endAt") > ${sinceDate}
+    )
+    SELECT
+      uc."ctoonId" AS "ctoonId",
+      date_trunc('day', COALESCE(a."winnerAt", a."endAt")) AS "date",
+      AVG(a."highestBid")::float AS "avgPrice",
+      COUNT(*)::int AS "volume"
+    FROM "Auction" a
+    JOIN "UserCtoon" uc ON a."userCtoonId" = uc.id
+    WHERE a.status = 'CLOSED'
+      AND a."winnerId" IS NOT NULL
+      AND date_trunc('day', COALESCE(a."winnerAt", a."endAt")) IN (SELECT d FROM touched)
+    GROUP BY 1, 2
+  `
+
+  const dates = [...new Set(rows.map(r => r.date.getTime()))].map(t => new Date(t))
+  await replaceDays('AUCTION', dates, rows.map(r => ({
+    ctoonId: r.ctoonId,
+    source: 'AUCTION',
+    date: r.date,
+    avgPrice: r.avgPrice,
+    volume: r.volume
+  })))
+
+  return { days: dates.length, rows: rows.length }
+}
+
+async function aggregateTrades(sinceDate) {
+  const dayRows = await prisma.$queryRaw`
+    SELECT DISTINCT date_trunc('day', "updatedAt") AS d
     FROM "TradeOffer"
     WHERE status = 'ACCEPTED' AND "updatedAt" > ${sinceDate}
   `
-  for (const { day } of days) {
-    const nextDay = new Date(day.getTime() + 24 * 60 * 60 * 1000)
-    const offers = await prisma.tradeOffer.findMany({
-      where: { status: 'ACCEPTED', updatedAt: { gte: day, lt: nextDay } },
-      select: {
-        pointsOffered: true,
-        ctoons: { select: { userCtoon: { select: { ctoonId: true } } } }
-      }
-    })
-    if (!offers.length) continue
+  const days = dayRows.map(r => r.d).filter(Boolean)
+  if (!days.length) return { days: 0, rows: 0 }
 
-    const allCtoonIds = [...new Set(offers.flatMap(o => o.ctoons.map(c => c.userCtoon.ctoonId)))]
-    const [auctionRefs, cmartPrices] = await Promise.all([
-      getAuctionReferenceValues(allCtoonIds),
-      getCmartPrices(allCtoonIds)
-    ])
+  const rangeStart = new Date(Math.min(...days.map(d => d.getTime())))
+  const rangeEnd = new Date(Math.max(...days.map(d => d.getTime())) + 24 * 60 * 60 * 1000)
 
-    // ctoonId -> running total so multiple trades touching the same cToon
-    // on the same day average together into one daily row.
-    const perCtoon = new Map()
+  const offers = await prisma.tradeOffer.findMany({
+    where: { status: 'ACCEPTED', updatedAt: { gte: rangeStart, lt: rangeEnd } },
+    select: {
+      updatedAt: true,
+      pointsOffered: true,
+      ctoons: { select: { userCtoon: { select: { ctoonId: true } } } }
+    }
+  })
+  if (!offers.length) return { days: 0, rows: 0 }
 
-    for (const offer of offers) {
-      const ctoonIds = offer.ctoons.map(c => c.userCtoon.ctoonId)
-      if (!ctoonIds.length) continue
+  const allCtoonIds = [...new Set(offers.flatMap(o => o.ctoons.map(c => c.userCtoon.ctoonId)))]
+  const [auctionRefs, cmartPrices] = await Promise.all([
+    getAuctionReferenceValues(allCtoonIds),
+    getCmartPrices(allCtoonIds)
+  ])
 
-      let knownValueSum = offer.pointsOffered || 0
-      let knownCount = 0
-      for (const ctoonId of ctoonIds) {
-        const ref = pickReferenceValue(ctoonId, auctionRefs, cmartPrices)
-        if (ref != null) {
-          knownValueSum += ref
-          knownCount++
-        }
-      }
-      if (knownCount === 0) continue // nothing in this trade has a known value to impute from
+  // dayKey -> ctoonId -> running total, so multiple trades touching the same
+  // cToon on the same day average together into one daily row.
+  const byDay = new Map()
 
-      const impliedValue = knownValueSum / knownCount
-      for (const ctoonId of ctoonIds) {
-        const agg = perCtoon.get(ctoonId) || { sum: 0, count: 0 }
-        agg.sum += impliedValue
-        agg.count += 1
-        perCtoon.set(ctoonId, agg)
+  for (const offer of offers) {
+    const ctoonIds = offer.ctoons.map(c => c.userCtoon.ctoonId)
+    if (!ctoonIds.length) continue
+
+    let knownValueSum = offer.pointsOffered || 0
+    let knownCount = 0
+    for (const ctoonId of ctoonIds) {
+      const ref = pickReferenceValue(ctoonId, auctionRefs, cmartPrices)
+      if (ref != null) {
+        knownValueSum += ref
+        knownCount++
       }
     }
+    if (knownCount === 0) continue // nothing in this trade has a known value to impute from
 
-    for (const [ctoonId, agg] of perCtoon) {
-      const avgPrice = agg.sum / agg.count
-      await prisma.ctoonPriceDaily.upsert({
-        where: { ctoonId_source_date: { ctoonId, source: 'TRADE', date: day } },
-        create: { ctoonId, source: 'TRADE', date: day, avgPrice, volume: agg.count },
-        update: { avgPrice, volume: agg.count }
+    const impliedValue = knownValueSum / knownCount
+    const day = new Date(Date.UTC(
+      offer.updatedAt.getUTCFullYear(),
+      offer.updatedAt.getUTCMonth(),
+      offer.updatedAt.getUTCDate()
+    ))
+    const dayKey = day.getTime()
+
+    const dayMap = byDay.get(dayKey) || new Map()
+    for (const ctoonId of ctoonIds) {
+      const agg = dayMap.get(ctoonId) || { sum: 0, count: 0 }
+      agg.sum += impliedValue
+      agg.count += 1
+      dayMap.set(ctoonId, agg)
+    }
+    byDay.set(dayKey, dayMap)
+  }
+
+  const dates = []
+  const rows = []
+  for (const [dayKey, dayMap] of byDay) {
+    const date = new Date(dayKey)
+    dates.push(date)
+    for (const [ctoonId, agg] of dayMap) {
+      rows.push({
+        ctoonId,
+        source: 'TRADE',
+        date,
+        avgPrice: agg.sum / agg.count,
+        volume: agg.count
       })
     }
   }
-  return days.length
+
+  await replaceDays('TRADE', dates, rows)
+  return { days: dates.length, rows: rows.length }
 }
 
 export async function runEconomyAggregate() {
@@ -139,8 +197,8 @@ export async function runEconomyAggregate() {
     const cursor = await getCursor()
     const runStartedAt = new Date()
 
-    const auctionDayCount = await aggregateAuctionDays(cursor.lastAuctionProcessedAt)
-    const tradeDayCount = await aggregateTradeDays(cursor.lastTradeProcessedAt)
+    const auctions = await aggregateAuctions(cursor.lastAuctionProcessedAt)
+    const trades = await aggregateTrades(cursor.lastTradeProcessedAt)
 
     const newCursor = new Date(runStartedAt.getTime() - SAFETY_BUFFER_MS)
     await prisma.economyAggregateCursor.update({
@@ -148,6 +206,19 @@ export async function runEconomyAggregate() {
       data: { lastAuctionProcessedAt: newCursor, lastTradeProcessedAt: newCursor }
     })
 
-    console.log(`[economy-aggregate] processed ${auctionDayCount} auction day(s), ${tradeDayCount} trade day(s)`)
+    console.log(
+      `[economy-aggregate] auctions: ${auctions.days} day(s)/${auctions.rows} row(s), ` +
+      `trades: ${trades.days} day(s)/${trades.rows} row(s)`
+    )
+  })
+}
+
+// Reset the cursor so the next run re-scans and rebuilds all history.
+export async function resetEconomyCursor() {
+  const epoch = new Date(0)
+  await prisma.economyAggregateCursor.upsert({
+    where: { id: 'singleton' },
+    create: { id: 'singleton', lastAuctionProcessedAt: epoch, lastTradeProcessedAt: epoch },
+    update: { lastAuctionProcessedAt: epoch, lastTradeProcessedAt: epoch }
   })
 }

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -1203,8 +1203,12 @@ cron.schedule('*/15 * * * *', runTournamentCron)
 cron.schedule('* * * * *', checkAndCreateWeeklyCZoneContest, { timezone: 'America/Chicago' })
 
 // Economy page daily price/volume aggregation — offset from the 3am achievements
-// run to avoid overlapping load on Auction/UserCtoon tables. Runs once on
-// startup too (advisory-lock + cursor guarded, so this is always safe/cheap)
-// so the first deploy doesn't have to wait until 4:10am for data to appear.
-await runEconomyAggregate()
+// run to avoid overlapping load on Auction/UserCtoon tables. Also kicked off once
+// on startup (advisory-lock + cursor guarded) so a fresh deploy doesn't wait until
+// 4:10am for data. Deliberately not awaited: the first run backfills all history
+// and must not delay registering the schedules below. Run it by hand at any time
+// with `npm run economy:aggregate`.
+runEconomyAggregate().catch(err =>
+  console.error('[economy-aggregate] startup run failed:', err?.message || err)
+)
 cron.schedule('10 4 * * *', runEconomyAggregate, { timezone: 'America/Chicago' })

--- a/server/utils/economyValuation.js
+++ b/server/utils/economyValuation.js
@@ -10,6 +10,12 @@ import { Prisma } from '@prisma/client'
 // return null (and the client should render "Not enough data yet") instead.
 export const MIN_SAMPLE_SIZE = 3
 
+// The official/system account. It holds an enormous point balance that isn't
+// real player wealth, so including it makes "average points per player" wildly
+// unrepresentative. Every leaderboard and the admin points-distribution chart
+// already exclude this same id.
+export const EXCLUDED_SYSTEM_USER_ID = '4f0e8b3b-7d0b-466b-99e7-8996c91d7eb3'
+
 // All-time average closed-auction sale price per cToon, batched across a
 // list of ctoonIds. Same underlying query as server/api/ctoon/valuations.post.js.
 export async function getAuctionReferenceValues(ctoonIds) {


### PR DESCRIPTION
Follow-up to #827 (merged). Three fixes and additions from testing the live Economy page.

## 1. Average points per player read ~2.4M

The official/system account (`4f0e8b3b…`) holds a balance near the int4 ceiling, which on its own produced the 2,412,618.97 figure. Every leaderboard and the admin points-distribution chart already exclude this same id; the Economy summary didn't. Now excluded, with a **median** shown alongside the mean since point balances are heavily right-skewed and the mean still overstates a typical player.

## 2. No auction or trade data appeared

The aggregation keyed auction days off `winnerAt` alone. That column was only added in the `20250611235321_auction_bids_and_winner` migration, which simultaneously dropped the old `closedAt` column — so every auction closed before then has `winnerAt` NULL and was silently skipped. Now keys off `COALESCE(winnerAt, endAt)`.

Also rewrote the job's write path to bulk `deleteMany` + `createMany` per affected day instead of row-by-row upserts, so a full backfill over the existing auction history is practical, and added an on-demand runner:

```
npm run economy:aggregate            # incremental
npm run economy:aggregate -- --full  # reset cursor, rebuild all history
```

The startup run is no longer awaited, so a long backfill can't delay registering the other cron schedules.

## 3. Net points issued and inflation metrics

- A "Net Points (7d)" stat tile and a 30-day daily net chart with the same 7-day moving average the admin analytics chart uses, via a new `/api/economy/net-points` endpoint that mirrors the admin query but is readable by any logged-in player (pure economy-wide aggregate, no per-user data).
- A caption under the chart: a net of 0 means no point inflation, positive means inflation, negative means deflation.
- Two new figures: **year-to-date** and **trailing-30-day** point inflation as percentages, derived as the change in circulating player point supply over each period. Supply at the start of a period is computed by subtracting that period's net issuance from today's supply, so no historical snapshot table is needed.

Two judgment calls worth review:

- The official/system account is excluded from **both** the supply and the net in the inflation math. Its balance is a static house hoard, and leaving it in the denominator flattens every rate to ~0%. The chart itself still includes all accounts, matching the admin graph.
- "Annual to date" is calendar year-to-date; "monthly" is a trailing 30 days rather than the current calendar month, to match the chart's own window.

## Schema change

Adds an index on `PointsLog(createdAt)` to support the year-to-date scan. The existing admin analytics date-range queries benefit from it too. It's a plain `CREATE INDEX IF NOT EXISTS`, so it will briefly lock writes on `PointsLog` — if that table is large, consider applying it with `CONCURRENTLY` by hand instead.

## Test plan

- [ ] Run `prisma migrate deploy` and confirm the `PointsLog_createdAt_idx` index is created.
- [ ] Run `npm run economy:aggregate -- --full` and confirm it reports a non-zero auction and trade row count.
- [ ] Load `/newsite/economy`; confirm avg points is now a plausible player figure and the median shows beneath it.
- [ ] Confirm trending, both Top-10 modals, and browse-list prices now show data instead of N/A.
- [ ] Confirm the net points chart renders with both series, and the YTD / 30-day inflation percentages look sane against the chart's direction.

*Built and syntax/schema-validated in a sandbox without a live Postgres/Redis instance, so the SQL hasn't been executed. The inflation query is the one most worth eyeballing against real data.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMs5Hom5G4RgdZjayoVjJ5)_