### PR TITLE
Add AuctionOnly error log surfaced on Manage Auction Only page

### DIFF
--- a/pages/admin/manage-auctions.vue
+++ b/pages/admin/manage-auctions.vue
@@ -62,6 +62,38 @@
 
       <p v-else class="text-gray-500 mt-6">No upcoming auctions.</p>
       <p v-if="error" class="text-red-600 mt-4">{{ error }}</p>
+
+      <div class="mt-10">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-xl font-semibold">Error Log</h2>
+          <button
+            v-if="errorLog.length"
+            type="button"
+            class="px-3 py-1 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50"
+            @click="clearErrorLog"
+          >
+            Clear Log
+          </button>
+        </div>
+
+        <div v-if="errorLog.length" class="bg-white rounded-lg shadow divide-y">
+          <div v-for="e in errorLog" :key="e.id" class="p-4">
+            <div class="flex items-center gap-2 text-sm">
+              <span
+                class="px-2 py-0.5 rounded text-xs font-medium"
+                :class="e.context === 'activation' ? 'bg-orange-100 text-orange-800' : 'bg-purple-100 text-purple-800'"
+              >
+                {{ e.context === 'activation' ? 'Go-live' : 'Scheduling' }}
+              </span>
+              <span class="text-gray-500">{{ fmtCST(e.createdAt) }}</span>
+              <span v-if="e.auctionOnlyId" class="text-gray-400 truncate">• {{ e.auctionOnlyId }}</span>
+            </div>
+            <pre class="text-xs text-red-700 mt-2 whitespace-pre-wrap break-words">{{ e.message }}</pre>
+          </div>
+        </div>
+        <p v-else class="text-gray-500">No errors logged.</p>
+        <p v-if="errorLogError" class="text-red-600 mt-2">{{ errorLogError }}</p>
+      </div>
     </div>
 
     <div v-if="showEdit" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
@@ -136,6 +168,8 @@ const upcomingAuctions = computed(() => {
     .sort((a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime())
 })
 const error = ref('')
+const errorLog = ref([])
+const errorLogError = ref('')
 const showEdit = ref(false)
 const editing = ref(null)
 const editPrice = ref(0)
@@ -314,5 +348,38 @@ async function load() {
   }
 }
 
-onMounted(load)
+async function loadErrorLog() {
+  try {
+    const res = await fetch('/api/admin/auction-only/errors', { credentials: 'include' })
+    if (!res.ok) {
+      const t = await res.text()
+      throw new Error(t || 'Failed to load error log')
+    }
+    errorLog.value = await res.json()
+  } catch (e) {
+    errorLogError.value = e.message
+  }
+}
+
+async function clearErrorLog() {
+  if (!confirm('Clear the error log?')) return
+  try {
+    const res = await fetch('/api/admin/auction-only/errors', {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (!res.ok) {
+      const t = await res.text()
+      throw new Error(t || 'Failed to clear error log')
+    }
+    errorLog.value = []
+  } catch (e) {
+    errorLogError.value = e.message
+  }
+}
+
+onMounted(() => {
+  load()
+  loadErrorLog()
+})
 </script>

--- a/prisma/migrations/20260801000000_auction_only_error_log/migration.sql
+++ b/prisma/migrations/20260801000000_auction_only_error_log/migration.sql
@@ -1,0 +1,15 @@
+-- Scheduling (admin create/edit) and activation (cron go-live) errors for
+-- AuctionOnly were previously either surfaced as a raw 500 response or
+-- silently swallowed with zero trace. This gives the "Manage Auction Only"
+-- admin page a durable log to read from.
+CREATE TABLE "AuctionOnlyErrorLog" (
+    "id" TEXT NOT NULL,
+    "auctionOnlyId" TEXT,
+    "context" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuctionOnlyErrorLog_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AuctionOnlyErrorLog_createdAt_idx" ON "AuctionOnlyErrorLog"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1750,6 +1750,16 @@ model AuctionOnly {
   @@index([endsAt])
 }
 
+model AuctionOnlyErrorLog {
+  id            String   @id @default(uuid())
+  auctionOnlyId String? // best-effort reference; not a FK since the source row may never have been created (schedule errors) or may be long gone
+  context       String // "schedule" | "activation"
+  message       String
+  createdAt     DateTime @default(now())
+
+  @@index([createdAt])
+}
+
 model DissolveAuctionQueue {
   id             String    @id @default(uuid())
   userCtoonId    String    @unique

--- a/server/api/admin/auction-only/[id].put.js
+++ b/server/api/admin/auction-only/[id].put.js
@@ -1,8 +1,21 @@
 // server/api/admin/auction-only/[id].put.js
 import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { logAuctionOnlyError } from '@/server/utils/auctionOnlyErrorLog'
 
 export default defineEventHandler(async (event) => {
+  try {
+    return await handleAuctionOnlyUpdate(event)
+  } catch (err) {
+    const statusCode = err?.statusCode || 500
+    if (statusCode >= 500) {
+      await logAuctionOnlyError('schedule', err, event.context.params?.id || null)
+    }
+    throw err
+  }
+})
+
+async function handleAuctionOnlyUpdate(event) {
   const cookie = getRequestHeader(event, 'cookie') || ''
   let me
   try {
@@ -55,4 +68,4 @@ export default defineEventHandler(async (event) => {
   })
 
   return { ok: true, id: updated.id }
-})
+}

--- a/server/api/admin/auction-only/errors.delete.js
+++ b/server/api/admin/auction-only/errors.delete.js
@@ -1,0 +1,18 @@
+// server/api/admin/auction-only/errors.delete.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  await prisma.auctionOnlyErrorLog.deleteMany({})
+
+  return { ok: true }
+})

--- a/server/api/admin/auction-only/errors.get.js
+++ b/server/api/admin/auction-only/errors.get.js
@@ -1,0 +1,21 @@
+// server/api/admin/auction-only/errors.get.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const rows = await prisma.auctionOnlyErrorLog.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: 100
+  })
+
+  return rows
+})

--- a/server/api/admin/auction-only/index.post.js
+++ b/server/api/admin/auction-only/index.post.js
@@ -3,9 +3,24 @@ import dotenv from 'dotenv'
 dotenv.config()
 import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { logAuctionOnlyError } from '@/server/utils/auctionOnlyErrorLog'
 const OWNER_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
 
 export default defineEventHandler(async (event) => {
+  try {
+    return await handleAuctionOnlyCreate(event)
+  } catch (err) {
+    // Validation errors (createError with 4xx) are expected admin input mistakes —
+    // only log the ones the admin couldn't have foreseen from the form itself.
+    const statusCode = err?.statusCode || 500
+    if (statusCode >= 500) {
+      await logAuctionOnlyError('schedule', err, null)
+    }
+    throw err
+  }
+})
+
+async function handleAuctionOnlyCreate(event) {
   // auth
   const cookie = getRequestHeader(event, 'cookie') || ''
   let me
@@ -198,4 +213,4 @@ export default defineEventHandler(async (event) => {
   }, { timeout: 30000, maxWait: 10000 })
 
   return result
-})
+}

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -12,6 +12,7 @@ import { syncWordleResults } from '../../server/utils/wordle.js'
 import { checkAndCreateWeeklyCZoneContest } from './create-weekly-czone-contest.js'
 import { runEconomyAggregate } from './economy-aggregate.js'
 import { getFeaturedDissolveConfig, isCtoonFeatured } from '../utils/featuredDissolveConfig.js'
+import { logAuctionOnlyError } from '../utils/auctionOnlyErrorLog.js'
 
 const BOT_TOKEN   = process.env.BOT_TOKEN
 const ANNOUNCEMENTS_BOT_TOKEN = process.env.DISCORD_ANNOUNCEMENTS_BOT_TOKEN || BOT_TOKEN
@@ -833,9 +834,13 @@ async function startDueAuctions() {
         // Discord notification (best effort)
         await sendAuctionDiscordAnnouncement(result, isHolidayItem)
       } catch (e2) {
+        console.error('[startDueAuctions] failed to activate AuctionOnly', row.id, e2)
+        await logAuctionOnlyError('activation', e2, row.id)
       }
     }
   } catch (e3) {
+    console.error('[startDueAuctions] failed', e3)
+    await logAuctionOnlyError('activation', e3, null)
   }
 }
 

--- a/server/utils/auctionOnlyErrorLog.js
+++ b/server/utils/auctionOnlyErrorLog.js
@@ -1,0 +1,19 @@
+import { prisma } from '../prisma.js'
+
+/**
+ * Best-effort error log entry for AuctionOnly scheduling/activation failures,
+ * surfaced on the "Manage Auction Only" admin page. Never throws.
+ * @param {'schedule'|'activation'} context
+ * @param {unknown} err
+ * @param {string|null} auctionOnlyId
+ */
+export async function logAuctionOnlyError(context, err, auctionOnlyId = null) {
+  try {
+    const message = err?.stack || err?.message || String(err)
+    await prisma.auctionOnlyErrorLog.create({
+      data: { context, message: message.slice(0, 4000), auctionOnlyId }
+    })
+  } catch (e2) {
+    console.error('[auction-only-error-log] failed to record error:', e2?.message)
+  }
+}


### PR DESCRIPTION
Both the scheduling API (create/edit) and the go-live activation cron
previously either returned a bare 500 or silently swallowed failures
with zero trace, making it impossible to see why a scheduled auction
didn't go live. Errors are now persisted to AuctionOnlyErrorLog and
shown/clearable from the Manage Auction Only admin page.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ULwowL1v7YAbBftffmc59i