### PR TITLE
Add auction re-listing and a sale-price guide to the listing modal

### DIFF
--- a/components/newsite/AuctionDetails.vue
+++ b/components/newsite/AuctionDetails.vue
@@ -41,9 +41,16 @@
 
           <!-- Timer / winner -->
           <div v-if="!ended" class="adet-timer">Ends in {{ formatRemaining(auction.endAt) }}</div>
-          <div v-else class="adet-winner">
+          <div v-else-if="displayWinner" class="adet-winner">
             🎉 Winner:
-            <span class="adet-winner-name">{{ displayWinner ?? '—' }}</span>
+            <span class="adet-winner-name">{{ displayWinner }}</span>
+          </div>
+          <div v-else class="adet-unsold">Ended with no bids.</div>
+
+          <!-- Re-list: this cToon never left its owner, so it can go back up -->
+          <div v-if="auction.canRelist" class="adet-relist-wrap">
+            <button class="adet-relist" @click="openRelist">Re-list this cToon</button>
+            <div class="adet-hint">Starts a new auction — you can change the price and duration.</div>
           </div>
 
           <!-- Bid info -->
@@ -143,6 +150,7 @@ const { user, fetchSelf } = useAuth()
 const config  = useRuntimeConfig()
 const scavenger = useScavengerHunt()
 const { open: openCtoonModal } = useCtoonModal()
+const { open: openAuctionModal, createdSignal: auctionCreatedSignal } = useAuctionModal()
 
 const loading  = ref(true)
 const auction  = ref({ ctoon: {}, winnerUsername: null, endAt: null, highestBid: 0, initialBet: 0 })
@@ -255,6 +263,34 @@ function openInfoModal() {
     name:        auction.value.ctoon.name        || null,
   })
 }
+
+function openRelist() {
+  if (!auction.value?.canRelist) return
+  const duration = reconstructDurationPrefill(auction.value.createdAt, auction.value.endAt)
+  openAuctionModal({
+    ctoon: {
+      id:         auction.value.ctoon.userCtoonId,
+      ctoonId:    auction.value.ctoon.id,
+      name:       auction.value.ctoon.name,
+      assetPath:  auction.value.ctoon.assetPath,
+      rarity:     auction.value.ctoon.rarity,
+      mintNumber: auction.value.ctoon.mintNumber,
+    },
+    prefill: {
+      isRelist:       true,
+      initialBet:     auction.value.initialBet,
+      durationPreset: duration.preset,
+      timeframe:      duration.timeframe,
+    },
+  })
+}
+
+// This page still shows the old, closed auction. Once it's been re-listed the
+// cToon has an active auction again, so retire the button rather than leave one
+// that the server would now reject.
+watch(auctionCreatedSignal, () => {
+  if (auction.value) auction.value.canRelist = false
+})
 
 async function placeBid() {
   if (!canBid.value) return
@@ -682,4 +718,33 @@ onUnmounted(() => {
 }
 .adet-toast.success { background: #16a34a; color: #fff; }
 .adet-toast.error   { background: #dc2626; color: #fff; }
+
+/* ── Unsold / re-list ── */
+.adet-unsold { font-size: 0.72rem; font-weight: bold; color: rgba(255,255,255,0.5); }
+
+.adet-relist-wrap { display: flex; flex-direction: column; gap: 3px; }
+
+.adet-relist {
+  align-self: flex-start;
+  padding: 6px 14px;
+  background: rgba(102,204,0,0.15);
+  border: 1px solid var(--OrbitGreen);
+  border-radius: 6px;
+  color: var(--OrbitGreen);
+  font-size: 0.7rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.adet-relist:hover { background: rgba(102,204,0,0.3); }
+
+@media (max-width: 768px) {
+  .adet-bottom { grid-template-columns: 1fr; }
+  /* Full-width and taller: this is the primary action on a finished listing,
+     and the shared button styles here sit well under a comfortable tap size. */
+  .adet-relist { align-self: stretch; width: 100%; min-height: 36px; }
+  .adet-bid-btn { min-height: 36px; }
+  /* Sub-16px inputs make iOS Safari zoom the page on focus. */
+  .adet-autobid-input { font-size: 16px; }
+}
 </style>

--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -88,8 +88,15 @@
             <template v-else>{{ formatDate(item.endAt) }}</template>
           </div>
 
-          <!-- View button -->
-          <button class="ah-view" @click="goToAuction(item.id)">View</button>
+          <!-- Actions -->
+          <div class="ah-actions">
+            <button class="ah-view" @click="goToAuction(item.id)">View</button>
+            <button
+              v-if="item.canRelist"
+              class="ah-relist"
+              @click.stop="openRelist(item)"
+            >Re-list</button>
+          </div>
         </div>
       </template>
     </div>
@@ -153,7 +160,14 @@
             </span>
           </template>
           <template #footer-right>
-            <button class="ah-card-view-btn" @click.stop="goToAuction(item.id)">View</button>
+            <div class="ah-card-actions">
+              <button class="ah-card-view-btn" @click.stop="goToAuction(item.id)">View</button>
+              <button
+                v-if="item.canRelist"
+                class="ah-card-relist-btn"
+                @click.stop="openRelist(item)"
+              >Re-list</button>
+            </div>
           </template>
         </ShortCard>
       </template>
@@ -175,6 +189,7 @@ const filter   = useNewSiteCtoonFilter()
 const aFilters = useAuctionHouseFilters()
 const cmartCtoons = useState('cmartCtoons', () => [])
 const { open: openCtoonModal } = useCtoonModal()
+const { open: openAuctionModal, createdSignal: auctionCreatedSignal } = useAuctionModal()
 const router = useRouter()
 
 function goToAuction(id) {
@@ -364,6 +379,11 @@ watch(() => filter.value.sortField, () => {
   if (activeTab.value === 'all')    { allPage.value = 1;     loadAllAuctions()}
 })
 
+// A re-list creates a new auction and retires the old one's re-list button.
+watch(auctionCreatedSignal, () => {
+  if (activeTab.value === 'mine') loadMyAuctions()
+})
+
 watch(myPage,     () => { if (activeTab.value === 'mine')   loadMyAuctions() })
 watch(myBidsPage, () => { if (activeTab.value === 'mybids') loadMyBids()     })
 watch(allPage,    () => { if (activeTab.value === 'all')    loadAllAuctions()})
@@ -538,6 +558,31 @@ function openInfoModal(item) {
     userCtoonId: item.userCtoonId || null,
     assetPath:   item.assetPath  || null,
     name:        item.name       || null,
+  })
+}
+
+// Put an unsold cToon straight back up, starting from the terms it didn't sell
+// under. canRelist is advisory — POST /api/auctions re-checks ownership, burned
+// state, active auctions and pending trades before creating anything.
+function openRelist(item) {
+  if (!item?.canRelist) return
+  const duration = reconstructDurationPrefill(item.createdAt, item.endAt)
+  openAuctionModal({
+    ctoon: {
+      id:         item.userCtoonId,
+      ctoonId:    item.ctoonId,
+      name:       item.name,
+      assetPath:  item.assetPath,
+      rarity:     item.rarity,
+      mintNumber: item.mintNumber,
+      price:      item.price,
+    },
+    prefill: {
+      isRelist:       true,
+      initialBet:     item.initialBid,
+      durationPreset: duration.preset,
+      timeframe:      duration.timeframe,
+    },
   })
 }
 
@@ -761,9 +806,20 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
 }
 .ah-time.ended { color: rgba(255,255,255,0.38); font-size: 0.57rem; font-weight: normal; }
 
-/* View button */
-.ah-view {
+/* Action buttons */
+/* Stacked rather than side by side: the row's fixed columns already consume
+   nearly the full width on a phone, so a second column would push View
+   off-screen. Fixed width so rows without a Re-list button don't jump. */
+.ah-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 54px;
   flex-shrink: 0;
+}
+
+.ah-view, .ah-relist {
+  width: 100%;
   padding: 3px 8px;
   background: rgba(0,0,0,0.3);
   border: 1px solid var(--OrbitLightBlue);
@@ -776,6 +832,12 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
   transition: background 0.12s;
 }
 .ah-view:hover { background: var(--OrbitLightBlue); }
+
+.ah-relist {
+  border-color: var(--OrbitGreen);
+  color: var(--OrbitGreen);
+}
+.ah-relist:hover { background: rgba(102,204,0,0.25); }
 
 /* ── Card grid ── */
 .ah-card-grid {
@@ -902,6 +964,28 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
 }
 .ah-card-view-btn:hover { background: var(--OrbitLightBlue); }
 
+.ah-card-actions {
+  display: flex;
+  gap: 2px;
+  width: 100%;
+  height: 100%;
+}
+
+.ah-card-relist-btn {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  background: rgba(102,204,0,0.15);
+  border: 1px solid var(--OrbitGreen);
+  border-radius: 4px;
+  color: var(--OrbitGreen);
+  font-size: 0.6rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.ah-card-relist-btn:hover { background: rgba(102,204,0,0.3); }
+
 /* ── Owned/Unowned image badge ── */
 .ah-img-wrap {
   position: relative;
@@ -992,6 +1076,11 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
   .ah-card-grid {
     grid-template-columns: repeat(3, 1fr);
     grid-auto-rows: auto;
+    /* Two buttons can't share a 40%-wide footer on a ~110px card, so the
+       footer stacks — same approach as MyCollection's grid. */
+    --footer-height: 48px;
+    --footer-left-width: 100%;
+    --footer-right-width: 100%;
   }
 
   .ah-card-grid :deep(.sc) {
@@ -999,5 +1088,17 @@ function rarityKey(r)   { return (r || '').toLowerCase().replace(/\s+/g, '-') }
     height: auto;
     aspect-ratio: 3 / 4;
   }
+
+  .ah-card-grid :deep(.sc-footer) { flex-direction: column; gap: 2px; }
+  .ah-card-grid :deep(.sc-footer-right) { justify-content: flex-start; }
+
+  /* Reclaim width for the name: the row's fixed columns leave the body almost
+     nothing at 360px once a second action button is in play. */
+  .ah-img-wrap, .ah-img-wrap .ah-img { width: 72px; height: 72px; }
+  .ah-bid  { width: 68px; }
+  .ah-time { width: 52px; }
+
+  /* Bare minimum tap targets — these buttons create a real auction. */
+  .ah-view, .ah-relist { min-height: 28px; }
 }
 </style>

--- a/components/newsite/AuctionModal.vue
+++ b/components/newsite/AuctionModal.vue
@@ -5,7 +5,7 @@
 
         <!-- ── Header ── -->
         <div class="am-header">
-          <span class="am-title">Send to Auction</span>
+          <span class="am-title">{{ isRelist ? 'Re-list at Auction' : 'Send to Auction' }}</span>
           <button class="am-close" @click="$emit('close')">✕</button>
         </div>
 
@@ -44,6 +44,27 @@
             />
             <div v-if="initialBet < minInitialBet" class="am-error">
               Must be at least {{ minInitialBet }} pts
+            </div>
+
+            <!-- What this cToon has actually sold for. Sits below the input on
+                 purpose: it's a sale-price history, not a starting-bid target. -->
+            <div class="am-guide">
+              <template v-if="loadingSuggestion">
+                <div class="am-guide-loading">Checking recent sales…</div>
+              </template>
+              <template v-else-if="suggestion && suggestion.basis !== 'none'">
+                <div class="am-guide-top">
+                  <span class="am-guide-label">{{ guideLabel }}</span>
+                  <span class="am-guide-value">{{ guideValue }}</span>
+                </div>
+                <div class="am-guide-note">{{ guideNote }}</div>
+                <div v-if="showsRange" class="am-guide-note">
+                  Starting bids are usually set lower.
+                </div>
+              </template>
+              <template v-else>
+                <div class="am-guide-note">Not enough sales data yet.</div>
+              </template>
             </div>
           </div>
 
@@ -94,7 +115,10 @@
 
 <script setup>
 const props = defineProps({
-  ctoon: { type: Object, required: true },
+  ctoon:   { type: Object, required: true },
+  // Optional starting values, used when re-listing something that didn't sell:
+  // { initialBet, durationPreset, timeframe, isRelist }
+  prefill: { type: Object, default: null },
 })
 const emit = defineEmits(['close', 'created'])
 
@@ -116,18 +140,80 @@ const RARITY_MIN = {
 const instaBidValue = computed(() => RARITY_MIN[(props.ctoon.rarity || '').toLowerCase()] ?? 50)
 const minInitialBet = computed(() => Math.max(1, instaBidValue.value))
 
-const initialBet     = ref(Math.max(props.ctoon.price || 0, instaBidValue.value))
-const durationPreset = ref('days')
-const timeframe      = ref(1)
+// When re-listing, start from the terms that didn't sell last time so the
+// seller only has to change what they want to change.
+const isRelist = computed(() => !!props.prefill?.isRelist)
+
+const initialBet = ref(
+  props.prefill?.initialBet != null
+    ? Math.max(props.prefill.initialBet, instaBidValue.value)
+    : Math.max(props.ctoon.price || 0, instaBidValue.value)
+)
+const durationPreset = ref(props.prefill?.durationPreset || 'days')
+const timeframe      = ref(props.prefill?.timeframe || 1)
 const sending        = ref(false)
 const recentAuctions = ref([])
+const suggestion     = ref(null)
+const loadingSuggestion = ref(true)
 const toast          = reactive({ message: '', type: 'success' })
 
 onMounted(async () => {
   try {
-    const res = await $fetch(`/api/ctoon/${props.ctoon.ctoonId}/getRecentAuctions`)
-    recentAuctions.value = Array.isArray(res) ? res : []
-  } catch { recentAuctions.value = [] }
+    const res = await $fetch(`/api/ctoon/${props.ctoon.ctoonId}/getRecentAuctions`, {
+      query: {
+        suggest: '1',
+        ...(props.ctoon.id ? { userCtoonId: props.ctoon.id } : {})
+      }
+    })
+    recentAuctions.value = Array.isArray(res?.sales) ? res.sales : []
+    suggestion.value     = res?.suggestion ?? null
+  } catch {
+    recentAuctions.value = []
+    suggestion.value     = null
+  } finally {
+    loadingSuggestion.value = false
+  }
+})
+
+// ── Price guide copy ──────────────────────────────────────────────
+// Deliberately worded as "sold for", never "recommended" or "list at": the
+// numbers come from completed sales, while the field above is the starting bid.
+const showsRange = computed(() =>
+  ['recent', 'alltime'].includes(suggestion.value?.basis)
+)
+
+const guideLabel = computed(() => {
+  switch (suggestion.value?.basis) {
+    case 'recent':      return 'Recent sales'
+    case 'alltime':     return 'Past sales'
+    case 'estimate':    return 'cMart price'
+    case 'below_floor': return 'Minimum bid'
+    default:            return ''
+  }
+})
+
+const guideValue = computed(() => {
+  const s = suggestion.value
+  if (!s) return ''
+  if (s.basis === 'below_floor') return `${s.floor} pts`
+  if (s.basis === 'estimate')    return `${s.mid} pts`
+  if (s.low === s.high)          return `${s.low} pts`
+  return `${s.low}–${s.high} pts`
+})
+
+const guideNote = computed(() => {
+  const s = suggestion.value
+  if (!s) return ''
+  const n = s.sampleSize
+  const plural = n === 1 ? 'sale' : 'sales'
+  const mint = s.mintAdjusted ? ', adjusted for mint' : ''
+  switch (s.basis) {
+    case 'recent':      return `From ${n} ${plural} in the last ${s.windowDays} days${mint}.`
+    case 'alltime':     return `No sales in ${s.windowDays} days. From ${n} older ${plural}${mint}.`
+    case 'estimate':    return 'No auction history — this is a list price, not a sale.'
+    case 'below_floor': return `Recent sales averaged ${s.mid} pts, below the minimum.`
+    default:            return ''
+  }
 })
 
 function showToast(message, type = 'error') {
@@ -197,6 +283,8 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 12px;
+  box-sizing: border-box;
 }
 
 /* ── Modal box ── */
@@ -204,6 +292,10 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
   position: relative;
   width: 420px;
   max-width: 95vw;
+  /* Without a height cap the footer ends up under the on-screen keyboard when
+     the bid input is focused, and the overlay is fixed so it can't be scrolled
+     to. Never binds on desktop, where the modal is well under this height. */
+  max-height: calc(100dvh - 24px);
   background: var(--OrbitDarkBlue);
   border: 2px solid var(--OrbitLightBlue);
   border-radius: 10px;
@@ -249,6 +341,11 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
   padding: 12px;
   overflow-y: auto;
   scrollbar-width: thin;
+  /* min-height:0 is what actually lets this shrink under the modal's
+     max-height — the default min-height:auto refuses to. */
+  flex: 1;
+  min-height: 0;
+  overscroll-behavior: contain;
 }
 
 /* ── Preview ── */
@@ -365,9 +462,13 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
   border-top: 1px solid rgba(255,255,255,0.1);
   flex-shrink: 0;
   gap: 6px;
+  /* The buttons are nowrap, so without this they get clipped by the modal's
+     overflow:hidden on narrow phones instead of moving to a second line. */
+  flex-wrap: wrap;
+  row-gap: 6px;
 }
 
-.am-footer-right { display: flex; gap: 6px; }
+.am-footer-right { display: flex; gap: 6px; margin-left: auto; }
 
 .am-instabid {
   border: 1px solid var(--OrbitGreen);
@@ -427,4 +528,47 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
 }
 .am-toast.success { background: #16a34a; color: #fff; }
 .am-toast.error   { background: #dc2626; color: #fff; }
+
+/* ── Price guide ── */
+.am-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 2px;
+  /* Reserved so the modal doesn't grow under the user's finger when the
+     suggestion resolves after mount. */
+  min-height: 30px;
+}
+
+.am-guide-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 4px;
+}
+
+.am-guide-label {
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: rgba(255,255,255,0.4);
+}
+
+.am-guide-value {
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: var(--OrbitGreen);
+  white-space: nowrap;
+}
+
+.am-guide-note    { font-size: 0.65rem; color: rgba(255,255,255,0.5); line-height: 1.35; }
+.am-guide-loading { font-size: 0.65rem; color: rgba(255,255,255,0.35); font-style: italic; }
+
+@media (max-width: 768px) {
+  /* Anything under 16px makes iOS Safari zoom the page on focus, which shoves
+     the fixed-position modal half off-screen. */
+  .am-input { font-size: 16px; }
+  .am-preset, .am-instabid, .am-cancel, .am-submit { min-height: 30px; }
+}
 </style>

--- a/components/newsite/MyCollection.vue
+++ b/components/newsite/MyCollection.vue
@@ -4,14 +4,6 @@
     <!-- ── Header bar ────────────────────────────────────────────── -->
     <div class="mc-header">My Collection</div>
 
-    <!-- ── Auction modal ──────────────────────────────────────────── -->
-    <AuctionModal
-      v-if="auctionCtoon"
-      :ctoon="auctionCtoon"
-      @close="auctionCtoon = null"
-      @created="onAuctionCreated"
-    />
-
     <!-- ── Pagination (top) ─────────────────────────────────────── -->
     <div class="mc-pagination">
       <button class="mc-pg-btn" :disabled="currentPage <= 1" @click="prevPage">‹</button>
@@ -89,7 +81,8 @@ function rarityColor(rarity) {
 const allCtoons   = useState('myCollectionCtoons', () => [])
 const loading     = ref(true)
 const filter      = useNewSiteCtoonFilter()
-const auctionCtoon = ref(null)
+// The modal itself is mounted once in layouts/newsite-template.vue.
+const { open: openAuctionModal, createdSignal, lastCreated } = useAuctionModal()
 
 const PAGE_SIZE   = 30
 const currentPage = ref(1)
@@ -102,7 +95,7 @@ function hasActiveAuction(c) {
 
 function openAuction(c) {
   if (hasActiveAuction(c)) return
-  auctionCtoon.value = c
+  openAuctionModal({ ctoon: c })
 }
 
 async function toggleTradeList(c) {
@@ -113,12 +106,11 @@ async function toggleTradeList(c) {
   }
 }
 
-function onAuctionCreated(userCtoonId) {
-  // Mark the ctoon as having an active auction so button could be disabled in future
-  const ctoon = allCtoons.value.find(c => c.id === userCtoonId)
+// Mark the ctoon as having an active auction so its button stays disabled.
+watch(createdSignal, () => {
+  const ctoon = allCtoons.value.find(c => c.id === lastCreated.value)
   if (ctoon) ctoon.hasActiveAuction = true
-  auctionCtoon.value = null
-}
+})
 
 const ctoons = computed(() => {
   const f = filter.value

--- a/composables/useAuctionModal.js
+++ b/composables/useAuctionModal.js
@@ -1,0 +1,82 @@
+// The durations the modal offers, in minutes.
+const DURATION_CHOICES = [
+  { preset: '3m',   timeframe: 1, minutes: 3 },
+  { preset: '30m',  timeframe: 1, minutes: 30 },
+  { preset: '1h',   timeframe: 1, minutes: 60 },
+  { preset: '4h',   timeframe: 1, minutes: 240 },
+  { preset: '6h',   timeframe: 1, minutes: 360 },
+  { preset: '12h',  timeframe: 1, minutes: 720 },
+  ...[1, 2, 3, 4, 5].map(d => ({ preset: 'days', timeframe: d, minutes: d * 1440 }))
+]
+
+const DEFAULT_DURATION = { preset: 'days', timeframe: 1 }
+
+/**
+ * Work out which duration preset a finished auction was listed under.
+ *
+ * Auction.duration only stores whole days, so every sub-day listing records a 0
+ * and the real length has to come from endAt - createdAt. That delta can't be
+ * trusted verbatim: when the server is down across an auction's end time it
+ * extends endAt by the whole outage (server/socket-server.js), and that happens
+ * regardless of whether anyone bid. Snapping to the nearest offered preset
+ * absorbs the drift and keeps the value inside what the server will accept.
+ */
+export function reconstructDurationPrefill(createdAt, endAt) {
+  const start = new Date(createdAt).getTime()
+  const end   = new Date(endAt).getTime()
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return { ...DEFAULT_DURATION }
+
+  const minutes = (end - start) / 60000
+  if (!(minutes > 0)) return { ...DEFAULT_DURATION }
+
+  let best = DURATION_CHOICES[0]
+  for (const choice of DURATION_CHOICES) {
+    if (Math.abs(choice.minutes - minutes) < Math.abs(best.minutes - minutes)) best = choice
+  }
+  return { preset: best.preset, timeframe: best.timeframe }
+}
+
+// Shared state for the "Send to Auction" modal.
+//
+// The modal is mounted once in layouts/newsite-template.vue and opened from
+// anywhere (My Collection, the Auction House "My Auctions" tab, an auction's
+// detail page), mirroring how useCtoonModal drives CtoonInfoCard.
+export function useAuctionModal() {
+  const isOpen  = useState('auction-modal-open', () => false)
+  const ctoon   = useState('auction-modal-ctoon', () => null)
+  const prefill = useState('auction-modal-prefill', () => null)
+  // Bumped after a successful listing so open pages can refresh themselves
+  // without the opener having to hold on to a callback. `lastCreated` carries
+  // the userCtoonId that was just listed.
+  const createdSignal = useState('auction-modal-created-signal', () => 0)
+  const lastCreated   = useState('auction-modal-last-created', () => null)
+
+  /**
+   * @param ctoon    the cToon being listed; needs at least { id, ctoonId, name,
+   *                 assetPath, rarity, mintNumber }
+   * @param prefill  optional { initialBet, durationPreset, timeframe, isRelist }
+   *                 used when re-listing something that didn't sell
+   */
+  function open({ ctoon: nextCtoon, prefill: nextPrefill = null } = {}) {
+    if (!nextCtoon) return
+    ctoon.value   = nextCtoon
+    prefill.value = nextPrefill
+    isOpen.value  = true
+  }
+
+  function close() {
+    isOpen.value  = false
+    ctoon.value   = null
+    prefill.value = null
+  }
+
+  function notifyCreated(userCtoonId = null) {
+    lastCreated.value = userCtoonId
+    createdSignal.value += 1
+  }
+
+  return {
+    isOpen, ctoon, prefill, createdSignal, lastCreated,
+    open, close, notifyCreated
+  }
+}

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -265,6 +265,13 @@ html.newsite-active body {
     <div class="main-content" :class="{ 'main-content-full': !showSidebar && !isMobile, 'main-content-expand': !showFooter }" :style="[{ border: mainContentBorder }, mainContentMobileStyle]"><slot /></div>
     <div class="footer" :style="[{ display: showFooter ? '' : 'none' }, isMobile ? { width: '100%', height: 'auto', aspectRatio: '800 / 60' } : {}]"><slot name="footer" /></div>
     <CtoonInfoCard v-if="ctoonModalIsOpen" />
+    <AuctionModal
+      v-if="auctionModalIsOpen && auctionModalCtoon"
+      :ctoon="auctionModalCtoon"
+      :prefill="auctionModalPrefill"
+      @close="closeAuctionModal"
+      @created="onAuctionCreated"
+    />
   </div>
   <Onboarding />
 </template>
@@ -272,6 +279,17 @@ html.newsite-active body {
 <script setup>
 const route = useRoute()
 const { isOpen: ctoonModalIsOpen } = useCtoonModal()
+const {
+  isOpen:  auctionModalIsOpen,
+  ctoon:   auctionModalCtoon,
+  prefill: auctionModalPrefill,
+  close:   closeAuctionModal,
+  notifyCreated: notifyAuctionCreated
+} = useAuctionModal()
+
+function onAuctionCreated(userCtoonId) {
+  notifyAuctionCreated(userCtoonId)
+}
 const { sidebarMiddleComponent, mobileSidebarCollapsed } = useNewsiteLayout()
 const czoneState = useNewSiteCzoneState()
 

--- a/prisma/migrations/20260731000000_auction_creator_endat_idx/migration.sql
+++ b/prisma/migrations/20260731000000_auction_creator_endat_idx/migration.sql
@@ -1,0 +1,4 @@
+-- /api/my-auctions filters on creatorId and orders by endAt desc. Postgres does
+-- not index foreign keys automatically, so this query has been sequentially
+-- scanning the whole Auction table on every load of the "My Auctions" tab.
+CREATE INDEX IF NOT EXISTS "Auction_creatorId_endAt_idx" ON "Auction"("creatorId", "endAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1240,6 +1240,10 @@ model Auction {
   @@index([userCtoonId, status])
   @@index([status, winnerId, highestBid])
   @@index([isFeatured, status, highestBidderId])
+  // /api/my-auctions filters on creatorId and orders by endAt desc. Postgres
+  // doesn't index foreign keys automatically, so without this the "My Auctions"
+  // tab sequentially scans every auction ever created.
+  @@index([creatorId, endAt])
 }
 
 model Bid {

--- a/server/api/auction/[id].get.js
+++ b/server/api/auction/[id].get.js
@@ -58,6 +58,22 @@ export default defineEventHandler(async (event) => {
     blockedByFeaturedLead = !!conflict
   }
 
+  // Closed with nobody bidding: the cToon never left its owner, so whoever holds
+  // it now can put it straight back up. Deliberately keyed on current ownership
+  // rather than auction.creatorId — an unsold cToon becomes tradeable again and
+  // may have changed hands since it closed.
+  let canRelist = false
+  if (auction.status === 'CLOSED' &&
+      auction.winnerId === null &&
+      auction.userCtoon.userId === userId &&
+      !auction.userCtoon.burnedAt) {
+    const blocking = await prisma.auction.findFirst({
+      where: { userCtoonId: auction.userCtoonId, status: 'ACTIVE' },
+      select: { id: true }
+    })
+    canRelist = !blocking
+  }
+
   return {
     id: auction.id,
     isFeatured: auction.isFeatured,
@@ -79,9 +95,13 @@ export default defineEventHandler(async (event) => {
       secondEditionOverlaySize: auction.userCtoon.ctoon.secondEditionOverlaySize
     },
     isHolidayItem, // ← added
+    createdAt:  auction.createdAt.toISOString(),
     endAt:      auction.endAt.toISOString(),
     initialBet: auction.initialBet,
+    duration:   auction.duration,
     status:     auction.status,
+    bidCount:   bids.length,
+    canRelist,
     highestBid: auction.highestBid ?? currentBid,
     highestBidderUsername: auction.highestBidder?.username || null,
     bids: bids.map(b => ({ user: b.user.username, amount: b.amount })),

--- a/server/api/auctions.post.js
+++ b/server/api/auctions.post.js
@@ -9,6 +9,11 @@ import { useRuntimeConfig } from '#imports'
 import fetch from 'node-fetch'
 import { scheduleAuctionClose } from '@/server/utils/queues'
 import { resolveUserCtoonId } from '@/server/utils/userCtoonId'
+import { rarityFloor } from '@/server/utils/auctionPriceSuggestion'
+
+// Longest listing the UI offers: 5 days, or 12 hours for the sub-day presets.
+const MAX_DURATION_DAYS = 5
+const MAX_DURATION_MINUTES = 12 * 60
 
 function formatDuration(days, minutes) {
   if (minutes > 0) {
@@ -49,6 +54,23 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 422, statusMessage: 'Missing required fields' })
   }
 
+  // Bound the duration. Without this a negative value puts endAt in the past and
+  // a huge one locks the cToon out of trading for years while overflowing the
+  // BullMQ delay. Re-listing sends a duration the client reconstructed from the
+  // previous auction, so this can't be left to the UI.
+  const days = Number(durationDays)
+  const minutes = Number(durationMinutes)
+  if (!Number.isInteger(days) || !Number.isInteger(minutes) ||
+      days < 0 || days > MAX_DURATION_DAYS ||
+      minutes < 0 || minutes > MAX_DURATION_MINUTES ||
+      (days === 0 && minutes === 0)) {
+    throw createError({ statusCode: 422, statusMessage: 'Invalid auction duration' })
+  }
+
+  if (!Number.isInteger(Number(initialBet)) || Number(initialBet) <= 0) {
+    throw createError({ statusCode: 422, statusMessage: 'Initial bet must be a positive whole number' })
+  }
+
   const resolvedUserCtoonId = await resolveUserCtoonId(userCtoonId)
   if (!resolvedUserCtoonId) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid cToon reference' })
@@ -72,23 +94,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'This cToon has been burned and cannot be auctioned' })
   }
 
-  // Helper: map rarity -> insta-bid floor (must match client)
-  const rarityToExpectedBid = (rarityRaw) => {
-    const r = (rarityRaw || '').trim().toLowerCase()
-    switch (r) {
-      case 'common': return 25
-      case 'uncommon': return 50
-      case 'rare': return 100
-      case 'very rare': return 187
-      case 'crazy rare': return 312
-      case 'code only': return 50
-      case 'prize only': return 50
-      case 'auction only': return 50
-      default: return 50
-    }
-  }
-
-  const expectedInitialBet = rarityToExpectedBid(userCtoonRec.ctoon?.rarity)
+  // Rarity -> insta-bid floor. Shared with the pricing hint so the two can't drift.
+  const expectedInitialBet = rarityFloor(userCtoonRec.ctoon?.rarity)
 
   // Enforce minimum initial bet
   if (Number(initialBet) < expectedInitialBet) {
@@ -120,8 +127,8 @@ export default defineEventHandler(async (event) => {
 
   // 5. Compute endAt
   const nowMs    = Date.now()
-  const daysMs   = durationDays * 24 * 60 * 60 * 1000
-  const minsMs   = durationMinutes * 60 * 1000
+  const daysMs   = days * 24 * 60 * 60 * 1000
+  const minsMs   = minutes * 60 * 1000
   const endAtUtc = new Date(nowMs + daysMs + minsMs).toISOString()
 
   // 6. Create auction
@@ -129,7 +136,7 @@ export default defineEventHandler(async (event) => {
     data: {
       userCtoonId: resolvedUserCtoonId,
       initialBet: Number(initialBet),
-      duration: durationDays,
+      duration: days,
       endAt: endAtUtc,
       ...(userId ? { creatorId: userId } : {})
     }
@@ -230,7 +237,7 @@ export default defineEventHandler(async (event) => {
 
       const { name, rarity, assetPath, isSecondEdition } = userCtoonRec.ctoon || {}
       const mintNumber   = userCtoonRec.mintNumber
-      const durationText = formatDuration(durationDays, durationMinutes)
+      const durationText = formatDuration(days, minutes)
 
       const auctionLink = `${baseUrl}/auction/${auction.id}`
       const rawImageUrl = assetPath

--- a/server/api/ctoon/[id]/getRecentAuctions.get.js
+++ b/server/api/ctoon/[id]/getRecentAuctions.get.js
@@ -1,7 +1,34 @@
 // server/api/ctoon/[id]/getRecentAuctions.get.js
 
-import { defineEventHandler, createError, getRequestHeader } from 'h3'
+import { defineEventHandler, createError, getRequestHeader, getQuery } from 'h3'
 import { prisma } from '@/server/prisma'
+import { resolveUserCtoonId } from '@/server/utils/userCtoonId'
+import {
+  computePriceSuggestion,
+  isSystemSale,
+  RECENT_WINDOW_DAYS,
+  MAX_SAMPLE_SIZE
+} from '@/server/utils/auctionPriceSuggestion'
+import { getSystemUserIds } from '@/server/utils/systemAccounts'
+
+// How many sale rows to show in the "Recent Sales" list.
+const DISPLAY_COUNT = 3
+
+// Read a few extra rows so that dropping system-account sales still leaves a
+// full sample to work with.
+const FETCH_COUNT = MAX_SAMPLE_SIZE * 2
+
+const SALE_SELECT = {
+  endAt: true,
+  highestBid: true,
+  initialBet: true,
+  winnerId: true,
+  userCtoon: { select: { mintNumber: true } }
+}
+
+function toDisplay(sale) {
+  return { endedAt: sale.endAt, soldFor: sale.highestBid }
+}
 
 export default defineEventHandler(async (event) => {
   const { id } = event.context.params || {}
@@ -21,23 +48,110 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
   }
 
-  // Find the last 3 closed, successfully sold auctions for this cToon
-  const recent = await prisma.auction.findMany({
-    where: {
-      userCtoon: { ctoonId: id },
-      status: 'CLOSED',
-      winnerId: { not: null }
-    },
-    orderBy: { endAt: 'desc' },
-    take: 3,
-    select: {
-      endAt: true,
-      highestBid: true
+  const query = getQuery(event)
+  const wantSuggestion = ['1', 'true', 'yes'].includes(
+    String(Array.isArray(query.suggest) ? query.suggest[0] : query.suggest ?? '').toLowerCase()
+  )
+
+  const soldWhere = {
+    userCtoon: { ctoonId: id },
+    status: 'CLOSED',
+    winnerId: { not: null }
+  }
+
+  // Callers that only want the display list (the legacy Add-to-Auction modal)
+  // get exactly the response shape they always had.
+  if (!wantSuggestion) {
+    const recent = await prisma.auction.findMany({
+      where: soldWhere,
+      orderBy: { endAt: 'desc' },
+      take: DISPLAY_COUNT,
+      select: { endAt: true, highestBid: true }
+    })
+    return recent.map(toDisplay)
+  }
+
+  // The window is a server constant on purpose — a caller-supplied cutoff would
+  // let anyone hand-pick the sales the suggestion is built from.
+  const cutoff = new Date(Date.now() - RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+
+  const [recentRows, ctoonRec, highestMintRow, systemUserIds, holidayRec] = await Promise.all([
+    prisma.auction.findMany({
+      where: { ...soldWhere, endAt: { gte: cutoff } },
+      orderBy: { endAt: 'desc' },
+      take: FETCH_COUNT,
+      select: SALE_SELECT
+    }),
+    prisma.ctoon.findUnique({
+      where: { id },
+      select: { price: true, rarity: true, quantity: true, inCmart: true }
+    }),
+    // Cheaper than a groupBy: an index-only backward scan on the
+    // UserCtoon @@unique([ctoonId, mintNumber]) index.
+    prisma.userCtoon.findFirst({
+      where: { ctoonId: id },
+      orderBy: { mintNumber: 'desc' },
+      select: { mintNumber: true }
+    }),
+    getSystemUserIds(),
+    prisma.holidayEventItem.findFirst({ where: { ctoonId: id }, select: { id: true } })
+  ])
+
+  if (!ctoonRec) {
+    throw createError({ statusCode: 404, statusMessage: 'cToon not found' })
+  }
+
+  const dropSystemSales = rows => rows.filter(r => !isSystemSale(r, systemUserIds))
+
+  let sales = dropSystemSales(recentRows).slice(0, MAX_SAMPLE_SIZE)
+  let basis = 'recent'
+
+  // Nothing recent — reach further back before giving up on sale data.
+  if (!sales.length) {
+    const allTimeRows = await prisma.auction.findMany({
+      where: soldWhere,
+      orderBy: { endAt: 'desc' },
+      take: FETCH_COUNT,
+      select: SALE_SELECT
+    })
+    sales = dropSystemSales(allTimeRows).slice(0, MAX_SAMPLE_SIZE)
+    if (sales.length) basis = 'alltime'
+  }
+
+  // Mint context, only if the caller actually owns the cToon they named. The
+  // encoded id is unsigned and forgeable, so an unverified one would let anyone
+  // probe whether a given (user, cToon, mint) exists.
+  let mintNumber = null
+  const rawUserCtoonId = Array.isArray(query.userCtoonId) ? query.userCtoonId[0] : query.userCtoonId
+  if (rawUserCtoonId) {
+    const resolvedId = await resolveUserCtoonId(String(rawUserCtoonId))
+    if (resolvedId) {
+      const owned = await prisma.userCtoon.findUnique({
+        where: { id: resolvedId },
+        select: { userId: true, ctoonId: true, mintNumber: true, burnedAt: true }
+      })
+      if (owned && owned.userId === me.id && owned.ctoonId === id && !owned.burnedAt) {
+        mintNumber = owned.mintNumber
+      }
     }
+  }
+
+  const suggestion = computePriceSuggestion({
+    sales: sales.map(s => ({
+      highestBid: s.highestBid,
+      mintNumber: s.userCtoon?.mintNumber ?? null
+    })),
+    cMartPrice: ctoonRec.inCmart ? ctoonRec.price : null,
+    mintNumber,
+    highestMint: highestMintRow?.mintNumber ?? null,
+    isUnlimited: ctoonRec.quantity == null,
+    isHolidayItem: !!holidayRec,
+    rarity: ctoonRec.rarity,
+    basis
   })
 
-  return recent.map(a => ({
-    endedAt: a.endAt,
-    soldFor: a.highestBid
-  }))
+  return {
+    sales: sales.slice(0, DISPLAY_COUNT).map(toDisplay),
+    suggestion
+  }
 })

--- a/server/api/my-auctions.get.js
+++ b/server/api/my-auctions.get.js
@@ -142,6 +142,7 @@ export default defineEventHandler(async (event) => {
           userId: true,
           ctoonId: true,
           mintNumber: true,
+          burnedAt: true,
           ctoon: {
             select: {
               assetPath: true,
@@ -178,6 +179,19 @@ export default defineEventHandler(async (event) => {
     orderBy: { endAt: 'desc' },
   })
 
+  // An auction that closed without a winner never changed hands, so the cToon is
+  // still sitting in the creator's collection and can go straight back up.
+  // Gate on who owns it *now*, not on who created the auction: after an unsold
+  // close the cToon is tradeable again and may since have been traded away,
+  // while the closed auction still carries this user as its creator.
+  const canRelistAuction = (a) => (
+    a.status === 'CLOSED' &&
+    a.winnerId === null &&
+    a.userCtoon?.userId === userId &&
+    !a.userCtoon?.burnedAt &&
+    (a.userCtoon?.auctions?.length ?? 0) === 0
+  )
+
   const items = auctions.map(a => ({
     id:               a.id,
     status:           a.status,
@@ -209,6 +223,7 @@ export default defineEventHandler(async (event) => {
     isOwned:          a.userCtoon?.userId === userId,
     isOwner:          a.userCtoon?.userId === userId,
     hasActiveAuction: (a.userCtoon?.auctions?.length ?? 0) > 0,
+    canRelist:        canRelistAuction(a),
   }))
 
   const filtered = applyAuctionFilters(items, {

--- a/server/utils/auctionPriceSuggestion.js
+++ b/server/utils/auctionPriceSuggestion.js
@@ -1,0 +1,229 @@
+// server/utils/auctionPriceSuggestion.js
+//
+// Pricing helpers for the "what has this been selling for?" hint shown in the
+// send-to-auction modal. Everything in here is pure so it can be unit-tested
+// (see tests/auctionPriceSuggestion.test.js); the queries that feed it live in
+// server/api/ctoon/[id]/getRecentAuctions.get.js.
+
+// Minimum initial bid per rarity. This is the authoritative copy — the check in
+// server/api/auctions.post.js imports it, and the client mirrors it for display.
+export const RARITY_FLOORS = {
+  'common': 25,
+  'uncommon': 50,
+  'rare': 100,
+  'very rare': 187,
+  'crazy rare': 312,
+  'code only': 50,
+  'prize only': 50,
+  'auction only': 50
+}
+
+export const DEFAULT_RARITY_FLOOR = 50
+
+export function rarityFloor(rarity) {
+  const key = String(rarity ?? '').trim().toLowerCase()
+  return RARITY_FLOORS[key] ?? DEFAULT_RARITY_FLOOR
+}
+
+// How far back a sale can be and still count as "recent".
+export const RECENT_WINDOW_DAYS = 90
+
+// How many sales the average is built from.
+export const MAX_SAMPLE_SIZE = 10
+
+/**
+ * Mint-number premium, matching the trade tool (components/newsite/Trade.vue).
+ * Mint #1 of 500 -> ~1.998x, mint #500 of 500 -> 1.0x.
+ *
+ * Returns 1 (no adjustment) when a premium would be meaningless or misleading:
+ *  - the cToon has no mint number
+ *  - there is only one mint in existence
+ *  - the cToon is unlimited-print (quantity null): `highestMint` climbs forever,
+ *    so the same mint would silently inflate as more copies are printed
+ *  - the cToon is a holiday item: its mint number is deliberately hidden in the
+ *    UI, and an adjusted price is invertible back to the mint
+ */
+export function mintMultiplier(mintNumber, highestMint, opts = {}) {
+  const { isUnlimited = false, isHolidayItem = false } = opts
+  if (isUnlimited || isHolidayItem) return 1
+  if (mintNumber == null || !highestMint || highestMint <= 1) return 1
+  if (mintNumber > highestMint) return 1
+  return 1 + (highestMint - mintNumber) / highestMint
+}
+
+/**
+ * True when a closed auction was won by the official/system account rather
+ * than by a player.
+ *
+ * The insta-bid path (server/api/auctions.post.js) places a bid from the
+ * official account at exactly the rarity floor. If no player ever outbids it,
+ * the auction still closes with a winner, so it looks like a sale at the floor
+ * price. Those are buyout floors, not market prices, and leaving them in drags
+ * every average down toward the rarity minimum — for free, since the seller is
+ * paid out of the system account.
+ */
+export function isSystemSale(sale, systemUserIds) {
+  const winnerId = sale?.winnerId
+  if (!winnerId) return false
+  if (Array.isArray(systemUserIds)) return systemUserIds.filter(Boolean).includes(winnerId)
+  return !!systemUserIds && winnerId === systemUserIds
+}
+
+function mean(nums) {
+  if (!nums.length) return 0
+  return nums.reduce((a, b) => a + b, 0) / nums.length
+}
+
+/**
+ * Middle value of the sample. Preferred over the mean for the headline number:
+ * a handful of collusive or freak sales can move an average a long way, but
+ * they have to make up half the window to move a median.
+ */
+function median(nums) {
+  if (!nums.length) return 0
+  const sorted = [...nums].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+function stdDev(nums) {
+  if (nums.length < 2) return 0
+  const m = mean(nums)
+  const variance = nums.reduce((acc, n) => acc + (n - m) ** 2, 0) / (nums.length - 1)
+  return Math.sqrt(variance)
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Half-width of the range, as a fraction of the midpoint.
+ *
+ * A fixed +/-15% band is fake precision when it's built from one sale, so the
+ * band widens with a small sample and with a noisy one:
+ *   n=1            -> +/-40%
+ *   n=3,  CV=0.20  -> +/-43%
+ *   n=10, CV=0.10  -> +/-23%
+ */
+export function rangeFactor(bases) {
+  const n = bases.length
+  if (!n) return 0.15
+  const m = mean(bases)
+  const cv = m > 0 ? stdDev(bases) / m : 0
+  return clamp(cv + 0.40 / Math.sqrt(n), 0.15, 0.60)
+}
+
+/**
+ * Build the price hint.
+ *
+ * `sales` are already-filtered closed+sold auctions, newest first, each
+ * { highestBid, mintNumber }. `cMartPrice` is the fallback when there is no
+ * sale history at all.
+ *
+ * Returns { basis, low, high, mid, sampleSize, windowDays, floor, mintAdjusted }
+ * where basis is one of:
+ *   'recent'      – built from sales inside the 90-day window
+ *   'alltime'     – no recent sales, built from older ones
+ *   'estimate'    – no sales at all, using the cMart price
+ *   'below_floor' – the market sits under the rarity minimum
+ *   'none'        – nothing to go on
+ */
+export function computePriceSuggestion({
+  sales = [],
+  cMartPrice = null,
+  mintNumber = null,
+  highestMint = null,
+  isUnlimited = false,
+  isHolidayItem = false,
+  rarity = null,
+  basis = 'recent',
+  windowDays = RECENT_WINDOW_DAYS
+} = {}) {
+  const floor = rarityFloor(rarity)
+  const mintOpts = { isUnlimited, isHolidayItem }
+  const myMultiplier = mintMultiplier(mintNumber, highestMint, mintOpts)
+  const mintAdjusted = myMultiplier !== 1
+
+  const empty = {
+    basis: 'none',
+    low: null,
+    high: null,
+    mid: null,
+    sampleSize: 0,
+    windowDays,
+    floor,
+    mintAdjusted: false
+  }
+
+  const usable = (Array.isArray(sales) ? sales : [])
+    .slice(0, MAX_SAMPLE_SIZE)
+    .filter(s => Number.isFinite(Number(s?.highestBid)) && Number(s.highestBid) > 0)
+
+  if (!usable.length) {
+    if (cMartPrice == null || cMartPrice <= 0) return empty
+    // No sale history: the cMart price is a list price, not a sale price, so it
+    // gets no mint premium and no invented range.
+    const mid = Math.round(cMartPrice)
+    return {
+      basis: 'estimate',
+      low: mid,
+      high: mid,
+      mid,
+      sampleSize: 0,
+      windowDays,
+      floor,
+      mintAdjusted: false
+    }
+  }
+
+  // Normalise each sale back to a "mint-neutral" base before averaging.
+  //
+  // Without this the number comes out ~1.5x too high: the average already
+  // blends low mints (which sold at a premium) with high ones, and multiplying
+  // that average by the premium again applies it twice. Dividing each sale by
+  // its own multiplier first means the average is a true base value, and the
+  // premium is then applied exactly once, for the mint being listed. The
+  // relative gap between mints stays identical to what the trade tool shows.
+  const bases = usable.map(s => {
+    const mult = mintMultiplier(s.mintNumber, highestMint, mintOpts)
+    return Number(s.highestBid) / (mult || 1)
+  })
+
+  const base = median(bases)
+  const mid = Math.round(base * myMultiplier)
+  const factor = rangeFactor(bases)
+
+  let low = Math.round(mid * (1 - factor))
+  const high = Math.round(mid * (1 + factor))
+
+  // The whole range sits under the minimum the seller is allowed to enter.
+  // Saying so is more useful than showing a range they can't use.
+  if (high < floor) {
+    return {
+      basis: 'below_floor',
+      low: floor,
+      high: floor,
+      mid,
+      sampleSize: usable.length,
+      windowDays,
+      floor,
+      mintAdjusted
+    }
+  }
+
+  // Lift the bottom of the range to the floor, but never push the top down —
+  // that would hide real upside.
+  low = Math.max(low, floor)
+
+  return {
+    basis: basis === 'alltime' ? 'alltime' : 'recent',
+    low,
+    high,
+    mid,
+    sampleSize: usable.length,
+    windowDays,
+    floor,
+    mintAdjusted
+  }
+}

--- a/server/utils/systemAccounts.js
+++ b/server/utils/systemAccounts.js
@@ -1,0 +1,50 @@
+// server/utils/systemAccounts.js
+//
+// The app has a couple of non-player accounts that hold cToons and place bids:
+// the official account used for insta-bid listings (server/api/auctions.post.js)
+// and whatever OFFICIAL_USERNAME points at for dissolve payouts
+// (server/socket-server.js). Anything they "win" is a system transfer, not a
+// market sale, so valuation code needs to be able to exclude them.
+
+import { prisma } from '@/server/prisma'
+import { EXCLUDED_SYSTEM_USER_ID } from '@/server/utils/economyValuation'
+
+const OFFICIAL_AUCTION_USERNAME = 'CartoonReOrbitOfficial'
+
+// These ids never change for the life of the process, so resolve them once.
+let cached = null
+let inFlight = null
+
+export async function getSystemUserIds() {
+  if (cached) return cached
+  if (inFlight) return inFlight
+
+  inFlight = (async () => {
+    const usernames = [OFFICIAL_AUCTION_USERNAME]
+    if (process.env.OFFICIAL_USERNAME) usernames.push(process.env.OFFICIAL_USERNAME)
+
+    let rows = []
+    try {
+      rows = await prisma.user.findMany({
+        where: { username: { in: [...new Set(usernames)] } },
+        select: { id: true }
+      })
+    } catch {
+      // A lookup failure must not take down the endpoints that call this —
+      // worst case we filter nothing out this time around.
+      inFlight = null
+      return [EXCLUDED_SYSTEM_USER_ID]
+    }
+
+    cached = [...new Set([EXCLUDED_SYSTEM_USER_ID, ...rows.map(r => r.id)])].filter(Boolean)
+    inFlight = null
+    return cached
+  })()
+
+  return inFlight
+}
+
+export function clearSystemUserIdsCache() {
+  cached = null
+  inFlight = null
+}

--- a/tests/auctionPriceSuggestion.test.js
+++ b/tests/auctionPriceSuggestion.test.js
@@ -1,0 +1,217 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  RARITY_FLOORS,
+  DEFAULT_RARITY_FLOOR,
+  rarityFloor,
+  mintMultiplier,
+  isSystemSale,
+  rangeFactor,
+  computePriceSuggestion,
+  MAX_SAMPLE_SIZE
+} from '../server/utils/auctionPriceSuggestion.js'
+
+test('rarityFloor matches the server-side minimums and is case/space tolerant', () => {
+  assert.equal(rarityFloor('Common'), 25)
+  assert.equal(rarityFloor('  crazy rare  '), 312)
+  assert.equal(rarityFloor('Very Rare'), 187)
+  assert.equal(rarityFloor('Auction Only'), 50)
+  // Unknown or missing rarity falls back rather than throwing.
+  assert.equal(rarityFloor('nonsense'), DEFAULT_RARITY_FLOOR)
+  assert.equal(rarityFloor(null), DEFAULT_RARITY_FLOOR)
+  assert.equal(rarityFloor(undefined), DEFAULT_RARITY_FLOOR)
+  // Every declared floor is reachable through the lookup.
+  for (const [rarity, floor] of Object.entries(RARITY_FLOORS)) {
+    assert.equal(rarityFloor(rarity), floor)
+  }
+})
+
+test('mintMultiplier reproduces the trade tool premium', () => {
+  // Documented in components/newsite/Trade.vue: #1 of 500 ~= 1.998x, last = 1x.
+  assert.ok(Math.abs(mintMultiplier(1, 500) - 1.998) < 0.001)
+  assert.equal(mintMultiplier(250, 500), 1.5)
+  assert.equal(mintMultiplier(500, 500), 1)
+})
+
+test('mintMultiplier declines to adjust where a premium would mislead', () => {
+  assert.equal(mintMultiplier(null, 500), 1, 'no mint number')
+  assert.equal(mintMultiplier(1, 1), 1, 'single mint in existence')
+  assert.equal(mintMultiplier(1, 0), 1, 'unknown highest mint')
+  assert.equal(mintMultiplier(1, null), 1, 'missing highest mint')
+  assert.equal(mintMultiplier(5, 500, { isUnlimited: true }), 1, 'unlimited print run')
+  assert.equal(mintMultiplier(5, 500, { isHolidayItem: true }), 1, 'hidden mint number')
+  // Stale highestMint (mint above the known max) must not produce a <1 discount.
+  assert.equal(mintMultiplier(600, 500), 1)
+})
+
+test('isSystemSale identifies auctions won by the system account', () => {
+  const official = 'official-user-id'
+  const dissolve = 'dissolve-account-id'
+
+  assert.equal(isSystemSale({ winnerId: official }, official), true)
+  // A player won it — a real sale, keep it.
+  assert.equal(isSystemSale({ winnerId: 'someone-else' }, official), false)
+  // Unsold auctions have no winner and never reach this filter.
+  assert.equal(isSystemSale({ winnerId: null }, official), false)
+  // No system account resolved: never filter anything out.
+  assert.equal(isSystemSale({ winnerId: official }, null), false)
+
+  // Accepts a list, since the app has more than one system-ish account.
+  assert.equal(isSystemSale({ winnerId: dissolve }, [official, dissolve]), true)
+  assert.equal(isSystemSale({ winnerId: 'player' }, [official, dissolve]), false)
+  assert.equal(isSystemSale({ winnerId: 'player' }, [null, undefined]), false)
+})
+
+test('computePriceSuggestion uses the median so outliers cannot drag it', () => {
+  // Four honest sales around 100 plus one absurd outlier.
+  const withOutlier = computePriceSuggestion({
+    sales: [
+      { highestBid: 100 }, { highestBid: 105 },
+      { highestBid: 95 },  { highestBid: 100 },
+      { highestBid: 5000 }
+    ],
+    rarity: 'common'
+  })
+  // A mean would be ~1080 here.
+  assert.equal(withOutlier.mid, 100)
+  // The band still widens to reflect how noisy the sample is.
+  assert.ok(withOutlier.high - withOutlier.low > 40)
+})
+
+test('rangeFactor widens for small and noisy samples, and stays clamped', () => {
+  const oneSale = rangeFactor([100])
+  assert.ok(Math.abs(oneSale - 0.40) < 0.001, 'n=1 gives +/-40%')
+
+  const tenTight = rangeFactor(Array(10).fill(100))
+  assert.ok(Math.abs(tenTight - 0.1265) < 0.01 || tenTight === 0.15)
+  assert.ok(tenTight >= 0.15, 'never narrower than +/-15%')
+
+  // More samples of the same data must never widen the band.
+  assert.ok(rangeFactor(Array(10).fill(100)) <= rangeFactor([100]))
+
+  // Wild variance is capped so the range stays meaningful.
+  assert.ok(rangeFactor([10, 1000, 5, 2000, 8]) <= 0.60)
+})
+
+test('computePriceSuggestion averages sales and brackets them', () => {
+  const res = computePriceSuggestion({
+    sales: [{ highestBid: 100 }, { highestBid: 120 }, { highestBid: 110 }],
+    rarity: 'common'
+  })
+  assert.equal(res.basis, 'recent')
+  assert.equal(res.sampleSize, 3)
+  assert.equal(res.mid, 110)
+  assert.ok(res.low < res.mid && res.mid < res.high)
+  assert.equal(res.mintAdjusted, false)
+})
+
+test('computePriceSuggestion does not double-count the mint premium', () => {
+  // Sales evenly spread across the mint range of a 100-mint cToon whose true
+  // base value is 100/mint-neutral. Under the naive formula (average x premium)
+  // a mint #1 estimate comes out near 297; the correct answer is ~199.
+  const highestMint = 100
+  const sales = [1, 25, 50, 75, 100].map(m => ({
+    highestBid: Math.round(100 * (1 + (highestMint - m) / highestMint)),
+    mintNumber: m
+  }))
+
+  const forMint1 = computePriceSuggestion({
+    sales, highestMint, mintNumber: 1, rarity: 'common'
+  })
+  assert.ok(
+    Math.abs(forMint1.mid - 199) < 6,
+    `mint #1 should land near 199, got ${forMint1.mid}`
+  )
+  assert.equal(forMint1.mintAdjusted, true)
+
+  const forLastMint = computePriceSuggestion({
+    sales, highestMint, mintNumber: 100, rarity: 'common'
+  })
+  assert.ok(
+    Math.abs(forLastMint.mid - 100) < 5,
+    `last mint should land near 100, got ${forLastMint.mid}`
+  )
+
+  // The relative premium between mints is preserved exactly.
+  assert.ok(Math.abs(forMint1.mid / forLastMint.mid - 1.99) < 0.05)
+})
+
+test('computePriceSuggestion clamps the low end to the rarity floor', () => {
+  const res = computePriceSuggestion({
+    sales: [{ highestBid: 330 }, { highestBid: 320 }, { highestBid: 325 }],
+    rarity: 'crazy rare' // floor 312
+  })
+  assert.equal(res.floor, 312)
+  assert.equal(res.low, 312, 'low is lifted to the floor')
+  assert.ok(res.high > 312, 'high is never pushed down')
+})
+
+test('computePriceSuggestion reports when the market is under the floor', () => {
+  const res = computePriceSuggestion({
+    sales: [{ highestBid: 60 }, { highestBid: 55 }, { highestBid: 58 }],
+    rarity: 'crazy rare' // floor 312, way above these sales
+  })
+  assert.equal(res.basis, 'below_floor')
+  assert.equal(res.low, 312)
+  assert.equal(res.high, 312)
+  assert.ok(res.mid < 312, 'the real market midpoint is still reported')
+})
+
+test('computePriceSuggestion falls back to the cMart price with no sales', () => {
+  const res = computePriceSuggestion({
+    sales: [],
+    cMartPrice: 400,
+    mintNumber: 1,
+    highestMint: 500,
+    rarity: 'rare'
+  })
+  assert.equal(res.basis, 'estimate')
+  assert.equal(res.mid, 400)
+  assert.equal(res.low, 400)
+  assert.equal(res.high, 400)
+  assert.equal(res.sampleSize, 0)
+  assert.equal(res.mintAdjusted, false, 'a list price gets no mint premium')
+})
+
+test('computePriceSuggestion returns none when there is nothing to go on', () => {
+  const res = computePriceSuggestion({ sales: [], cMartPrice: null, rarity: 'rare' })
+  assert.equal(res.basis, 'none')
+  assert.equal(res.low, null)
+  assert.equal(res.high, null)
+  assert.equal(res.mid, null)
+
+  const zeroPriced = computePriceSuggestion({ sales: [], cMartPrice: 0, rarity: 'rare' })
+  assert.equal(zeroPriced.basis, 'none')
+})
+
+test('computePriceSuggestion ignores junk sale rows', () => {
+  const res = computePriceSuggestion({
+    sales: [
+      { highestBid: 100 },
+      { highestBid: 0 },
+      { highestBid: null },
+      { highestBid: 'abc' },
+      { highestBid: 120 }
+    ],
+    rarity: 'common'
+  })
+  assert.equal(res.sampleSize, 2)
+  assert.equal(res.mid, 110)
+})
+
+test('computePriceSuggestion caps the sample and preserves the alltime basis', () => {
+  const many = Array.from({ length: 25 }, (_, i) => ({ highestBid: 100 + i }))
+  const res = computePriceSuggestion({ sales: many, rarity: 'common', basis: 'alltime' })
+  assert.equal(res.sampleSize, MAX_SAMPLE_SIZE)
+  assert.equal(res.basis, 'alltime')
+
+  // Defaults to the recent basis when not told otherwise.
+  assert.equal(computePriceSuggestion({ sales: many, rarity: 'common' }).basis, 'recent')
+})
+
+test('computePriceSuggestion handles an empty call without throwing', () => {
+  const res = computePriceSuggestion()
+  assert.equal(res.basis, 'none')
+  assert.equal(res.floor, DEFAULT_RARITY_FLOOR)
+})


### PR DESCRIPTION
## What this does

**Re-list.** An auction that closes with no bids leaves the cToon with its owner, so it can go straight back up. The "My Auctions" tab (list + card view) and an auction's detail page now show a Re-list button on those, opening the listing modal prefilled with the terms that didn't sell.

**Price guide.** The listing modal now shows what the cToon has actually been selling for — up to 10 sales in the last 90 days, falling back to older sales and then to the cMart price. Display-only; it never touches the Initial Bid field.

Newsite only. `pages/auctions.vue` and `components/AddToAuction.vue` are untouched, and `/api/ctoon/[id]/getRecentAuctions` keeps its existing array response unless a caller opts in with `?suggest=1`.

## Notes on the pricing math

- **Median, not mean, and system-won auctions are dropped.** The insta-bid path places a bid from `CartoonReOrbitOfficial` at the rarity floor (`server/api/auctions.post.js`), so an unbid insta-bid listing closes looking like a sale *at the floor*. Those are buyout floors, not market prices, and they drag every average toward the rarity minimum. This contamination affects the existing trade-tool valuations too; I did not change those.

- **The mint premium is applied once, not twice.** Each sale is normalised by its own mint multiplier before averaging, then the premium is applied for the mint being listed. Applying the trade tool's multiplier straight to an all-mints average double-counts it and lands roughly 1.5x high — a mint #1 of 100 comes out ~297 when the honest number is ~199. It is invisible in the trade tool because the factor appears on both sides of a fairness ratio and cancels; it does not cancel in an absolute price. The relative premium between mints is unchanged, so the two tools stay consistent. Pinned by a test.

- No premium is applied to unlimited-print cToons (where `MAX(mintNumber)` climbs forever, so the same mint would silently inflate) or to holiday items (whose mint numbers are deliberately hidden in the UI, and an adjusted price is invertible back to the mint).

- The band widens for small or noisy samples rather than using a fixed percentage, and the low end is lifted to the rarity floor while the high end is never pushed down.

- It is labelled "Recent sales", never "recommended". The numbers are completed sale prices; the field above is the *starting* bid. Presenting sold prices as a suggested starting bid would produce exactly the overpriced listings that re-list exists to mop up.

## Fixes made along the way

- **`POST /api/auctions` did not bound the duration.** A negative value put `endAt` in the past; a large one locked the cToon out of trading for years while overflowing the BullMQ delay. Latent before, but re-listing round-trips a client-reconstructed duration, so this could not be left to the UI.

- **`Auction.creatorId` was unindexed.** `/api/my-auctions` filters on it and orders by `endAt`, so it sequentially scanned the whole Auction table on every load of the tab this feature lives in. Adds `@@index([creatorId, endAt])` plus a migration.

## Correctness details

- `canRelist` is keyed on **who owns the cToon now**, not who created the auction. An unsold cToon becomes tradeable again and may have changed hands since, while the closed auction still carries the original creator. It is advisory only — `POST /api/auctions` re-checks ownership, burned state, active auctions and pending trades before creating anything.

- The mint context passed to the price guide is verified against the caller before use. The encoded `userCtoonId` is unsigned and forgeable, and raw ids pass through `resolveUserCtoonId` unchecked, so an unverified one would let anyone probe whether a given holding exists.

- Duration is reconstructed from `endAt - createdAt` and snapped to the nearest preset. `Auction.duration` only stores whole days, and downtime recovery extends `endAt` for any active auction whether or not it had bids, so the raw delta cannot be trusted verbatim.

- The 90-day window is a server constant, not a query parameter, so a caller cannot hand-pick which sales the guide is built from.

## Mobile

- The modal had no `max-height`, so with the keyboard open the footer sat under it on a fixed overlay with no way to scroll to the Send button. Adds a height cap and the `min-height: 0` needed for the body to actually shrink.
- The auction row's fixed columns already consume nearly the full width at 360px, so the actions stack vertically instead of adding a column that would push View off-screen.
- Card footers stack on mobile, following the existing MyCollection pattern.
- Number inputs go to 16px on mobile so iOS Safari stops zooming the page on focus.

## Refactor

`AuctionModal` moved to a `useAuctionModal` composable with a single mount in `layouts/newsite-template.vue`, mirroring how `useCtoonModal` drives `CtoonInfoCard`, rather than adding two more local mounts.

## Testing

`npm test` — 16 new tests in `tests/auctionPriceSuggestion.test.js` covering the mint premium, the double-count correction, median robustness, floor clamping, fallbacks and junk input. `nuxt build` is clean.

One pre-existing failure in `tests/monsterBattleEngine.test.js` is unrelated — it fails on a clean tree too.

## Follow-up, not addressed here

`server/api/ctoon/valuations.post.js` selects by id with no ownership check, so 50 forged encoded IDs per request confirm which `(user, cToon, mint)` tuples exist. Pre-existing and low-sensitivity; I guarded the new path but left that endpoint alone as it is outside this feature.

---
_Generated by [Claude Code](https://claude.ai/code/session_017r5CMDsrHSCxb9UN41byUf)_