### PR TITLE
Add sort and gToon/Pokemon filters to the Economy page, and make it fluid-width

### DIFF
--- a/components/newsite/Economy.vue
+++ b/components/newsite/Economy.vue
@@ -14,7 +14,49 @@
       </div>
     </div>
 
+    <!-- Filters & sort. v-show rather than v-if so the id in aria-controls
+         always resolves to a real element. -->
+    <button
+      type="button"
+      class="filter-toggle"
+      :class="{ 'filter-toggle--active': activeFilterCount > 0 }"
+      :aria-expanded="filtersOpen ? 'true' : 'false'"
+      aria-controls="economy-filters"
+      @click="filtersOpen = !filtersOpen"
+    >
+      <span aria-hidden="true">{{ filtersOpen ? '▲' : '▼' }}</span>
+      <span>Filters &amp; Sort</span>
+      <span v-if="activeFilterCount" class="filter-badge" aria-hidden="true">{{ activeFilterCount }}</span>
+      <span v-if="activeFilterCount" class="sr-only">, {{ activeFilterCount }} active</span>
+    </button>
+
+    <div id="economy-filters" v-show="filtersOpen" class="filter-panel">
+      <div class="filter-group">
+        <label class="filter-label" for="economy-sort">Sort Browse All cToons</label>
+        <select id="economy-sort" v-model="filter.sort" class="filter-select">
+          <option v-for="opt in ECONOMY_SORTS" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+        </select>
+      </div>
+
+      <fieldset class="filter-group filter-fieldset">
+        <legend class="filter-label">Hide from Trending, Top 10 and Browse</legend>
+        <label class="filter-check">
+          <input type="checkbox" v-model="filter.hideGtoons" />
+          <span>Hide gToons</span>
+        </label>
+        <label class="filter-check">
+          <input type="checkbox" v-model="filter.hidePokemon" />
+          <span>Hide Pokémon cToons</span>
+        </label>
+      </fieldset>
+
+      <button type="button" class="filter-clear" :disabled="!activeFilterCount" @click="clearFilters">
+        Clear Filters
+      </button>
+    </div>
+
     <!-- Stat tiles -->
+    <p class="stat-note">Site-wide totals — the filters above don't apply here.</p>
     <div class="stat-row">
       <div class="stat-card">
         <div class="stat-label">Avg Points / Player</div>
@@ -38,10 +80,28 @@
       </div>
     </div>
 
+    <!-- Active exclusions stay visible while the panel is collapsed: they change
+         what every list below means, so hiding that in a closed accordion would
+         make them invisible global state. Each chip is its own undo. -->
+    <div v-if="exclusionChips.length" class="filter-chip-row" aria-live="polite">
+      <span class="filter-chip-label">Filters:</span>
+      <button
+        v-for="chip in exclusionChips"
+        :key="chip.key"
+        type="button"
+        class="filter-chip"
+        @click="filter[chip.key] = false"
+      >
+        {{ chip.label }} <span aria-hidden="true">×</span><span class="sr-only">, remove filter</span>
+      </button>
+    </div>
+
     <!-- Trending -->
     <section class="economy-section">
       <h2 class="section-title">Trending cToons</h2>
-      <p class="section-sub">By combined trade + auction activity ({{ windowLabel }})</p>
+      <p class="section-sub">
+        By combined trade + auction activity ({{ windowLabel }}){{ exclusionSuffix }}
+      </p>
       <ul v-if="trending?.length" class="ctoon-list">
         <li
           v-for="(row, idx) in trending"
@@ -57,12 +117,17 @@
           <span class="ctoon-metric">{{ row.volume }} txns</span>
         </li>
       </ul>
-      <p v-else class="empty-note">Not enough activity yet to show trends.</p>
+      <p v-else class="empty-note">
+        {{ activeExclusionCount
+          ? 'No trending cToons match your filters.'
+          : 'Not enough activity yet to show trends.' }}
+      </p>
     </section>
 
     <!-- Top 10 -->
     <section class="economy-section">
       <h2 class="section-title">Top 10 Most Valuable</h2>
+      <p v-if="activeExclusionCount" class="section-sub">Ranked among cToons matching your filters.</p>
       <div class="top10-buttons">
         <GreenButton @click="openTopValuable('AUCTION')">By Auction</GreenButton>
         <GreenButton @click="openTopValuable('TRADE')">By Trade</GreenButton>
@@ -72,6 +137,10 @@
     <!-- Browse all -->
     <section class="economy-section">
       <h2 class="section-title">Browse All cToons</h2>
+      <p class="section-sub">
+        {{ browseSortLabel }} · all-time figures — the time window above applies to
+        Trending and Top 10 only{{ exclusionSuffix }}
+      </p>
       <input
         v-model="searchInput"
         type="text"
@@ -91,6 +160,12 @@
         >
           <img v-if="row.assetPath" class="ctoon-thumb" :src="row.assetPath" :alt="row.name" />
           <span class="ctoon-name">{{ row.name }}</span>
+          <!-- Show the key the list was ordered by, or a volume sort looks like
+               it did nothing — most rows' prices read "N/A". -->
+          <span v-if="isVolumeSort" class="ctoon-price-chip ctoon-price-chip--sort">
+            <span class="chip-label">{{ volumeChipLabel }}</span>
+            <span>{{ formatVolume(row.sortVolume) }}</span>
+          </span>
           <span class="ctoon-price-chip">
             <span class="chip-label">Auction</span>
             <span>{{ formatPrice(row.avgAuctionPrice) }}</span>
@@ -101,7 +176,12 @@
           </span>
         </li>
       </ul>
-      <p v-else-if="!browsePending" class="empty-note">No cToons found.</p>
+      <p v-else-if="browseError" class="empty-note">
+        Couldn't load cToons just now — {{ browseError }}
+      </p>
+      <p v-else-if="!browsePending" class="empty-note">
+        {{ activeExclusionCount ? 'No cToons match your filters.' : 'No cToons found.' }}
+      </p>
       <div v-if="browseTotal > pageSize" class="pagination">
         <button type="button" :disabled="browsePage <= 1" @click="browsePage--">Prev</button>
         <span>Page {{ browsePage }} of {{ totalPages }}</span>
@@ -113,6 +193,8 @@
       v-if="showTopValuable"
       :source="topValuableSource"
       :window="windowValue"
+      :hide-gtoons="filter.hideGtoons"
+      :hide-pokemon="filter.hidePokemon"
       @close="showTopValuable = false"
       @select="openHistory"
     />
@@ -156,14 +238,55 @@ function openHistory(ctoonId) {
   historyCtoonId.value = ctoonId
 }
 
-// Summary + trending
-const { data: summary, refresh: refreshSummary } = useFetch('/api/economy/summary', { headers })
-const { data: trending, refresh: refreshTrending } = useFetch('/api/economy/trending', {
-  query: { window: windowValue },
-  headers
+// Sort + exclusion state, shared with pages/newsite/economy.vue for URL sync.
+const filter = useEconomyFilter()
+const filtersOpen = ref(false)
+
+// Sent as the app's usual `1` flag, or omitted entirely when off.
+const hideGtoonsParam = computed(() => (filter.value.hideGtoons ? '1' : undefined))
+const hidePokemonParam = computed(() => (filter.value.hidePokemon ? '1' : undefined))
+
+const activeExclusionCount = computed(
+  () => (filter.value.hideGtoons ? 1 : 0) + (filter.value.hidePokemon ? 1 : 0)
+)
+const activeFilterCount = computed(
+  () => activeExclusionCount.value + (filter.value.sort !== ECONOMY_FILTER_DEFAULTS.sort ? 1 : 0)
+)
+
+const exclusionChips = computed(() => {
+  const chips = []
+  if (filter.value.hideGtoons) chips.push({ key: 'hideGtoons', label: 'gToons hidden' })
+  if (filter.value.hidePokemon) chips.push({ key: 'hidePokemon', label: 'Pokémon hidden' })
+  return chips
 })
 
-watch(windowValue, () => refreshTrending())
+const exclusionSuffix = computed(() => {
+  const parts = []
+  if (filter.value.hideGtoons) parts.push('gToons')
+  if (filter.value.hidePokemon) parts.push('Pokémon')
+  if (!parts.length) return ''
+  return ` · excluding ${parts.join(' and ')}`
+})
+
+const browseSortLabel = computed(
+  () => ECONOMY_SORTS.find(s => s.value === filter.value.sort)?.label || ''
+)
+const isVolumeSort = computed(
+  () => filter.value.sort === 'tradeVolume' || filter.value.sort === 'auctionVolume'
+)
+const volumeChipLabel = computed(() => (filter.value.sort === 'tradeVolume' ? 'Trades' : 'Auctions'))
+
+function clearFilters() {
+  Object.assign(filter.value, ECONOMY_FILTER_DEFAULTS)
+}
+
+// Summary + trending. useFetch already refetches when a reactive `query` value
+// changes — an extra manual watch here would double every request.
+const { data: summary, refresh: refreshSummary } = useFetch('/api/economy/summary', { headers })
+const { data: trending, refresh: refreshTrending } = useFetch('/api/economy/trending', {
+  query: { window: windowValue, hideGtoons: hideGtoonsParam, hidePokemon: hidePokemonParam },
+  headers
+})
 
 const netPointsClass = computed(() => {
   const v = summary.value?.netPoints7d
@@ -196,28 +319,79 @@ const browsePage = ref(1)
 const pageSize = ref(20)
 const browseResults = ref([])
 const browseTotal = ref(0)
-const browsePending = ref(false)
+// Starts true so the "No cToons found." note doesn't flash before the first load.
+const browsePending = ref(true)
+const browseError = ref('')
 const totalPages = computed(() => Math.max(1, Math.ceil(browseTotal.value / pageSize.value)))
 
+// Filter toggles and the sort dropdown fire discrete events, so without both a
+// sequence guard and an abort a user flipping three of them can have the first
+// response land last, and a stale `finally` can clear the spinner while a newer
+// request is still in flight.
+let browseReqId = 0
+let browseAbort = null
+
 async function loadBrowse() {
+  const myId = ++browseReqId
+  browseAbort?.abort()
+  browseAbort = new AbortController()
   browsePending.value = true
   try {
     const res = await $fetch('/api/economy/ctoons/search', {
-      query: { q: debouncedQuery.value, page: browsePage.value },
-      headers
+      query: {
+        q: debouncedQuery.value,
+        page: browsePage.value,
+        sort: filter.value.sort,
+        hideGtoons: hideGtoonsParam.value,
+        hidePokemon: hidePokemonParam.value
+      },
+      headers,
+      signal: browseAbort.signal
     })
+    if (myId !== browseReqId) return
     browseResults.value = res.results
-    browseTotal.value = res.total
+    browseTotal.value = Number(res.total) || 0
     pageSize.value = res.pageSize
-  } catch {
-    browseResults.value = []
-    browseTotal.value = 0
+    browseError.value = ''
+  } catch (err) {
+    if (err?.name === 'AbortError' || myId !== browseReqId) return
+    // Keep the previous results on screen. Blanking the list would render
+    // "No cToons found." for what is actually a rate limit or a server error.
+    browseError.value = err?.statusCode === 429
+      ? 'too many requests, give it a moment.'
+      : 'please try again.'
   } finally {
-    browsePending.value = false
+    if (myId === browseReqId) browsePending.value = false
   }
 }
 
-watch([debouncedQuery, browsePage], loadBrowse, { immediate: true })
+// The filter controls aren't debounced by the search box's timer, and the
+// endpoint caps volume sorts at 10 requests/minute, so coalesce bursts here.
+let browseScheduleHandle = null
+function scheduleBrowse() {
+  if (browseScheduleHandle) clearTimeout(browseScheduleHandle)
+  browseScheduleHandle = setTimeout(loadBrowse, 200)
+}
+
+watch([debouncedQuery, browsePage], scheduleBrowse)
+watch(
+  () => [filter.value.sort, filter.value.hideGtoons, filter.value.hidePokemon],
+  () => {
+    // Reset synchronously here rather than in a watcher on browsePage: a
+    // separate watcher would queue a second load for the page change.
+    browsePage.value = 1
+    scheduleBrowse()
+  }
+)
+// Client-only: the response can't be awaited from setup, so an SSR fetch here
+// would never reach the rendered HTML — it would just be a wasted round trip on
+// every page render.
+if (process.client) loadBrowse()
+
+onBeforeUnmount(() => {
+  if (browseScheduleHandle) clearTimeout(browseScheduleHandle)
+  browseAbort?.abort()
+})
 
 function formatNumber(n, maximumFractionDigits = 0) {
   if (n == null) return '—'
@@ -230,9 +404,17 @@ function formatSigned(n) {
   return `${v >= 0 ? '+' : '−'}${Math.abs(v).toLocaleString()}`
 }
 
+// Prices below MIN_SAMPLE_SIZE transactions are withheld server-side to keep
+// individual trades anonymous, so a missing price means "not enough data yet",
+// not "free".
 function formatPrice(n) {
-  if (n == null) return 'N/A'
+  if (n == null) return '—'
   return `${Number(n).toLocaleString(undefined, { maximumFractionDigits: 0 })} pts`
+}
+
+function formatVolume(n) {
+  if (n == null) return '< 3'
+  return Number(n).toLocaleString()
 }
 </script>
 
@@ -282,6 +464,189 @@ function formatPrice(n) {
 
 .window-pill--active {
   background: var(--OrbitLightBlue, #3399CC);
+}
+
+/* Filters & sort.
+   This page's content box is a fixed var(--main-content-width, 800px) that the
+   layout pans horizontally on phones, so every control here is capped to the
+   leftmost ~340px — the part visible on a 390px viewport without panning.
+   Sizes are intrinsic rather than breakpoint-driven for the same reason: a
+   viewport media query can't tell you how much of an 800px box is on screen. */
+.filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 14px;
+  margin-bottom: 10px;
+  border-radius: 999px;
+  border: 2px solid var(--OrbitLightBlue, #3399CC);
+  background: transparent;
+  color: #fff;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+/* Filled as well as badged, so the active state doesn't rely on colour alone. */
+.filter-toggle--active {
+  background: var(--OrbitLightBlue, #3399CC);
+}
+
+.filter-toggle:focus-visible,
+.filter-select:focus-visible,
+.filter-check input:focus-visible,
+.filter-clear:focus-visible,
+.filter-chip:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: #fff;
+  color: #003466;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.filter-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 340px;
+  padding: 12px;
+  margin-bottom: 12px;
+  box-sizing: border-box;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.filter-fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.filter-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.75;
+  padding: 0;
+}
+
+.filter-select {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 44px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-family: inherit;
+  font-size: 1rem; /* >=16px so iOS Safari doesn't auto-zoom on focus */
+}
+
+.filter-select option {
+  background: #003466;
+  color: #fff;
+}
+
+.filter-check {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px; /* whole label is the tap target */
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.filter-check input {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  accent-color: var(--OrbitLightBlue, #3399CC);
+}
+
+.filter-clear {
+  min-height: 44px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.filter-clear:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Wraps rather than scrolls: a horizontal scroller nested inside an already
+   horizontally-panned page is close to unusable on touch. */
+.filter-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  max-width: 340px;
+  margin-bottom: 14px;
+}
+
+.filter-chip-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+}
+
+.filter-chip {
+  min-height: 36px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--OrbitLightBlue, #3399CC);
+  background: var(--OrbitLightBlue, #3399CC);
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.stat-note {
+  font-size: 0.7rem;
+  opacity: 0.6;
+  margin: 0 0 6px;
 }
 
 /* Horizontally-scrollable row instead of stacked full-width cards, so the
@@ -426,6 +791,10 @@ function formatPrice(n) {
   font-size: 0.65rem;
   text-transform: uppercase;
   opacity: 0.65;
+}
+
+.ctoon-price-chip--sort {
+  color: var(--OrbitLightGreen, #8CE046);
 }
 
 .search-input {

--- a/components/newsite/Economy.vue
+++ b/components/newsite/Economy.vue
@@ -419,9 +419,16 @@ function formatVolume(n) {
 </script>
 
 <style scoped>
+/* Fluid, like every other newsite page component (.ah, .cmart, .all-ctoons,
+   .leaderboards). On desktop the layout's .main-content is a fixed
+   var(--main-content-width) box, so this still resolves to 800px and the
+   internal vertical scroll is unchanged; at <=768px .main-content switches to
+   width:100% + overflow-x:auto, and a fixed min-width here is what used to
+   leave ~half the page off-screen behind a horizontal pan. */
 .economy {
-  width: var(--main-content-width, 800px);
-  min-width: var(--main-content-width, 800px);
+  width: 100%;
+  max-width: var(--main-content-width, 800px);
+  min-width: 0;
   height: 100%;
   padding: 16px;
   box-sizing: border-box;
@@ -466,12 +473,9 @@ function formatVolume(n) {
   background: var(--OrbitLightBlue, #3399CC);
 }
 
-/* Filters & sort.
-   This page's content box is a fixed var(--main-content-width, 800px) that the
-   layout pans horizontally on phones, so every control here is capped to the
-   leftmost ~340px — the part visible on a 390px viewport without panning.
-   Sizes are intrinsic rather than breakpoint-driven for the same reason: a
-   viewport media query can't tell you how much of an 800px box is on screen. */
+/* Filters & sort. The panel is capped well under the container width because
+   full-width form controls read as broken at 800px; it shrinks with the page on
+   narrow screens rather than being pinned to a breakpoint. */
 .filter-toggle {
   display: inline-flex;
   align-items: center;
@@ -521,6 +525,7 @@ function formatVolume(n) {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 100%;
   max-width: 340px;
   padding: 12px;
   margin-bottom: 12px;
@@ -601,14 +606,13 @@ function formatVolume(n) {
   cursor: not-allowed;
 }
 
-/* Wraps rather than scrolls: a horizontal scroller nested inside an already
-   horizontally-panned page is close to unusable on touch. */
+/* Wraps rather than scrolls, so no chip can end up off-screen on a narrow
+   viewport where it's also the only visible undo for an active filter. */
 .filter-chip-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-  max-width: 340px;
   margin-bottom: 14px;
 }
 
@@ -842,13 +846,44 @@ function formatVolume(n) {
   cursor: not-allowed;
 }
 
-@media (max-width: 640px) {
+/* 768px is the layout's own MOBILE_BREAKPOINT (layouts/newsite-template.vue) —
+   the point where .main-content stops being a fixed 800px box and starts
+   tracking the viewport. Below it this component is genuinely narrow; above it
+   it's always 800px no matter how wide the window is, so a smaller breakpoint
+   here would fire in a range where nothing had actually changed size. */
+@media (max-width: 768px) {
+  .economy {
+    padding: 12px;
+  }
+
   .economy-title {
     font-size: 1.3rem;
   }
 
   .ctoon-row--browse {
     align-items: flex-start;
+  }
+
+  /* Narrow enough that single-line ellipsis eats most of a real cToon name
+     ("1 Year Anniversary Miss Sara Bellum"). Wrapping costs a line; truncating
+     costs the identity of the row. */
+  .ctoon-name {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+
+  /* Let the name claim the rest of the thumbnail's line so the price chips wrap
+     underneath it. Otherwise the name is flex-shrinkable to nothing and three
+     70px chips truncate it to an ellipsis. 46px = 36px thumb + 10px row gap. */
+  .ctoon-row--browse .ctoon-name {
+    flex: 1 1 calc(100% - 46px);
+  }
+
+  /* Right-aligned chips read as misaligned once they wrap onto their own line. */
+  .ctoon-row--browse .ctoon-price-chip {
+    align-items: flex-start;
+    min-width: 64px;
   }
 }
 </style>

--- a/components/newsite/EconomyTopValuableModal.vue
+++ b/components/newsite/EconomyTopValuableModal.vue
@@ -1,7 +1,11 @@
 <template>
   <Modal close-on-backdrop @close="$emit('close')">
-    <h3 class="tv-title">Top 10 Most Valuable — {{ source === 'AUCTION' ? 'Auction' : 'Trade' }}</h3>
-    <p class="tv-sub">{{ windowLabel }} · anonymous aggregate data</p>
+    <!-- Count-aware: exclusions can leave fewer than 10 rows, and a "Top 10"
+         heading over four entries reads as a bug. -->
+    <h3 class="tv-title">
+      Top {{ rows.length || 10 }} Most Valuable — {{ source === 'AUCTION' ? 'Auction' : 'Trade' }}
+    </h3>
+    <p class="tv-sub">{{ windowLabel }} · anonymous aggregate data{{ exclusionSuffix }}</p>
 
     <p v-if="pending" class="tv-empty">Loading…</p>
     <p v-else-if="error" class="tv-empty">Couldn't load this list. Try again shortly.</p>
@@ -20,39 +24,73 @@
         <span class="tv-price">{{ formatPrice(row.avgPrice) }}</span>
       </li>
     </ul>
-    <p v-else class="tv-empty">Not enough {{ source === 'AUCTION' ? 'auction' : 'trade' }} activity yet.</p>
+    <p v-else class="tv-empty">
+      {{ exclusionSuffix
+        ? 'No cToons match your filters.'
+        : `Not enough ${source === 'AUCTION' ? 'auction' : 'trade'} activity yet.` }}
+    </p>
   </Modal>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 
 const props = defineProps({
   source: { type: String, required: true }, // 'AUCTION' | 'TRADE'
-  window: { type: String, default: 'all' }
+  window: { type: String, default: 'all' },
+  hideGtoons: { type: Boolean, default: false },
+  hidePokemon: { type: Boolean, default: false }
 })
 const emit = defineEmits(['close', 'select'])
 
 const WINDOW_LABELS = { '7d': 'Last 7 days', '30d': 'Last 30 days', all: 'All time' }
 const windowLabel = computed(() => WINDOW_LABELS[props.window] || 'All time')
 
+const exclusionSuffix = computed(() => {
+  const parts = []
+  if (props.hideGtoons) parts.push('gToons')
+  if (props.hidePokemon) parts.push('Pokémon')
+  return parts.length ? ` · excluding ${parts.join(' and ')}` : ''
+})
+
 const rows = ref([])
 const pending = ref(true)
 const error = ref(false)
 
-onMounted(async () => {
+// Watched rather than fetched once on mount: the modal stays open while the
+// window pill and filters behind it can still change, and it silently went
+// stale on a window change before this.
+let reqId = 0
+async function load() {
+  const myId = ++reqId
   pending.value = true
   error.value = false
   try {
-    rows.value = await $fetch('/api/economy/top-valuable', {
-      query: { source: props.source, window: props.window }
+    const res = await $fetch('/api/economy/top-valuable', {
+      query: {
+        source: props.source,
+        window: props.window,
+        hideGtoons: props.hideGtoons ? '1' : undefined,
+        hidePokemon: props.hidePokemon ? '1' : undefined
+      }
     })
+    if (myId !== reqId) return
+    rows.value = res
   } catch {
+    if (myId !== reqId) return
     error.value = true
   } finally {
-    pending.value = false
+    if (myId === reqId) pending.value = false
   }
-})
+}
+
+watch(
+  () => [props.source, props.window, props.hideGtoons, props.hidePokemon],
+  load,
+  { immediate: true }
+)
+
+onBeforeUnmount(() => { reqId++ })
 
 function select(row) {
   emit('select', row.ctoonId)

--- a/composables/useEconomyFilter.js
+++ b/composables/useEconomyFilter.js
@@ -1,0 +1,37 @@
+// Sort/exclusion state for the Economy page, shared between
+// components/newsite/Economy.vue (which renders and applies it) and
+// pages/newsite/economy.vue (which syncs it to the URL), matching how
+// useAllCtoonsFilter / useNewSiteCtoonFilter are used by their pages.
+//
+// Sort tokens carry their own direction (nameAsc / releaseDesc / ...) instead of
+// the sortField+sortAsc pair the list pages use: "Most Traded" and "Most
+// Auctioned" have no meaningful ascending counterpart, so a field+direction pair
+// would produce two unreachable states. Same convention as
+// AuctionHouse.vue's sort tokens. Keep these in sync with BROWSE_SORTS in
+// server/utils/economyFilters.js.
+export const ECONOMY_SORTS = [
+  { value: 'nameAsc', label: 'Name (A→Z)' },
+  { value: 'nameDesc', label: 'Name (Z→A)' },
+  { value: 'releaseDesc', label: 'Release Date (Newest)' },
+  { value: 'releaseAsc', label: 'Release Date (Oldest)' },
+  { value: 'tradeVolume', label: 'Most Traded (all time)' },
+  { value: 'auctionVolume', label: 'Most Auctioned (all time)' }
+]
+
+export const ECONOMY_FILTER_DEFAULTS = {
+  sort: 'nameAsc',
+  hideGtoons: false,
+  hidePokemon: false
+}
+
+export const useEconomyFilter = () => useState('economyFilter', () => ({ ...ECONOMY_FILTER_DEFAULTS }))
+
+export const isValidEconomySort = (sort) => ECONOMY_SORTS.some(s => s.value === sort)
+
+export function economyFilterToQuery(filter) {
+  const query = {}
+  if (filter.sort && filter.sort !== ECONOMY_FILTER_DEFAULTS.sort) query.sort = filter.sort
+  if (filter.hideGtoons) query.hideGtoons = '1'
+  if (filter.hidePokemon) query.hidePokemon = '1'
+  return query
+}

--- a/pages/newsite/economy.vue
+++ b/pages/newsite/economy.vue
@@ -14,6 +14,35 @@ definePageMeta({
 
 const { clearSidebarMiddle } = useNewsiteLayout()
 clearSidebarMiddle()
+
+// Filter state lives in useState, so it survives client-side navigation. Reset
+// from the URL on every mount (same as allCtoons.vue / cmart.vue) — otherwise a
+// user who hid Pokémon, wandered off to cMart and came back via a bare
+// /newsite/economy link would get silently filtered numbers with nothing in the
+// URL to explain them.
+const route = useRoute()
+const router = useRouter()
+const filter = useEconomyFilter()
+
+const q = route.query
+Object.assign(filter.value, {
+  ...ECONOMY_FILTER_DEFAULTS,
+  // An unknown sort (stale bookmark, truncated share link) degrades to the
+  // default rather than breaking the page.
+  sort: isValidEconomySort(q.sort) ? q.sort : ECONOMY_FILTER_DEFAULTS.sort,
+  hideGtoons: q.hideGtoons === '1',
+  hidePokemon: q.hidePokemon === '1'
+})
+
+// The exclusions change what every number on this page means, so they belong in
+// the URL — a screenshot or shared link of filtered figures is misleading
+// otherwise. Guard on equality so the debounced search doesn't churn history.
+watch(filter, () => {
+  const next = economyFilterToQuery(filter.value)
+  if (JSON.stringify(route.query) !== JSON.stringify(next)) {
+    router.replace({ path: route.path, query: next })
+  }
+}, { deep: true })
 </script>
 
 <style>

--- a/prisma/migrations/20260730050000_economy_browse_filters/migration.sql
+++ b/prisma/migrations/20260730050000_economy_browse_filters/migration.sql
@@ -1,0 +1,21 @@
+-- Economy page: sort/filter controls on "Browse All cToons".
+
+-- Trade activity that couldn't be priced (no cToon in the trade had a known
+-- reference value) was previously dropped entirely, volume included, which
+-- biased any "most traded" ranking toward cToons that already had auction or
+-- cMart pricing. Volume is now always recorded; avgPrice is NULL when the day's
+-- activity had no basis to impute a price from.
+ALTER TABLE "CtoonPriceDaily" ALTER COLUMN "avgPrice" DROP NOT NULL;
+
+-- Trending filters on "date" with no "source" predicate, so
+-- CtoonPriceDaily_source_date_ctoonId_idx cannot serve it and it seq-scans the
+-- whole table on every cold cache. Trailing "volume" keeps the scan index-only.
+CREATE INDEX IF NOT EXISTS "CtoonPriceDaily_date_ctoonId_volume_idx"
+  ON "CtoonPriceDaily"("date", "ctoonId", "volume");
+
+-- The "Most Traded"/"Most Auctioned" browse sorts aggregate SUM(volume) per
+-- cToon across all dates for one source. Leading on source and grouping by
+-- ctoonId lets Postgres GroupAggregate straight off the index with no heap
+-- fetches and no sort.
+CREATE INDEX IF NOT EXISTS "CtoonPriceDaily_source_ctoonId_volume_idx"
+  ON "CtoonPriceDaily"("source", "ctoonId", "volume");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1265,17 +1265,28 @@ enum EconomySource {
 }
 
 model CtoonPriceDaily {
-  id       String        @id @default(uuid())
-  ctoonId  String
-  source   EconomySource
-  date     DateTime // truncated to day (UTC)
-  avgPrice Float
+  id      String        @id @default(uuid())
+  ctoonId String
+  source  EconomySource
+  date    DateTime // truncated to day (UTC)
+  // NULL means "this activity happened but couldn't be priced" — a trade where
+  // nothing involved had a known reference value. Volume is still recorded so
+  // the Economy page's activity rankings aren't biased toward cToons that
+  // already have auction/cMart pricing. Readers must exclude NULLs from
+  // weighted averages (SUM(...) FILTER (WHERE "avgPrice" IS NOT NULL)).
+  avgPrice Float?
   volume   Int // number of transactions this cToon appeared in that day
 
   ctoon Ctoon @relation(fields: [ctoonId], references: [id], onDelete: Cascade)
 
   @@unique([ctoonId, source, date])
   @@index([source, date, ctoonId])
+  // Trending filters on date with no source predicate, so the index above can't
+  // serve it (no btree skip-scan before PG18) and it seq-scans today.
+  @@index([date, ctoonId, volume])
+  // Makes the Browse "most traded/auctioned" all-time aggregate index-only and
+  // pre-grouped by ctoonId.
+  @@index([source, ctoonId, volume])
 }
 
 // Singleton cursor tracking how far server/cron/economy-aggregate.js has

--- a/server/api/economy/ctoons/[id]/history.get.js
+++ b/server/api/economy/ctoons/[id]/history.get.js
@@ -61,20 +61,32 @@ export default defineEventHandler(async (event) => {
   const buckets = new Map()
   for (const row of rows) {
     const key = bucketKey(row.date, granularity)
-    const bucket = buckets.get(key) || { key, weightedSum: 0, volume: 0 }
-    bucket.weightedSum += row.avgPrice * row.volume
+    const bucket = buckets.get(key) || { key, weightedSum: 0, volume: 0, pricedVolume: 0 }
+    // avgPrice is NULL for activity with no basis to price it (see
+    // server/cron/economy-aggregate.js) — it still counts toward volume, but
+    // averaging it in would multiply by null and poison the bucket.
+    if (row.avgPrice != null) {
+      bucket.weightedSum += row.avgPrice * row.volume
+      bucket.pricedVolume += row.volume
+    }
     bucket.volume += row.volume
     buckets.set(key, bucket)
   }
 
   const points = [...buckets.values()]
     .sort((a, b) => a.key.localeCompare(b.key))
-    .map((b) => ({
-      period: b.key,
-      volume: b.volume,
-      avgPrice: b.volume >= MIN_SAMPLE_SIZE ? Math.round((b.weightedSum / b.volume) * 100) / 100 : null,
-      insufficientData: b.volume < MIN_SAMPLE_SIZE
-    }))
+    .map((b) => {
+      const insufficientData = b.pricedVolume < MIN_SAMPLE_SIZE
+      return {
+        period: b.key,
+        // Withheld below the sample threshold for the same reason the price is:
+        // "traded exactly once, in this week" identifies the trade as surely as
+        // its price would.
+        volume: insufficientData ? null : b.volume,
+        avgPrice: insufficientData ? null : Math.round((b.weightedSum / b.pricedVolume) * 100) / 100,
+        insufficientData
+      }
+    })
 
   return {
     ctoonId: ctoon.id,

--- a/server/api/economy/ctoons/search.get.js
+++ b/server/api/economy/ctoons/search.get.js
@@ -1,13 +1,24 @@
-// GET /api/economy/ctoons/search?q=&page=
-// "Browse all cToons" — paginated, name-searchable list with each cToon's
-// all-time average auction/trade price. Name search goes through Prisma's
-// query builder (not raw SQL) so the free-text q param can't reach a query string.
+// GET /api/economy/ctoons/search?q=&page=&sort=&hideGtoons=&hidePokemon=
+// "Browse all cToons" — paginated, name-searchable, sortable list with each
+// cToon's all-time average auction/trade price and activity volume.
+//
+// Every caller-supplied value is either a bind parameter or a key into a frozen
+// whitelist (see server/utils/economyFilters.js); nothing is concatenated into
+// SQL. The count and page queries share one WHERE fragment so `total` can never
+// describe a different population than `results`.
 import { defineEventHandler, getQuery, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { Prisma } from '@prisma/client'
 import { redis } from '@/server/utils/redis'
 import { MIN_SAMPLE_SIZE } from '@/server/utils/economyValuation'
 import { ensureEconomyDataFresh } from '@/server/utils/economyFreshness'
+import {
+  parseExclusions,
+  exclusionCacheKey,
+  buildSearchWhereSql,
+  resolveBrowseSort,
+  firstQueryValue
+} from '@/server/utils/economyFilters'
 
 const PAGE_SIZE = 20
 const MAX_QUERY_LEN = 100
@@ -18,16 +29,23 @@ const MAX_PAGE = 500 // sane upper bound; prevents deep-pagination abuse
 // than relying on the (currently nonexistent) global rate limiter.
 const RATE_LIMIT_MAX = 30
 const RATE_LIMIT_WINDOW_SEC = 60
+// Volume sorts aggregate all of CtoonPriceDaily instead of touching only the
+// requested page of Ctoon rows, so they get their own tighter budget.
+const VOLUME_RATE_LIMIT_MAX = 10
 
-async function checkRateLimit(userId) {
-  try {
-    const key = `economy:search-rl:${userId}`
-    const count = await redis.incr(key)
-    if (count === 1) await redis.expire(key, RATE_LIMIT_WINDOW_SEC)
-    return count <= RATE_LIMIT_MAX
-  } catch {
-    return true // fail open if redis is unavailable — don't take the page down over rate limiting
-  }
+// CtoonPriceDaily can't change faster than economyFreshness.js's 300s gate
+// allows, so a shorter TTL would buy no freshness and 5x the Postgres work.
+const CACHE_TTL = 300
+// Only the first few pages of an unsearched browse are cached: caching keyed on
+// free-text `q` would give any authenticated user an unbounded Redis keyspace,
+// and MAX_PAGE=500 x 6 sorts x 4 exclusion combos would be ~60MB of pages.
+const MAX_CACHED_PAGE = 5
+
+async function checkRateLimit(userId, max) {
+  const key = `economy:search-rl:${userId}`
+  const count = await redis.incr(key)
+  if (count === 1) await redis.expire(key, RATE_LIMIT_WINDOW_SEC)
+  return count <= max
 }
 
 export default defineEventHandler(async (event) => {
@@ -35,38 +53,99 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
   }
 
-  if (!(await checkRateLimit(event.context.userId))) {
-    throw createError({ statusCode: 429, statusMessage: 'Too many requests, slow down.' })
+  const query = getQuery(event)
+  const rawQ = firstQueryValue(query, 'q')
+  const q = typeof rawQ === 'string' ? rawQ.slice(0, MAX_QUERY_LEN).trim() : ''
+  const rawPage = firstQueryValue(query, 'page')
+  const page = Math.max(1, Math.min(MAX_PAGE, parseInt(rawPage, 10) || 1))
+  const exclusions = parseExclusions(query)
+  const sort = resolveBrowseSort(firstQueryValue(query, 'sort'))
+  const isVolumeSort = sort.volumeSource !== null
+
+  try {
+    const allowed = await checkRateLimit(
+      event.context.userId,
+      isVolumeSort ? VOLUME_RATE_LIMIT_MAX : RATE_LIMIT_MAX
+    )
+    if (!allowed) {
+      throw createError({ statusCode: 429, statusMessage: 'Too many requests, slow down.' })
+    }
+  } catch (err) {
+    if (err?.statusCode === 429) throw err
+    // Redis is down. Fail open for the cheap sorts so the page stays usable,
+    // but fail closed for the aggregate ones rather than serving unlimited
+    // full-table scans.
+    if (isVolumeSort) {
+      throw createError({ statusCode: 503, statusMessage: 'Sorting by activity is temporarily unavailable.' })
+    }
   }
 
-  const query = getQuery(event)
-  const rawQ = Array.isArray(query.q) ? query.q[0] : query.q
-  const q = typeof rawQ === 'string' ? rawQ.slice(0, MAX_QUERY_LEN).trim() : ''
-  const rawPage = Array.isArray(query.page) ? query.page[0] : query.page
-  const page = Math.max(1, Math.min(MAX_PAGE, parseInt(rawPage, 10) || 1))
+  const cacheable = !q && page <= MAX_CACHED_PAGE
+  const cacheKey = `economy:browse:v1:${sort.key}:${exclusionCacheKey(exclusions)}:${page}`
+  if (cacheable) {
+    try {
+      const cached = await redis.get(cacheKey)
+      if (cached) return JSON.parse(cached)
+    } catch {}
+  }
 
-  const where = q ? { name: { contains: q, mode: 'insensitive' } } : {}
+  // Must run before the ranking query, not after it: a volume sort's ordering
+  // is read straight out of CtoonPriceDaily.
+  await ensureEconomyDataFresh()
 
-  const [total, ctoons] = await Promise.all([
-    prisma.ctoon.count({ where }),
-    prisma.ctoon.findMany({
-      where,
-      select: { id: true, name: true, assetPath: true, rarity: true, releaseDate: true, createdAt: true },
-      orderBy: { name: 'asc' },
-      skip: (page - 1) * PAGE_SIZE,
-      take: PAGE_SIZE
-    })
-  ])
+  const whereSql = buildSearchWhereSql(q, exclusions)
+  const offset = (page - 1) * PAGE_SIZE
+
+  // `total` comes from Ctoon alone. Because the volume sort LEFT JOINs, the
+  // matching population is identical for all six sorts, so the pager doesn't
+  // jump when the user changes sort — and an over-the-end page still reports a
+  // real total instead of the undefined a COUNT(*) OVER() would give.
+  const countPromise = prisma.$queryRaw`
+    SELECT COUNT(*)::int AS "total" FROM "Ctoon" c ${whereSql}
+  `
+
+  const pagePromise = isVolumeSort
+    ? prisma.$queryRaw`
+        WITH vol AS (
+          SELECT "ctoonId", SUM("volume")::int AS "v"
+          FROM "CtoonPriceDaily"
+          WHERE "source" = ${sort.volumeSource}::"EconomySource"
+          GROUP BY "ctoonId"
+        )
+        SELECT
+          c."id", c."name", c."assetPath", c."rarity", c."releaseDate", c."createdAt",
+          -- Anything below MIN_SAMPLE_SIZE ranks as 0, so a cToon with one or two
+          -- transactions is indistinguishable from one with none. Ranking on the
+          -- raw count would turn the tail of this list into an enumeration of
+          -- every single-trade cToon, which is what MIN_SAMPLE_SIZE exists to stop.
+          (CASE WHEN COALESCE(vol."v", 0) >= ${MIN_SAMPLE_SIZE} THEN COALESCE(vol."v", 0) ELSE 0 END) AS "rankVolume"
+        FROM "Ctoon" c
+        LEFT JOIN vol ON vol."ctoonId" = c."id"
+        ${whereSql}
+        ORDER BY ${sort.orderBy}
+        LIMIT ${PAGE_SIZE} OFFSET ${offset}
+      `
+    : prisma.$queryRaw`
+        SELECT c."id", c."name", c."assetPath", c."rarity", c."releaseDate", c."createdAt"
+        FROM "Ctoon" c
+        ${whereSql}
+        ORDER BY ${sort.orderBy}
+        LIMIT ${PAGE_SIZE} OFFSET ${offset}
+      `
+
+  const [countRows, ctoons] = await Promise.all([countPromise, pagePromise])
+  const total = countRows[0]?.total ?? 0
 
   const ctoonIds = ctoons.map(c => c.id)
   let priceRows = []
   if (ctoonIds.length) {
-    await ensureEconomyDataFresh()
     priceRows = await prisma.$queryRaw`
       SELECT
         "ctoonId", "source",
-        (SUM("avgPrice" * "volume") / SUM("volume"))::float AS "avgPrice",
-        SUM("volume")::int AS "volume"
+        (SUM("avgPrice" * "volume") FILTER (WHERE "avgPrice" IS NOT NULL)
+          / NULLIF(SUM("volume") FILTER (WHERE "avgPrice" IS NOT NULL), 0))::float AS "avgPrice",
+        SUM("volume")::int AS "volume",
+        COALESCE(SUM("volume") FILTER (WHERE "avgPrice" IS NOT NULL), 0)::int AS "pricedVolume"
       FROM "CtoonPriceDaily"
       WHERE "ctoonId" IN (${Prisma.join(ctoonIds)})
       GROUP BY "ctoonId", "source"
@@ -76,19 +155,25 @@ export default defineEventHandler(async (event) => {
   const priceByCtoon = new Map()
   for (const row of priceRows) {
     const entry = priceByCtoon.get(row.ctoonId) || {}
-    const enoughData = row.volume >= MIN_SAMPLE_SIZE
+    // Volume backed by too few transactions is withheld entirely, not just
+    // nulled out of the price: "traded exactly once" is the same disclosure the
+    // price suppression is meant to prevent.
+    const showVolume = row.volume >= MIN_SAMPLE_SIZE
+    const showPrice = row.pricedVolume >= MIN_SAMPLE_SIZE
     if (row.source === 'AUCTION') {
-      entry.avgAuctionPrice = enoughData ? row.avgPrice : null
-      entry.auctionVolume = row.volume
+      entry.avgAuctionPrice = showPrice ? row.avgPrice : null
+      entry.auctionVolume = showVolume ? row.volume : null
     } else {
-      entry.avgTradePrice = enoughData ? row.avgPrice : null
-      entry.tradeVolume = row.volume
+      entry.avgTradePrice = showPrice ? row.avgPrice : null
+      entry.tradeVolume = showVolume ? row.volume : null
     }
     priceByCtoon.set(row.ctoonId, entry)
   }
 
   const results = ctoons.map((c) => {
     const prices = priceByCtoon.get(c.id) || {}
+    const auctionVolume = prices.auctionVolume ?? null
+    const tradeVolume = prices.tradeVolume ?? null
     return {
       ctoonId: c.id,
       name: c.name,
@@ -97,10 +182,23 @@ export default defineEventHandler(async (event) => {
       releaseDate: c.releaseDate || c.createdAt,
       avgAuctionPrice: prices.avgAuctionPrice ?? null,
       avgTradePrice: prices.avgTradePrice ?? null,
-      auctionVolume: prices.auctionVolume || 0,
-      tradeVolume: prices.tradeVolume || 0
+      auctionVolume,
+      tradeVolume,
+      // The value this page was ordered by, so the client can show the sort key
+      // on the row instead of leaving the ordering unexplained.
+      sortVolume: sort.volumeSource === 'TRADE'
+        ? tradeVolume
+        : sort.volumeSource === 'AUCTION' ? auctionVolume : null
     }
   })
 
-  return { page, pageSize: PAGE_SIZE, total, results }
+  const payload = { page, pageSize: PAGE_SIZE, total, sort: sort.key, results }
+
+  if (cacheable) {
+    try {
+      await redis.set(cacheKey, JSON.stringify(payload), 'EX', CACHE_TTL)
+    } catch {}
+  }
+
+  return payload
 })

--- a/server/api/economy/top-valuable.get.js
+++ b/server/api/economy/top-valuable.get.js
@@ -1,4 +1,4 @@
-// GET /api/economy/top-valuable?source=AUCTION|TRADE&window=7d|30d|all
+// GET /api/economy/top-valuable?source=AUCTION|TRADE&window=7d|30d|all&hideGtoons=&hidePokemon=
 // Top 10 most valuable cToons for one source, shown in the two "Top 10"
 // modals on the Economy page.
 import { defineEventHandler, getQuery, createError } from 'h3'
@@ -6,23 +6,32 @@ import { prisma } from '@/server/prisma'
 import { redis } from '@/server/utils/redis'
 import { isValidWindow, isValidSource, resolveWindowCutoffSql, MIN_SAMPLE_SIZE } from '@/server/utils/economyValuation'
 import { ensureEconomyDataFresh } from '@/server/utils/economyFreshness'
+import { parseExclusions, exclusionCacheKey, buildExclusionSql, firstQueryValue } from '@/server/utils/economyFilters'
 
-const CACHE_TTL = 60
-const cacheKey = (source, window) => `economy:top-valuable:${source}:${window}:v1`
+// See trending.get.js — bounded by economyFreshness.js's 300s aggregation gate.
+const CACHE_TTL = 300
+// v2: the key gained an exclusion segment and the payload's meaning depends on
+// it, so a rolling deploy must not serve an unfiltered v1 payload as filtered.
+const cacheKey = (source, window, exKey) => `economy:top-valuable:${source}:${window}:${exKey}:v2`
 
-async function computeTopValuable(source, window) {
+async function computeTopValuable(source, window, exclusions) {
   const cutoff = resolveWindowCutoffSql(window)
+  // Rows with a NULL avgPrice are activity that couldn't be priced, so they're
+  // excluded from both the weighted average and the sample-size test — a cToon
+  // shouldn't rank as "most valuable" on the strength of unpriced trades.
   return prisma.$queryRaw`
     SELECT
       c."id" AS "ctoonId", c."name", c."assetPath", c."rarity",
-      (SUM(cpd."avgPrice" * cpd."volume") / SUM(cpd."volume"))::float AS "avgPrice",
+      (SUM(cpd."avgPrice" * cpd."volume") FILTER (WHERE cpd."avgPrice" IS NOT NULL)
+        / NULLIF(SUM(cpd."volume") FILTER (WHERE cpd."avgPrice" IS NOT NULL), 0))::float AS "avgPrice",
       SUM(cpd."volume")::int AS "volume"
     FROM "CtoonPriceDaily" cpd
     JOIN "Ctoon" c ON c."id" = cpd."ctoonId"
-    WHERE cpd."source" = ${source}::"EconomySource" AND cpd."date" >= ${cutoff}
+    WHERE cpd."source" = ${source}::"EconomySource"
+      AND cpd."date" >= ${cutoff}${buildExclusionSql(exclusions)}
     GROUP BY c."id", c."name", c."assetPath", c."rarity"
-    HAVING SUM(cpd."volume") >= ${MIN_SAMPLE_SIZE}
-    ORDER BY "avgPrice" DESC
+    HAVING SUM(cpd."volume") FILTER (WHERE cpd."avgPrice" IS NOT NULL) >= ${MIN_SAMPLE_SIZE}
+    ORDER BY "avgPrice" DESC, c."name" ASC, c."id" ASC
     LIMIT 10
   `
 }
@@ -33,12 +42,13 @@ export default defineEventHandler(async (event) => {
   }
 
   const query = getQuery(event)
-  const rawSource = Array.isArray(query.source) ? query.source[0] : query.source
-  const rawWindow = Array.isArray(query.window) ? query.window[0] : query.window
+  const rawSource = firstQueryValue(query, 'source')
+  const rawWindow = firstQueryValue(query, 'window')
   const source = isValidSource(rawSource) ? rawSource : 'AUCTION'
   const window = isValidWindow(rawWindow) ? rawWindow : 'all'
+  const exclusions = parseExclusions(query)
 
-  const key = cacheKey(source, window)
+  const key = cacheKey(source, window, exclusionCacheKey(exclusions))
   try {
     const cached = await redis.get(key)
     if (cached) return JSON.parse(cached)
@@ -46,7 +56,7 @@ export default defineEventHandler(async (event) => {
 
   await ensureEconomyDataFresh()
 
-  const topValuable = await computeTopValuable(source, window)
+  const topValuable = await computeTopValuable(source, window, exclusions)
   try {
     await redis.set(key, JSON.stringify(topValuable), 'EX', CACHE_TTL)
   } catch {}

--- a/server/api/economy/trending.get.js
+++ b/server/api/economy/trending.get.js
@@ -1,15 +1,20 @@
-// GET /api/economy/trending?window=7d|30d|all
+// GET /api/economy/trending?window=7d|30d|all&hideGtoons=&hidePokemon=
 // "Trending cToons" — combined trade+auction transaction volume in the window.
 import { defineEventHandler, getQuery, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { redis } from '@/server/utils/redis'
 import { isValidWindow, resolveWindowCutoffSql, MIN_SAMPLE_SIZE } from '@/server/utils/economyValuation'
 import { ensureEconomyDataFresh } from '@/server/utils/economyFreshness'
+import { parseExclusions, exclusionCacheKey, buildExclusionSql, firstQueryValue } from '@/server/utils/economyFilters'
 
-const CACHE_TTL = 60
-const cacheKey = (window) => `economy:trending:${window}:v1`
+// Bounded by economyFreshness.js's 300s aggregation gate — a shorter TTL can't
+// surface fresher data, it just multiplies cold-cache full aggregates.
+const CACHE_TTL = 300
+// v2: the key gained an exclusion segment, and the payload's meaning now depends
+// on it. A rolling deploy must not serve an unfiltered v1 payload as filtered.
+const cacheKey = (window, exKey) => `economy:trending:${window}:${exKey}:v2`
 
-async function computeTrending(window) {
+async function computeTrending(window, exclusions) {
   const cutoff = resolveWindowCutoffSql(window)
   return prisma.$queryRaw`
     SELECT
@@ -17,10 +22,10 @@ async function computeTrending(window) {
       SUM(cpd."volume")::int AS "volume"
     FROM "CtoonPriceDaily" cpd
     JOIN "Ctoon" c ON c."id" = cpd."ctoonId"
-    WHERE cpd."date" >= ${cutoff}
+    WHERE cpd."date" >= ${cutoff}${buildExclusionSql(exclusions)}
     GROUP BY c."id", c."name", c."assetPath", c."rarity"
     HAVING SUM(cpd."volume") >= ${MIN_SAMPLE_SIZE}
-    ORDER BY "volume" DESC
+    ORDER BY "volume" DESC, c."name" ASC, c."id" ASC
     LIMIT 10
   `
 }
@@ -31,10 +36,13 @@ export default defineEventHandler(async (event) => {
   }
 
   const query = getQuery(event)
-  const rawWindow = Array.isArray(query.window) ? query.window[0] : query.window
+  const rawWindow = firstQueryValue(query, 'window')
   const window = isValidWindow(rawWindow) ? rawWindow : '7d'
+  const exclusions = parseExclusions(query)
 
-  const key = cacheKey(window)
+  // Exclusions are applied in the WHERE, before GROUP BY/ORDER BY/LIMIT, so
+  // ranks 11+ backfill rather than the list simply getting shorter.
+  const key = cacheKey(window, exclusionCacheKey(exclusions))
   try {
     const cached = await redis.get(key)
     if (cached) return JSON.parse(cached)
@@ -42,7 +50,7 @@ export default defineEventHandler(async (event) => {
 
   await ensureEconomyDataFresh()
 
-  const trending = await computeTrending(window)
+  const trending = await computeTrending(window, exclusions)
   try {
     await redis.set(key, JSON.stringify(trending), 'EX', CACHE_TTL)
   } catch {}

--- a/server/cron/economy-aggregate.js
+++ b/server/cron/economy-aggregate.js
@@ -14,8 +14,10 @@
 // average, falling back to cMart price) of every cToon in the trade that
 // has one, divided by how many of those cToons had a known reference value.
 // That single imputed number is then recorded against every cToon in the
-// trade for that day. cToons with no known reference anywhere in the trade
-// are skipped (no basis to price them from).
+// trade for that day. A trade where nothing has a known reference anywhere
+// still records volume, with avgPrice NULL — the trade happened even though
+// there's no basis to price it, and the Economy page's activity rankings would
+// otherwise ignore every cToon that has never been auctioned or sold in cMart.
 //
 // Reference values used for imputation reflect *current* auction averages,
 // not a historical snapshot as of the trade's date — acceptable for a
@@ -154,9 +156,12 @@ async function aggregateTrades(sinceDate) {
         knownCount++
       }
     }
-    if (knownCount === 0) continue // nothing in this trade has a known value to impute from
+    // Nothing in this trade has a known value to impute a price from. The trade
+    // still happened, so its volume is recorded and only the price contribution
+    // is skipped — dropping the whole offer used to make a never-auctioned,
+    // non-cMart cToon read as zero trades no matter how often it changed hands.
+    const impliedValue = knownCount > 0 ? knownValueSum / knownCount : null
 
-    const impliedValue = knownValueSum / knownCount
     const day = new Date(Date.UTC(
       offer.updatedAt.getUTCFullYear(),
       offer.updatedAt.getUTCMonth(),
@@ -166,9 +171,12 @@ async function aggregateTrades(sinceDate) {
 
     const dayMap = byDay.get(dayKey) || new Map()
     for (const ctoonId of ctoonIds) {
-      const agg = dayMap.get(ctoonId) || { sum: 0, count: 0 }
-      agg.sum += impliedValue
+      const agg = dayMap.get(ctoonId) || { sum: 0, pricedCount: 0, count: 0 }
       agg.count += 1
+      if (impliedValue != null) {
+        agg.sum += impliedValue
+        agg.pricedCount += 1
+      }
       dayMap.set(ctoonId, agg)
     }
     byDay.set(dayKey, dayMap)
@@ -184,7 +192,7 @@ async function aggregateTrades(sinceDate) {
         ctoonId,
         source: 'TRADE',
         date,
-        avgPrice: agg.sum / agg.count,
+        avgPrice: agg.pricedCount > 0 ? agg.sum / agg.pricedCount : null,
         volume: agg.count
       })
     }

--- a/server/utils/economyFilters.js
+++ b/server/utils/economyFilters.js
@@ -1,0 +1,159 @@
+// server/utils/economyFilters.js
+// Query-param parsing and SQL fragments for the Economy page's sort/filter
+// controls (components/newsite/Economy.vue).
+//
+// Deliberately imports nothing but @prisma/client: server/utils/economyValuation.js
+// pulls in `@/server/prisma`, a Nuxt-only alias that bare Node can't resolve, which
+// would make these helpers untestable under `npm test` (`node --test`).
+//
+// Security invariants this module exists to enforce:
+//   * Nothing caller-supplied is ever concatenated into SQL. Sort keys select a
+//     pre-built Prisma.sql fragment (ORDER BY cannot be a bind parameter, so a
+//     whitelist is the only safe option); exclusions are booleans that pick
+//     between constant fragments.
+//   * Redis cache-key suffixes come from a frozen lookup table indexed by
+//     booleans, so a request byte can never reach a key name. Economy shares a
+//     Redis namespace with `economy:aggregate:fresh` and `economy:search-rl:*`;
+//     an attacker-chosen key there would let them freeze price aggregation or
+//     disable another user's rate limit.
+import { Prisma } from '@prisma/client'
+
+// Matches the app's existing flag convention (server/api/auctions/all.get.js).
+export function isTruthy(value) {
+  if (typeof value !== 'string') return false
+  const v = value.trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'yes'
+}
+
+// h3's getQuery returns an array when a param is repeated (?x=1&x=2).
+export function firstQueryValue(query, key) {
+  const raw = query?.[key]
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return typeof value === 'string' ? value : undefined
+}
+
+// `Ctoon.series` is nullable free text — the admin form is an <input> with a
+// suggestion-only <datalist> (pages/admin/addCtoon.vue), and bulk edit writes it
+// untrimmed (server/api/admin/ctoons/bulk-edit.post.js). Real rows therefore
+// carry casing and whitespace drift, so match on a normalized alias list rather
+// than `series = 'Pokemon'`.
+export const POKEMON_SERIES_ALIASES = Object.freeze(['pokemon', 'pokémon'])
+
+export function parseExclusions(query) {
+  return {
+    hideGtoons: isTruthy(firstQueryValue(query, 'hideGtoons')),
+    hidePokemon: isTruthy(firstQueryValue(query, 'hidePokemon'))
+  }
+}
+
+// Extra WHERE predicates for a query that aliases "Ctoon" as `c`. Returns
+// Prisma.empty when nothing is excluded so callers can splice it in
+// unconditionally. The alias is hardcoded on purpose: it would land in an
+// identifier position, which can't be parameterised, so accepting it as an
+// argument would be an injection hole waiting for its first caller.
+export function buildExclusionSql(ex) {
+  const parts = []
+  if (ex.hideGtoons === true) {
+    parts.push(Prisma.sql`c."isGtoon" = false`)
+  }
+  if (ex.hidePokemon === true) {
+    // COALESCE keeps NULL-series cToons visible: `series <> 'Pokemon'` evaluates
+    // to NULL for them, which SQL treats as not-true, silently hiding most of
+    // the table.
+    parts.push(Prisma.sql`
+      COALESCE(LOWER(BTRIM(c."series")), '') <> ALL (ARRAY[${Prisma.join(POKEMON_SERIES_ALIASES)}])
+    `)
+  }
+  if (!parts.length) return Prisma.empty
+  return Prisma.sql` AND ${Prisma.join(parts, ' AND ')}`
+}
+
+// Frozen 2x2 table rather than a template string: the output is provably one of
+// four constants, so no request value can shape a Redis key.
+const EXCLUSION_KEYS = Object.freeze([
+  Object.freeze(['g0p0', 'g0p1']),
+  Object.freeze(['g1p0', 'g1p1'])
+])
+
+export function exclusionCacheKey(ex) {
+  return EXCLUSION_KEYS[ex.hideGtoons === true ? 1 : 0][ex.hidePokemon === true ? 1 : 0]
+}
+
+export function hasExclusions(ex) {
+  return ex.hideGtoons === true || ex.hidePokemon === true
+}
+
+// LIKE metacharacters in user input would otherwise stay live — Prisma's
+// `contains` doesn't escape them either, so `q=%` currently matches every cToon.
+// `!` is the escape char because a backslash's meaning depends on
+// standard_conforming_strings. Escape AFTER the length cap so a trailing `!`
+// can't be truncated away from the character it escapes.
+export function buildNamePattern(q) {
+  return `%${q.replace(/[!%_]/g, (ch) => `!${ch}`)}%`
+}
+
+export function buildSearchWhereSql(q, exclusions) {
+  const nameSql = q
+    ? Prisma.sql` AND c."name" ILIKE ${buildNamePattern(q)} ESCAPE '!'`
+    : Prisma.empty
+  return Prisma.sql`WHERE TRUE${nameSql}${buildExclusionSql(exclusions)}`
+}
+
+export const DEFAULT_BROWSE_SORT = 'nameAsc'
+
+// Every ORDER BY terminates in `c."id" ASC`. `Ctoon.name` is not unique (second
+// editions, re-releases) and thousands of cToons tie at volume 0, so without a
+// total order Postgres is free to return rows in a different arbitrary order per
+// page and rows visibly repeat or vanish across Prev/Next.
+//
+// `effectiveRelease` mirrors what the endpoint actually returns to the client
+// (`releaseDate || createdAt`). Ordering on `releaseDate` alone would clump every
+// NULL-releaseDate cToon at one end instead of interleaving it by the date shown
+// on screen — and Prisma's orderBy has no COALESCE, which is why this is raw SQL.
+//
+// Volume sorts are DESC-only by design: an ascending volume sort would put every
+// cToon with a single transaction on page 1, which is exactly the
+// de-anonymisation MIN_SAMPLE_SIZE exists to prevent. Do not add one.
+const BROWSE_SORTS = Object.freeze({
+  nameAsc: {
+    orderBy: Prisma.sql`c."name" ASC, c."id" ASC`,
+    volumeSource: null
+  },
+  nameDesc: {
+    orderBy: Prisma.sql`c."name" DESC, c."id" ASC`,
+    volumeSource: null
+  },
+  releaseDesc: {
+    orderBy: Prisma.sql`COALESCE(c."releaseDate", c."createdAt") DESC, c."name" ASC, c."id" ASC`,
+    volumeSource: null
+  },
+  releaseAsc: {
+    orderBy: Prisma.sql`COALESCE(c."releaseDate", c."createdAt") ASC, c."name" ASC, c."id" ASC`,
+    volumeSource: null
+  },
+  tradeVolume: {
+    orderBy: Prisma.sql`"rankVolume" DESC, c."name" ASC, c."id" ASC`,
+    volumeSource: 'TRADE'
+  },
+  auctionVolume: {
+    orderBy: Prisma.sql`"rankVolume" DESC, c."name" ASC, c."id" ASC`,
+    volumeSource: 'AUCTION'
+  }
+})
+
+export const BROWSE_SORT_KEYS = Object.freeze(Object.keys(BROWSE_SORTS))
+
+export function isValidBrowseSort(sort) {
+  return Object.prototype.hasOwnProperty.call(BROWSE_SORTS, sort)
+}
+
+// Unknown sorts fall back to the default rather than 400ing, so a stale bookmark
+// or a truncated share link degrades instead of breaking the page.
+export function resolveBrowseSort(sort) {
+  const key = isValidBrowseSort(sort) ? sort : DEFAULT_BROWSE_SORT
+  return { key, ...BROWSE_SORTS[key] }
+}
+
+export function isVolumeSort(sort) {
+  return resolveBrowseSort(sort).volumeSource !== null
+}

--- a/tests/economyFilters.test.js
+++ b/tests/economyFilters.test.js
@@ -1,0 +1,169 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  isTruthy,
+  firstQueryValue,
+  parseExclusions,
+  buildExclusionSql,
+  exclusionCacheKey,
+  hasExclusions,
+  buildNamePattern,
+  buildSearchWhereSql,
+  resolveBrowseSort,
+  isValidBrowseSort,
+  isVolumeSort,
+  BROWSE_SORT_KEYS,
+  DEFAULT_BROWSE_SORT
+} from '../server/utils/economyFilters.js'
+
+test('isTruthy accepts the app\'s flag spellings and nothing else', () => {
+  for (const v of ['1', 'true', 'TRUE', 'yes', ' Yes ']) {
+    assert.equal(isTruthy(v), true, `expected ${JSON.stringify(v)} to be truthy`)
+  }
+  for (const v of ['0', 'false', 'no', '', 'nope', undefined, null, 1, true, {}, []]) {
+    assert.equal(isTruthy(v), false, `expected ${JSON.stringify(v)} to be falsy`)
+  }
+})
+
+test('firstQueryValue survives repeated params without throwing', () => {
+  assert.equal(firstQueryValue({ q: 'bugs' }, 'q'), 'bugs')
+  assert.equal(firstQueryValue({ q: ['bugs', 'daffy'] }, 'q'), 'bugs')
+  assert.equal(firstQueryValue({}, 'q'), undefined)
+  assert.equal(firstQueryValue({ q: 7 }, 'q'), undefined)
+  assert.equal(firstQueryValue(undefined, 'q'), undefined)
+})
+
+test('parseExclusions handles arrays and non-strings without bypassing the filter', () => {
+  assert.deepEqual(parseExclusions({ hideGtoons: '1', hidePokemon: 'true' }), {
+    hideGtoons: true,
+    hidePokemon: true
+  })
+  // A repeated param must not silently disable the filter the user asked for.
+  assert.deepEqual(parseExclusions({ hideGtoons: ['1', '1'] }), {
+    hideGtoons: true,
+    hidePokemon: false
+  })
+  assert.deepEqual(parseExclusions({ hideGtoons: {}, hidePokemon: [] }), {
+    hideGtoons: false,
+    hidePokemon: false
+  })
+  assert.deepEqual(parseExclusions({}), { hideGtoons: false, hidePokemon: false })
+})
+
+test('exclusionCacheKey is one of four constants and never collides', () => {
+  const keys = [
+    exclusionCacheKey({ hideGtoons: false, hidePokemon: false }),
+    exclusionCacheKey({ hideGtoons: false, hidePokemon: true }),
+    exclusionCacheKey({ hideGtoons: true, hidePokemon: false }),
+    exclusionCacheKey({ hideGtoons: true, hidePokemon: true })
+  ]
+  assert.equal(new Set(keys).size, 4)
+  for (const k of keys) assert.match(k, /^g[01]p[01]$/)
+  // A collision here would serve Pokemon-filtered data to a gToon-filtered request.
+  assert.notEqual(keys[1], keys[2])
+})
+
+test('exclusionCacheKey cannot be shaped by a request value', () => {
+  // Anything non-boolean-true must fall into the "off" slot rather than reach
+  // the key string — Economy shares a Redis namespace with the aggregation
+  // freshness flag and the per-user rate-limit counters.
+  const key = exclusionCacheKey({ hideGtoons: 'economy:aggregate:fresh', hidePokemon: '1' })
+  assert.equal(key, 'g0p0')
+})
+
+test('hasExclusions only reports real booleans', () => {
+  assert.equal(hasExclusions({ hideGtoons: false, hidePokemon: false }), false)
+  assert.equal(hasExclusions({ hideGtoons: true, hidePokemon: false }), true)
+  assert.equal(hasExclusions({ hideGtoons: 'true', hidePokemon: 'true' }), false)
+})
+
+test('buildExclusionSql parameterises the series list and keeps NULL series visible', () => {
+  const none = buildExclusionSql({ hideGtoons: false, hidePokemon: false })
+  assert.equal(none.strings.join(''), '')
+  assert.deepEqual(none.values, [])
+
+  const gtoons = buildExclusionSql({ hideGtoons: true, hidePokemon: false })
+  assert.match(gtoons.strings.join('?'), /"isGtoon" = false/)
+  assert.deepEqual(gtoons.values, [])
+
+  const pokemon = buildExclusionSql({ hideGtoons: false, hidePokemon: true })
+  const sql = pokemon.strings.join('?')
+  // COALESCE keeps NULL-series cToons in the result; a bare `<>` would drop them.
+  assert.match(sql, /COALESCE\(LOWER\(BTRIM\(c\."series"\)\), ''\)/)
+  assert.match(sql, /<> ALL/)
+  // The alias list is bound, never inlined.
+  assert.ok(pokemon.values.includes('pokemon'))
+
+  const both = buildExclusionSql({ hideGtoons: true, hidePokemon: true })
+  assert.match(both.strings.join('?'), /"isGtoon" = false/)
+  assert.match(both.strings.join('?'), /BTRIM/)
+})
+
+test('buildNamePattern escapes LIKE metacharacters', () => {
+  assert.equal(buildNamePattern('bugs'), '%bugs%')
+  // Unescaped, `%` would match every cToon and `_` every single character.
+  assert.equal(buildNamePattern('%'), '%!%%')
+  assert.equal(buildNamePattern('_'), '%!_%')
+  // The escape character itself must be escaped, or a trailing `!` would eat
+  // the closing wildcard.
+  assert.equal(buildNamePattern('!'), '%!!%')
+  assert.equal(buildNamePattern('50%_off'), '%50!%!_off%')
+})
+
+test('buildSearchWhereSql binds the search term rather than inlining it', () => {
+  const empty = buildSearchWhereSql('', { hideGtoons: false, hidePokemon: false })
+  assert.match(empty.strings.join('?'), /WHERE TRUE/)
+  assert.deepEqual(empty.values, [])
+
+  const injected = "'; DROP TABLE \"Ctoon\"; --"
+  const withQ = buildSearchWhereSql(injected, { hideGtoons: false, hidePokemon: false })
+  assert.deepEqual(withQ.values, [`%${injected}%`])
+  assert.ok(!withQ.strings.join('?').includes('DROP TABLE'))
+  assert.match(withQ.strings.join('?'), /ILIKE .* ESCAPE '!'/s)
+})
+
+test('browse sort whitelist rejects anything not defined', () => {
+  for (const key of BROWSE_SORT_KEYS) assert.equal(isValidBrowseSort(key), true)
+  for (const bad of ['', 'volume', 'name; DROP TABLE "Ctoon"', undefined, null, 'constructor', '__proto__', 'toString']) {
+    assert.equal(isValidBrowseSort(bad), false, `expected ${JSON.stringify(bad)} to be rejected`)
+  }
+})
+
+test('resolveBrowseSort falls back to the default instead of reaching SQL', () => {
+  const resolved = resolveBrowseSort('ORDER BY 1; DROP TABLE "Ctoon"')
+  assert.equal(resolved.key, DEFAULT_BROWSE_SORT)
+  assert.equal(resolved.volumeSource, null)
+  assert.deepEqual(resolved.orderBy.values, [])
+})
+
+test('every sort ends in a unique-column tiebreaker so pagination is stable', () => {
+  for (const key of BROWSE_SORT_KEYS) {
+    const { orderBy } = resolveBrowseSort(key)
+    const sql = orderBy.strings.join('?')
+    assert.match(sql, /c\."id" ASC\s*$/, `${key} is missing the c."id" tiebreaker`)
+    assert.deepEqual(orderBy.values, [], `${key} should not bind values into ORDER BY`)
+  }
+})
+
+test('release-date sorts order by the same value the API returns', () => {
+  for (const key of ['releaseDesc', 'releaseAsc']) {
+    const sql = resolveBrowseSort(key).orderBy.strings.join('?')
+    // The endpoint returns `releaseDate || createdAt`; ordering on releaseDate
+    // alone would clump every NULL-releaseDate cToon at one end.
+    assert.match(sql, /COALESCE\(c\."releaseDate", c\."createdAt"\)/)
+  }
+})
+
+test('volume sorts are descending-only and resolve to a fixed source', () => {
+  assert.equal(resolveBrowseSort('tradeVolume').volumeSource, 'TRADE')
+  assert.equal(resolveBrowseSort('auctionVolume').volumeSource, 'AUCTION')
+  assert.equal(isVolumeSort('tradeVolume'), true)
+  assert.equal(isVolumeSort('nameAsc'), false)
+  // An ascending volume sort would surface every single-transaction cToon on
+  // page one — the exact disclosure MIN_SAMPLE_SIZE exists to prevent.
+  for (const key of BROWSE_SORT_KEYS) {
+    if (!isVolumeSort(key)) continue
+    assert.match(resolveBrowseSort(key).orderBy.strings.join('?'), /"rankVolume" DESC/)
+  }
+})


### PR DESCRIPTION
Adds a collapsible **Filters & Sort** panel to the Economy page, and fixes the page's fixed-width layout so it resizes with the viewport like the other newsite pages.

- **Sort** (Browse All cToons): Name A→Z / Z→A, Release Date Newest / Oldest, Most Traded, Most Auctioned
- **Hide gToons** / **Hide Pokémon cToons** — applied page-wide, so Trending and Top 10 re-rank too, not just Browse

Filter state syncs to the URL the way `allCtoons` and `cmart` already do, and resets from the query on mount so it can't leak across client-side navigation. Active exclusions render as dismissible chips while the panel is collapsed, since they change what every number below them means.

## Responsive layout

`.economy` was the only newsite page component pinned to a fixed `var(--main-content-width)` with a matching `min-width`; `.ah`, `.cmart`, `.all-ctoons` and `.leaderboards` are all `width: 100%`. It's now fluid to match.

Above the layout's 768px breakpoint `.main-content` *is* a fixed 800px box, so desktop renders identically and the 669px internal scrollport is unchanged. At or below it, `.main-content` becomes `width: 100%; overflow-x: auto` — and the `min-width` was what left roughly half the page off-screen behind a horizontal pan on a phone.

Alongside that:
- The component's media query moved from 640px to 768px, the layout's own `MOBILE_BREAKPOINT`. The old value both missed the 641–768px range (already in mobile mode) and could fire above 768px where the component is always 800px regardless of viewport.
- Browse rows give the name the rest of the thumbnail's line so the three price chips wrap underneath, instead of the name flex-shrinking to an ellipsis behind them.
- cToon names wrap rather than truncate on narrow screens — single-line ellipsis was rendering `1 Year Anniversary Miss Sara Bellum` as `1 Year Anniversary M…`.

The stat tiles keep their `overflow-x: auto` scroll deliberately: it's a self-contained scroller that stops four cards stacking vertically and pushing Trending below the fold, and now that the page itself doesn't pan it behaves like a normal carousel.

## Server

- **New `server/utils/economyFilters.js`** holds all query-param parsing and SQL fragments. It imports only `@prisma/client` so it's testable under `node --test` — `economyValuation.js` pulls in the Nuxt-only `@/server/prisma` alias, which bare Node can't resolve.
- **`search.get.js`** now builds one `WHERE` fragment shared by its count and page queries, so `total` can never describe a different population than `results`. Release-date sorts order by `COALESCE(releaseDate, createdAt)` — the value the endpoint actually returns — and every sort terminates in `c."id" ASC` so pages don't repeat or drop rows on ties. Volume sorts `LEFT JOIN`, so a cToon with no recorded activity still matches a name search instead of returning "No cToons found."
- **`trending.get.js` / `top-valuable.get.js`** take the exclusions in their `WHERE` (before `GROUP BY`/`LIMIT`, so ranks 11+ backfill) and carry an exclusion segment in their cache keys, bumped to `:v2`.

## Correctness fix

`economy-aggregate.js` discarded any trade where nothing involved had a known reference value — **volume included, not just price**. A cToon that had never been auctioned and isn't in cMart could be traded 50 times and still read as zero trades, which biased any activity ranking toward cToons that already had pricing. Volume is now always recorded and only the price contribution is skipped. `CtoonPriceDaily.avgPrice` becomes nullable and all four readers exclude NULLs from their weighted averages.

## Privacy

The page nulls prices backed by fewer than `MIN_SAMPLE_SIZE` transactions to keep individual trades anonymous, but was returning raw volume alongside. Sorting on that would have made the tail of the list an enumeration of every single-trade cToon. Sub-threshold volumes are now withheld and rank as zero, volume sorts are descending-only by design, and sub-threshold bucket volumes in the history endpoint are suppressed too.

## Security

`ORDER BY` can't be parameterised, so sort keys index a frozen table of `Prisma.sql` fragments — no `Prisma.raw` (the repo has zero uses today). Redis cache suffixes come from a boolean-indexed frozen table rather than a request value; that namespace is shared with the aggregation freshness flag and the per-user rate-limit counters. Search terms are bound with LIKE metacharacters escaped, so `q=%` no longer matches the whole table.

Pokémon is matched on a normalized alias list rather than `series = 'Pokemon'`: `series` is nullable free text written through an admin `<input>` with a suggestion-only datalist, and the codebase already trims it on read in eight places. `COALESCE` keeps NULL-series cToons visible — a bare `<>` would have silently hidden most of the table.

## Performance

- Two `CtoonPriceDaily` indexes: `(date, ctoonId, volume)` for Trending, which filters on `date` with no `source` predicate and can't use the existing index, and `(source, ctoonId, volume)` to make the all-time volume aggregate index-only.
- Cache TTLs raised 60s → 300s to match the aggregation gate that already bounds staleness. Unsearched Browse pages 1–5 are cached; free-text ones never are (unbounded keyspace).
- Volume sorts get their own tighter rate-limit budget and fail closed if Redis is down; the cheap sorts still fail open.
- `loadBrowse` gained a request-sequence guard and an `AbortController`. A failed load no longer blanks the list into a false "No cToons found." Dropped a duplicate Trending refetch, and the Top 10 modal now watches its props instead of fetching once on mount.

## Migration

`prisma/migrations/20260730050000_economy_browse_filters/` — drops `NOT NULL` on `CtoonPriceDaily.avgPrice` and adds the two indexes. Plain `CREATE INDEX` (not `CONCURRENTLY`), since Prisma wraps migrations in a transaction.

Note this one is forward-only: rolling it back needs the column repopulated or the NULL rows removed first. The aggregator recomputes affected days in full on each run, so a rebuild is cheap (`npm run economy:aggregate`).

## Testing

14 new tests in `tests/economyFilters.test.js` (`node --test`, matching the existing test's style) covering the sort whitelist, cache-key collisions, LIKE escaping, NULL-series handling, and the ORDER BY tiebreaker. All pass.

The responsive change was verified by rendering the component's own CSS headlessly rather than by eye: zero horizontal overflow at 320 / 360 / 390 / 430 / 600 / 767 / 768px with no descendant escaping the content box, and `.economy` still measuring exactly 800px inside the desktop `main-content` box with its scrollport intact.

`nuxt build` is clean and `prisma validate` passes. Two pre-existing issues unchanged by this PR: the `monsterBattleEngine` "attack-vs-attack KO prevents counterattack" test fails on `dev`, and `npm run lint` is broken repo-wide (ESLint 10 wants a flat config the repo doesn't have).