### PR TITLE
Guess that cToon!: fix clipped artwork, unlimited plays with a scored cap

### DIFF
--- a/pages/admin/games.vue
+++ b/pages/admin/games.vue
@@ -915,6 +915,64 @@
           </button>
         </section>
 
+        <!-- Guess that cToon! -->
+        <section v-if="activeTab === 'GuessCtoon'" role="tabpanel" aria-label="Guess that cToon Settings">
+          <h2 class="text-2xl font-semibold mb-4">Guess that cToon! Settings</h2>
+
+          <p class="text-sm text-gray-500 mb-4">
+            Plays are unlimited. Only the first few runs each day count toward points and the
+            leaderboard — everything after that is playable as practice.
+            Saved changes apply to new games within about a minute, and never disrupt a run
+            already in progress.
+          </p>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Scoring Plays Per Period</label>
+              <p class="text-xs text-gray-400 mb-1">
+                Runs per 24-hour period (resets 8 PM CT) that count for points and the
+                leaderboard. Set to 0 to make every run practice-only.
+              </p>
+              <input type="number" v-model.number="guessCtoonScoredPlaysPerPeriod" min="0" max="100" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-400 mb-1">Points awarded toward the shared daily cap when a scoring run ends</p>
+              <input type="number" v-model.number="guessCtoonPointsPerGame" min="0" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Seconds Per cToon</label>
+              <p class="text-xs text-gray-400 mb-1">Countdown per question — running out counts as a wrong answer (4–120)</p>
+              <input type="number" v-model.number="guessCtoonSecondsPerQuestion" min="4" max="120" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Answer Choices</label>
+              <p class="text-xs text-gray-400 mb-1">How many names to pick from, including the correct one</p>
+              <select v-model.number="guessCtoonChoices" class="input">
+                <option :value="3">3 choices</option>
+                <option :value="4">4 choices</option>
+                <option :value="5">5 choices</option>
+                <option :value="6">6 choices</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Questions Per Run</label>
+              <p class="text-xs text-gray-400 mb-1">Longest possible streak — answering them all is a perfect run (5–100)</p>
+              <input type="number" v-model.number="guessCtoonMaxQuestions" min="5" max="100" class="input" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Minimum Streak For Points</label>
+              <p class="text-xs text-gray-400 mb-1">Runs shorter than this record a score but earn no points</p>
+              <input type="number" v-model.number="guessCtoonMinStreakForPoints" min="0" max="100" class="input" />
+            </div>
+          </div>
+
+          <button @click="saveGuessCtoonConfig" :disabled="loadingGuessCtoon" class="btn-primary">
+            <span v-if="!loadingGuessCtoon">Save Guess that cToon! Settings</span>
+            <span v-else>Saving…</span>
+          </button>
+        </section>
+
         <!-- TKO -->
         <section v-if="activeTab === 'TKO'" role="tabpanel" aria-label="TKO Events">
           <h2 class="text-2xl font-semibold mb-4">TKO Events</h2>
@@ -1058,7 +1116,8 @@ const tabs = [
   { key: 'TKO',          label: 'TKO' },
   { key: 'ReOrbitMatch', label: 'ReOrbit Match' },
   { key: 'TowerStack',   label: 'Tower Stack' },
-  { key: 'ReOrbitMemory', label: 'ReOrbit Memory' }
+  { key: 'ReOrbitMemory', label: 'ReOrbit Memory' },
+  { key: 'GuessCtoon',   label: 'Guess that cToon!' }
 ]
 const activeTab = ref('Global')
 async function switchTab(k) {
@@ -1488,6 +1547,14 @@ async function loadSettings() {
   reorbitMemoryTimeSecondsInput.value  = rm.reorbitMemoryTimeSeconds != null ? String(rm.reorbitMemoryTimeSeconds) : ''
   reorbitMemoryFlipBackDelayMs.value   = rm.reorbitMemoryFlipBackDelayMs ?? 800
   reorbitMemoryCardBackImage.value     = rm.reorbitMemoryCardBackImagePath || ''
+
+  const gc = await $fetch('/api/admin/game-config?gameName=GuessCtoon')
+  guessCtoonScoredPlaysPerPeriod.value = gc.guessCtoonScoredPlaysPerPeriod ?? 3
+  guessCtoonPointsPerGame.value        = gc.guessCtoonPointsPerGame ?? 50
+  guessCtoonSecondsPerQuestion.value   = gc.guessCtoonSecondsPerQuestion ?? 12
+  guessCtoonChoices.value              = gc.guessCtoonChoices ?? 4
+  guessCtoonMaxQuestions.value         = gc.guessCtoonMaxQuestions ?? 25
+  guessCtoonMinStreakForPoints.value   = gc.guessCtoonMinStreakForPoints ?? 3
 }
 
 // Win Wheel state
@@ -1954,6 +2021,39 @@ async function saveReorbitMemoryConfig() {
     toastMessage.value = 'Error saving ReOrbit Memory settings'; toastType.value = 'error'
   } finally {
     loadingReorbitMemory.value = false
+  }
+}
+
+// ── Guess that cToon! ──────────────────────────────────────────────────────────
+const guessCtoonScoredPlaysPerPeriod = ref(3)
+const guessCtoonPointsPerGame        = ref(50)
+const guessCtoonSecondsPerQuestion   = ref(12)
+const guessCtoonChoices              = ref(4)
+const guessCtoonMaxQuestions         = ref(25)
+const guessCtoonMinStreakForPoints   = ref(3)
+const loadingGuessCtoon              = ref(false)
+
+async function saveGuessCtoonConfig() {
+  loadingGuessCtoon.value = true
+  try {
+    await $fetch('/api/admin/game-config', {
+      method: 'POST',
+      body: {
+        gameName:                       'GuessCtoon',
+        guessCtoonScoredPlaysPerPeriod: guessCtoonScoredPlaysPerPeriod.value,
+        guessCtoonPointsPerGame:        guessCtoonPointsPerGame.value,
+        guessCtoonSecondsPerQuestion:   guessCtoonSecondsPerQuestion.value,
+        guessCtoonChoices:              guessCtoonChoices.value,
+        guessCtoonMaxQuestions:         guessCtoonMaxQuestions.value,
+        guessCtoonMinStreakForPoints:   guessCtoonMinStreakForPoints.value
+      }
+    })
+    toastMessage.value = 'Guess that cToon! settings saved!'; toastType.value = 'success'
+  } catch (err) {
+    console.error(err)
+    toastMessage.value = 'Error saving Guess that cToon! settings'; toastType.value = 'error'
+  } finally {
+    loadingGuessCtoon.value = false
   }
 }
 

--- a/pages/newsite/guessctoon.vue
+++ b/pages/newsite/guessctoon.vue
@@ -7,15 +7,6 @@
           <div class="gc-spinner" aria-label="Loading game…"></div>
         </div>
 
-        <!-- No plays left -->
-        <div v-else-if="uiState === 'noplays'" class="gc-center">
-          <div class="gc-card">
-            <h1 class="gc-title">Guess that cToon!</h1>
-            <p class="gc-card-text">No plays left today.</p>
-            <p class="gc-muted">Resets {{ resetLabel }}</p>
-          </div>
-        </div>
-
         <!-- Start -->
         <div v-else-if="uiState === 'start'" class="gc-center">
           <div class="gc-card">
@@ -25,11 +16,24 @@
               streak — one wrong answer ends the run.
             </p>
             <div class="gc-badges">
-              <span class="gc-badge">{{ playsLeft }} play{{ playsLeft !== 1 ? 's' : '' }} left</span>
+              <span v-if="scoredPlaysLeft > 0" class="gc-badge">
+                {{ scoredPlaysLeft }} scoring play{{ scoredPlaysLeft !== 1 ? 's' : '' }} left
+              </span>
+              <span v-else class="gc-badge gc-badge--practice">Practice mode</span>
               <span v-if="allTimeHigh != null" class="gc-badge gc-badge--alt">Best streak: {{ allTimeHigh }}</span>
             </div>
             <p class="gc-muted">
-              {{ config.secondsPerQuestion }}s per cToon · {{ config.maxQuestions }} to go perfect · Resets {{ resetLabel }}
+              <template v-if="scoredPlaysLeft > 0">
+                Play as much as you like — your next {{ scoredPlaysLeft }} run{{ scoredPlaysLeft !== 1 ? 's' : '' }}
+                count for points and the leaderboard.
+              </template>
+              <template v-else>
+                Play as much as you like. Today's scoring runs are used up, so these won't count
+                for points or the leaderboard. Resets {{ resetLabel }}.
+              </template>
+            </p>
+            <p class="gc-muted">
+              {{ config.secondsPerQuestion }}s per cToon · {{ config.maxQuestions }} to go perfect
             </p>
             <button class="gc-btn-start" :disabled="starting" @click="startGame">
               {{ starting ? 'Loading…' : 'Play' }}
@@ -59,8 +63,9 @@
               <span class="gc-hud-value">{{ questionIndex + 1 }}<span class="gc-hud-sub">/{{ totalQuestions }}</span></span>
             </div>
             <div class="gc-hud-item gc-hud-item--right">
-              <span class="gc-hud-label">Best</span>
-              <span class="gc-hud-value">{{ allTimeHigh ?? '—' }}</span>
+              <span class="gc-hud-label">{{ counted ? 'Best' : 'Mode' }}</span>
+              <span v-if="counted" class="gc-hud-value">{{ allTimeHigh ?? '—' }}</span>
+              <span v-else class="gc-hud-value gc-hud-value--practice">Practice</span>
             </div>
           </div>
 
@@ -74,6 +79,7 @@
               decoding="async"
               fetchpriority="high"
               draggable="false"
+              :ref="onImgRef"
               @load="imgReady = true"
               @error="imgReady = true"
             />
@@ -122,7 +128,10 @@
               It was <strong>{{ finalResult.correctName }}</strong>.
             </p>
             <p v-if="isPersonalBest" class="gc-pb">New personal best!</p>
-            <p v-if="finalResult?.pointsAwarded" class="gc-muted">
+            <p v-if="finalResult && !finalResult.counted" class="gc-muted">
+              Practice run — didn't count for points or the leaderboard.
+            </p>
+            <p v-else-if="finalResult?.pointsAwarded" class="gc-muted">
               +{{ finalResult.pointsAwarded }} points
             </p>
             <p
@@ -133,14 +142,20 @@
             </p>
 
             <div class="gc-actions">
-              <button v-if="playsLeft > 0" class="gc-btn-start" :disabled="starting" @click="startGame">
+              <button class="gc-btn-start" :disabled="starting" @click="startGame">
                 {{ starting ? 'Loading…' : 'Play Again' }}
               </button>
-              <span v-else class="gc-muted">No plays left · Resets {{ resetLabel }}</span>
               <NuxtLink to="/newsite/leaderboards" class="gc-btn-secondary">Leaderboard</NuxtLink>
               <NuxtLink to="/newsite/Games" class="gc-btn-secondary">Games Home</NuxtLink>
             </div>
-            <p class="gc-muted">{{ playsLeft }} play{{ playsLeft !== 1 ? 's' : '' }} left today</p>
+            <p class="gc-muted">
+              <template v-if="scoredPlaysLeft > 0">
+                {{ scoredPlaysLeft }} scoring play{{ scoredPlaysLeft !== 1 ? 's' : '' }} left today
+              </template>
+              <template v-else>
+                Unlimited practice runs · Scoring resets {{ resetLabel }}
+              </template>
+            </p>
           </div>
         </div>
       </div>
@@ -155,12 +170,14 @@ definePageMeta({ ssr: false })
 
 const LETTERS = ['A', 'B', 'C', 'D', 'E', 'F']
 
-const uiState = ref('loading') // loading | noplays | start | playing | gameover
+const uiState = ref('loading') // loading | start | playing | gameover
 const starting = ref(false)
 const startError = ref('')
 
-const config = ref({ secondsPerQuestion: 12, maxQuestions: 25, minStreakForPoints: 3, playsPerPeriod: 3 })
-const playsLeft = ref(0)
+const config = ref({ secondsPerQuestion: 12, maxQuestions: 25, minStreakForPoints: 3, scoredPlaysPerPeriod: 3 })
+// Plays are unlimited; this is how many more will count toward points and the leaderboard.
+const scoredPlaysLeft = ref(0)
+const counted = ref(true)
 const playsResetAt = ref(null)
 const allTimeHigh = ref(null)
 
@@ -203,6 +220,14 @@ const resetLabel = computed(() => {
 
 function imageUrl (token) {
   return token ? `/api/game/guessctoon/image/${token}` : ''
+}
+
+// The next question's image is prefetched while the current one is on screen, so by the
+// time it becomes current it is usually already in cache and can finish decoding BEFORE
+// the freshly-keyed <img> attaches its load handler. Without this check `load` never
+// fires, imgReady stays false, and the placeholder sits on top of the artwork forever.
+function onImgRef (el) {
+  if (el && el.complete && el.naturalWidth > 0) imgReady.value = true
 }
 
 function answerClass (i) {
@@ -294,7 +319,7 @@ async function loadStatus () {
   try {
     const s = await $fetch('/api/game/guessctoon/status')
     config.value = s.config
-    playsLeft.value = s.playsLeft
+    scoredPlaysLeft.value = s.scoredPlaysLeft
     playsResetAt.value = s.playsResetAt
     allTimeHigh.value = s.allTimeHigh
     return s
@@ -311,23 +336,19 @@ async function startGame () {
     const res = await $fetch('/api/game/guessctoon/start', { method: 'POST' })
     totalQuestions.value = res.totalQuestions
     config.value = { ...config.value, secondsPerQuestion: res.secondsPerQuestion }
+    counted.value = res.counted !== false
+    scoredPlaysLeft.value = res.scoredPlaysLeft ?? scoredPlaysLeft.value
+    playsResetAt.value = res.playsResetAt ?? playsResetAt.value
     streak.value = 0
     reveal.value = null
     finalResult.value = null
     isPersonalBest.value = false
     locked.value = false
-    playsLeft.value = Math.max(0, playsLeft.value - 1)
     uiState.value = 'playing'
     await nextTick()
     setQuestion(res.question, res.secondsPerQuestion * 1000)
   } catch (err) {
-    const status = err?.statusCode || err?.response?.status
-    if (status === 429) {
-      await loadStatus()
-      uiState.value = 'noplays'
-    } else {
-      startError.value = err?.statusMessage || err?.data?.statusMessage || 'Could not start a game. Try again.'
-    }
+    startError.value = err?.statusMessage || err?.data?.statusMessage || 'Could not start a game. Try again.'
   } finally {
     starting.value = false
   }
@@ -357,7 +378,7 @@ async function submitAnswer (choice) {
       return
     }
     await loadStatus()
-    uiState.value = playsLeft.value > 0 ? 'start' : 'noplays'
+    uiState.value = 'start'
     locked.value = false
     return
   }
@@ -381,10 +402,14 @@ async function submitAnswer (choice) {
       streak: res.streak,
       perfect: res.perfect,
       correctName: res.correctName,
+      counted: res.counted !== false,
       pointsAwarded: res.pointsAwarded,
       minStreakForPoints: res.minStreakForPoints
     }
-    isPersonalBest.value = allTimeHigh.value == null || res.streak > allTimeHigh.value
+    if (res.counted !== false) scoredPlaysLeft.value = Math.max(0, scoredPlaysLeft.value - 1)
+    // Practice runs never set a personal best — they aren't on the leaderboard.
+    isPersonalBest.value = res.counted !== false &&
+      (allTimeHigh.value == null || res.streak > allTimeHigh.value)
     if (isPersonalBest.value) allTimeHigh.value = res.streak
     reveal.value = null
     uiState.value = 'gameover'
@@ -411,8 +436,7 @@ function bankOnExit () {
 onMounted(async () => {
   reduceMotion.value = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches || false
   const s = await loadStatus()
-  if (!s) { uiState.value = 'start'; return }
-  uiState.value = s.playsLeft > 0 ? 'start' : 'noplays'
+  uiState.value = 'start'
 
   document.addEventListener('visibilitychange', onVisibility)
   window.addEventListener('keydown', onKey)
@@ -566,6 +590,8 @@ onBeforeUnmount(() => {
   font-weight: 800;
 }
 .gc-badge--alt { background: #FFCC33; color: #2A1B00; }
+.gc-badge--practice { background: #7C5CBF; color: #fff; }
+.gc-hud-value--practice { font-size: 15px; color: #C9B6F5; }
 
 .gc-btn-start {
   display: inline-block;
@@ -707,16 +733,30 @@ onBeforeUnmount(() => {
 
 /* ── Stage ──────────────────────────────────────────────────── */
 
-/* Fixed height + object-fit: contain. cToon art ranges from 55×50 to 200×117 (a ~9× aspect
-   spread), so an intrinsically-sized image would resize the page every question and push
-   the answer buttons out from under the player's thumb. */
+/* The image area takes whatever vertical space the HUD and answer buttons leave, between a
+   floor and a ceiling — rather than a fixed viewport-derived height, which guesses wrong in
+   both directions. The layout gives this page a fixed 682px box on desktop and an
+   auto-height one on mobile, so `flex: 1` fills the desktop leftover while `min-height`
+   guarantees the floor on mobile, where there is no definite height to distribute.
+   object-fit: contain keeps a stable box regardless of source aspect ratio — cToon art runs
+   from 55x50 to 200x117, a ~9x spread, so an intrinsically-sized image would resize the
+   page every question and shift the answer buttons under the player's thumb. */
 .gc-stage {
   position: relative;
-  flex: 0 0 auto;
-  height: clamp(120px, 26svh, 220px);
+  flex: 1 1 auto;
+  /* The ceiling is viewport-relative as well as absolute so that on a short phone the
+     image yields space rather than pushing the fourth answer button below the fold — on a
+     timed game, an answer you have to scroll to is an answer you lose. */
+  min-height: 110px;
+  max-height: min(320px, 34svh);
   width: 100%;
   display: grid;
-  place-items: center;
+  /* Deliberately `stretch`, not `center`. Centering a grid item stops it from stretching,
+     which leaves height:100% on a replaced element resolving to auto — the intrinsic
+     aspect ratio then wins and the <img> box goes square, overflowing this fixed-height
+     stage and getting clipped to a zoomed crop of the artwork's middle. Stretching makes
+     the box exactly the stage; object-fit: contain does the centring instead. */
+  place-items: stretch;
   padding: 8px;
   box-sizing: border-box;
   overflow: hidden;
@@ -725,7 +765,15 @@ onBeforeUnmount(() => {
 .gc-stage-img {
   width: 100%;
   height: 100%;
+  /* Grid/flex items floor at min-content by default, which a replaced element would use to
+     push the box back out to its intrinsic size. */
+  min-width: 0;
+  min-height: 0;
   object-fit: contain;
+  /* Positioned so the image paints ABOVE the absolutely-positioned loading placeholder.
+     Without this, any path that leaves imgReady false hides the artwork completely. */
+  position: relative;
+  z-index: 1;
   /* These are small GIFs shown 3-4× up; nearest-neighbour reads as deliberate retro
      pixel art rather than a blurry upscale. */
   image-rendering: pixelated;
@@ -739,6 +787,7 @@ onBeforeUnmount(() => {
 .gc-stage-skeleton {
   position: absolute;
   inset: 8px;
+  z-index: 0;
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.06);
 }
@@ -881,6 +930,18 @@ onBeforeUnmount(() => {
 @media (min-width: 641px) {
   .gc-answers { grid-template-columns: 1fr 1fr; }
   .gc-answer { height: 64px; font-size: 16px; }
+  /* Two rows of answers instead of four frees a lot of height here, so the artwork —
+     the actual thing being guessed — gets to use it. */
+  .gc-stage { max-height: min(420px, 46svh); }
+}
+
+/* On mobile the layout hands this page an auto-height box, so without a definite height
+   here the stage would never grow past its floor and the artwork would sit small at the top
+   of a mostly-empty screen. Giving the wrapper a viewport-derived minimum lets the stage's
+   `flex: 1` claim the leftover. svh, not dvh, so a collapsing URL bar doesn't resize the
+   image mid-question. */
+@media (max-width: 768px) {
+  .gc-wrapper { min-height: calc(100svh - 200px); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/prisma/migrations/20260801010000_guess_ctoon_unlimited_plays/migration.sql
+++ b/prisma/migrations/20260801010000_guess_ctoon_unlimited_plays/migration.sql
@@ -1,0 +1,38 @@
+-- Guess that cToon!: unlimited plays, with a per-day cap on how many COUNT.
+--
+-- Replaces the old hard play limit. Plays are no longer rationed; what is rationed is how
+-- many runs per day earn points and are eligible for the leaderboard. Runs past that cap
+-- stay playable as practice and are still recorded, so a player keeps their history.
+
+-- The old column capped total plays per day; the new one caps SCORING plays per day.
+-- Carry the existing value over where an environment already has it configured.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'GameConfig' AND column_name = 'guessCtoonPlaysPerPeriod'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'GameConfig' AND column_name = 'guessCtoonScoredPlaysPerPeriod'
+  ) THEN
+    ALTER TABLE "GameConfig" RENAME COLUMN "guessCtoonPlaysPerPeriod" TO "guessCtoonScoredPlaysPerPeriod";
+  END IF;
+END $$;
+
+-- Covers a database that never had the original column (fresh install ordering).
+ALTER TABLE "GameConfig"
+  ADD COLUMN IF NOT EXISTS "guessCtoonScoredPlaysPerPeriod" INTEGER NOT NULL DEFAULT 3;
+
+ALTER TABLE "GameConfig"
+  DROP COLUMN IF EXISTS "guessCtoonPlaysPerPeriod";
+
+-- Whether a run counts is decided at /start and recorded on both the play and the score.
+ALTER TABLE "GuessCtoonPlay"
+  ADD COLUMN IF NOT EXISTS "counted" BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE "GuessCtoonScore"
+  ADD COLUMN IF NOT EXISTS "counted" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "GuessCtoonScore_userId_counted_streak_idx"   ON "GuessCtoonScore"("userId", "counted", "streak");
+CREATE INDEX IF NOT EXISTS "GuessCtoonPlay_userId_counted_createdAt_idx" ON "GuessCtoonPlay"("userId", "counted", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1045,7 +1045,9 @@ model GameConfig {
   reorbitMemoryCardBackImagePath String?
 
   // — Guess that cToon! settings —
-  guessCtoonPlaysPerPeriod      Int @default(3)
+  // Plays are unlimited (like Winball); this caps how many per day actually COUNT toward
+  // points and the leaderboard. Runs past the cap are playable but purely for practice.
+  guessCtoonScoredPlaysPerPeriod Int @default(3)
   guessCtoonPointsPerGame       Int @default(50)
   guessCtoonSecondsPerQuestion  Int @default(12)
   guessCtoonChoices             Int @default(4)
@@ -2872,6 +2874,9 @@ model GuessCtoonScore {
   id              String   @id @default(uuid())
   userId          String
   streak          Int
+  // False for runs played past the daily scored-play cap: kept so a player can see their
+  // practice history, but excluded from the leaderboard and never worth points.
+  counted         Boolean  @default(true)
   suspicious      Boolean  @default(false)
   medianAnswerMs  Int?
   stdDevAnswerMs  Int?
@@ -2883,16 +2888,21 @@ model GuessCtoonScore {
   // Covering index: the weekly/monthly leaderboards filter on createdAt and then
   // only need userId + streak, so they run index-only with no heap access.
   @@index([createdAt, userId, streak])
+  @@index([userId, counted, streak])
 }
 
 model GuessCtoonPlay {
   id        String   @id @default(uuid())
   userId    String
+  // Decided at /start under an advisory lock, so the player knows before answering whether
+  // the run will count.
+  counted   Boolean  @default(true)
   createdAt DateTime @default(now())
 
   user User @relation(fields: [userId], references: [id])
 
   @@index([userId, createdAt])
+  @@index([userId, counted, createdAt])
 }
 
 // ── VPN Detection ─────────────────────────────────────────────────────────────

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -75,7 +75,7 @@ async function seedGameConfigs() {
     update: {},
     create: {
       gameName: 'GuessCtoon',
-      guessCtoonPlaysPerPeriod: 3,
+      guessCtoonScoredPlaysPerPeriod: 3,
       guessCtoonPointsPerGame: 50,
       guessCtoonSecondsPerQuestion: 12,
       guessCtoonChoices: 4,

--- a/server/api/admin/game-config.get.js
+++ b/server/api/admin/game-config.get.js
@@ -166,13 +166,12 @@ export default defineEventHandler(async (event) => {
           }
         })
       } else if (gameName === 'GuessCtoon') {
-        // No admin tab drives this game, but the row still has to exist for its column
-        // defaults to be reachable (the migration seeds it too; this covers a config
-        // fetched before that migration ran).
+        // The migration seeds this row too; this branch covers a config fetched on an
+        // environment where that migration has not run yet.
         config = await db.gameConfig.create({
           data: {
             gameName,
-            guessCtoonPlaysPerPeriod: 3,
+            guessCtoonScoredPlaysPerPeriod: 3,
             guessCtoonPointsPerGame: 50,
             guessCtoonSecondsPerQuestion: 12,
             guessCtoonChoices: 4,

--- a/server/api/admin/game-config.post.js
+++ b/server/api/admin/game-config.post.js
@@ -167,6 +167,27 @@ function validatePayload(payload) {
     if (payload.reorbitMemoryCardBackImagePath != null && typeof payload.reorbitMemoryCardBackImagePath !== 'string') {
       throw createError({ statusCode: 400, statusMessage: '"reorbitMemoryCardBackImagePath" must be a string or null' })
     }
+  } else if (payload.gameName === 'GuessCtoon') {
+    // Plays are unlimited; this caps how many per day COUNT. 0 is legal — it turns scoring
+    // off entirely while leaving the game playable.
+    if (payload.guessCtoonScoredPlaysPerPeriod == null || typeof payload.guessCtoonScoredPlaysPerPeriod !== 'number' || payload.guessCtoonScoredPlaysPerPeriod < 0 || payload.guessCtoonScoredPlaysPerPeriod > 100) {
+      throw createError({ statusCode: 400, statusMessage: '"guessCtoonScoredPlaysPerPeriod" must be between 0 and 100' })
+    }
+    if (payload.guessCtoonPointsPerGame == null || typeof payload.guessCtoonPointsPerGame !== 'number' || payload.guessCtoonPointsPerGame < 0) {
+      throw createError({ statusCode: 400, statusMessage: '"guessCtoonPointsPerGame" must be a non-negative number' })
+    }
+    if (payload.guessCtoonSecondsPerQuestion == null || typeof payload.guessCtoonSecondsPerQuestion !== 'number' || payload.guessCtoonSecondsPerQuestion < 4 || payload.guessCtoonSecondsPerQuestion > 120) {
+      throw createError({ statusCode: 400, statusMessage: '"guessCtoonSecondsPerQuestion" must be between 4 and 120' })
+    }
+    if (payload.guessCtoonChoices == null || typeof payload.guessCtoonChoices !== 'number' || payload.guessCtoonChoices < 3 || payload.guessCtoonChoices > 6) {
+      throw createError({ statusCode: 400, statusMessage: '"guessCtoonChoices" must be between 3 and 6' })
+    }
+    if (payload.guessCtoonMaxQuestions == null || typeof payload.guessCtoonMaxQuestions !== 'number' || payload.guessCtoonMaxQuestions < 5 || payload.guessCtoonMaxQuestions > 100) {
+      throw createError({ statusCode: 400, statusMessage: '"guessCtoonMaxQuestions" must be between 5 and 100' })
+    }
+    if (payload.guessCtoonMinStreakForPoints == null || typeof payload.guessCtoonMinStreakForPoints !== 'number' || payload.guessCtoonMinStreakForPoints < 0 || payload.guessCtoonMinStreakForPoints > 100) {
+      throw createError({ statusCode: 400, statusMessage: '"guessCtoonMinStreakForPoints" must be between 0 and 100' })
+    }
   } else {
     throw createError({ statusCode: 400, statusMessage: `Unknown gameName "${payload.gameName}"` })
   }
@@ -213,6 +234,13 @@ export default defineEventHandler(async (event) => {
     reorbitMemoryTimeSeconds = null,
     reorbitMemoryFlipBackDelayMs,
     reorbitMemoryCardBackImagePath = null,
+    // GuessCtoon fields
+    guessCtoonScoredPlaysPerPeriod,
+    guessCtoonPointsPerGame,
+    guessCtoonSecondsPerQuestion,
+    guessCtoonChoices,
+    guessCtoonMaxQuestions,
+    guessCtoonMinStreakForPoints,
     // Winball fields
     leftCupPoints,
     rightCupPoints,
@@ -417,6 +445,17 @@ export default defineEventHandler(async (event) => {
         }
         createData = { ...createData, ...memoryData }
         updateData = { ...updateData, ...memoryData }
+      } else if (gameName === 'GuessCtoon') {
+        const guessData = {
+          guessCtoonScoredPlaysPerPeriod,
+          guessCtoonPointsPerGame,
+          guessCtoonSecondsPerQuestion,
+          guessCtoonChoices,
+          guessCtoonMaxQuestions,
+          guessCtoonMinStreakForPoints
+        }
+        createData = { ...createData, ...guessData }
+        updateData = { ...updateData, ...guessData }
       } else if (gameName === 'Clash' || gameName === 'TKO') {
         createData = { ...createData, pointsPerWin }
         updateData = { ...updateData, pointsPerWin }
@@ -614,6 +653,20 @@ export default defineEventHandler(async (event) => {
           for (const [key, prev, next] of changes) {
             if (prev !== next) {
               await logAdminChange(tx, { userId: me.id, area: 'GameConfig:ReOrbitMemory', key, prevValue: prev, newValue: next })
+            }
+          }
+        } else if (gameName === 'GuessCtoon') {
+          const changes = [
+            ['guessCtoonScoredPlaysPerPeriod', before?.guessCtoonScoredPlaysPerPeriod, guessCtoonScoredPlaysPerPeriod],
+            ['guessCtoonPointsPerGame', before?.guessCtoonPointsPerGame, guessCtoonPointsPerGame],
+            ['guessCtoonSecondsPerQuestion', before?.guessCtoonSecondsPerQuestion, guessCtoonSecondsPerQuestion],
+            ['guessCtoonChoices', before?.guessCtoonChoices, guessCtoonChoices],
+            ['guessCtoonMaxQuestions', before?.guessCtoonMaxQuestions, guessCtoonMaxQuestions],
+            ['guessCtoonMinStreakForPoints', before?.guessCtoonMinStreakForPoints, guessCtoonMinStreakForPoints]
+          ]
+          for (const [key, prev, next] of changes) {
+            if (prev !== next) {
+              await logAdminChange(tx, { userId: me.id, area: 'GameConfig:GuessCtoon', key, prevValue: prev, newValue: next })
             }
           }
         } else if (gameName === 'Clash' || gameName === 'TKO') {

--- a/server/api/game/guessctoon/answer.post.js
+++ b/server/api/game/guessctoon/answer.post.js
@@ -112,6 +112,7 @@ export default defineEventHandler(async (event) => {
   // a user banned mid-run must not keep earning.
   let pointsAwarded = 0
   let finalStreak = result.streak
+  let counted = result.counted !== false
   const denial = await assertPlayable(userId)
   if (!denial) {
     try {
@@ -120,10 +121,12 @@ export default defineEventHandler(async (event) => {
         streak: result.streak,
         latencies: result.latencies,
         startedAt: result.startedAt,
+        counted: result.counted !== false,
         config
       })
       pointsAwarded = banked.pointsAwarded
       finalStreak = banked.streak
+      counted = banked.counted
     } catch {
       // Recording failed — still report the run honestly rather than 500ing the player out
       // of their own game-over screen.
@@ -138,6 +141,7 @@ export default defineEventHandler(async (event) => {
     streak: finalStreak,
     gameOver: true,
     perfect: Boolean(result.perfect),
+    counted,
     pointsAwarded,
     minStreakForPoints: config.minStreakForPoints
   }

--- a/server/api/game/guessctoon/end.post.js
+++ b/server/api/game/guessctoon/end.post.js
@@ -54,11 +54,13 @@ export default defineEventHandler(async (event) => {
     streak: result.streak,
     latencies: result.latencies,
     startedAt: result.startedAt,
+    counted: result.counted !== false,
     config
   })
 
   return {
     streak: banked.streak,
+    counted: banked.counted,
     pointsAwarded: banked.pointsAwarded,
     minStreakForPoints: config.minStreakForPoints,
     alreadyRecorded: false

--- a/server/api/game/guessctoon/leaderboard.get.js
+++ b/server/api/game/guessctoon/leaderboard.get.js
@@ -22,6 +22,9 @@ const MAX_RANKED = 5000
 // tie-break (what the other boards use) would leave hundreds of players sorted by username
 // and make the board unwinnable for anyone late in the alphabet.
 //
+// Plays are unlimited, so only runs marked `counted` — the first few each day, per the
+// admin-configured cap — are eligible here. Practice runs are recorded but never ranked.
+//
 // `suspicious` runs are excluded rather than deleted: a run whose answer cadence looks
 // machine-generated keeps its row for auditing but does not occupy a leaderboard slot.
 
@@ -32,6 +35,7 @@ function rankedAllTime () {
              s."userId", s."streak", s."createdAt"
       FROM "GuessCtoonScore" s
       WHERE s."suspicious" = false
+        AND s."counted" = true
       ORDER BY s."userId", s."streak" DESC, s."createdAt" ASC
     )
     SELECT u."id" AS "userId", u."username", u."avatar", b."streak"::int AS "score",
@@ -53,6 +57,7 @@ function rankedSince (days) {
              s."userId", s."streak", s."createdAt"
       FROM "GuessCtoonScore" s
       WHERE s."suspicious" = false
+        AND s."counted" = true
         AND s."createdAt" >= NOW() - (${days} || ' days')::interval
       ORDER BY s."userId", s."streak" DESC, s."createdAt" ASC
     )

--- a/server/api/game/guessctoon/start.post.js
+++ b/server/api/game/guessctoon/start.post.js
@@ -46,23 +46,26 @@ export default defineEventHandler(async (event) => {
     const config = await getGuessCtoonConfig()
     const boundary = getDailyBoundary()
 
-    // Count-then-insert is not atomic on its own, and a Redis lock can evaporate on
-    // eviction or failover. The advisory lock makes Postgres the authority on the play
-    // limit. Salted so it can't collide with the points award's lock on the same userId.
+    // Plays are unlimited. What is rationed is how many of them COUNT: the first
+    // `scoredPlaysPerPeriod` runs each day are worth points and eligible for the
+    // leaderboard, and everything after that is a practice run.
+    //
+    // The decision is made here rather than at bank time so the player knows before they
+    // answer anything whether the run counts. Count-then-insert is not atomic on its own,
+    // and a Redis lock can evaporate on eviction or failover, so the advisory lock makes
+    // Postgres the authority. Salted so it can't collide with the points award's lock on
+    // the same userId.
+    let counted = false
+    let scoredPlaysUsed = 0
     try {
       await prisma.$transaction(async (tx) => {
         await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`${userId}:guessctoon`}))`
-        const playsToday = await tx.guessCtoonPlay.count({
-          where: { userId, createdAt: { gte: boundary } }
+        scoredPlaysUsed = await tx.guessCtoonPlay.count({
+          where: { userId, counted: true, createdAt: { gte: boundary } }
         })
-        if (playsToday >= config.playsPerPeriod) {
-          throw createError({
-            statusCode: 429,
-            statusMessage: 'Daily play limit reached',
-            data: { nextReset: getNextResetAt(boundary).toISOString() }
-          })
-        }
-        await tx.guessCtoonPlay.create({ data: { userId } })
+        counted = scoredPlaysUsed < config.scoredPlaysPerPeriod
+        await tx.guessCtoonPlay.create({ data: { userId, counted } })
+        if (counted) scoredPlaysUsed += 1
       })
     } catch (err) {
       if (err?.statusCode) throw err
@@ -106,6 +109,10 @@ export default defineEventHandler(async (event) => {
       i: 0,
       streak: 0,
       state: 'live',
+      // Whether this run counts was settled at start; carrying it in the session means the
+      // bank path cannot re-derive it differently (e.g. if the daily boundary rolls over
+      // mid-run).
+      counted,
       secs: config.secondsPerQuestion,
       startedAt: nowMs,
       // Stamped by Node here for the first question only; every subsequent issuedAt comes
@@ -119,6 +126,10 @@ export default defineEventHandler(async (event) => {
     return {
       totalQuestions: qs.length,
       secondsPerQuestion: config.secondsPerQuestion,
+      counted,
+      scoredPlaysLeft: Math.max(0, config.scoredPlaysPerPeriod - scoredPlaysUsed),
+      scoredPlaysPerPeriod: config.scoredPlaysPerPeriod,
+      playsResetAt: getNextResetAt(boundary).toISOString(),
       question: {
         questionIndex: 0,
         imageToken: qs[0].t,

--- a/server/api/game/guessctoon/status.get.js
+++ b/server/api/game/guessctoon/status.get.js
@@ -15,32 +15,33 @@ export default defineEventHandler(async (event) => {
   const boundary = getDailyBoundary()
   const weekBoundary = getWeekBoundary()
 
-  const [playsToday, allTimeHigh, weekHigh] = await Promise.all([
+  const [scoredPlaysUsed, allTimeHigh, weekHigh] = await Promise.all([
     prisma.guessCtoonPlay.count({
-      where: { userId, createdAt: { gte: boundary } }
+      where: { userId, counted: true, createdAt: { gte: boundary } }
     }),
     prisma.guessCtoonScore.aggregate({
-      where: { userId },
+      where: { userId, counted: true },
       _max: { streak: true }
     }),
     // Global best this week, matching the other games' status endpoints (which likewise
     // filter on createdAt only, not on the viewer).
     prisma.guessCtoonScore.aggregate({
-      where: { createdAt: { gte: weekBoundary }, suspicious: false },
+      where: { createdAt: { gte: weekBoundary }, counted: true, suspicious: false },
       _max: { streak: true }
     })
   ])
 
   return {
     config: {
-      playsPerPeriod: config.playsPerPeriod,
+      scoredPlaysPerPeriod: config.scoredPlaysPerPeriod,
       pointsPerGame: config.pointsPerGame,
       secondsPerQuestion: config.secondsPerQuestion,
       choices: config.choices,
       maxQuestions: config.maxQuestions,
       minStreakForPoints: config.minStreakForPoints
     },
-    playsLeft: Math.max(0, config.playsPerPeriod - playsToday),
+    // Plays themselves are unlimited; this is how many more will count today.
+    scoredPlaysLeft: Math.max(0, config.scoredPlaysPerPeriod - scoredPlaysUsed),
     playsResetAt: getNextResetAt(boundary).toISOString(),
     allTimeHigh: allTimeHigh._max.streak ?? null,
     weekHigh: weekHigh._max.streak ?? null

--- a/server/utils/guessCtoonEngine.js
+++ b/server/utils/guessCtoonEngine.js
@@ -27,7 +27,7 @@
 // one-way flip to `banked` that guarantees exactly one caller can ever record a run.
 
 const DEFAULTS = {
-  playsPerPeriod: 3,
+  scoredPlaysPerPeriod: 3,
   pointsPerGame: 50,
   secondsPerQuestion: 12,
   choices: 4,
@@ -642,7 +642,7 @@ if correct then
     return cjson.encode({
       correct=true, correctIndex=q.k, correctName=q.n, assetPath=q.a,
       streak=s.streak, gameOver=true, perfect=true,
-      latencies=s.lat, startedAt=s.startedAt
+      counted=s.counted, latencies=s.lat, startedAt=s.startedAt
     })
   end
 
@@ -671,7 +671,7 @@ redis.call('SET', KEYS[1], cjson.encode(s), 'EX', bankedTtl)
 return cjson.encode({
   correct=false, correctIndex=q.k, correctName=q.n, assetPath=q.a,
   timedOut=timedOut, streak=s.streak, gameOver=true, perfect=false,
-  latencies=s.lat, startedAt=s.startedAt
+  counted=s.counted, latencies=s.lat, startedAt=s.startedAt
 })
 `
 
@@ -692,7 +692,7 @@ s.state = 'banked'
 redis.call('SET', KEYS[1], cjson.encode(s), 'EX', tonumber(ARGV[1]))
 
 return cjson.encode({
-  streak=s.streak, latencies=s.lat, startedAt=s.startedAt, answered=#s.lat
+  streak=s.streak, counted=s.counted, latencies=s.lat, startedAt=s.startedAt, answered=#s.lat
 })
 `
 

--- a/server/utils/guessCtoonRuntime.js
+++ b/server/utils/guessCtoonRuntime.js
@@ -16,11 +16,16 @@ const BANKED_TTL_SECONDS = 120
 export function sessionKey (userId) { return `guessctoon:session:${userId}` }
 export function lockKey (userId) { return `guessctoon:lock:${userId}` }
 
-// GameConfig for this game is one never-changing row read on every /start and /status.
-// Cached in-process with a short TTL, mirroring server/middleware/daily-points.js.
+// GameConfig for this game is one small row read on every /start and /status. Cached
+// in-process to absorb bursts, mirroring server/middleware/daily-points.js.
+//
+// The TTL is deliberately short: the app runs multiple PM2 instances, so an admin saving
+// on the Games page cannot reliably invalidate every instance's copy. Bounding staleness
+// to well under a minute is simpler and more predictable than a cross-process bust, and
+// the read it saves is a single indexed lookup on a tiny table.
 let cachedConfig = null
 let cachedConfigAt = 0
-const CONFIG_TTL_MS = 5 * 60 * 1000
+const CONFIG_TTL_MS = 20 * 1000
 
 export async function getGuessCtoonConfig () {
   const now = Date.now()
@@ -34,7 +39,7 @@ export async function getGuessCtoonConfig () {
   }
 
   const config = {
-    playsPerPeriod: clampInt(row?.guessCtoonPlaysPerPeriod, 1, 50, DEFAULTS.playsPerPeriod),
+    scoredPlaysPerPeriod: clampInt(row?.guessCtoonScoredPlaysPerPeriod, 0, 100, DEFAULTS.scoredPlaysPerPeriod),
     pointsPerGame: clampInt(row?.guessCtoonPointsPerGame, 0, 100000, DEFAULTS.pointsPerGame),
     secondsPerQuestion: clampInt(row?.guessCtoonSecondsPerQuestion, 4, 120, DEFAULTS.secondsPerQuestion),
     choices: clampInt(row?.guessCtoonChoices, CHOICES_MIN, CHOICES_MAX, DEFAULTS.choices),
@@ -82,9 +87,10 @@ export function getWeekBoundary () {
  * failure the ReOrbit Memory handler guards against when it refuses to score an incomplete
  * board. A score row is still written for any streak — it's the *award* that is gated.
  */
-export async function bankRun ({ userId, streak, latencies, startedAt, config }) {
+export async function bankRun ({ userId, streak, latencies, startedAt, config, counted = true }) {
   const finalStreak = Math.max(0, Math.min(Number(streak) || 0, config.maxQuestions))
   const cadence = scoreCadence(latencies)
+  const isCounted = counted !== false
 
   // Wall-clock floor, mirroring the belt-and-suspenders check in reorbitmemory/end: a run
   // cannot have taken less time than its own minimum answer pacing allows.
@@ -98,18 +104,21 @@ export async function bankRun ({ userId, streak, latencies, startedAt, config })
     data: {
       userId,
       streak: finalStreak,
+      counted: isCounted,
       suspicious,
       medianAnswerMs: cadence.median ?? null,
       stdDevAnswerMs: cadence.stdDev ?? null
     }
   })
 
+  // Practice runs (played past the daily scored-play cap) are recorded for the player's own
+  // history but never pay out and never reach the leaderboard.
   let pointsAwarded = 0
-  if (finalStreak >= config.minStreakForPoints && config.pointsPerGame > 0) {
+  if (isCounted && finalStreak >= config.minStreakForPoints && config.pointsPerGame > 0) {
     pointsAwarded = await awardPoints(userId, config.pointsPerGame)
   }
 
-  return { streak: finalStreak, pointsAwarded, suspicious }
+  return { streak: finalStreak, pointsAwarded, suspicious, counted: isCounted }
 }
 
 /**


### PR DESCRIPTION
Follow-up to #838 (already merged). Two changes.

## 1. The cToon artwork was being clipped, not displayed

The image stage centred its grid item. Centring stops a grid item from stretching, so `height: 100%` on a replaced element fell back to `auto`, the intrinsic aspect ratio took over, and the `<img>` box went square — overflowing a fixed-height, `overflow: hidden` stage. On desktop that was a **776px-tall box inside a 320px stage**, so players saw a heavily zoomed crop of the middle of each cToon rather than the whole thing.

The stage now stretches its item and lets `object-fit: contain` do the centring, with the image box floored at zero so it can't be pushed back out to its intrinsic size.

Two supporting fixes found along the way:

- **The loading placeholder could permanently cover the artwork.** It's absolutely positioned and sits after the image in DOM order, so it paints on top. Because the next question's image is prefetched, it's usually already cached and can finish decoding *before* the freshly-keyed `<img>` attaches its `load` handler — so `load` never fires, `imgReady` stays false, and the placeholder covers the image for the rest of the run. The image is now explicitly stacked above it, and a ref callback catches the already-complete case.
- **Sizing now comes from leftover space** between a floor and a viewport-relative ceiling, instead of a fixed viewport-derived guess. The image fills the roomier desktop box (two rows of answers instead of four) without pushing the fourth answer below the fold on a short phone.

Verified by rendering the real markup and scoped styles at three viewports:

| Viewport | Image box | Inside content box | Horizontal overflow |
|---|---|---|---|
| 1280x900 desktop | 776x398 | yes | none |
| 390x844 phone | 366x271 | yes | none |
| 360x640 phone | 336x202 | yes | none |

Before the fix the desktop image box measured 776x**776** and reported outside the content box.

## 2. Unlimited plays, with only some counting

Plays are now unlimited, like Winball. What's rationed is how many runs per day **count**: the first few earn points and are eligible for the leaderboard, and everything after is playable as practice.

Whether a run counts is decided at `/start` under the existing advisory lock and carried in the session, so the player knows before answering anything, and a daily-boundary crossing mid-run can't change the answer. Practice runs are still recorded — a player keeps their history — but they never pay out, never rank, and never set a personal best.

The UI shows how many scoring runs are left, switches to a "Practice mode" badge when they're used up, marks practice runs in the HUD, and always offers Play Again.

## Admin settings

These now live on the admin Games page alongside the other games, with validation and audit logging to match: scoring plays per period, points per game, seconds per cToon, answer choices, questions per run, and minimum streak for points. Setting scoring plays to **0** makes every run practice while leaving the game playable.

The config cache TTL is now short enough that saves take effect within about a minute — a promise an in-process cache can actually keep across multiple app instances, where a cross-process invalidation cannot.

## Migration note

The rename from the old play-limit column ships as its **own** migration rather than an edit to the one merged in #838. Editing an already-merged migration would change its checksum and break `prisma migrate deploy` on any environment that had already applied it. The new migration carries a configured value across, so an environment that had tuned the old limit keeps it.

Tested both paths:
- **Fresh database** — full chain applies, config row lands with the new column and correct defaults, old column absent.
- **Upgrade** — applied the merged migration first, set the old limit to a custom `7`, then applied the follow-up: value carried over to `guessCtoonScoredPlaysPerPeriod`, old column dropped, both `counted` columns added. Re-running the migration is clean (0 errors).

## Testing

- Scoring cap end to end: first 3 runs count and award points, 4th and 5th are playable but flagged practice and earn nothing, 3 counted score rows vs 2 practice rows, all plays recorded.
- Leaderboard excludes practice runs (a planted 900-streak practice row stays off it) and `allTimeHigh` ignores them.
- Admin round-trip: GET/POST, persistence, audit log, validation rejects out-of-range values, non-admins get 403 on both read and write.
- Settings actually reach gameplay: 6 choices, 20s timer and 40-question runs all served as configured, choices still unique at 6.
- `counted` verified surviving the Lua round trip on wrong answer, perfect run, and cash-out.
- Security regressions from #838 all still pass: no assetPath leak, opaque image tokens, path traversal rejected, body type-confusion rejected, single-bank guarantee, no userId in leaderboard output.
- Engine unit tests pass; full suite has one pre-existing `monsterBattleEngine` failure that also fails on a clean tree.

One note: the anti-cheat flagged my own test harness the first time through, because answering on a fixed 430ms timer looks exactly like a bot (median 437ms, stdDev 0–1). Re-running with human-like variance cleared it — the detector is doing its job.

**Not verified:** the page's runtime behaviour in a browser. The client bundle doesn't initialize in this sandbox (`window.__NUXT__` is undefined even on the home page, and the shipped ReOrbit Memory page fails identically), so the timer, reveal, and keyboard paths still want a manual pass on the dev box. The CSS geometry above was verified by rendering the real styles standalone, which doesn't depend on hydration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Enz3GSACiDyDkwVuzzqf6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Enz3GSACiDyDkwVuzzqf6m)_