### PR TITLE
Add "Guess that cToon!" streak game to newsite

### DIFF
--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -44,6 +44,10 @@
         <img v-if="tiles.reorbitmemory" :src="tiles.reorbitmemory" alt="ReOrbit Memory" class="tile-img" />
         <span v-else>ReOrbit Memory</span>
       </NuxtLink>
+      <NuxtLink to="/newsite/guessctoon" class="quadrant quadrant--guessctoon">
+        <img v-if="tiles.guessctoon" :src="tiles.guessctoon" alt="Guess that cToon!" class="tile-img" />
+        <span v-else>Guess that cToon!</span>
+      </NuxtLink>
     </div>
   </div>
 </template>
@@ -79,7 +83,7 @@ const tiles = computed(() => tileData.value ?? {})
 .gameshome {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: repeat(4, 1fr);
+  grid-template-rows: repeat(5, 1fr);
   width: 100%;
   flex: 1;
   gap: 6px;
@@ -131,12 +135,24 @@ const tiles = computed(() => tileData.value ?? {})
 .quadrant--reorbit    { background: #1a6a8a; }
 .quadrant--tower      { background: #5a2a8a; }
 .quadrant--reorbitmemory { background: #2a7a5a; }
+.quadrant--guessctoon    { background: #8a2a5a; }
+
+/* Ninth tile in a two-column grid would otherwise sit alone with an empty cell beside it. */
+.quadrant--guessctoon { grid-column: 1 / -1; }
 
 @media (max-width: 768px) {
   .gameshome {
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(8, minmax(70px, 1fr));
-    height: max(300px, calc(100dvh - 276px));
+    /* Nine 70px-minimum rows can't fit in a fixed 100dvh-based height, so the grid used to
+       overflow into a nested scroller inside the page's own scroller — on iOS the outer
+       page then refuses to scroll until the inner one bottoms out. Let the page scroll
+       instead. svh, not dvh, so the URL bar collapsing doesn't resize the tiles. */
+    grid-template-rows: none;
+    grid-auto-rows: minmax(84px, auto);
+    height: auto;
+    min-height: calc(100svh - 276px);
   }
+
+  .quadrant--guessctoon { grid-column: auto; }
 }
 </style>

--- a/components/newsite/Leaderboards.vue
+++ b/components/newsite/Leaderboards.vue
@@ -92,7 +92,8 @@ const { data: totalData, pending: totalPending } = useFetch('/api/leaderboard/to
 const gameOptions = [
   { key: 'reorbitmatch', label: 'ReOrbit Match', endpoint: '/api/game/reorbitmatch/leaderboard' },
   { key: 'tower',        label: 'Tower Stack',   endpoint: '/api/game/tower/leaderboard' },
-  { key: 'reorbitmemory', label: 'ReOrbit Memory', endpoint: '/api/game/reorbitmemory/leaderboard', lowerIsBetter: true }
+  { key: 'reorbitmemory', label: 'ReOrbit Memory', endpoint: '/api/game/reorbitmemory/leaderboard', lowerIsBetter: true },
+  { key: 'guessctoon',   label: 'Guess cToon',    endpoint: '/api/game/guessctoon/leaderboard' }
 ]
 const selectedGame = ref('reorbitmatch')
 const gameDataCache = ref({})

--- a/pages/admin/games.vue
+++ b/pages/admin/games.vue
@@ -1393,6 +1393,7 @@ async function loadSettings() {
   gameTileImages.value.reorbitmatch = g.gameTileReorbitmatchImagePath || ''
   gameTileImages.value.tower        = g.gameTileTowerImagePath        || ''
   gameTileImages.value.reorbitmemory = g.gameTileReorbitmemoryImagePath || ''
+  gameTileImages.value.guessctoon   = g.gameTileGuessctoonImagePath   || ''
 
   const wb = await $fetch('/api/admin/game-config?gameName=Winball')
   leftCupPoints.value  = wb.leftCupPoints
@@ -1830,11 +1831,12 @@ const gameTileSlots = [
   { slot: 'tko',          label: 'TKO' },
   { slot: 'reorbitmatch', label: 'ReOrbit Match' },
   { slot: 'tower',        label: 'Tower Stack' },
-  { slot: 'reorbitmemory', label: 'ReOrbit Memory' }
+  { slot: 'reorbitmemory', label: 'ReOrbit Memory' },
+  { slot: 'guessctoon',   label: 'Guess that cToon!' }
 ]
-const gameTileImages = ref({ winball: '', lotto: '', winwheel: '', clash: '', tko: '', reorbitmatch: '', tower: '', reorbitmemory: '' })
-const gameTileFiles  = ref({ winball: null, lotto: null, winwheel: null, clash: null, tko: null, reorbitmatch: null, tower: null, reorbitmemory: null })
-const uploadingGameTile = ref({ winball: false, lotto: false, winwheel: false, clash: false, tko: false, reorbitmatch: false, tower: false, reorbitmemory: false })
+const gameTileImages = ref({ winball: '', lotto: '', winwheel: '', clash: '', tko: '', reorbitmatch: '', tower: '', reorbitmemory: '', guessctoon: '' })
+const gameTileFiles  = ref({ winball: null, lotto: null, winwheel: null, clash: null, tko: null, reorbitmatch: null, tower: null, reorbitmemory: null, guessctoon: null })
+const uploadingGameTile = ref({ winball: false, lotto: false, winwheel: false, clash: false, tko: false, reorbitmatch: false, tower: false, reorbitmemory: false, guessctoon: false })
 
 function onGameTileFile(slot, e) {
   gameTileFiles.value[slot] = e.target.files?.[0] || null

--- a/pages/newsite/guessctoon.vue
+++ b/pages/newsite/guessctoon.vue
@@ -1,0 +1,893 @@
+<template>
+  <div>
+    <NuxtLayout name="newsite-template" :show-adbar="true" :show-nav="true">
+      <div class="gc-wrapper">
+        <!-- Loading -->
+        <div v-if="uiState === 'loading'" class="gc-center">
+          <div class="gc-spinner" aria-label="Loading game…"></div>
+        </div>
+
+        <!-- No plays left -->
+        <div v-else-if="uiState === 'noplays'" class="gc-center">
+          <div class="gc-card">
+            <h1 class="gc-title">Guess that cToon!</h1>
+            <p class="gc-card-text">No plays left today.</p>
+            <p class="gc-muted">Resets {{ resetLabel }}</p>
+          </div>
+        </div>
+
+        <!-- Start -->
+        <div v-else-if="uiState === 'start'" class="gc-center">
+          <div class="gc-card">
+            <h1 class="gc-title">Guess that cToon!</h1>
+            <p class="gc-card-text">
+              Name the cToon before the clock runs out. Get them right in a row to build your
+              streak — one wrong answer ends the run.
+            </p>
+            <div class="gc-badges">
+              <span class="gc-badge">{{ playsLeft }} play{{ playsLeft !== 1 ? 's' : '' }} left</span>
+              <span v-if="allTimeHigh != null" class="gc-badge gc-badge--alt">Best streak: {{ allTimeHigh }}</span>
+            </div>
+            <p class="gc-muted">
+              {{ config.secondsPerQuestion }}s per cToon · {{ config.maxQuestions }} to go perfect · Resets {{ resetLabel }}
+            </p>
+            <button class="gc-btn-start" :disabled="starting" @click="startGame">
+              {{ starting ? 'Loading…' : 'Play' }}
+            </button>
+            <p v-if="startError" class="gc-error" role="alert">{{ startError }}</p>
+          </div>
+        </div>
+
+        <!-- Playing -->
+        <template v-else-if="uiState === 'playing'">
+          <div class="gc-timer" aria-hidden="true">
+            <div
+              :key="barKey"
+              class="gc-timer-fill"
+              :class="{ 'gc-timer-fill--urgent': urgent }"
+              :style="timerStyle"
+            ></div>
+          </div>
+
+          <div class="gc-hud">
+            <div class="gc-hud-item">
+              <span class="gc-hud-label">Streak</span>
+              <span class="gc-hud-value gc-streak">{{ streak }}</span>
+            </div>
+            <div class="gc-hud-item gc-hud-item--center">
+              <span class="gc-hud-label">cToon</span>
+              <span class="gc-hud-value">{{ questionIndex + 1 }}<span class="gc-hud-sub">/{{ totalQuestions }}</span></span>
+            </div>
+            <div class="gc-hud-item gc-hud-item--right">
+              <span class="gc-hud-label">Best</span>
+              <span class="gc-hud-value">{{ allTimeHigh ?? '—' }}</span>
+            </div>
+          </div>
+
+          <div class="gc-stage">
+            <img
+              v-if="question"
+              :key="question.questionIndex"
+              class="gc-stage-img"
+              :src="imageUrl(question.imageToken)"
+              alt=""
+              decoding="async"
+              fetchpriority="high"
+              draggable="false"
+              @load="imgReady = true"
+              @error="imgReady = true"
+            />
+            <div v-if="!imgReady" class="gc-stage-skeleton" aria-hidden="true"></div>
+            <div v-if="reveal" class="gc-stamp" :class="reveal.correct ? 'gc-stamp--yes' : 'gc-stamp--no'">
+              {{ reveal.correct ? 'CORRECT!' : (reveal.timedOut ? 'TIME!' : 'NOPE!') }}
+            </div>
+          </div>
+
+          <div
+            class="gc-answers"
+            role="group"
+            :aria-labelledby="`gc-q-${questionIndex}`"
+            :data-locked="locked ? 'true' : 'false'"
+          >
+            <h2 :id="`gc-q-${questionIndex}`" class="gc-sr-only">
+              Question {{ questionIndex + 1 }}. Which cToon is this?
+            </h2>
+            <button
+              v-for="(choice, i) in (question?.choices || [])"
+              :key="`${questionIndex}-${i}`"
+              type="button"
+              class="gc-answer"
+              :class="answerClass(i)"
+              :aria-disabled="locked ? 'true' : 'false'"
+              @click="submitAnswer(i)"
+            >
+              <span class="gc-answer-badge" aria-hidden="true">{{ LETTERS[i] }}</span>
+              <span class="gc-answer-label">{{ choice }}</span>
+            </button>
+          </div>
+
+          <p class="gc-sr-only" role="status" aria-live="polite">{{ announcement }}</p>
+        </template>
+
+        <!-- Game over -->
+        <div v-else-if="uiState === 'gameover'" class="gc-center">
+          <div class="gc-card">
+            <h1 class="gc-title gc-title--small">
+              {{ finalResult?.perfect ? 'Perfect Run!' : 'Run Over' }}
+            </h1>
+            <p class="gc-final-label">Streak</p>
+            <p class="gc-final-streak">{{ finalResult?.streak ?? 0 }}</p>
+
+            <p v-if="finalResult && !finalResult.perfect && finalResult.correctName" class="gc-card-text">
+              It was <strong>{{ finalResult.correctName }}</strong>.
+            </p>
+            <p v-if="isPersonalBest" class="gc-pb">New personal best!</p>
+            <p v-if="finalResult?.pointsAwarded" class="gc-muted">
+              +{{ finalResult.pointsAwarded }} points
+            </p>
+            <p
+              v-else-if="finalResult && finalResult.minStreakForPoints > (finalResult.streak ?? 0)"
+              class="gc-muted"
+            >
+              Reach a streak of {{ finalResult.minStreakForPoints }} to earn points.
+            </p>
+
+            <div class="gc-actions">
+              <button v-if="playsLeft > 0" class="gc-btn-start" :disabled="starting" @click="startGame">
+                {{ starting ? 'Loading…' : 'Play Again' }}
+              </button>
+              <span v-else class="gc-muted">No plays left · Resets {{ resetLabel }}</span>
+              <NuxtLink to="/newsite/leaderboards" class="gc-btn-secondary">Leaderboard</NuxtLink>
+              <NuxtLink to="/newsite/Games" class="gc-btn-secondary">Games Home</NuxtLink>
+            </div>
+            <p class="gc-muted">{{ playsLeft }} play{{ playsLeft !== 1 ? 's' : '' }} left today</p>
+          </div>
+        </div>
+      </div>
+    </NuxtLayout>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
+
+definePageMeta({ ssr: false })
+
+const LETTERS = ['A', 'B', 'C', 'D', 'E', 'F']
+
+const uiState = ref('loading') // loading | noplays | start | playing | gameover
+const starting = ref(false)
+const startError = ref('')
+
+const config = ref({ secondsPerQuestion: 12, maxQuestions: 25, minStreakForPoints: 3, playsPerPeriod: 3 })
+const playsLeft = ref(0)
+const playsResetAt = ref(null)
+const allTimeHigh = ref(null)
+
+const question = ref(null)
+const questionIndex = ref(0)
+const totalQuestions = ref(0)
+const streak = ref(0)
+const imgReady = ref(false)
+const locked = ref(false)
+const reveal = ref(null)
+const finalResult = ref(null)
+const isPersonalBest = ref(false)
+const announcement = ref('')
+
+const barKey = ref(0)
+const barDurationMs = ref(12000)
+const barStartScale = ref(1)
+const urgent = ref(false)
+const reduceMotion = ref(false)
+
+let deadlineAt = 0
+let urgentTimer = null
+let timeoutTimer = null
+
+const timerStyle = computed(() => ({
+  '--gc-duration': `${barDurationMs.value}ms`,
+  '--gc-start-scale': String(barStartScale.value)
+}))
+
+const resetLabel = computed(() => {
+  if (!playsResetAt.value) return 'daily'
+  try {
+    return new Date(playsResetAt.value).toLocaleString(undefined, {
+      weekday: 'short', hour: 'numeric', minute: '2-digit'
+    })
+  } catch {
+    return 'daily'
+  }
+})
+
+function imageUrl (token) {
+  return token ? `/api/game/guessctoon/image/${token}` : ''
+}
+
+function answerClass (i) {
+  if (!reveal.value) return ''
+  if (i === reveal.value.correctIndex) return 'gc-answer--correct'
+  if (i === reveal.value.chosen && !reveal.value.correct) return 'gc-answer--wrong'
+  return 'gc-answer--muted'
+}
+
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function clearTimers () {
+  if (urgentTimer) { clearTimeout(urgentTimer); urgentTimer = null }
+  if (timeoutTimer) { clearTimeout(timeoutTimer); timeoutTimer = null }
+}
+
+// The countdown bar is decoration; the server's clock is the authority. This only keeps the
+// visual in sync and fires an automatic submit when the local clock says time is up.
+function armTimer (durationMs) {
+  clearTimers()
+  deadlineAt = Date.now() + durationMs
+  barDurationMs.value = durationMs
+  barStartScale.value = 1
+  urgent.value = false
+  // Remounting the fill element restarts the CSS animation cleanly — resetting a property
+  // in the same tick gets batched and the animation silently never replays.
+  barKey.value++
+
+  const untilUrgent = durationMs - 3000
+  if (untilUrgent > 0) urgentTimer = setTimeout(() => { urgent.value = true }, untilUrgent)
+  else urgent.value = true
+
+  timeoutTimer = setTimeout(() => { submitAnswer(-1) }, durationMs + 250)
+}
+
+// Backgrounding a tab pauses CSS animations but not wall-clock time, so a player returning
+// to the tab would see a half-full bar against an already-expired server deadline.
+function onVisibility () {
+  if (document.hidden || uiState.value !== 'playing' || locked.value) return
+  const remaining = deadlineAt - Date.now()
+  if (remaining <= 0) { submitAnswer(-1); return }
+  clearTimers()
+  barStartScale.value = Math.max(0, Math.min(1, remaining / (config.value.secondsPerQuestion * 1000)))
+  barDurationMs.value = remaining
+  barKey.value++
+  urgent.value = remaining <= 3000
+  if (!urgent.value) urgentTimer = setTimeout(() => { urgent.value = true }, remaining - 3000)
+  timeoutTimer = setTimeout(() => { submitAnswer(-1) }, remaining + 250)
+}
+
+function onKey (e) {
+  if (uiState.value !== 'playing' || locked.value) return
+  if (e.metaKey || e.ctrlKey || e.altKey) return
+  const count = question.value?.choices?.length || 0
+  let i = '123456'.indexOf(e.key)
+  if (i < 0) i = 'abcdef'.indexOf(String(e.key).toLowerCase())
+  if (i >= 0 && i < count) {
+    e.preventDefault()
+    submitAnswer(i)
+  }
+}
+
+function buzz (pattern) {
+  try { navigator.vibrate?.(pattern) } catch {}
+}
+
+function prefetch (token) {
+  if (!token) return
+  // A detached Image populates the HTTP cache without being animated or composited —
+  // hidden <img> elements in the DOM keep decoding GIF frames.
+  const img = new Image()
+  img.src = imageUrl(token)
+}
+
+function setQuestion (q, remainingMs) {
+  question.value = q
+  questionIndex.value = q.questionIndex
+  imgReady.value = false
+  prefetch(q.prefetchToken)
+  armTimer(remainingMs ?? config.value.secondsPerQuestion * 1000)
+  announcement.value =
+    `Question ${q.questionIndex + 1}. ` +
+    q.choices.map((c, i) => `${LETTERS[i]}, ${c}.`).join(' ')
+}
+
+async function loadStatus () {
+  try {
+    const s = await $fetch('/api/game/guessctoon/status')
+    config.value = s.config
+    playsLeft.value = s.playsLeft
+    playsResetAt.value = s.playsResetAt
+    allTimeHigh.value = s.allTimeHigh
+    return s
+  } catch {
+    return null
+  }
+}
+
+async function startGame () {
+  if (starting.value) return
+  starting.value = true
+  startError.value = ''
+  try {
+    const res = await $fetch('/api/game/guessctoon/start', { method: 'POST' })
+    totalQuestions.value = res.totalQuestions
+    config.value = { ...config.value, secondsPerQuestion: res.secondsPerQuestion }
+    streak.value = 0
+    reveal.value = null
+    finalResult.value = null
+    isPersonalBest.value = false
+    locked.value = false
+    playsLeft.value = Math.max(0, playsLeft.value - 1)
+    uiState.value = 'playing'
+    await nextTick()
+    setQuestion(res.question, res.secondsPerQuestion * 1000)
+  } catch (err) {
+    const status = err?.statusCode || err?.response?.status
+    if (status === 429) {
+      await loadStatus()
+      uiState.value = 'noplays'
+    } else {
+      startError.value = err?.statusMessage || err?.data?.statusMessage || 'Could not start a game. Try again.'
+    }
+  } finally {
+    starting.value = false
+  }
+}
+
+async function submitAnswer (choice) {
+  if (locked.value || uiState.value !== 'playing' || !question.value) return
+  locked.value = true
+  clearTimers()
+  buzz(8)
+
+  let res
+  try {
+    res = await $fetch('/api/game/guessctoon/answer', {
+      method: 'POST',
+      body: { questionIndex: questionIndex.value, choice }
+    })
+  } catch (err) {
+    const status = err?.statusCode || err?.response?.status
+    // A rejected duplicate/too-fast answer is a no-op, not an error the player should see
+    // mid-question — re-arm and let them answer.
+    if (status === 429) {
+      locked.value = false
+      const remaining = Math.max(0, deadlineAt - Date.now())
+      if (remaining > 0) armTimer(remaining)
+      else submitAnswer(-1)
+      return
+    }
+    await loadStatus()
+    uiState.value = playsLeft.value > 0 ? 'start' : 'noplays'
+    locked.value = false
+    return
+  }
+
+  reveal.value = {
+    correct: res.correct,
+    correctIndex: res.correctIndex,
+    chosen: choice,
+    timedOut: Boolean(res.timedOut)
+  }
+  streak.value = res.streak
+  buzz(res.correct ? [10, 30, 10] : [20, 40, 20])
+  announcement.value = res.correct
+    ? `Correct. ${res.correctName}. Streak ${res.streak}.`
+    : `${res.timedOut ? 'Out of time' : 'Wrong'}. The answer was ${res.correctName}. Final streak ${res.streak}.`
+
+  await wait(reduceMotion.value ? 500 : 900)
+
+  if (res.gameOver) {
+    finalResult.value = {
+      streak: res.streak,
+      perfect: res.perfect,
+      correctName: res.correctName,
+      pointsAwarded: res.pointsAwarded,
+      minStreakForPoints: res.minStreakForPoints
+    }
+    isPersonalBest.value = allTimeHigh.value == null || res.streak > allTimeHigh.value
+    if (isPersonalBest.value) allTimeHigh.value = res.streak
+    reveal.value = null
+    uiState.value = 'gameover'
+    locked.value = false
+    return
+  }
+
+  reveal.value = null
+  setQuestion(res.question, res.remainingMs)
+  await nextTick()
+  // Unlock only once the new buttons have actually painted, so a thumb already descending
+  // toward the old layout cannot register on the new question.
+  requestAnimationFrame(() => { locked.value = false })
+}
+
+// Abandoning mid-run banks whatever streak was earned rather than silently discarding it.
+function bankOnExit () {
+  if (uiState.value !== 'playing') return
+  try {
+    navigator.sendBeacon?.('/api/game/guessctoon/end', new Blob([], { type: 'application/json' }))
+  } catch {}
+}
+
+onMounted(async () => {
+  reduceMotion.value = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches || false
+  const s = await loadStatus()
+  if (!s) { uiState.value = 'start'; return }
+  uiState.value = s.playsLeft > 0 ? 'start' : 'noplays'
+
+  document.addEventListener('visibilitychange', onVisibility)
+  window.addEventListener('keydown', onKey)
+  window.addEventListener('pagehide', bankOnExit)
+})
+
+onBeforeUnmount(() => {
+  clearTimers()
+  bankOnExit()
+  document.removeEventListener('visibilitychange', onVisibility)
+  window.removeEventListener('keydown', onKey)
+  window.removeEventListener('pagehide', bankOnExit)
+})
+</script>
+
+<style>
+/* Self-hosted, already shipped with the Winball page. Avoids adding a second render-blocking
+   Google Fonts request on top of the layout's Nunito import. */
+@font-face {
+  font-family: "FuturaBdCnBT";
+  src: url("/newwinball/fonts/84_Futura BdCn BT.ttf") format("truetype");
+  font-weight: 700;
+  font-display: swap;
+}
+
+/* Unscoped: reaches into the layout's .main-content. The body class is set by
+   newsite-template from the route name. svh (not dvh) so the stage does not resize as the
+   iOS URL bar collapses mid-question. */
+@media (max-width: 768px) {
+  body.page-newsite-guessctoon .main-content {
+    min-height: calc(100svh - 190px);
+    max-width: 100% !important;
+    overflow-x: hidden !important;
+    box-sizing: border-box !important;
+  }
+}
+</style>
+
+<style scoped>
+.gc-wrapper {
+  --ink: clamp(2px, 0.9vw, 4px);
+  --gc-btn-h: 56px;
+  --gc-gap: 8px;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  height: 100%;
+  min-height: 420px;
+  overflow-x: hidden;
+  box-sizing: border-box;
+  background: #001230;
+  overscroll-behavior: contain;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Static halftone. Tiled once and rasterised — never animated, and never
+   background-attachment: fixed, which repaints the whole area on every scroll frame. */
+.gc-wrapper::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle at 1.5px 1.5px, rgba(255, 255, 255, 0.10) 1.2px, transparent 1.3px);
+  background-size: 7px 7px;
+}
+.gc-wrapper > * { position: relative; z-index: 1; }
+
+/* ── Cards / shared ─────────────────────────────────────────── */
+
+.gc-center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 10px;
+  box-sizing: border-box;
+}
+
+.gc-card {
+  width: 100%;
+  max-width: 460px;
+  text-align: center;
+  padding: 20px 16px;
+  box-sizing: border-box;
+  background: #0A47A1;
+  border: var(--ink) solid #000;
+  border-radius: 14px;
+  box-shadow: 0 6px 0 #000;
+}
+
+.gc-title {
+  font-family: "FuturaBdCnBT", "Nunito", sans-serif;
+  font-size: clamp(28px, 9vw, 46px);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #FFCC33;
+  margin: 0 0 12px;
+  transform: rotate(-1.5deg);
+  text-shadow:
+    -2px -2px 0 #000, 0 -2px 0 #000, 2px -2px 0 #000,
+    -2px 0 0 #000, 2px 0 0 #000,
+    -2px 2px 0 #000, 0 2px 0 #000, 2px 2px 0 #000,
+    0 5px 0 rgba(0, 0, 0, 0.35);
+}
+.gc-title--small { font-size: clamp(24px, 7vw, 36px); }
+
+.gc-card-text {
+  font-size: 15px;
+  line-height: 1.4;
+  margin: 0 0 12px;
+  color: #fff;
+}
+
+.gc-muted {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 8px 0 0;
+}
+
+.gc-error {
+  margin: 10px 0 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: #FFD3D0;
+}
+
+.gc-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+  margin-bottom: 6px;
+}
+
+.gc-badge {
+  display: inline-block;
+  padding: 5px 12px;
+  border: 2px solid #000;
+  border-radius: 999px;
+  background: #66CC00;
+  color: #06240A;
+  font-size: 13px;
+  font-weight: 800;
+}
+.gc-badge--alt { background: #FFCC33; color: #2A1B00; }
+
+.gc-btn-start {
+  display: inline-block;
+  margin-top: 14px;
+  padding: 14px 34px;
+  min-height: 52px;
+  font-family: "FuturaBdCnBT", "Nunito", sans-serif;
+  font-size: 24px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #06240A;
+  background: #66CC00;
+  border: var(--ink) solid #000;
+  border-radius: 12px;
+  box-shadow: 0 5px 0 #000;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.gc-btn-start:active { transform: translateY(3px); box-shadow: 0 2px 0 #000; }
+.gc-btn-start:disabled { opacity: 0.6; cursor: default; }
+
+.gc-btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 8px 18px;
+  border: 2px solid #000;
+  border-radius: 10px;
+  background: #3399CC;
+  color: #fff;
+  font-weight: 800;
+  font-size: 14px;
+  text-decoration: none;
+  box-shadow: 0 3px 0 #000;
+  touch-action: manipulation;
+}
+
+.gc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 14px;
+}
+
+.gc-final-label {
+  margin: 4px 0 0;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.gc-final-streak {
+  font-family: "FuturaBdCnBT", "Nunito", sans-serif;
+  font-size: clamp(56px, 20vw, 96px);
+  line-height: 1;
+  margin: 0 0 8px;
+  color: #FFCC33;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    -2px -2px 0 #000, 0 -2px 0 #000, 2px -2px 0 #000,
+    -2px 0 0 #000, 2px 0 0 #000,
+    -2px 2px 0 #000, 0 2px 0 #000, 2px 2px 0 #000;
+}
+
+.gc-pb {
+  margin: 6px 0 0;
+  font-weight: 800;
+  color: #66CC00;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ── Timer ──────────────────────────────────────────────────── */
+
+.gc-timer {
+  flex: 0 0 auto;
+  height: 10px;
+  background: rgba(0, 0, 0, 0.35);
+  border-bottom: 2px solid #000;
+  overflow: hidden;
+}
+
+.gc-timer-fill {
+  height: 100%;
+  transform-origin: left center;
+  will-change: transform;
+  background: #66CC00;
+  animation: gc-drain var(--gc-duration, 12000ms) linear forwards;
+}
+
+/* Pattern shift as well as colour, so "almost out of time" is not colour-only. */
+.gc-timer-fill--urgent {
+  background: repeating-linear-gradient(45deg, #E8342A 0 6px, #B3221A 6px 12px);
+}
+
+@keyframes gc-drain {
+  from { transform: scaleX(var(--gc-start-scale, 1)); }
+  to   { transform: scaleX(0); }
+}
+
+/* ── HUD ────────────────────────────────────────────────────── */
+
+.gc-hud {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+}
+
+.gc-hud-item { display: flex; flex-direction: column; min-width: 0; }
+.gc-hud-item--center { align-items: center; }
+.gc-hud-item--right { align-items: flex-end; }
+
+.gc-hud-label {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.gc-hud-value {
+  font-family: "FuturaBdCnBT", "Nunito", sans-serif;
+  font-size: 22px;
+  line-height: 1.1;
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+}
+
+.gc-hud-sub { font-size: 13px; color: rgba(255, 255, 255, 0.6); }
+
+/* Reserved width so 9 → 10 never shifts the row. */
+.gc-streak { color: #FFCC33; min-width: 3ch; }
+
+/* ── Stage ──────────────────────────────────────────────────── */
+
+/* Fixed height + object-fit: contain. cToon art ranges from 55×50 to 200×117 (a ~9× aspect
+   spread), so an intrinsically-sized image would resize the page every question and push
+   the answer buttons out from under the player's thumb. */
+.gc-stage {
+  position: relative;
+  flex: 0 0 auto;
+  height: clamp(120px, 26svh, 220px);
+  width: 100%;
+  display: grid;
+  place-items: center;
+  padding: 8px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.gc-stage-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  /* These are small GIFs shown 3-4× up; nearest-neighbour reads as deliberate retro
+     pixel art rather than a blurry upscale. */
+  image-rendering: pixelated;
+  -webkit-user-drag: none;
+  /* Suppresses the iOS long-press sheet — "Copy Image Address" mid-countdown is both a UX
+     annoyance and an invitation to poke at the image URL. */
+  -webkit-touch-callout: none;
+  pointer-events: none;
+}
+
+.gc-stage-skeleton {
+  position: absolute;
+  inset: 8px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* Absolutely positioned so the reveal contributes nothing to layout. */
+.gc-stamp {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) rotate(-6deg) scale(0.6);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 5;
+  padding: 6px 18px;
+  border: 3px solid #000;
+  border-radius: 8px;
+  font-family: "FuturaBdCnBT", "Nunito", sans-serif;
+  font-size: clamp(26px, 8vw, 44px);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  animation: gc-stamp-in 260ms cubic-bezier(0.2, 1.6, 0.4, 1) forwards;
+}
+.gc-stamp--yes { background: #66CC00; color: #06240A; }
+.gc-stamp--no  { background: #E8342A; color: #fff; }
+
+@keyframes gc-stamp-in {
+  to { transform: translate(-50%, -50%) rotate(-6deg) scale(1); opacity: 1; }
+}
+
+/* ── Answers ────────────────────────────────────────────────── */
+
+.gc-answers {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--gc-gap);
+  padding: 0 8px 12px;
+  box-sizing: border-box;
+}
+
+/* pointer-events on the group rather than `disabled` on the buttons: disabling a focused
+   button drops focus to <body>, which silently ejects keyboard players every question. */
+.gc-answers[data-locked="true"] { pointer-events: none; }
+
+.gc-answer {
+  /* Fixed height, never min-height — identical geometry on every question is what stops
+     mis-taps when the layout would otherwise reflow around longer names. */
+  height: var(--gc-btn-h);
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  box-sizing: border-box;
+  font: 700 15px/1.15 var(--font-family, 'Nunito', sans-serif);
+  text-align: left;
+  color: #1a1000;
+  background: #FFCC33;
+  border: var(--ink) solid #000;
+  border-radius: 10px;
+  box-shadow: 0 4px 0 #000;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: background 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+}
+.gc-answer:active { transform: translateY(3px); box-shadow: 0 1px 0 #000; }
+
+.gc-answer-badge {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border: 2px solid #000;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.12);
+  font-size: 14px;
+  font-weight: 900;
+}
+
+.gc-answer-label {
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
+}
+
+/* Result is encoded three ways — colour, glyph and strikethrough — so it does not depend
+   on colour vision. */
+.gc-answer--correct {
+  background: #2E7D32;
+  color: #fff;
+  box-shadow: 0 0 0 3px #A5FF6B, 0 4px 0 #000;
+}
+.gc-answer--correct .gc-answer-badge { font-size: 0; }
+.gc-answer--correct .gc-answer-badge::after { content: '✓'; font-size: 16px; }
+
+.gc-answer--wrong {
+  background: #B3221A;
+  color: #fff;
+  box-shadow: 0 0 0 3px #FF8A80, 0 4px 0 #000;
+}
+.gc-answer--wrong .gc-answer-badge { font-size: 0; }
+.gc-answer--wrong .gc-answer-badge::after { content: '✕'; font-size: 16px; }
+.gc-answer--wrong .gc-answer-label { text-decoration: line-through; }
+
+.gc-answer--muted { opacity: 0.45; }
+
+/* ── Misc ───────────────────────────────────────────────────── */
+
+.gc-spinner {
+  width: 42px;
+  height: 42px;
+  border: 5px solid rgba(255, 255, 255, 0.25);
+  border-top-color: #FFCC33;
+  border-radius: 50%;
+  animation: gc-spin 800ms linear infinite;
+}
+@keyframes gc-spin { to { transform: rotate(360deg); } }
+
+.gc-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Two columns once there is genuinely room. Deliberately not tied to the layout's 768px
+   mobile breakpoint — that one is also evaluated in JS against a zoom-adjusted width, and
+   the two can disagree. */
+@media (min-width: 641px) {
+  .gc-answers { grid-template-columns: 1fr 1fr; }
+  .gc-answer { height: 64px; font-size: 16px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gc-timer-fill { animation: none; transform: scaleX(var(--gc-start-scale, 1)); }
+  .gc-stamp { animation: none; opacity: 1; transform: translate(-50%, -50%) rotate(-6deg); }
+  .gc-answer { transition: none; }
+  .gc-spinner { animation: none; }
+  .gc-title { transform: none; }
+}
+</style>

--- a/prisma/migrations/20260801000000_add_guess_ctoon/migration.sql
+++ b/prisma/migrations/20260801000000_add_guess_ctoon/migration.sql
@@ -1,0 +1,62 @@
+-- AddField: "Guess that cToon!" settings on GameConfig
+ALTER TABLE "GameConfig"
+  ADD COLUMN IF NOT EXISTS "guessCtoonPlaysPerPeriod"     INTEGER NOT NULL DEFAULT 3,
+  ADD COLUMN IF NOT EXISTS "guessCtoonPointsPerGame"      INTEGER NOT NULL DEFAULT 50,
+  ADD COLUMN IF NOT EXISTS "guessCtoonSecondsPerQuestion" INTEGER NOT NULL DEFAULT 12,
+  ADD COLUMN IF NOT EXISTS "guessCtoonChoices"            INTEGER NOT NULL DEFAULT 4,
+  ADD COLUMN IF NOT EXISTS "guessCtoonMaxQuestions"       INTEGER NOT NULL DEFAULT 25,
+  ADD COLUMN IF NOT EXISTS "guessCtoonMinStreakForPoints" INTEGER NOT NULL DEFAULT 3;
+
+-- AddField: Guess that cToon tile image on GlobalGameConfig
+ALTER TABLE "GlobalGameConfig"
+  ADD COLUMN IF NOT EXISTS "gameTileGuessctoonImagePath" TEXT;
+
+-- AddField: per-cToon opt-out from the Guess that cToon answer pool
+ALTER TABLE "Ctoon"
+  ADD COLUMN IF NOT EXISTS "guessCtoonExcluded" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable: GuessCtoonScore
+CREATE TABLE IF NOT EXISTS "GuessCtoonScore" (
+  "id"             TEXT         NOT NULL,
+  "userId"         TEXT         NOT NULL,
+  "streak"         INTEGER      NOT NULL,
+  "suspicious"     BOOLEAN      NOT NULL DEFAULT false,
+  "medianAnswerMs" INTEGER,
+  "stdDevAnswerMs" INTEGER,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "GuessCtoonScore_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: GuessCtoonPlay
+CREATE TABLE IF NOT EXISTS "GuessCtoonPlay" (
+  "id"        TEXT         NOT NULL,
+  "userId"    TEXT         NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "GuessCtoonPlay_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "GuessCtoonScore_userId_streak_idx"            ON "GuessCtoonScore"("userId", "streak");
+CREATE INDEX IF NOT EXISTS "GuessCtoonScore_createdAt_userId_streak_idx"  ON "GuessCtoonScore"("createdAt", "userId", "streak");
+CREATE INDEX IF NOT EXISTS "GuessCtoonPlay_userId_createdAt_idx"          ON "GuessCtoonPlay"("userId", "createdAt");
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GuessCtoonScore_userId_fkey') THEN
+    ALTER TABLE "GuessCtoonScore" ADD CONSTRAINT "GuessCtoonScore_userId_fkey"
+      FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GuessCtoonPlay_userId_fkey') THEN
+    ALTER TABLE "GuessCtoonPlay" ADD CONSTRAINT "GuessCtoonPlay_userId_fkey"
+      FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- Seed the GameConfig row so the column defaults above actually materialize.
+-- Unlike the other mini-games, this one has no admin tab to lazily create its row
+-- (see server/api/admin/game-config.get.js), so without this INSERT every setting
+-- would live only as a JS fallback and the columns would be unreachable.
+INSERT INTO "GameConfig" ("id", "gameName")
+VALUES (gen_random_uuid()::text, 'GuessCtoon')
+ON CONFLICT ("gameName") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -298,6 +298,11 @@ model Ctoon {
   saleDailyPurchases     SaleDailyPurchase[]
   priceDaily             CtoonPriceDaily[]
 
+  // Lets an admin pull a cToon out of the "Guess that cToon!" answer pool without a
+  // deploy — for art that doesn't show the character clearly, or a name that makes an
+  // unanswerable question. Excluded cToons can still be used as wrong answers.
+  guessCtoonExcluded Boolean @default(false)
+
   @@index([isSecondEdition])
   @@index([name])
 }
@@ -515,6 +520,10 @@ model User {
   // ReOrbit Memory
   reOrbitMemoryScores ReOrbitMemoryScore[]
   reOrbitMemoryPlays  ReOrbitMemoryPlay[]
+
+  // Guess that cToon!
+  guessCtoonScores GuessCtoonScore[]
+  guessCtoonPlays  GuessCtoonPlay[]
 
   @@unique([discordId, active]) // at most one active user per Discord ID
 }
@@ -1035,6 +1044,14 @@ model GameConfig {
   reorbitMemoryFlipBackDelayMs   Int     @default(800)
   reorbitMemoryCardBackImagePath String?
 
+  // — Guess that cToon! settings —
+  guessCtoonPlaysPerPeriod      Int @default(3)
+  guessCtoonPointsPerGame       Int @default(50)
+  guessCtoonSecondsPerQuestion  Int @default(12)
+  guessCtoonChoices             Int @default(4)
+  guessCtoonMaxQuestions        Int @default(25)
+  guessCtoonMinStreakForPoints  Int @default(3)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 }
@@ -1085,6 +1102,7 @@ model GlobalGameConfig {
   gameTileReorbitmatchImagePath  String?
   gameTileTowerImagePath         String?
   gameTileReorbitmemoryImagePath String?
+  gameTileGuessctoonImagePath    String?
   // Account-dissolve "featured auction" rules: cToons matching any of these
   // rarities/series/sets are marked isFeatured when an account is dissolved.
   // Each is a JSON array of strings, edited via the "Edit Featured" modal on
@@ -2809,6 +2827,40 @@ model ReOrbitMemoryScore {
 }
 
 model ReOrbitMemoryPlay {
+  id        String   @id @default(uuid())
+  userId    String
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId, createdAt])
+}
+
+// ── Guess that cToon! ──────────────────────────────────────────────────────────
+// `streak` is the number of consecutive correct answers in one run — higher is
+// better. `suspicious` marks runs whose answer cadence is too machine-regular or
+// too fast to be human (see scoreCadence in guessCtoonEngine); those rows are kept
+// for auditing but filtered out of the leaderboard rather than deleted, so a false
+// positive costs a player their leaderboard slot and nothing else.
+
+model GuessCtoonScore {
+  id              String   @id @default(uuid())
+  userId          String
+  streak          Int
+  suspicious      Boolean  @default(false)
+  medianAnswerMs  Int?
+  stdDevAnswerMs  Int?
+  createdAt       DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId, streak])
+  // Covering index: the weekly/monthly leaderboards filter on createdAt and then
+  // only need userId + streak, so they run index-only with no heap access.
+  @@index([createdAt, userId, streak])
+}
+
+model GuessCtoonPlay {
   id        String   @id @default(uuid())
   userId    String
   createdAt DateTime @default(now())

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -67,6 +67,22 @@ async function seedGameConfigs() {
       winWheelImagePath: null
     }
   })
+
+  // Guess that cToon! config. Unlike the other mini-games this one has no admin tab to
+  // lazily create its row, so seeding it is what makes its settings tunable at all.
+  await prisma.gameConfig.upsert({
+    where: { gameName: 'GuessCtoon' },
+    update: {},
+    create: {
+      gameName: 'GuessCtoon',
+      guessCtoonPlaysPerPeriod: 3,
+      guessCtoonPointsPerGame: 50,
+      guessCtoonSecondsPerQuestion: 12,
+      guessCtoonChoices: 4,
+      guessCtoonMaxQuestions: 25,
+      guessCtoonMinStreakForPoints: 3
+    }
+  })
 }
 
 async function seedHomepageConfig() {

--- a/server/api/admin/game-config.get.js
+++ b/server/api/admin/game-config.get.js
@@ -165,6 +165,21 @@ export default defineEventHandler(async (event) => {
             reorbitMemoryCardBackImagePath: null
           }
         })
+      } else if (gameName === 'GuessCtoon') {
+        // No admin tab drives this game, but the row still has to exist for its column
+        // defaults to be reachable (the migration seeds it too; this covers a config
+        // fetched before that migration ran).
+        config = await db.gameConfig.create({
+          data: {
+            gameName,
+            guessCtoonPlaysPerPeriod: 3,
+            guessCtoonPointsPerGame: 50,
+            guessCtoonSecondsPerQuestion: 12,
+            guessCtoonChoices: 4,
+            guessCtoonMaxQuestions: 25,
+            guessCtoonMinStreakForPoints: 3
+          }
+        })
       } else {
         throw createError({
           statusCode: 400,

--- a/server/api/admin/game-tile-image.delete.js
+++ b/server/api/admin/game-tile-image.delete.js
@@ -10,7 +10,8 @@ const SLOT_FIELD = {
   tko:          'gameTileTkoImagePath',
   reorbitmatch: 'gameTileReorbitmatchImagePath',
   tower:        'gameTileTowerImagePath',
-  reorbitmemory: 'gameTileReorbitmemoryImagePath'
+  reorbitmemory: 'gameTileReorbitmemoryImagePath',
+  guessctoon:   'gameTileGuessctoonImagePath'
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/admin/game-tile-image.post.js
+++ b/server/api/admin/game-tile-image.post.js
@@ -25,7 +25,8 @@ const SLOT_FIELD = {
   tko:          'gameTileTkoImagePath',
   reorbitmatch: 'gameTileReorbitmatchImagePath',
   tower:        'gameTileTowerImagePath',
-  reorbitmemory: 'gameTileReorbitmemoryImagePath'
+  reorbitmemory: 'gameTileReorbitmemoryImagePath',
+  guessctoon:   'gameTileGuessctoonImagePath'
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/game-tile-images.get.js
+++ b/server/api/game-tile-images.get.js
@@ -12,7 +12,8 @@ export default defineEventHandler(async () => {
       gameTileTkoImagePath:          true,
       gameTileReorbitmatchImagePath: true,
       gameTileTowerImagePath:        true,
-      gameTileReorbitmemoryImagePath: true
+      gameTileReorbitmemoryImagePath: true,
+      gameTileGuessctoonImagePath:   true
     }
   })
 
@@ -24,6 +25,7 @@ export default defineEventHandler(async () => {
     tko:          cfg?.gameTileTkoImagePath          ?? null,
     reorbitmatch: cfg?.gameTileReorbitmatchImagePath ?? null,
     tower:        cfg?.gameTileTowerImagePath        ?? null,
-    reorbitmemory: cfg?.gameTileReorbitmemoryImagePath ?? null
+    reorbitmemory: cfg?.gameTileReorbitmemoryImagePath ?? null,
+    guessctoon:   cfg?.gameTileGuessctoonImagePath    ?? null
   }
 })

--- a/server/api/game/guessctoon/answer.post.js
+++ b/server/api/game/guessctoon/answer.post.js
@@ -1,0 +1,144 @@
+import { defineEventHandler, readBody, createError } from 'h3'
+import { redis } from '@/server/utils/redis'
+import {
+  ANSWER_SCRIPT,
+  MIN_ANSWER_INTERVAL_MS,
+  DEADLINE_GRACE_MS
+} from '@/server/utils/guessCtoonEngine'
+import {
+  sessionKey,
+  getGuessCtoonConfig,
+  bankRun,
+  assertPlayable,
+  BANKED_TTL_SECONDS
+} from '@/server/utils/guessCtoonRuntime'
+
+const MAX_BODY_BYTES = 1024 // tiny payload — a question index and a choice index
+
+const ERROR_STATUS = {
+  no_session: [409, 'Game session not found or expired. Start a new game.'],
+  bad_request: [400, 'Invalid request body'],
+  too_fast: [429, 'Answers submitted too fast']
+}
+
+// Registered once on the shared client so answers go out as EVALSHA instead of shipping the
+// whole script body on every tap. ioredis falls back to EVAL automatically on NOSCRIPT.
+let commandReady = false
+function ensureCommand () {
+  if (commandReady) return
+  if (typeof redis.guessCtoonAnswer !== 'function') {
+    redis.defineCommand('guessCtoonAnswer', { numberOfKeys: 1, lua: ANSWER_SCRIPT })
+  }
+  commandReady = true
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const contentLength = Number(event.node.req.headers['content-length'] || 0)
+  if (contentLength > MAX_BODY_BYTES) {
+    throw createError({ statusCode: 413, statusMessage: 'Request too large' })
+  }
+
+  const body = await readBody(event)
+
+  // Strict primitive checks. Number() would happily coerce ["2"], " 2 " and true, and the
+  // body is never spread anywhere, so only these two scalars are ever read.
+  const questionIndex = body?.questionIndex
+  const choice = body?.choice
+  if (typeof questionIndex !== 'number' || !Number.isInteger(questionIndex) || questionIndex < 0 || questionIndex > 500) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid request body' })
+  }
+  // -1 is the client reporting its own countdown expired; the server re-derives the timeout
+  // from its own clock regardless, so this only makes game-over immediate instead of
+  // waiting for the player to tap.
+  if (typeof choice !== 'number' || !Number.isInteger(choice) || choice < -1 || choice > 16) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid request body' })
+  }
+
+  const config = await getGuessCtoonConfig()
+
+  ensureCommand()
+
+  // No app-level lock: ANSWER_SCRIPT is one atomic Lua script, so Redis's single-threaded
+  // execution IS the lock. A lock here would add latency to every tap without closing any
+  // race the script does not already close.
+  let raw
+  try {
+    raw = await redis.guessCtoonAnswer(
+      sessionKey(userId),
+      String(questionIndex),
+      String(choice),
+      String(MIN_ANSWER_INTERVAL_MS),
+      String(DEADLINE_GRACE_MS),
+      String(BANKED_TTL_SECONDS)
+    )
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+
+  let result
+  try {
+    result = JSON.parse(raw)
+  } catch {
+    throw createError({ statusCode: 500, statusMessage: 'Unexpected game state' })
+  }
+
+  if (result.error) {
+    const [statusCode, statusMessage] = ERROR_STATUS[result.error] || [400, 'Invalid answer']
+    throw createError({ statusCode, statusMessage })
+  }
+
+  // Still playing: reveal only the question just answered, plus the next question's choices
+  // and opaque image token. The answered question's real assetPath is deliberately NOT
+  // forwarded — the client has no use for it, and every path handed to the browser is one
+  // more row of a name↔image map an attacker would otherwise have to build themselves.
+  if (!result.gameOver) {
+    return {
+      correct: result.correct,
+      correctIndex: result.correctIndex,
+      correctName: result.correctName,
+      streak: result.streak,
+      gameOver: false,
+      question: result.nextQuestion,
+      remainingMs: result.remainingMs
+    }
+  }
+
+  // Terminal answer. The atomic flip to `banked` inside the script guarantees exactly one
+  // request can ever reach this branch for a given run, so /end cannot double-record it.
+  // Re-check eligibility here (and only here) because this is the branch that pays out —
+  // a user banned mid-run must not keep earning.
+  let pointsAwarded = 0
+  let finalStreak = result.streak
+  const denial = await assertPlayable(userId)
+  if (!denial) {
+    try {
+      const banked = await bankRun({
+        userId,
+        streak: result.streak,
+        latencies: result.latencies,
+        startedAt: result.startedAt,
+        config
+      })
+      pointsAwarded = banked.pointsAwarded
+      finalStreak = banked.streak
+    } catch {
+      // Recording failed — still report the run honestly rather than 500ing the player out
+      // of their own game-over screen.
+    }
+  }
+
+  return {
+    correct: result.correct,
+    correctIndex: result.correctIndex,
+    correctName: result.correctName,
+    timedOut: Boolean(result.timedOut),
+    streak: finalStreak,
+    gameOver: true,
+    perfect: Boolean(result.perfect),
+    pointsAwarded,
+    minStreakForPoints: config.minStreakForPoints
+  }
+})

--- a/server/api/game/guessctoon/end.post.js
+++ b/server/api/game/guessctoon/end.post.js
@@ -1,0 +1,66 @@
+import { defineEventHandler, createError } from 'h3'
+import { redis } from '@/server/utils/redis'
+import { BANK_SCRIPT } from '@/server/utils/guessCtoonEngine'
+import {
+  sessionKey,
+  getGuessCtoonConfig,
+  bankRun,
+  assertPlayable,
+  BANKED_TTL_SECONDS
+} from '@/server/utils/guessCtoonRuntime'
+
+// "Stop here and keep my streak", also used when the player navigates away.
+//
+// This is not an exploit route: banking early can never beat answering correctly, so a
+// player who bails is strictly giving up expected value. The one thing it must not do is
+// pay out for a run with no answers in it — POST /start immediately followed by POST /end
+// would otherwise be the cheapest possible way to farm the daily point award. That gate
+// lives in bankRun() via minStreakForPoints.
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const config = await getGuessCtoonConfig()
+
+  let raw
+  try {
+    // Atomic flip to `banked` — a concurrent /answer game-over and this call cannot both
+    // win, so a run is never recorded twice.
+    raw = await redis.eval(BANK_SCRIPT, 1, sessionKey(userId), String(BANKED_TTL_SECONDS))
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+
+  let result
+  try {
+    result = JSON.parse(raw)
+  } catch {
+    throw createError({ statusCode: 500, statusMessage: 'Unexpected game state' })
+  }
+
+  if (result.error === 'no_session') {
+    throw createError({ statusCode: 409, statusMessage: 'Game session not found or expired. Start a new game.' })
+  }
+  // The run already ended through /answer — report it without recording anything again.
+  if (result.error === 'already_banked') {
+    return { streak: 0, pointsAwarded: 0, alreadyRecorded: true }
+  }
+
+  const denial = await assertPlayable(userId)
+  if (denial) throw createError({ statusCode: 403, statusMessage: denial })
+
+  const banked = await bankRun({
+    userId,
+    streak: result.streak,
+    latencies: result.latencies,
+    startedAt: result.startedAt,
+    config
+  })
+
+  return {
+    streak: banked.streak,
+    pointsAwarded: banked.pointsAwarded,
+    minStreakForPoints: config.minStreakForPoints,
+    alreadyRecorded: false
+  }
+})

--- a/server/api/game/guessctoon/image/[token].get.js
+++ b/server/api/game/guessctoon/image/[token].get.js
@@ -1,0 +1,125 @@
+import { defineEventHandler, createError, getRouterParam, setHeader } from 'h3'
+import { readFile, access } from 'node:fs/promises'
+import { join, resolve, sep } from 'node:path'
+import { redis } from '@/server/utils/redis'
+import { sessionKey } from '@/server/utils/guessCtoonRuntime'
+
+// Serves a question's artwork behind an opaque, per-run token.
+//
+// This route exists because Ctoon.assetPath is self-documenting: paths look like
+// /images/cToons/Ed Edd n Eddy/space_outlaw_ed.gif, so the filename is the answer and the
+// directory is the series. Handing that URL to the browser would let anyone read the answer
+// off the DOM — and would eliminate every cross-series wrong answer for free. So the client
+// only ever receives a random token, and only the caller's OWN session can redeem it.
+//
+// A token resolves for exactly two questions: the one currently pending, and the one after
+// it (so the client can warm the next image). The next question's image without its choices
+// is not an answerable question, so that prefetch leaks nothing.
+
+// cToon art lives under public/ in development and under a sibling
+// cartoon-reorbit-images/ directory in production, and the process's cwd differs between
+// `nuxt dev` and the built Nitro output. Rather than guess, probe both roots — every
+// candidate is still containment-checked before it is read.
+const BASE_DIRS = [process.cwd(), resolve(process.cwd(), '..')]
+
+const MIME_BY_EXT = {
+  '.gif': 'image/gif',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml'
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const token = getRouterParam(event, 'token')
+  if (!token || !/^[a-f0-9]{32}$/.test(token)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid image token' })
+  }
+
+  let raw
+  try {
+    raw = await redis.get(sessionKey(userId))
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+  if (!raw) throw createError({ statusCode: 404, statusMessage: 'Not found' })
+
+  let session
+  try {
+    session = JSON.parse(raw)
+  } catch {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+
+  const questions = Array.isArray(session?.qs) ? session.qs : []
+  const cursor = Number(session?.i) || 0
+  const redeemable = [questions[cursor], questions[cursor + 1]].filter(Boolean)
+  const match = redeemable.find(q => q && q.t === token)
+  if (!match) throw createError({ statusCode: 404, statusMessage: 'Not found' })
+
+  const filePath = await resolveAssetFile(match.a)
+  if (!filePath) throw createError({ statusCode: 404, statusMessage: 'Not found' })
+
+  let bytes
+  try {
+    bytes = await readFile(filePath)
+  } catch {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+
+  const ext = extOf(filePath)
+  setHeader(event, 'Content-Type', MIME_BY_EXT[ext] || 'application/octet-stream')
+  // No filename in the disposition, and no ETag/Last-Modified — anything derived from the
+  // real file would put the answer back on the wire.
+  setHeader(event, 'Content-Disposition', 'inline')
+  setHeader(event, 'Cache-Control', 'private, no-store')
+  setHeader(event, 'X-Content-Type-Options', 'nosniff')
+  return bytes
+})
+
+function extOf (p) {
+  const i = p.lastIndexOf('.')
+  return i < 0 ? '' : p.slice(i).toLowerCase()
+}
+
+// assetPath is admin-controlled, but the filename inside it comes straight from an
+// unsanitized multipart upload (server/api/admin/ctoon.post.js writes imagePart.filename
+// verbatim), so it is treated as hostile here: resolve, then confirm the result is still
+// inside an allowed root before reading it.
+async function resolveAssetFile (assetPath) {
+  if (!assetPath || typeof assetPath !== 'string') return null
+  if (assetPath.startsWith('http://') || assetPath.startsWith('https://')) return null
+  if (assetPath.includes('\0')) return null
+
+  const trimmed = assetPath.replace(/^\//, '')
+  const candidates = []
+
+  for (const baseDir of BASE_DIRS) {
+    const publicRoot = join(baseDir, 'public')
+    candidates.push({ root: publicRoot, path: join(publicRoot, trimmed) })
+
+    const imagesRoot = join(baseDir, 'cartoon-reorbit-images')
+    const rel = assetPath.startsWith('/images/cToons/')
+      ? assetPath.replace(/^\/images\/cToons\//, '')
+      : assetPath.startsWith('/cToons/')
+        ? assetPath.replace(/^\/cToons\//, '')
+        : null
+    if (rel) candidates.push({ root: imagesRoot, path: join(imagesRoot, 'cToons', rel) })
+  }
+
+  for (const candidate of candidates) {
+    const resolved = resolve(candidate.path)
+    const rootResolved = resolve(candidate.root)
+    if (resolved !== rootResolved && !resolved.startsWith(rootResolved + sep)) continue
+    try {
+      await access(resolved)
+      return resolved
+    } catch {}
+  }
+
+  return null
+}

--- a/server/api/game/guessctoon/leaderboard.get.js
+++ b/server/api/game/guessctoon/leaderboard.get.js
@@ -1,0 +1,107 @@
+import { defineEventHandler } from 'h3'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { mergeViewerRow } from '@/server/utils/leaderboardRank'
+
+const CACHE_KEY = 'guessctoon:leaderboard:v1'
+const CACHE_TTL = 1800 // 30 minutes
+const EXCLUDE_ID = '4f0e8b3b-7d0b-466b-99e7-8996c91d7eb3'
+
+// Safety valve on the cached payload. A viewer ranked below this simply gets no personal
+// row, which is a far better failure mode than an unbounded cache entry.
+const MAX_RANKED = 5000
+
+// Unlike the other games' leaderboards, the FULL ranked list is cached rather than just the
+// top 11. Those endpoints run a second, uncached, full GROUP BY (three times — once per
+// period) for every viewer outside the top 11, which is an unbounded aggregation over the
+// whole score table on every page view. Caching the ranked list instead makes the viewer's
+// rank an in-memory lookup and takes Postgres out of the request entirely on a cache hit.
+//
+// Ranking is by best streak descending, tie-broken by who reached it first. Streaks are
+// small integers, so ties are the common case, not the exception — an alphabetical
+// tie-break (what the other boards use) would leave hundreds of players sorted by username
+// and make the board unwinnable for anyone late in the alphabet.
+//
+// `suspicious` runs are excluded rather than deleted: a run whose answer cadence looks
+// machine-generated keeps its row for auditing but does not occupy a leaderboard slot.
+
+function rankedAllTime () {
+  return prisma.$queryRaw`
+    WITH best AS (
+      SELECT DISTINCT ON (s."userId")
+             s."userId", s."streak", s."createdAt"
+      FROM "GuessCtoonScore" s
+      WHERE s."suspicious" = false
+      ORDER BY s."userId", s."streak" DESC, s."createdAt" ASC
+    )
+    SELECT u."id" AS "userId", u."username", u."avatar", b."streak"::int AS "score",
+           (ROW_NUMBER() OVER (ORDER BY b."streak" DESC, b."createdAt" ASC))::int AS rank
+    FROM best b
+    JOIN "User" u ON u."id" = b."userId"
+    WHERE u."active" = true
+      AND COALESCE(u."banned", false) = false
+      AND b."userId" <> ${EXCLUDE_ID}
+    ORDER BY rank
+    LIMIT ${MAX_RANKED};
+  `
+}
+
+function rankedSince (days) {
+  return prisma.$queryRaw`
+    WITH best AS (
+      SELECT DISTINCT ON (s."userId")
+             s."userId", s."streak", s."createdAt"
+      FROM "GuessCtoonScore" s
+      WHERE s."suspicious" = false
+        AND s."createdAt" >= NOW() - (${days} || ' days')::interval
+      ORDER BY s."userId", s."streak" DESC, s."createdAt" ASC
+    )
+    SELECT u."id" AS "userId", u."username", u."avatar", b."streak"::int AS "score",
+           (ROW_NUMBER() OVER (ORDER BY b."streak" DESC, b."createdAt" ASC))::int AS rank
+    FROM best b
+    JOIN "User" u ON u."id" = b."userId"
+    WHERE u."active" = true
+      AND COALESCE(u."banned", false) = false
+      AND b."userId" <> ${EXCLUDE_ID}
+    ORDER BY rank
+    LIMIT ${MAX_RANKED};
+  `
+}
+
+async function fetchRanked () {
+  const [allTime, monthly, weekly] = await Promise.all([
+    rankedAllTime(),
+    rankedSince('30'),
+    rankedSince('7')
+  ])
+  return { allTime, monthly, weekly }
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId || null
+
+  let ranked
+  try {
+    const cached = await redis.get(CACHE_KEY)
+    if (cached) ranked = JSON.parse(cached)
+  } catch {}
+
+  if (!ranked) {
+    ranked = await fetchRanked()
+    try {
+      await redis.set(CACHE_KEY, JSON.stringify(ranked), 'EX', CACHE_TTL)
+    } catch {}
+  }
+
+  const result = {}
+  for (const period of ['allTime', 'monthly', 'weekly']) {
+    const rows = Array.isArray(ranked[period]) ? ranked[period] : []
+    const top11 = rows.slice(0, 11)
+    const viewerRow = userId && !top11.some(r => r.userId === userId)
+      ? rows.find(r => r.userId === userId) || null
+      : null
+    result[period] = mergeViewerRow(top11, viewerRow, userId)
+  }
+
+  return result
+})

--- a/server/api/game/guessctoon/start.post.js
+++ b/server/api/game/guessctoon/start.post.js
@@ -1,0 +1,134 @@
+import { defineEventHandler, createError } from 'h3'
+import { randomUUID, randomBytes } from 'node:crypto'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { getCatalogPool } from '@/server/utils/guessCtoonPool'
+import {
+  buildCatalogContext,
+  buildRun,
+  MIN_POOL_SIZE,
+  DEADLINE_GRACE_MS
+} from '@/server/utils/guessCtoonEngine'
+import {
+  sessionKey,
+  lockKey,
+  getGuessCtoonConfig,
+  getDailyBoundary,
+  getNextResetAt,
+  assertPlayable
+} from '@/server/utils/guessCtoonRuntime'
+
+const LOCK_TTL_MS = 10_000
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const denial = await assertPlayable(userId)
+  if (denial) throw createError({ statusCode: 403, statusMessage: denial })
+
+  // Cheap first line of defence against concurrent /start requests. The authoritative
+  // play-limit guard is the Postgres advisory lock below — this one just rejects the
+  // obvious double-tap without paying for a transaction.
+  const lockToken = randomUUID()
+  let lockAcquired = false
+  try {
+    const r = await redis.set(lockKey(userId), lockToken, 'NX', 'PX', LOCK_TTL_MS)
+    lockAcquired = r === 'OK'
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Service temporarily unavailable' })
+  }
+  if (!lockAcquired) throw createError({ statusCode: 429, statusMessage: 'Request already in progress' })
+
+  const casRelease = `if redis.call("get",KEYS[1])==ARGV[1] then return redis.call("del",KEYS[1]) else return 0 end`
+
+  try {
+    const config = await getGuessCtoonConfig()
+    const boundary = getDailyBoundary()
+
+    // Count-then-insert is not atomic on its own, and a Redis lock can evaporate on
+    // eviction or failover. The advisory lock makes Postgres the authority on the play
+    // limit. Salted so it can't collide with the points award's lock on the same userId.
+    try {
+      await prisma.$transaction(async (tx) => {
+        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`${userId}:guessctoon`}))`
+        const playsToday = await tx.guessCtoonPlay.count({
+          where: { userId, createdAt: { gte: boundary } }
+        })
+        if (playsToday >= config.playsPerPeriod) {
+          throw createError({
+            statusCode: 429,
+            statusMessage: 'Daily play limit reached',
+            data: { nextReset: getNextResetAt(boundary).toISOString() }
+          })
+        }
+        await tx.guessCtoonPlay.create({ data: { userId } })
+      })
+    } catch (err) {
+      if (err?.statusCode) throw err
+      throw createError({ statusCode: 503, statusMessage: 'Could not start a game right now' })
+    }
+
+    const pool = await getCatalogPool()
+    const ctx = buildCatalogContext(pool)
+    if (ctx.answerRows.length < MIN_POOL_SIZE) {
+      throw createError({ statusCode: 503, statusMessage: 'Not enough cToons available to start a game' })
+    }
+
+    const seedHex = randomUUID().replace(/-/g, '')
+    const questions = buildRun(ctx, seedHex, {
+      count: config.maxQuestions,
+      choiceCount: config.choices
+    })
+    if (!questions.length) {
+      throw createError({ statusCode: 503, statusMessage: 'Could not build a game right now' })
+    }
+
+    // Each question gets an opaque image token. The client never sees an assetPath while a
+    // question is live — the path spells out the answer (…/Dexters Lab/watcher_dexter.gif),
+    // so shipping it would reduce the game to reading the DOM.
+    const qs = questions.map(q => ({
+      t: randomBytes(16).toString('hex'),
+      a: q.assetPath,
+      n: q.name,
+      c: q.choices,
+      k: q.correctIndex
+    }))
+
+    const nowMs = Date.now()
+    // TTL bounds the whole run: every question at full duration, plus grace and slack.
+    const ttlSeconds = Math.ceil(
+      (qs.length * (config.secondsPerQuestion * 1000 + DEADLINE_GRACE_MS)) / 1000
+    ) + 300
+
+    await redis.set(sessionKey(userId), JSON.stringify({
+      qs,
+      i: 0,
+      streak: 0,
+      state: 'live',
+      secs: config.secondsPerQuestion,
+      startedAt: nowMs,
+      // Stamped by Node here for the first question only; every subsequent issuedAt comes
+      // from redis.call('TIME') inside ANSWER_SCRIPT. The grace window absorbs the skew on
+      // this one question.
+      issuedAt: nowMs,
+      lastAnswerAt: 0,
+      lat: []
+    }), 'EX', ttlSeconds)
+
+    return {
+      totalQuestions: qs.length,
+      secondsPerQuestion: config.secondsPerQuestion,
+      question: {
+        questionIndex: 0,
+        imageToken: qs[0].t,
+        choices: qs[0].c,
+        // Lets the client warm the next image while question 1 is on screen. Harmless:
+        // without its choices, an image alone is not an answerable question.
+        prefetchToken: qs[1] ? qs[1].t : null
+      }
+    }
+  } finally {
+    try { await redis.eval(casRelease, 1, lockKey(userId), lockToken) } catch {}
+  }
+})

--- a/server/api/game/guessctoon/status.get.js
+++ b/server/api/game/guessctoon/status.get.js
@@ -1,0 +1,48 @@
+import { defineEventHandler, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import {
+  getGuessCtoonConfig,
+  getDailyBoundary,
+  getNextResetAt,
+  getWeekBoundary
+} from '@/server/utils/guessCtoonRuntime'
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const config = await getGuessCtoonConfig()
+  const boundary = getDailyBoundary()
+  const weekBoundary = getWeekBoundary()
+
+  const [playsToday, allTimeHigh, weekHigh] = await Promise.all([
+    prisma.guessCtoonPlay.count({
+      where: { userId, createdAt: { gte: boundary } }
+    }),
+    prisma.guessCtoonScore.aggregate({
+      where: { userId },
+      _max: { streak: true }
+    }),
+    // Global best this week, matching the other games' status endpoints (which likewise
+    // filter on createdAt only, not on the viewer).
+    prisma.guessCtoonScore.aggregate({
+      where: { createdAt: { gte: weekBoundary }, suspicious: false },
+      _max: { streak: true }
+    })
+  ])
+
+  return {
+    config: {
+      playsPerPeriod: config.playsPerPeriod,
+      pointsPerGame: config.pointsPerGame,
+      secondsPerQuestion: config.secondsPerQuestion,
+      choices: config.choices,
+      maxQuestions: config.maxQuestions,
+      minStreakForPoints: config.minStreakForPoints
+    },
+    playsLeft: Math.max(0, config.playsPerPeriod - playsToday),
+    playsResetAt: getNextResetAt(boundary).toISOString(),
+    allTimeHigh: allTimeHigh._max.streak ?? null,
+    weekHigh: weekHigh._max.streak ?? null
+  }
+})

--- a/server/middleware/daily-points.js
+++ b/server/middleware/daily-points.js
@@ -2,6 +2,7 @@
 import { DateTime } from 'luxon'
 import { prisma }   from '@/server/prisma'
 import { defineEventHandler } from 'h3'
+import { isHotPath } from '@/server/utils/hotPaths'
 
 let cachedGlobalConfig     = null
 let cachedGlobalConfigTime = 0
@@ -15,6 +16,11 @@ export default defineEventHandler(async (event) => {
   // page. Every page load calls /api/auth/me, so the daily award still
   // triggers reliably.
   if (!event.path.startsWith('/api')) return
+
+  // Per-interaction game endpoints opt out for the same reason: one "Guess that cToon!"
+  // run is ~25 POSTs, and each would otherwise cost an upsert plus an interactive
+  // transaction on the same UserPoints row.
+  if (isHotPath(event.path)) return
 
   const userId = event.context.userId
   if (!userId) return

--- a/server/middleware/guild-check.js
+++ b/server/middleware/guild-check.js
@@ -1,11 +1,16 @@
 import { refreshDiscordTokenAndRoles } from '../utils/refreshDiscordTokenAndRoles.js'
 import { prisma } from '@/server/prisma'
+import { isHotPath } from '@/server/utils/hotPaths'
 
 export default defineEventHandler(async (event) => {
   // Only API routes need user context. Without this gate the middleware runs
   // for every static asset too (cToon images, backgrounds, JS chunks), and a
   // cZone full of cToons turns one page load into dozens of DB lookups.
   if (!event.path.startsWith('/api')) return
+
+  // Per-interaction game endpoints: one full-row User lookup per answer/image is pure
+  // overhead for handlers that never read event.context.user.
+  if (isHotPath(event.path)) return
 
   const userId = event.context.userId
   if (!userId) return

--- a/server/middleware/login-log.js
+++ b/server/middleware/login-log.js
@@ -4,8 +4,14 @@ import { prisma } from '@/server/prisma'
 import { isPrivateIp } from '@/server/utils/vpn-check'
 import { encryptIp } from '@/server/utils/ip-encrypt'
 import { enqueueVpnCheck } from '@/server/utils/vpn-queue'
+import { isHotPath } from '@/server/utils/hotPaths'
 
 export default defineEventHandler(async (event) => {
+  // Per-interaction game endpoints skip the login/IP bookkeeping — a 25-question run would
+  // otherwise repeat the same two lookups 25 times over. The surrounding page navigation
+  // still logs the session normally.
+  if (isHotPath(event.path)) return
+
   const userId = event.context?.userId
   if (!userId) return
 

--- a/server/utils/guessCtoonEngine.js
+++ b/server/utils/guessCtoonEngine.js
@@ -1,0 +1,722 @@
+// Server-only "Guess that cToon!" engine. Never import this from pages/ or components/.
+//
+// Game model: the player is shown a cToon image and picks its name from N choices.
+// Every correct answer extends a streak; the first wrong answer (or a timeout) ends the
+// run, and the streak is the leaderboard score.
+//
+// Two things drive the whole design:
+//
+// 1. The image IS the question, and `Ctoon.assetPath` spells the answer out loud —
+//    paths look like `/images/cToons/Ed Edd n Eddy/space_outlaw_ed.gif`, so the filename
+//    is the name and the directory is the series. Sending an assetPath to the client
+//    would make the game a DOM-reading exercise. Questions therefore carry an opaque
+//    per-run image token instead, resolved server-side by image/[token].get.js, and the
+//    real path/name are only revealed for a question the player has already answered.
+//
+// 2. A run is a fixed batch of questions generated up front (see MAX_QUESTIONS). There is
+//    deliberately no mid-run refill: refilling would mean a GET → build-in-Node → SET
+//    read-modify-write around the DB, and the ANSWER_SCRIPT's atomicity guarantee does not
+//    survive that window (two in-flight answers could clobber the cursor, rewind to an
+//    already-answered question, or resurrect a session that was already banked). Answering
+//    the whole batch correctly is a "perfect run" win state instead.
+//
+// Anti-cheat: ANSWER_SCRIPT is a single atomic Redis Lua script (one round trip, no
+// app-level lock needed — Redis's single-threaded execution IS the lock, same reasoning as
+// reorbitMemoryEngine's FLIP_SCRIPT). It owns the entire state machine: cursor validation,
+// the minimum inter-answer interval, the per-question deadline, streak accounting, and the
+// one-way flip to `banked` that guarantees exactly one caller can ever record a run.
+
+const DEFAULTS = {
+  playsPerPeriod: 3,
+  pointsPerGame: 50,
+  secondsPerQuestion: 12,
+  choices: 4,
+  maxQuestions: 25,
+  minStreakForPoints: 3
+}
+
+// Below this, two taps came from something that is not a pair of human thumbs. Kept well
+// above the ~250ms "ghost click" floor because the player also has to READ four names.
+const MIN_ANSWER_INTERVAL_MS = 400
+
+// Slack on top of the per-question countdown, covering the round trip on a bad mobile
+// connection. Deliberately modest: every extra millisecond is a free bonus that helps a
+// scripted client (never near the deadline) more than a slow human.
+const DEADLINE_GRACE_MS = 2000
+
+// A choice longer than this gets ellipsised in the fixed-height answer button, which would
+// make two choices visually indistinguishable — a correctness bug, not a cosmetic one.
+const MAX_CHOICE_LEN = 44
+
+// Hard floor on how many distinct cToons must be eligible before a run can be built.
+const MIN_POOL_SIZE = 40
+
+const CHOICES_MIN = 3
+const CHOICES_MAX = 6
+
+// Poses that read as plausible alternates for a "(Running)"-style suffix.
+const POSE_VOCAB = [
+  'Run', 'Running', 'Jump', 'Jumping', 'Fly', 'Flying', 'Standing', 'Sitting',
+  'Waving', 'Dancing', 'Posing', 'Sleeping', 'Walking', 'Falling'
+]
+
+// Names ending in a position word are slices of one larger image (Bat Signal
+// (Top)/(Middle)/(Bottom)); asking which third of a picture you're looking at is a coin
+// flip. Names ending in a bare integer are numbered item sets (Christmas Present 1..4) —
+// same problem. Both are barred from being the ANSWER but stay usable as wrong answers.
+const POSITIONAL_SUFFIX_RE = /\((?:top|middle|bottom|left|right|upper|lower|center|centre)\)\s*$/i
+const TRAILING_ORDINAL_RE = /\s+\d+\s*$/
+const POSE_SUFFIX_RE = /\s*\(([^)]+)\)\s*$/
+
+const VOWELS = new Set(['a', 'e', 'i', 'o', 'u'])
+
+// ── Name handling ─────────────────────────────────────────────────────────────
+
+// Collision key. Strips case, accents, curly quotes and every non-alphanumeric, so
+// "Dexter's Lab" ≡ "Dexters Lab" ≡ "DEXTERS  LAB". Used to guarantee no two choices in a
+// question are the same string wearing different punctuation.
+function normalizeName (name) {
+  return String(name || '')
+    .normalize('NFKD')
+    .replace(/[‘’ʼ]/g, "'")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+}
+
+// Splits "Space Outlaw Eddy" into modifiers ["Space","Outlaw"] + head "Eddy", and peels off
+// a trailing "(Pose)". The head is the token the player is actually identifying, so it is
+// the only part orthographic mutation is ever allowed to touch.
+function parseName (name) {
+  const raw = String(name || '').trim()
+  let base = raw
+  let pose = null
+
+  const poseMatch = base.match(POSE_SUFFIX_RE)
+  if (poseMatch) {
+    pose = poseMatch[1].trim()
+    base = base.slice(0, poseMatch.index).trim()
+  }
+
+  const tokens = base.split(/\s+/).filter(Boolean)
+  const head = tokens.length ? tokens[tokens.length - 1] : base
+  const modifiers = tokens.slice(0, -1)
+
+  return { raw, base, pose, tokens, head, modifiers }
+}
+
+function levenshtein (a, b) {
+  if (a === b) return 0
+  const m = a.length
+  const n = b.length
+  if (!m) return n
+  if (!n) return m
+  let prev = new Array(n + 1)
+  let curr = new Array(n + 1)
+  for (let j = 0; j <= n; j++) prev[j] = j
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+    }
+    const tmp = prev; prev = curr; curr = tmp
+  }
+  return prev[n]
+}
+
+// Rejects mutations that produce unpronounceable letter soup ("Skltor", "Chaeiard").
+function isPronounceable (word) {
+  const w = String(word || '').toLowerCase().replace(/[^a-z]/g, '')
+  if (w.length < 2) return false
+  let consonants = 0
+  let vowels = 0
+  for (const ch of w) {
+    if (VOWELS.has(ch)) { vowels++; consonants = 0 } else { consonants++; vowels = 0 }
+    if (consonants >= 3 || vowels >= 3) return false
+  }
+  return true
+}
+
+// ── Seeded PRNG ───────────────────────────────────────────────────────────────
+// splitmix32, identical construction to reorbitMatchEngine/reorbitMemoryEngine's makePRNG.
+// The questions never leave the server, so reproducibility isn't load-bearing here — it
+// just keeps RNG usage consistent across the three game engines.
+
+function makePRNG (seedHex) {
+  const hi = parseInt(seedHex.slice(0, 8), 16) >>> 0
+  const lo = parseInt(seedHex.slice(8, 16), 16) >>> 0
+  let s0 = hi >>> 0
+  let s1 = lo >>> 0
+  return function () {
+    s0 = (s0 + 0x9e3779b9) >>> 0
+    let z = s0
+    z = Math.imul(z ^ (z >>> 16), 0x85ebca6b) >>> 0
+    z = Math.imul(z ^ (z >>> 13), 0xc2b2ae35) >>> 0
+    z = (z ^ (z >>> 16)) >>> 0
+    s1 = (s1 + 0x6c62272e) >>> 0
+    let w = s1
+    w = Math.imul(w ^ (w >>> 16), 0x85ebca6b) >>> 0
+    w = Math.imul(w ^ (w >>> 13), 0xc2b2ae35) >>> 0
+    w = (w ^ (w >>> 16)) >>> 0
+    return ((z ^ w) >>> 0) / 4294967296
+  }
+}
+
+function shuffle (arr, rng) {
+  const a = arr.slice()
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
+function pick (arr, rng) {
+  if (!arr || !arr.length) return null
+  return arr[Math.floor(rng() * arr.length)]
+}
+
+// ── Answer-pool eligibility & fame ────────────────────────────────────────────
+
+// A cToon can be the ANSWER only if its picture is a fair question on its own.
+function isEligibleAnswer (row) {
+  if (!row || !row.name || !row.assetPath) return false
+  if (row.guessCtoonExcluded) return false
+  if (row.isSecondEdition) return false
+  if (POSITIONAL_SUFFIX_RE.test(row.name)) return false
+  if (TRAILING_ORDINAL_RE.test(row.name)) return false
+  if (row.name.length > MAX_CHOICE_LEN) return false
+  return true
+}
+
+// How likely a player is to have seen this cToon. Used to keep the opening questions
+// recognizable, so a run doesn't die on question 2 to a 1-of-1 nobody owns.
+function fameScore (row) {
+  const minted = Number(row.totalMinted || 0)
+  let score = Math.log10(1 + minted)
+  if (row.inCmart) score += 0.5
+  if (row.rarity === 'Common' || row.rarity === 'Uncommon') score += 0.5
+  return score
+}
+
+// Difficulty ramps through the DISTRACTORS, not through answer obscurity. Ramping
+// obscurity is what makes a streak game feel like a slot machine; ramping distractor
+// quality is what makes it feel like a test of knowledge.
+function tierForIndex (index) {
+  if (index < 5) return 1
+  if (index < 15) return 2
+  if (index < 30) return 3
+  return 4
+}
+
+// Per-tier sourcing quota for the wrong answers. Each slot still falls back down the chain
+// (sameSeries → sameSet → cross → mutation) when the catalog can't supply it, but the quota
+// stops question #1 from being as brutal as question #40 just because the answer happened
+// to come from a well-stocked series.
+function quotaForTier (tier, slots) {
+  const base = {
+    1: ['sameSeries', 'cross', 'cross'],
+    2: ['sameSeries', 'sameSeries', 'cross'],
+    3: ['sameSeries', 'sameSeries', 'sameSeries'],
+    4: ['sameSeries', 'sameSeries', 'sameSet']
+  }[tier] || ['sameSeries', 'cross', 'cross']
+
+  const out = base.slice(0, slots)
+  while (out.length < slots) out.push('cross')
+  return out
+}
+
+// ── Distractor generation ─────────────────────────────────────────────────────
+
+// Family A — recombination. Grafts real catalog vocabulary onto the answer's structure, so
+// the result reads exactly like a cToon that could plausibly exist. These are the good
+// distractors and they are always tried first.
+function familyAMutations (answerParsed, ctx, rng) {
+  const out = []
+  const seriesNames = ctx.namesBySeries.get(answerParsed.seriesKey) || []
+  const others = seriesNames.filter(n => normalizeName(n) !== normalizeName(answerParsed.raw))
+  const parsedOthers = others.map(parseName)
+
+  // A1 — modifier swap: keep the character, borrow another costume/rank word.
+  //      "Watcher Yogi" → "Lazy Yogi"
+  const donorMods = parsedOthers.filter(p => p.modifiers.length).map(p => p.modifiers.join(' '))
+  if (answerParsed.modifiers.length && donorMods.length) {
+    const mod = pick(donorMods, rng)
+    if (mod) out.push(withPose(`${mod} ${answerParsed.head}`, answerParsed.pose))
+  }
+
+  // A2 — head swap: keep the costume, swap the character.
+  //      "Lazy Scooby" → "Lazy Shaggy". Forces actual character identification.
+  const donorHeads = parsedOthers.map(p => p.head).filter(h => h && h.toLowerCase() !== answerParsed.head.toLowerCase())
+  if (answerParsed.modifiers.length && donorHeads.length) {
+    const head = pick(donorHeads, rng)
+    if (head) out.push(withPose(`${answerParsed.modifiers.join(' ')} ${head}`, answerParsed.pose))
+  }
+
+  // A3 — pose swap, only meaningful when the answer actually has a pose suffix.
+  if (answerParsed.pose) {
+    const alt = pick(POSE_VOCAB.filter(p => p.toLowerCase() !== answerParsed.pose.toLowerCase()), rng)
+    if (alt) out.push(`${answerParsed.base} (${alt})`)
+  }
+
+  // A5a — modifier drop: "Cybersuit Dexter" → "Dexter". Clean and believable.
+  if (answerParsed.modifiers.length) {
+    out.push(withPose(answerParsed.head, answerParsed.pose))
+  }
+
+  // A5b — modifier add, for bare names: "Charizard" → "Watcher Charizard".
+  if (!answerParsed.modifiers.length && donorMods.length) {
+    const mod = pick(donorMods, rng)
+    if (mod) out.push(withPose(`${mod} ${answerParsed.head}`, answerParsed.pose))
+  }
+
+  return out
+}
+
+function withPose (base, pose) {
+  return pose ? `${base} (${pose})` : base
+}
+
+// Family B — orthographic noise ("Skeletor" → "Skelator"). Weak by nature: on a famous
+// character it's a free elimination, on an obscure one it's a coin flip with no signal.
+// Emergency fallback only, capped at one per question by the caller, and never applied to a
+// short head where a one-letter edit becomes an eye test.
+function familyBMutations (answerParsed, rng) {
+  const head = answerParsed.head
+  if (!head || head.length < 5) return []
+
+  const out = []
+  const lower = head.toLowerCase()
+
+  // Vowel substitution.
+  const vowelIdxs = []
+  for (let i = 1; i < head.length; i++) if (VOWELS.has(lower[i])) vowelIdxs.push(i)
+  if (vowelIdxs.length) {
+    const i = pick(vowelIdxs, rng)
+    const alt = pick(['a', 'e', 'i', 'o', 'u'].filter(v => v !== lower[i]), rng)
+    if (alt != null) out.push(head.slice(0, i) + alt + head.slice(i + 1))
+  }
+
+  // Adjacent transposition, away from the first letter so the word stays recognizable.
+  if (head.length >= 5) {
+    const i = 1 + Math.floor(rng() * (head.length - 3))
+    if (lower[i] !== lower[i + 1]) {
+      out.push(head.slice(0, i) + head[i + 1] + head[i] + head.slice(i + 2))
+    }
+  }
+
+  // Doubled consonant.
+  const consIdxs = []
+  for (let i = 1; i < head.length - 1; i++) if (!VOWELS.has(lower[i]) && /[a-z]/.test(lower[i])) consIdxs.push(i)
+  if (consIdxs.length) {
+    const i = pick(consIdxs, rng)
+    out.push(head.slice(0, i + 1) + head[i] + head.slice(i + 1))
+  }
+
+  return out
+    .filter(isPronounceable)
+    .map(h => withPose(
+      answerParsed.modifiers.length ? `${answerParsed.modifiers.join(' ')} ${h}` : h,
+      answerParsed.pose
+    ))
+}
+
+// A cross-series name is usually a free elimination because it obviously comes from a
+// different show. Matching the answer's shape — token count, presence of a pose suffix,
+// rough length — makes it read as a plausible sibling instead.
+function shapeMatches (candidateParsed, answerParsed) {
+  if (Boolean(candidateParsed.pose) !== Boolean(answerParsed.pose)) return false
+  if (Math.abs(candidateParsed.tokens.length - answerParsed.tokens.length) > 1) return false
+  const a = candidateParsed.raw.length
+  const b = answerParsed.raw.length
+  return Math.abs(a - b) <= Math.max(8, Math.round(b * 0.6))
+}
+
+/**
+ * Builds one question: the answer plus `choiceCount - 1` wrong answers, shuffled.
+ *
+ * `ctx` is the prepared catalog context from buildCatalogContext(). `index` is the
+ * question's position in the run, which selects the difficulty tier.
+ *
+ * Returns null when no honest question can be built for this answer (the caller skips it).
+ */
+function buildQuestion (answerRow, ctx, rng, { index = 0, choiceCount = DEFAULTS.choices } = {}) {
+  const slots = Math.max(CHOICES_MIN, Math.min(CHOICES_MAX, choiceCount)) - 1
+  const answerParsed = parseName(answerRow.name)
+  answerParsed.seriesKey = seriesKey(answerRow.series)
+
+  const answerNorm = normalizeName(answerRow.name)
+  const answerHeadNorm = normalizeName(answerParsed.head)
+
+  const chosen = []
+  const usedNorms = new Set([answerNorm])
+  let headSharers = 0
+  let familyBUsed = 0
+
+  // Every candidate runs this gauntlet. A candidate that turns out to be a real catalog
+  // name is NOT rejected — a real name is the best possible distractor — it just has to be
+  // a different cToon than the answer.
+  const accept = (candidate) => {
+    if (!candidate) return false
+    const text = String(candidate).trim()
+    if (!text || text.length > MAX_CHOICE_LEN) return false
+
+    const norm = normalizeName(text)
+    if (!norm || usedNorms.has(norm)) return false
+
+    // An edit-distance-1 near-miss on a short name is an eye test, not a question.
+    if (answerNorm.length <= 8 && levenshtein(norm, answerNorm) <= 1) return false
+
+    // At most one wrong answer may be another variant of the same character, or the
+    // question degenerates into costume memorization.
+    const sharesHead = normalizeName(parseName(text).head) === answerHeadNorm
+    if (sharesHead && headSharers >= 1) return false
+    if (sharesHead) headSharers++
+
+    usedNorms.add(norm)
+    chosen.push(text)
+    return true
+  }
+
+  const fromNames = (names, requireShape) => {
+    if (!names || !names.length) return false
+    const candidates = shuffle(names, rng)
+    for (const n of candidates) {
+      if (requireShape && !shapeMatches(parseName(n), answerParsed)) continue
+      if (accept(n)) return true
+    }
+    return false
+  }
+
+  const sources = {
+    sameSeries: () => fromNames(ctx.namesBySeries.get(answerParsed.seriesKey), false),
+    sameSet: () => fromNames(ctx.namesBySet.get(setKey(answerRow.set)), false),
+    cross: () => fromNames(ctx.allNames, true) || fromNames(ctx.allNames, false)
+  }
+
+  const quota = quotaForTier(tierForIndex(index), slots)
+
+  for (const want of quota) {
+    if (sources[want] && sources[want]()) continue
+    // Degrade toward real names before ever reaching for a generated mutation.
+    if (want !== 'sameSet' && sources.sameSet()) continue
+    if (want !== 'cross' && sources.cross()) continue
+    if (want !== 'sameSeries' && sources.sameSeries()) continue
+
+    // Family A first — recombined real vocabulary still reads like a real cToon.
+    let filled = false
+    for (const m of shuffle(familyAMutations(answerParsed, ctx, rng), rng)) {
+      if (accept(m)) { filled = true; break }
+    }
+    if (filled) continue
+
+    // Family B last, and at most once per question.
+    if (familyBUsed < 1) {
+      for (const m of shuffle(familyBMutations(answerParsed, rng), rng)) {
+        if (accept(m)) { familyBUsed++; filled = true; break }
+      }
+    }
+    if (!filled) return null
+  }
+
+  if (chosen.length !== slots) return null
+
+  const choices = shuffle([answerRow.name, ...chosen], rng)
+  const correctIndex = choices.findIndex(c => normalizeName(c) === answerNorm)
+  if (correctIndex < 0) return null
+
+  return {
+    ctoonId: answerRow.id,
+    name: answerRow.name,
+    assetPath: answerRow.assetPath,
+    choices,
+    correctIndex
+  }
+}
+
+function seriesKey (series) { return normalizeName(series) || '__none__' }
+function setKey (set) { return normalizeName(set) || '__none__' }
+
+/**
+ * Prepares the lookup structures buildQuestion needs from a flat list of catalog rows.
+ *
+ * Answer eligibility and distractor eligibility are deliberately different: a cToon barred
+ * from being the answer (an image slice, a numbered item, an admin exclusion) is still a
+ * perfectly good wrong answer.
+ *
+ * The answer pool is deduped by assetPath because make-second-edition copies both `name`
+ * and `assetPath` verbatim from the original — two rows can be the same picture with the
+ * same name, which would produce a question with two identical correct choices.
+ */
+function buildCatalogContext (rows) {
+  const namesBySeries = new Map()
+  const namesBySet = new Map()
+  const allNames = []
+  const seenNames = new Set()
+
+  const answerRows = []
+  const seenAssets = new Set()
+
+  for (const row of rows) {
+    if (!row || !row.name) continue
+
+    const nameNorm = normalizeName(row.name)
+    if (nameNorm && !seenNames.has(nameNorm)) {
+      seenNames.add(nameNorm)
+      allNames.push(row.name)
+
+      const sk = seriesKey(row.series)
+      if (!namesBySeries.has(sk)) namesBySeries.set(sk, [])
+      namesBySeries.get(sk).push(row.name)
+
+      const stk = setKey(row.set)
+      if (!namesBySet.has(stk)) namesBySet.set(stk, [])
+      namesBySet.get(stk).push(row.name)
+    }
+
+    if (!isEligibleAnswer(row)) continue
+    if (seenAssets.has(row.assetPath)) continue
+    seenAssets.add(row.assetPath)
+    answerRows.push(row)
+  }
+
+  return { namesBySeries, namesBySet, allNames, answerRows }
+}
+
+/**
+ * Picks the run's answers, fame-weighting the early questions so the opening of a run is
+ * recognizable and the ramp lives in the distractors instead.
+ */
+function selectAnswers (ctx, rng, count) {
+  const scored = ctx.answerRows.map(r => ({ row: r, fame: fameScore(r) }))
+  const byFame = scored.slice().sort((a, b) => b.fame - a.fame)
+
+  const topQuartile = byFame.slice(0, Math.max(1, Math.ceil(byFame.length * 0.25))).map(s => s.row)
+  const topHalf = byFame.slice(0, Math.max(1, Math.ceil(byFame.length * 0.5))).map(s => s.row)
+  const all = ctx.answerRows
+
+  const poolForIndex = (i) => {
+    const tier = tierForIndex(i)
+    if (tier === 1) return topQuartile
+    if (tier === 2) return topHalf
+    return all
+  }
+
+  const used = new Set()
+  const out = []
+  for (let i = 0; i < count; i++) {
+    const pool = poolForIndex(i)
+    let choice = null
+    // Bounded probing — a run never repeats a cToon, and we'd rather return a short batch
+    // than spin when the eligible pool is small.
+    for (let attempt = 0; attempt < 40 && !choice; attempt++) {
+      const cand = pick(pool, rng)
+      if (cand && !used.has(cand.id)) choice = cand
+    }
+    if (!choice) choice = all.find(r => !used.has(r.id)) || null
+    if (!choice) break
+    used.add(choice.id)
+    out.push(choice)
+  }
+  return out
+}
+
+/**
+ * Builds the whole run: up to `count` questions, skipping answers for which no honest
+ * question could be assembled.
+ */
+function buildRun (ctx, seedHex, { count = DEFAULTS.maxQuestions, choiceCount = DEFAULTS.choices } = {}) {
+  const rng = makePRNG(seedHex)
+  // Over-draw so skipped answers don't shorten the run.
+  const answers = selectAnswers(ctx, rng, Math.ceil(count * 1.5))
+  const questions = []
+  for (const answerRow of answers) {
+    if (questions.length >= count) break
+    const q = buildQuestion(answerRow, ctx, rng, { index: questions.length, choiceCount })
+    if (q) questions.push(q)
+  }
+  return questions
+}
+
+// ── Cadence analysis ──────────────────────────────────────────────────────────
+
+/**
+ * Server-measured answer latencies are the one signal a DOM-reading bot can't fake: it has
+ * no reason to hesitate, so its intervals are both very fast and very regular. Humans on a
+ * 12-second timer scatter across hundreds of milliseconds.
+ *
+ * This flags rather than rejects. A false positive should cost a player their leaderboard
+ * slot, not their run or their points.
+ */
+function scoreCadence (latencies) {
+  const vals = (Array.isArray(latencies) ? latencies : [])
+    .map(Number)
+    .filter(n => Number.isFinite(n) && n >= 0)
+
+  if (vals.length < 5) {
+    return { median: vals.length ? median(vals) : null, stdDev: null, suspicious: false }
+  }
+
+  const med = median(vals)
+  const mean = vals.reduce((a, b) => a + b, 0) / vals.length
+  const variance = vals.reduce((a, b) => a + (b - mean) ** 2, 0) / vals.length
+  const stdDev = Math.sqrt(variance)
+
+  // Near-zero spread means a machine metronome; a sub-600ms median is faster than a human
+  // can read four names and move a thumb.
+  const suspicious = stdDev < 50 || med < 600
+
+  return { median: Math.round(med), stdDev: Math.round(stdDev), suspicious }
+}
+
+function median (vals) {
+  const s = vals.slice().sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2
+}
+
+// ── Atomic answer state machine ───────────────────────────────────────────────
+//
+// KEYS[1] = session key
+// ARGV[1] = questionIndex the client believes it is answering
+// ARGV[2] = chosen index, or -1 for a client-reported timeout
+// ARGV[3] = minimum inter-answer interval (ms)
+// ARGV[4] = deadline grace (ms)
+// ARGV[5] = TTL (seconds) to leave on a banked session
+//
+// All timestamps come from redis.call('TIME') and are only ever compared against other
+// TIME-derived values. Nothing the app server or the client stamps is trusted for timing —
+// app and Redis are separate hosts, and a few seconds of NTP skew would otherwise either
+// gift free time or expire every question instantly.
+//
+// The questions array is never mutated; a cursor advances instead. Mutating it would risk
+// cjson re-encoding an emptied or holed Lua table as a JSON *object*, silently corrupting
+// the session.
+const ANSWER_SCRIPT = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return cjson.encode({error='no_session'}) end
+
+local s = cjson.decode(raw)
+if s.state ~= 'live' then return cjson.encode({error='no_session'}) end
+
+local qi = tonumber(ARGV[1])
+local choice = tonumber(ARGV[2])
+local minInterval = tonumber(ARGV[3])
+local grace = tonumber(ARGV[4])
+local bankedTtl = tonumber(ARGV[5])
+
+if qi == nil or choice == nil then return cjson.encode({error='bad_request'}) end
+
+-- A cursor mismatch and a missing session return the SAME error, so a client cannot use
+-- the response to probe where a session actually is.
+if qi ~= s.i then return cjson.encode({error='no_session'}) end
+
+local t = redis.call('TIME')
+local now = (tonumber(t[1]) * 1000) + math.floor(tonumber(t[2]) / 1000)
+
+if s.lastAnswerAt and s.lastAnswerAt > 0 and (now - s.lastAnswerAt) < minInterval then
+  return cjson.encode({error='too_fast'})
+end
+
+local q = s.qs[s.i + 1]
+if not q then return cjson.encode({error='no_session'}) end
+
+local elapsed = now - s.issuedAt
+local timedOut = elapsed > ((s.secs * 1000) + grace)
+local correct = (choice == q.k) and (not timedOut)
+
+s.lat[#s.lat + 1] = math.floor(elapsed)
+s.lastAnswerAt = now
+
+local total = #s.qs
+
+if correct then
+  s.streak = s.streak + 1
+  local nextI = s.i + 1
+
+  if nextI >= total then
+    -- Perfect run: the whole batch answered correctly. Same terminal path as a wrong
+    -- answer, so banking stays single-winner.
+    s.state = 'banked'
+    redis.call('SET', KEYS[1], cjson.encode(s), 'EX', bankedTtl)
+    return cjson.encode({
+      correct=true, correctIndex=q.k, correctName=q.n, assetPath=q.a,
+      streak=s.streak, gameOver=true, perfect=true,
+      latencies=s.lat, startedAt=s.startedAt
+    })
+  end
+
+  s.i = nextI
+  s.issuedAt = now
+  local nq = s.qs[nextI + 1]
+  local following = s.qs[nextI + 2]
+  redis.call('SET', KEYS[1], cjson.encode(s), 'KEEPTTL')
+
+  return cjson.encode({
+    correct=true, correctIndex=q.k, correctName=q.n, assetPath=q.a,
+    streak=s.streak, gameOver=false,
+    nextQuestion={
+      questionIndex=nextI,
+      imageToken=nq.t,
+      choices=nq.c,
+      prefetchToken=(following and following.t or nil)
+    },
+    remainingMs=(s.secs * 1000)
+  })
+end
+
+-- Wrong answer or timeout: the run is over.
+s.state = 'banked'
+redis.call('SET', KEYS[1], cjson.encode(s), 'EX', bankedTtl)
+return cjson.encode({
+  correct=false, correctIndex=q.k, correctName=q.n, assetPath=q.a,
+  timedOut=timedOut, streak=s.streak, gameOver=true, perfect=false,
+  latencies=s.lat, startedAt=s.startedAt
+})
+`
+
+// Flips a live session to `banked` and returns its final streak — the "cash out / abandon"
+// path. Atomic so that a concurrent /answer game-over and a /end can never both record the
+// same run. Unlike GETDEL this leaves the session readable for a short TTL, which makes the
+// bank idempotent instead of losing the run if the DB write fails.
+//
+// KEYS[1] = session key, ARGV[1] = TTL (seconds) for the banked session.
+const BANK_SCRIPT = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return cjson.encode({error='no_session'}) end
+
+local s = cjson.decode(raw)
+if s.state ~= 'live' then return cjson.encode({error='already_banked'}) end
+
+s.state = 'banked'
+redis.call('SET', KEYS[1], cjson.encode(s), 'EX', tonumber(ARGV[1]))
+
+return cjson.encode({
+  streak=s.streak, latencies=s.lat, startedAt=s.startedAt, answered=#s.lat
+})
+`
+
+export {
+  DEFAULTS,
+  MIN_ANSWER_INTERVAL_MS,
+  DEADLINE_GRACE_MS,
+  MAX_CHOICE_LEN,
+  MIN_POOL_SIZE,
+  CHOICES_MIN,
+  CHOICES_MAX,
+  ANSWER_SCRIPT,
+  BANK_SCRIPT,
+  normalizeName,
+  parseName,
+  isEligibleAnswer,
+  fameScore,
+  tierForIndex,
+  quotaForTier,
+  buildCatalogContext,
+  buildQuestion,
+  buildRun,
+  selectAnswers,
+  scoreCadence,
+  makePRNG,
+  shuffle
+}

--- a/server/utils/guessCtoonPool.js
+++ b/server/utils/guessCtoonPool.js
@@ -1,0 +1,81 @@
+// Cached catalog pool for "Guess that cToon!".
+//
+// Distractor quality is the whole game, and it needs catalog-wide knowledge that a random
+// sample cannot provide:
+//
+//   • same-series wrong answers — with ~50 series, an 80-row random sample contains three
+//     same-series names only about a fifth of the time, so sampling per run would silently
+//     degrade almost every question to generated mutations;
+//   • collision checking — a recombined name like "Space Outlaw Ed" → "Space Outlaw Edd"
+//     has to be checked against EVERY name, not just the ones in this run.
+//
+// So the whole (narrow) catalog is cached in Redis for five minutes and shared across app
+// instances. At a few thousand cToons this is well under a megabyte, and it takes /start
+// off the database entirely.
+//
+// Rows come from prisma.ctoon.findMany rather than $queryRaw on purpose: the client
+// extension in server/prisma.js that swaps assetPath on April 1st only applies to model
+// operations, so a raw query would leave this game showing un-swapped art while the rest of
+// the site is swapped.
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+
+const POOL_KEY = 'guessctoon:pool:v1'
+const POOL_TTL_SECONDS = 300
+
+// Control characters (\p{Cc}) and surrogate code points (\p{Cs}). Admin-entered names are
+// free text, and a lone surrogate would make cjson throw inside ANSWER_SCRIPT — which would
+// 500 every answer for that session, permanently. Sanitize once, here.
+const UNSAFE_CHARS = /[\p{Cc}\p{Cs}]/gu
+
+export async function getCatalogPool () {
+  try {
+    const cached = await redis.get(POOL_KEY)
+    if (cached) {
+      const parsed = JSON.parse(cached)
+      if (Array.isArray(parsed) && parsed.length) return parsed
+    }
+  } catch {
+    // Cache miss or Redis hiccup — fall through to the database.
+  }
+
+  const rows = await prisma.ctoon.findMany({
+    where: { releaseDate: { not: null, lte: new Date() } },
+    select: {
+      id: true,
+      name: true,
+      series: true,
+      set: true,
+      assetPath: true,
+      rarity: true,
+      inCmart: true,
+      totalMinted: true,
+      isSecondEdition: true,
+      guessCtoonExcluded: true
+    }
+  })
+
+  const clean = rows
+    .filter(r => r && r.name && r.assetPath)
+    .map(r => ({
+      ...r,
+      name: sanitizeText(r.name),
+      series: r.series ? sanitizeText(r.series) : null,
+      set: r.set ? sanitizeText(r.set) : null
+    }))
+    .filter(r => r.name.length > 0)
+
+  try {
+    await redis.set(POOL_KEY, JSON.stringify(clean), 'EX', POOL_TTL_SECONDS)
+  } catch {
+    // Non-fatal: the pool is a cache, not the source of truth.
+  }
+
+  return clean
+}
+
+function sanitizeText (value) {
+  return String(value).replace(UNSAFE_CHARS, '').trim()
+}
+
+export { POOL_KEY, sanitizeText }

--- a/server/utils/guessCtoonRuntime.js
+++ b/server/utils/guessCtoonRuntime.js
@@ -1,0 +1,196 @@
+// Shared server runtime for "Guess that cToon!" — config loading, Redis keys, and the
+// single place a run is turned into a score row plus a points award.
+import { DateTime } from 'luxon'
+import { prisma } from '@/server/prisma'
+import { getDailyWindowStart } from '@/server/utils/centralTime'
+import { COMBAT_POOL_GAME_NAMES } from '@/server/utils/gamePoints'
+import { DEFAULTS, CHOICES_MIN, CHOICES_MAX, scoreCadence, MIN_ANSWER_INTERVAL_MS } from '@/server/utils/guessCtoonEngine'
+
+const GAME_NAME = 'GuessCtoon'
+const POINTS_METHOD = 'Game - Guess That cToon'
+
+// How long a banked session stays readable before Redis drops it. Long enough that the
+// game-over screen can still be reconciled, short enough that it isn't a leak.
+const BANKED_TTL_SECONDS = 120
+
+export function sessionKey (userId) { return `guessctoon:session:${userId}` }
+export function lockKey (userId) { return `guessctoon:lock:${userId}` }
+
+// GameConfig for this game is one never-changing row read on every /start and /status.
+// Cached in-process with a short TTL, mirroring server/middleware/daily-points.js.
+let cachedConfig = null
+let cachedConfigAt = 0
+const CONFIG_TTL_MS = 5 * 60 * 1000
+
+export async function getGuessCtoonConfig () {
+  const now = Date.now()
+  if (cachedConfig && (now - cachedConfigAt) < CONFIG_TTL_MS) return cachedConfig
+
+  let row = null
+  try {
+    row = await prisma.gameConfig.findUnique({ where: { gameName: GAME_NAME } })
+  } catch {
+    // Fall through to defaults — a config read failure should not take the game down.
+  }
+
+  const config = {
+    playsPerPeriod: clampInt(row?.guessCtoonPlaysPerPeriod, 1, 50, DEFAULTS.playsPerPeriod),
+    pointsPerGame: clampInt(row?.guessCtoonPointsPerGame, 0, 100000, DEFAULTS.pointsPerGame),
+    secondsPerQuestion: clampInt(row?.guessCtoonSecondsPerQuestion, 4, 120, DEFAULTS.secondsPerQuestion),
+    choices: clampInt(row?.guessCtoonChoices, CHOICES_MIN, CHOICES_MAX, DEFAULTS.choices),
+    maxQuestions: clampInt(row?.guessCtoonMaxQuestions, 5, 100, DEFAULTS.maxQuestions),
+    minStreakForPoints: clampInt(row?.guessCtoonMinStreakForPoints, 0, 100, DEFAULTS.minStreakForPoints)
+  }
+
+  cachedConfig = config
+  cachedConfigAt = now
+  return config
+}
+
+function clampInt (value, min, max, fallback) {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return fallback
+  return Math.max(min, Math.min(max, Math.round(n)))
+}
+
+export function getDailyBoundary () {
+  return getDailyWindowStart()
+}
+
+export function getNextResetAt (boundary) {
+  return new Date(boundary.getTime() + 24 * 60 * 60 * 1000)
+}
+
+export function getWeekBoundary () {
+  const chicagoNow = DateTime.now().setZone('America/Chicago')
+  const dow = chicagoNow.weekday % 7 // luxon: Mon=1…Sun=7; we want Mon=0
+  const monday = chicagoNow
+    .minus({ days: dow === 0 ? 6 : dow - 1 })
+    .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+  return monday.toUTC().toJSDate()
+}
+
+/**
+ * Records a finished run and awards points.
+ *
+ * Callers must already have won the atomic flip to `banked` in Redis (ANSWER_SCRIPT on a
+ * terminal answer, BANK_SCRIPT on cash-out), so exactly one caller ever reaches this for a
+ * given run.
+ *
+ * Points are gated on `minStreakForPoints`: without it, POST /start immediately followed by
+ * POST /end would pay the full per-game award for answering nothing, which is the same
+ * failure the ReOrbit Memory handler guards against when it refuses to score an incomplete
+ * board. A score row is still written for any streak — it's the *award* that is gated.
+ */
+export async function bankRun ({ userId, streak, latencies, startedAt, config }) {
+  const finalStreak = Math.max(0, Math.min(Number(streak) || 0, config.maxQuestions))
+  const cadence = scoreCadence(latencies)
+
+  // Wall-clock floor, mirroring the belt-and-suspenders check in reorbitmemory/end: a run
+  // cannot have taken less time than its own minimum answer pacing allows.
+  let suspicious = cadence.suspicious
+  if (Number.isFinite(startedAt) && startedAt > 0) {
+    const elapsedMs = Date.now() - startedAt
+    if (elapsedMs < finalStreak * MIN_ANSWER_INTERVAL_MS) suspicious = true
+  }
+
+  await prisma.guessCtoonScore.create({
+    data: {
+      userId,
+      streak: finalStreak,
+      suspicious,
+      medianAnswerMs: cadence.median ?? null,
+      stdDevAnswerMs: cadence.stdDev ?? null
+    }
+  })
+
+  let pointsAwarded = 0
+  if (finalStreak >= config.minStreakForPoints && config.pointsPerGame > 0) {
+    pointsAwarded = await awardPoints(userId, config.pointsPerGame)
+  }
+
+  return { streak: finalStreak, pointsAwarded, suspicious }
+}
+
+/**
+ * Awards up to `pointsPerGame`, capped by what remains of the shared daily general pool.
+ *
+ * The pool filter is a DENYLIST (everything that isn't TKO/Clash), matching every other
+ * general-pool game. Using an allowlist of just this game's name would give the player a
+ * whole extra daily allowance on top of Winball/Match/Memory/Tower rather than a share of
+ * the same one.
+ *
+ * The advisory lock serializes concurrent awards for the same user across games. Without
+ * it, two general-pool games finishing in the same millisecond both read the same stale
+ * "used today" total under READ COMMITTED and jointly blow through the cap.
+ */
+async function awardPoints (userId, pointsPerGame) {
+  let awarded = 0
+  try {
+    const globalConfig = await prisma.globalGameConfig.findUnique({
+      where: { id: 'singleton' },
+      select: { dailyPointLimit: true }
+    })
+    const dailyLimit = globalConfig?.dailyPointLimit ?? 100
+    const capped = Math.min(pointsPerGame, dailyLimit)
+    if (capped <= 0) return 0
+
+    const boundary = getDailyBoundary()
+
+    await prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}))`
+
+      const agg = await tx.gamePointLog.aggregate({
+        where: {
+          userId,
+          createdAt: { gte: boundary },
+          OR: [{ gameName: null }, { gameName: { notIn: COMBAT_POOL_GAME_NAMES } }]
+        },
+        _sum: { points: true }
+      })
+      const usedToday = Number(agg._sum?.points || 0)
+      const toGive = Math.min(capped, Math.max(0, dailyLimit - usedToday))
+      awarded = toGive
+
+      if (toGive > 0) {
+        await tx.gamePointLog.create({ data: { userId, points: toGive, gameName: GAME_NAME } })
+        const updated = await tx.userPoints.upsert({
+          where: { userId },
+          create: { userId, points: toGive },
+          update: { points: { increment: toGive } }
+        })
+        await tx.pointsLog.create({
+          data: {
+            userId,
+            direction: 'increase',
+            points: toGive,
+            total: updated.points,
+            method: POINTS_METHOD
+          }
+        })
+      }
+    })
+  } catch {
+    // Points award failure is non-fatal — the score is already recorded.
+    return awarded
+  }
+  return awarded
+}
+
+/**
+ * Loads the user and rejects anyone who must not be earning: deleted (the JWT outlives the
+ * row), banned, or deactivated. `user?.banned` alone would let a deleted user straight
+ * through, since undefined is falsy.
+ */
+export async function assertPlayable (userId) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { banned: true, active: true }
+  })
+  if (!user) return 'Account not found'
+  if (user.banned) return 'Account suspended'
+  if (user.active === false) return 'Account inactive'
+  return null
+}
+
+export { GAME_NAME, POINTS_METHOD, BANKED_TTL_SECONDS }

--- a/server/utils/hotPaths.js
+++ b/server/utils/hotPaths.js
@@ -1,0 +1,23 @@
+// Endpoints that are called many times within a single user action and must not pay for
+// the per-request user bookkeeping that the global middleware does.
+//
+// "Guess that cToon!" is the first game that talks to the server on every interaction
+// rather than once per game: a 25-question run is 25 POSTs, each of which would otherwise
+// cost ~8 Postgres queries and an interactive transaction across daily-points, guild-check
+// and login-log — none of which this handler reads. The image route is in the same
+// position: it serves one file per question and reads nothing but the Redis session.
+//
+// Skipping them is safe for the same reason those middlewares already skip non-/api
+// requests: every page load hits /api/auth/me, so the daily award, guild sync and login log
+// still fire reliably on the surrounding navigation.
+const HOT_PATHS = [
+  '/api/game/guessctoon/answer',
+  '/api/game/guessctoon/image/'
+]
+
+export function isHotPath (path) {
+  if (!path) return false
+  return HOT_PATHS.some(p => path.startsWith(p))
+}
+
+export { HOT_PATHS }

--- a/tests/guessCtoonEngine.test.js
+++ b/tests/guessCtoonEngine.test.js
@@ -1,0 +1,217 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  normalizeName,
+  parseName,
+  isEligibleAnswer,
+  tierForIndex,
+  quotaForTier,
+  buildCatalogContext,
+  buildQuestion,
+  buildRun,
+  scoreCadence,
+  MAX_CHOICE_LEN
+} from '../server/utils/guessCtoonEngine.js'
+
+// A slice of the real catalog shape: modifier+character names, parenthetical poses,
+// positional slices, numbered items, second editions and duplicate art.
+const CATALOG = [
+  ['Watcher Dexter', 'Dexters Lab'],
+  ['Cybersuit Dexter', 'Dexters Lab'],
+  ['Valentine Mandark', 'Dexters Lab'],
+  ['Dee Dee', 'Dexters Lab'],
+  ['Lazy Scooby', 'Scooby Doo'],
+  ['Shaggy', 'Scooby Doo'],
+  ['Velma', 'Scooby Doo'],
+  ['Fearless Flash', 'Justice League'],
+  ['Undaunted Hawkgirl', 'Justice League'],
+  ['The Batman', 'Justice League'],
+  ['Private John Stewart', 'Justice League'],
+  ['Space Outlaw Ed', 'Ed Edd n Eddy'],
+  ['Space Outlaw Edd', 'Ed Edd n Eddy'],
+  ['Space Outlaw Eddy', 'Ed Edd n Eddy'],
+  ['Ed (Run)', 'Ed Edd n Eddy'],
+  ['Funky Blue Bubbles', 'Powerpuff Girls'],
+  ['Funky Green Buttercup', 'Powerpuff Girls'],
+  ['Funky Pink Blossom', 'Powerpuff Girls'],
+  ['Goku', 'Dragon Ball Z'],
+  ['Charizard', 'Pokemon'],
+  ['Hamtaro', 'Hamtaro'],
+  ['Skeletor', 'He-Man'],
+  ['Johnny Bravo', 'Johnny Bravo'],
+  ['Schoolgirl Sakura', 'Cardcaptors'],
+  ['Space Ghost (Flying)', 'Space Ghost'],
+  ['Huckleberry (Waving)', 'The Huckleberry Hound Show'],
+  ['Fred Flintstone (Mowing)', 'Flintstones'],
+  ['Watcher Yogi', 'Yogi Bear'],
+  ['Obi-Wan Kenobi', 'Star Wars'],
+  ['Kungfu Hong Kong Phooey', 'Hong Kong Phooey']
+]
+
+function makeRows (extra = []) {
+  const rows = CATALOG.map(([name, series], i) => ({
+    id: `id-${i}`,
+    name,
+    series,
+    set: 'Original',
+    assetPath: `/cToons/${series}/${name.toLowerCase().replace(/[^a-z0-9]+/g, '_')}.gif`,
+    rarity: 'Common',
+    inCmart: true,
+    totalMinted: 100 - i,
+    isSecondEdition: false,
+    guessCtoonExcluded: false
+  }))
+  return rows.concat(extra)
+}
+
+test('normalizeName collapses punctuation, case and spacing', () => {
+  assert.equal(normalizeName("Dexter's Lab"), 'dexterslab')
+  assert.equal(normalizeName('DEXTERS  LAB'), 'dexterslab')
+  assert.equal(normalizeName('Obi-Wan Kenobi'), 'obiwankenobi')
+  assert.equal(normalizeName(null), '')
+})
+
+test('parseName splits modifiers, head and pose suffix', () => {
+  const a = parseName('Space Outlaw Eddy')
+  assert.deepEqual(a.modifiers, ['Space', 'Outlaw'])
+  assert.equal(a.head, 'Eddy')
+  assert.equal(a.pose, null)
+
+  const b = parseName('Fred Flintstone (Mowing)')
+  assert.equal(b.pose, 'Mowing')
+  assert.equal(b.base, 'Fred Flintstone')
+  assert.equal(b.head, 'Flintstone')
+})
+
+test('answer eligibility bars image slices, numbered items and exclusions', () => {
+  const base = { name: 'Goku', assetPath: '/a.gif', isSecondEdition: false, guessCtoonExcluded: false }
+  assert.equal(isEligibleAnswer(base), true)
+  assert.equal(isEligibleAnswer({ ...base, name: 'Bat Signal (Middle)' }), false)
+  assert.equal(isEligibleAnswer({ ...base, name: 'Bat Signal (Top)' }), false)
+  assert.equal(isEligibleAnswer({ ...base, name: 'Christmas Present 3' }), false)
+  assert.equal(isEligibleAnswer({ ...base, isSecondEdition: true }), false)
+  assert.equal(isEligibleAnswer({ ...base, guessCtoonExcluded: true }), false)
+  assert.equal(isEligibleAnswer({ ...base, name: 'x'.repeat(MAX_CHOICE_LEN + 1) }), false)
+})
+
+test('catalog context dedupes answers by assetPath and keeps second editions as distractors', () => {
+  // make-second-edition copies BOTH name and assetPath from the original, so without
+  // dedupe a question could offer the same string twice.
+  const dupe = {
+    id: 'dupe',
+    name: 'Goku',
+    series: 'Dragon Ball Z',
+    set: 'Second',
+    assetPath: '/cToons/Dragon Ball Z/goku.gif',
+    rarity: 'Common',
+    inCmart: false,
+    totalMinted: 5,
+    isSecondEdition: true,
+    guessCtoonExcluded: false
+  }
+  const rows = makeRows([dupe])
+  const ctx = buildCatalogContext(rows)
+
+  const gokuAnswers = ctx.answerRows.filter(r => normalizeName(r.name) === 'goku')
+  assert.equal(gokuAnswers.length, 1, 'only one Goku may be an answer')
+  assert.equal(ctx.answerRows.some(r => r.isSecondEdition), false)
+})
+
+test('tier and quota ramp difficulty through the distractors', () => {
+  assert.equal(tierForIndex(0), 1)
+  assert.equal(tierForIndex(4), 1)
+  assert.equal(tierForIndex(5), 2)
+  assert.equal(tierForIndex(15), 3)
+  assert.equal(tierForIndex(30), 4)
+
+  assert.deepEqual(quotaForTier(1, 3), ['sameSeries', 'cross', 'cross'])
+  assert.deepEqual(quotaForTier(3, 3), ['sameSeries', 'sameSeries', 'sameSeries'])
+  // A larger choice count still gets every slot filled.
+  assert.equal(quotaForTier(1, 5).length, 5)
+})
+
+test('buildQuestion never repeats a choice and always points at the real name', () => {
+  const ctx = buildCatalogContext(makeRows())
+  let built = 0
+
+  for (let seed = 0; seed < 60; seed++) {
+    const rng = seededRng(seed)
+    for (const answerRow of ctx.answerRows) {
+      const q = buildQuestion(answerRow, ctx, rng, { index: seed % 35, choiceCount: 4 })
+      if (!q) continue
+      built++
+
+      assert.equal(q.choices.length, 4)
+      assert.equal(q.choices[q.correctIndex], answerRow.name)
+
+      const norms = q.choices.map(normalizeName)
+      assert.equal(new Set(norms).size, 4, `duplicate choice in [${q.choices.join(' | ')}]`)
+
+      for (const c of q.choices) {
+        assert.ok(c.length <= MAX_CHOICE_LEN, `choice too long to render: ${c}`)
+        assert.ok(c.trim().length > 0)
+      }
+    }
+  }
+
+  assert.ok(built > 500, `expected plenty of questions, built ${built}`)
+})
+
+test('buildQuestion allows at most one wrong answer sharing the character', () => {
+  const ctx = buildCatalogContext(makeRows())
+  const dexter = ctx.answerRows.find(r => r.name === 'Watcher Dexter')
+
+  for (let seed = 0; seed < 40; seed++) {
+    const q = buildQuestion(dexter, ctx, seededRng(seed), { index: 20, choiceCount: 4 })
+    if (!q) continue
+    const answerHead = normalizeName(parseName(dexter.name).head)
+    const sharers = q.choices
+      .filter((_, i) => i !== q.correctIndex)
+      .filter(c => normalizeName(parseName(c).head) === answerHead)
+    assert.ok(sharers.length <= 1, `too many same-character choices: ${q.choices.join(' | ')}`)
+  }
+})
+
+test('buildRun produces a full, non-repeating batch', () => {
+  const ctx = buildCatalogContext(makeRows())
+  const questions = buildRun(ctx, 'deadbeefcafe0123', { count: 20, choiceCount: 4 })
+
+  assert.ok(questions.length >= 15, `expected a near-full run, got ${questions.length}`)
+
+  const ids = questions.map(q => q.ctoonId)
+  assert.equal(new Set(ids).size, ids.length, 'a run must not repeat a cToon')
+
+  for (const q of questions) {
+    assert.equal(q.choices[q.correctIndex], q.name)
+    assert.ok(q.assetPath)
+  }
+})
+
+test('scoreCadence flags metronomic and superhuman answering', () => {
+  // Too few samples to judge.
+  assert.equal(scoreCadence([900, 1200]).suspicious, false)
+
+  // Human-looking spread.
+  assert.equal(scoreCadence([2400, 1100, 3800, 900, 2600, 1750]).suspicious, false)
+
+  // Bot: near-zero variance.
+  assert.equal(scoreCadence([1000, 1001, 999, 1000, 1002, 1000]).suspicious, true)
+
+  // Bot: faster than a human can read four names.
+  assert.equal(scoreCadence([310, 420, 280, 500, 350, 390]).suspicious, true)
+
+  assert.equal(scoreCadence(null).suspicious, false)
+  assert.equal(scoreCadence(['x', NaN, -5]).suspicious, false)
+})
+
+// Small deterministic RNG so failures reproduce.
+function seededRng (seed) {
+  let s = (seed + 1) * 0x9e3779b9
+  return function () {
+    s = (s + 0x6d2b79f5) | 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}


### PR DESCRIPTION
Adds a new game at `/newsite/guessctoon`. A random cToon appears and the player names it from four choices. Every correct answer extends a streak; the first wrong answer or timeout ends the run, and the best streak is the leaderboard score. Styled after early-2000s Cartoon Network — chunky black outlines, hard-offset shadows, halftone, and the Futura Bold Condensed face already shipped with the Winball page (no new font request).

## Three findings that shaped the design

**The image URL was the answer.** `Ctoon.assetPath` is `/images/cToons/Ed Edd n Eddy/space_outlaw_ed.gif` — the filename is the name and the directory is the series. A few lines of userscript matching the four choices against `img.src` would win every question forever, and the directory alone eliminates every cross-series wrong answer. Questions now carry an opaque per-run token, resolved by a proxy route that only redeems the pending question and the one being prefetched, and only for the caller's own session. No `assetPath` is ever sent to the browser during play.

**A mid-run question refill would have broken the Lua script's atomicity.** Refilling meant a read-modify-write around the database, outside the script, so two in-flight answers could clobber the cursor, rewind to an already-answered question, or double-record a run. Runs are now a fixed batch with no refill — answering the whole batch is a "perfect run" win state — which keeps the script the sole writer.

**Hybrid distractors would have silently degraded.** With ~50 series, an 80-row random sample contains three same-series names only about a fifth of the time, so most questions would have fallen back to letter-mutations. The catalog is now cached in Redis, and distractor sourcing is a per-tier quota rather than a fallback chain.

## How it works

Wrong answers prefer real names from the answer's own series, then same-set, then shape-matched cross-series names. Recombined "derivative" names (modifier swap, character swap, pose swap, modifier drop) fill gaps, and single-letter mutations are a last resort capped at one per question and never applied to short names. Candidates are checked against the full catalog so a recombination can't accidentally mint another real cToon's name, and at most one wrong answer may be another variant of the same character.

Difficulty ramps through the distractors rather than through answer obscurity — the opening questions are fame-weighted by `totalMinted` so a run doesn't die on question two to a 1-of-1, while later questions are all same-series real names.

All game state lives in a Redis session driven by one atomic Lua script: cursor validation, minimum answer interval, per-question deadline, streak accounting, and a one-way flip to `banked` so exactly one request can ever record a run. Every timestamp comes from Redis `TIME` and is only compared against other `TIME` values — app and Redis are separate hosts, and NTP skew would otherwise gift free seconds or expire questions instantly.

Second editions and duplicate artwork are excluded from the answer pool (`make-second-edition` copies both name and `assetPath`, so two rows can be the same picture with the same name). Image slices like `Bat Signal (Middle)` and numbered sets like `Christmas Present 3` can be wrong answers but never the question.

## Economy and integrity

Points draw from the shared general daily pool via the usual denylist filter, and are gated on a minimum streak so `start` → immediate `end` can't farm the award. The award takes a per-user advisory lock, which closes the race where two general-pool games finishing in the same millisecond both read the same stale daily total. Play limits are enforced by a Postgres advisory lock rather than relying on the Redis lock alone.

Answer cadence is recorded per run. Near-zero variance or a superhuman median latency flags the row, keeping it off the leaderboard while preserving it for auditing — a false positive costs a leaderboard slot, not a run or its points.

## Performance

The `answer` and image endpoints opt out of the global per-request user bookkeeping. This is the first game that talks to the server on every interaction rather than once per game, and a 25-question run would otherwise cost roughly eight queries and an interactive transaction per tap for handlers that read none of it. The surrounding page navigation still logs the session and awards daily points as before.

The leaderboard caches the full ranked list instead of re-running an unbounded aggregation for every viewer outside the top 11, and ties break on who reached the streak first — streaks are small integers, so ties are the common case, and an alphabetical tie-break would make the board unwinnable for anyone late in the alphabet.

## Mobile

Fixed-height answer buttons with a two-line clamp, so the four choices occupy identical geometry on every question and the layout never reflows under a descending thumb. Fixed-height image stage with `object-fit: contain` (cToon art spans a ~9× aspect ratio range). Timer animates `transform: scaleX` on the compositor and resyncs against the server deadline on `visibilitychange`. Input locks from answer until the next question has painted. Result is encoded three ways — colour, glyph, and strikethrough — plus a live region, keyboard shortcuts, and `prefers-reduced-motion` handling.

## Configuration

Settings live as `GameConfig` columns on a `GuessCtoon` row seeded by the migration, so they're tunable by SQL without an admin tab: plays/day (3), points/game (50), seconds/question (12), choices (4), max questions (25), minimum streak for points (3). `Ctoon.guessCtoonExcluded` is an escape hatch for a cToon that makes an unanswerable question — currently SQL-only, no checkbox.

Wired into the Games home tile grid (including the admin tile-image upload/delete plumbing) and the Games leaderboard pills.

## Testing

- 9 engine unit tests: no duplicate or unrenderable choices, correct-index integrity, answer-pool eligibility, cadence scoring
- 20 Lua checks against real Redis, plus **600 concurrency trials** confirming exactly-one-bank under parallel answers, answer-vs-cash-out, and same-cursor races
- **39 HTTP checks against the built server** on a real Postgres and Redis: auth, no-answer-leak, path traversal, body type-confusion, play limits, the shared points cap, cadence flagging, leaderboard exclusion
- Full migration chain applied to a fresh database, and the new migration confirmed idempotent on re-run
- `nuxt build` clean; existing test suite unchanged (one pre-existing failure in `monsterBattleEngine` is present on a clean tree too)

**Not verified:** the Vue page's runtime behaviour. In the sandbox the client bundle serves but never initializes — the shipped ReOrbit Memory page fails identically, so it's environmental — which means the timer, reveal, and keyboard paths want a manual pass on the dev box.

## Noticed but not touched

Two pre-existing issues surfaced during review, both outside this change: the missing advisory lock lets a user exceed the daily point cap across the existing games, and the other three game leaderboards run an unbounded aggregation per viewer. Worth separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Enz3GSACiDyDkwVuzzqf6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Enz3GSACiDyDkwVuzzqf6m)_