### PR TITLE
Add Error Log/History modals and safe AuctionOnly removal to manage-auctions admin page

### DIFF
--- a/pages/admin/manage-auctions.vue
+++ b/pages/admin/manage-auctions.vue
@@ -3,14 +3,40 @@
     <Nav />
 
     <div class="max-w-5xl mx-auto mt-6">
-      <div class="flex items-center justify-between mb-4">
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
         <h1 class="text-2xl font-semibold">Manage Auctions (AuctionOnly)</h1>
-        <NuxtLink
-          to="/admin/add-auction"
-          class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        <div class="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            class="px-3 py-2 text-sm rounded border border-gray-400 text-gray-700 hover:bg-gray-100"
+            @click="openHistory"
+          >
+            History
+          </button>
+          <button
+            type="button"
+            class="px-3 py-2 text-sm rounded border border-gray-400 text-gray-700 hover:bg-gray-100"
+            @click="openErrorLog"
+          >
+            Error Log
+          </button>
+          <NuxtLink
+            to="/admin/add-auction"
+            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            Add Auction
+          </NuxtLink>
+        </div>
+      </div>
+
+      <div v-if="upcomingAuctions.length" class="flex justify-end mb-2">
+        <button
+          type="button"
+          class="px-3 py-1.5 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50"
+          @click="activeModal = 'removeAll'"
         >
-          Add Auction
-        </NuxtLink>
+          Remove All ({{ upcomingAuctions.length }})
+        </button>
       </div>
 
       <div v-if="upcomingAuctions.length" class="bg-white rounded-lg shadow divide-y">
@@ -62,45 +88,14 @@
 
       <p v-else class="text-gray-500 mt-6">No upcoming auctions.</p>
       <p v-if="error" class="text-red-600 mt-4">{{ error }}</p>
-
-      <div class="mt-10">
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-xl font-semibold">Error Log</h2>
-          <button
-            v-if="errorLog.length"
-            type="button"
-            class="px-3 py-1 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50"
-            @click="clearErrorLog"
-          >
-            Clear Log
-          </button>
-        </div>
-
-        <div v-if="errorLog.length" class="bg-white rounded-lg shadow divide-y">
-          <div v-for="e in errorLog" :key="e.id" class="p-4">
-            <div class="flex items-center gap-2 text-sm">
-              <span
-                class="px-2 py-0.5 rounded text-xs font-medium"
-                :class="e.context === 'activation' ? 'bg-orange-100 text-orange-800' : 'bg-purple-100 text-purple-800'"
-              >
-                {{ e.context === 'activation' ? 'Go-live' : 'Scheduling' }}
-              </span>
-              <span class="text-gray-500">{{ fmtCST(e.createdAt) }}</span>
-              <span v-if="e.auctionOnlyId" class="text-gray-400 truncate">• {{ e.auctionOnlyId }}</span>
-            </div>
-            <pre class="text-xs text-red-700 mt-2 whitespace-pre-wrap break-words">{{ e.message }}</pre>
-          </div>
-        </div>
-        <p v-else class="text-gray-500">No errors logged.</p>
-        <p v-if="errorLogError" class="text-red-600 mt-2">{{ errorLogError }}</p>
-      </div>
     </div>
 
-    <div v-if="showEdit" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
-      <div class="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
+    <!-- Edit modal -->
+    <div v-if="activeModal === 'edit'" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
+      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-lg max-h-[85vh] overflow-y-auto p-4 sm:p-6">
         <div class="flex items-center justify-between mb-4">
           <h2 class="text-xl font-semibold">Edit Auction</h2>
-          <button class="text-gray-500 hover:text-gray-700" @click="closeEdit">X</button>
+          <button class="text-gray-500 hover:text-gray-700 p-2 -m-2" @click="closeModal">X</button>
         </div>
 
         <form @submit.prevent="saveEdit" class="space-y-4">
@@ -137,7 +132,7 @@
             currently own 2+ of this cToon or have received 2+ in the last 30 days.
           </p>
 
-          <div class="pt-3 border-t">
+          <div class="pt-3 border-t flex flex-wrap items-center gap-2">
             <button
               type="submit"
               :disabled="editSaving"
@@ -145,17 +140,168 @@
             >
               Save Changes
             </button>
-            <button type="button" class="ml-2 px-4 py-2 rounded border" @click="closeEdit">Cancel</button>
-            <span v-if="editError" class="ml-3 text-red-600">{{ editError }}</span>
+            <button type="button" class="px-4 py-2 rounded border" @click="closeModal">Cancel</button>
+            <span v-if="editError" class="text-red-600 text-sm">{{ editError }}</span>
           </div>
         </form>
+      </div>
+    </div>
+
+    <!-- Remove All confirmation modal -->
+    <div v-if="activeModal === 'removeAll'" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
+      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-md max-h-[85vh] overflow-y-auto p-4 sm:p-6">
+        <h2 class="text-xl font-semibold mb-3">Remove All Upcoming Auctions?</h2>
+        <p class="text-sm text-gray-600">
+          This permanently deletes all {{ upcomingAuctions.length }} upcoming AuctionOnly
+          listing(s) shown on this page (none of them have gone live yet). This cannot be undone.
+        </p>
+        <p v-if="removeAllError" class="text-red-600 text-sm mt-3 whitespace-pre-wrap break-words">{{ removeAllError }}</p>
+        <div class="pt-4 mt-2 border-t flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 disabled:opacity-50 min-h-[40px]"
+            :disabled="removeAllBusy"
+            @click="removeAllUpcoming"
+          >
+            {{ removeAllBusy ? 'Removing…' : 'Yes, Remove All' }}
+          </button>
+          <button type="button" class="px-4 py-2 rounded border min-h-[40px]" :disabled="removeAllBusy" @click="closeModal">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error Log modal -->
+    <div v-if="activeModal === 'errorLog'" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
+      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-2xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
+        <div class="flex items-center justify-between mb-4 gap-2">
+          <h2 class="text-xl font-semibold">Error Log</h2>
+          <div class="flex items-center gap-2">
+            <button
+              v-if="errorLog.length"
+              type="button"
+              class="px-3 py-1.5 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50"
+              @click="clearErrorLog"
+            >
+              Clear Log
+            </button>
+            <button class="text-gray-500 hover:text-gray-700 p-2 -m-2" @click="closeModal">X</button>
+          </div>
+        </div>
+
+        <div v-if="errorLogLoading" class="text-gray-500 py-6 text-center">Loading…</div>
+        <template v-else>
+          <div v-if="errorLog.length" class="bg-gray-50 rounded-lg border divide-y">
+            <div v-for="e in errorLog" :key="e.id" class="p-3 sm:p-4">
+              <div class="flex flex-wrap items-center gap-2 text-sm">
+                <span
+                  class="px-2 py-0.5 rounded text-xs font-medium"
+                  :class="errorContextBadgeClass(e.context)"
+                >
+                  {{ errorContextLabel(e.context) }}
+                </span>
+                <span class="text-gray-500">{{ fmtCST(e.createdAt) }}</span>
+                <span v-if="e.auctionOnlyId" class="text-gray-400 truncate max-w-full">• {{ e.auctionOnlyId }}</span>
+              </div>
+              <pre class="text-xs text-red-700 mt-2 whitespace-pre-wrap break-words">{{ e.message }}</pre>
+            </div>
+          </div>
+          <p v-else class="text-gray-500">No errors logged.</p>
+        </template>
+        <p v-if="errorLogError" class="text-red-600 mt-2 text-sm">{{ errorLogError }}</p>
+      </div>
+    </div>
+
+    <!-- History modal -->
+    <div v-if="activeModal === 'history'" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
+      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-3xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
+        <div class="flex items-center justify-between mb-4 gap-2">
+          <h2 class="text-xl font-semibold">History (last 7 days)</h2>
+          <button class="text-gray-500 hover:text-gray-700 p-2 -m-2" @click="closeModal">X</button>
+        </div>
+
+        <div v-if="historyLoading" class="text-gray-500 py-6 text-center">Loading…</div>
+        <template v-else>
+          <div v-if="history.length" class="bg-gray-50 rounded-lg border divide-y">
+            <div v-for="h in history" :key="h.id" class="p-3 sm:p-4">
+              <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+                <div class="flex items-center gap-3 min-w-0 flex-1">
+                  <img
+                    v-if="h.ctoon?.assetPath"
+                    :src="h.ctoon.assetPath"
+                    class="w-12 h-12 rounded object-cover border shrink-0"
+                    alt="cToon"
+                  />
+                  <div class="min-w-0">
+                    <div class="font-medium truncate">{{ h.ctoon?.name || 'Unknown cToon' }}</div>
+                    <div class="text-xs text-gray-500 truncate">
+                      <span v-if="h.mintNumber !== null && h.mintNumber !== undefined">Mint #{{ h.mintNumber }} • </span>
+                      <span v-if="h.ownerUsername">{{ h.ownerUsername }} • </span>
+                      {{ fmtCST(h.startsAt) }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2 sm:shrink-0">
+                  <span
+                    class="px-2 py-1 rounded text-xs font-medium border-l-4"
+                    :class="historyStatusBadgeClass(h.status)"
+                  >
+                    {{ historyStatusLabel(h.status) }}
+                  </span>
+
+                  <button
+                    v-if="h.removable && confirmingId !== h.id"
+                    type="button"
+                    class="px-3 py-1.5 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50 min-h-[40px]"
+                    :disabled="removingId === h.id"
+                    @click="confirmingId = h.id"
+                  >
+                    Remove
+                  </button>
+
+                  <template v-else-if="confirmingId === h.id">
+                    <button
+                      type="button"
+                      class="px-3 py-1.5 text-sm rounded bg-red-600 text-white hover:bg-red-700 min-h-[40px] disabled:opacity-50"
+                      :disabled="removingId === h.id"
+                      @click="removeHistoryItem(h)"
+                    >
+                      {{ removingId === h.id ? 'Removing…' : 'Confirm Remove' }}
+                    </button>
+                    <button
+                      type="button"
+                      class="px-3 py-1.5 text-sm rounded border min-h-[40px]"
+                      :disabled="removingId === h.id"
+                      @click="confirmingId = null"
+                    >
+                      Cancel
+                    </button>
+                  </template>
+
+                  <span v-else class="text-xs text-gray-400 italic">Not removable</span>
+                </div>
+              </div>
+
+              <p v-if="h.blockedReason && confirmingId !== h.id" class="text-xs text-gray-500 mt-2">
+                {{ h.blockedReason }}
+              </p>
+              <p v-if="historyErrors[h.id]" class="text-xs text-red-700 mt-2 whitespace-pre-wrap break-words">
+                {{ historyErrors[h.id] }}
+              </p>
+            </div>
+          </div>
+          <p v-else class="text-gray-500">No auctions were scheduled to go live in the last 7 days.</p>
+        </template>
+        <p v-if="historyError" class="text-red-600 mt-2 text-sm">{{ historyError }}</p>
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue'
 import Nav from '~/components/Nav.vue'
 
 definePageMeta({ title: 'Admin - Manage Auctions', middleware: ['auth', 'admin'], layout: 'admin' })
@@ -168,9 +314,24 @@ const upcomingAuctions = computed(() => {
     .sort((a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime())
 })
 const error = ref('')
+
+// Only one modal can be open at a time: null | 'edit' | 'errorLog' | 'history' | 'removeAll'
+const activeModal = ref(null)
+
+const removeAllBusy = ref(false)
+const removeAllError = ref('')
+
 const errorLog = ref([])
 const errorLogError = ref('')
-const showEdit = ref(false)
+const errorLogLoading = ref(false)
+
+const history = ref([])
+const historyError = ref('')
+const historyLoading = ref(false)
+const confirmingId = ref(null)
+const removingId = ref(null)
+const historyErrors = ref({})
+
 const editing = ref(null)
 const editPrice = ref(0)
 const editStartDate = ref('')
@@ -181,6 +342,14 @@ const editError = ref('')
 const editSaving = ref(false)
 
 const hourOptions = Array.from({ length: 24 }, (_, i) => `${String(i).padStart(2, '0')}:00`)
+
+watch(activeModal, (val) => {
+  if (typeof document === 'undefined') return
+  document.documentElement.style.overflow = val ? 'hidden' : ''
+})
+onBeforeUnmount(() => {
+  if (typeof document !== 'undefined') document.documentElement.style.overflow = ''
+})
 
 function fmtCST(iso) {
   const d = new Date(iso)
@@ -201,6 +370,37 @@ function formatPts(n) {
   } catch {
     return `${n} pts`
   }
+}
+
+function errorContextLabel(context) {
+  if (context === 'activation') return 'Go-live'
+  if (context === 'removal') return 'Removal'
+  return 'Scheduling'
+}
+
+function errorContextBadgeClass(context) {
+  if (context === 'activation') return 'bg-orange-100 text-orange-800'
+  if (context === 'removal') return 'bg-red-100 text-red-800'
+  return 'bg-purple-100 text-purple-800'
+}
+
+const HISTORY_STATUS_META = {
+  pending: { label: 'Pending', class: 'bg-gray-100 text-gray-800 border-gray-400' },
+  stuck: { label: 'Stuck / Never Went Live', class: 'bg-yellow-100 text-yellow-800 border-yellow-500' },
+  live_untracked: { label: 'Live (untracked)', class: 'bg-blue-100 text-blue-800 border-blue-500' },
+  live_no_bids: { label: 'Live — No Bids', class: 'bg-blue-100 text-blue-800 border-blue-500' },
+  live_with_bids: { label: 'Live — Has Bids', class: 'bg-green-100 text-green-800 border-green-500' },
+  closed: { label: 'Completed', class: 'bg-green-100 text-green-800 border-green-500' },
+  cancelled: { label: 'Cancelled', class: 'bg-gray-100 text-gray-800 border-gray-400' },
+  unknown: { label: 'Unknown', class: 'bg-red-100 text-red-800 border-red-500' }
+}
+
+function historyStatusLabel(status) {
+  return HISTORY_STATUS_META[status]?.label || status
+}
+
+function historyStatusBadgeClass(status) {
+  return HISTORY_STATUS_META[status]?.class || 'bg-gray-100 text-gray-800 border-gray-400'
 }
 
 function utcToChicagoDateHour(iso) {
@@ -255,6 +455,35 @@ function chicagoLocalToUtcISO(dateStr, timeStr) {
   return new Date(utcMs).toISOString()
 }
 
+function closeModal() {
+  activeModal.value = null
+  editing.value = null
+  editError.value = ''
+  confirmingId.value = null
+  removeAllError.value = ''
+}
+
+async function removeAllUpcoming() {
+  removeAllError.value = ''
+  removeAllBusy.value = true
+  try {
+    const res = await fetch('/api/admin/auction-only/bulk', {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    const body = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      throw new Error(body.message || body.statusMessage || `Remove All failed (status ${res.status})`)
+    }
+    activeModal.value = null
+    await load()
+  } catch (e) {
+    removeAllError.value = e.message
+  } finally {
+    removeAllBusy.value = false
+  }
+}
+
 function openEdit(a) {
   if (new Date(a.startsAt).getTime() <= Date.now()) return
   editing.value = a
@@ -266,13 +495,7 @@ function openEdit(a) {
   const diffDays = Math.round((new Date(a.endsAt).getTime() - new Date(a.startsAt).getTime()) / 86400000)
   editDurationDays.value = Math.min(5, Math.max(1, diffDays || 1))
   editError.value = ''
-  showEdit.value = true
-}
-
-function closeEdit() {
-  showEdit.value = false
-  editing.value = null
-  editError.value = ''
+  activeModal.value = 'edit'
 }
 
 async function saveEdit() {
@@ -306,10 +529,9 @@ async function saveEdit() {
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      throw new Error(err.message || 'Update failed')
+      throw new Error(err.message || err.statusMessage || 'Update failed')
     }
-    showEdit.value = false
-    editing.value = null
+    closeModal()
     await load()
   } catch (e) {
     editError.value = e.message
@@ -327,7 +549,7 @@ async function deleteAuction(a) {
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      throw new Error(err.message || 'Delete failed')
+      throw new Error(err.message || err.statusMessage || 'Delete failed')
     }
     await load()
   } catch (e) {
@@ -348,7 +570,14 @@ async function load() {
   }
 }
 
+function openErrorLog() {
+  activeModal.value = 'errorLog'
+  loadErrorLog()
+}
+
 async function loadErrorLog() {
+  errorLogError.value = ''
+  errorLogLoading.value = true
   try {
     const res = await fetch('/api/admin/auction-only/errors', { credentials: 'include' })
     if (!res.ok) {
@@ -358,6 +587,8 @@ async function loadErrorLog() {
     errorLog.value = await res.json()
   } catch (e) {
     errorLogError.value = e.message
+  } finally {
+    errorLogLoading.value = false
   }
 }
 
@@ -378,8 +609,51 @@ async function clearErrorLog() {
   }
 }
 
+function openHistory() {
+  activeModal.value = 'history'
+  loadHistory()
+}
+
+async function loadHistory() {
+  historyError.value = ''
+  historyLoading.value = true
+  try {
+    const res = await fetch('/api/admin/auction-only/history', { credentials: 'include' })
+    if (!res.ok) {
+      const t = await res.text()
+      throw new Error(t || 'Failed to load history')
+    }
+    history.value = await res.json()
+  } catch (e) {
+    historyError.value = e.message
+  } finally {
+    historyLoading.value = false
+  }
+}
+
+async function removeHistoryItem(h) {
+  historyErrors.value = { ...historyErrors.value, [h.id]: '' }
+  removingId.value = h.id
+  try {
+    const res = await fetch(`/api/admin/auction-only/${h.id}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.message || err.statusMessage || `Remove failed (status ${res.status})`)
+    }
+    history.value = history.value.filter(row => row.id !== h.id)
+    confirmingId.value = null
+    await load()
+  } catch (e) {
+    historyErrors.value = { ...historyErrors.value, [h.id]: e.message }
+  } finally {
+    removingId.value = null
+  }
+}
+
 onMounted(() => {
   load()
-  loadErrorLog()
 })
 </script>

--- a/prisma/migrations/20260801020000_add_auction_only_id_to_auction/migration.sql
+++ b/prisma/migrations/20260801020000_add_auction_only_id_to_auction/migration.sql
@@ -1,0 +1,5 @@
+-- Back-reference so admin removal of an AuctionOnly listing can reliably find
+-- the Auction it activated into, instead of guessing via userCtoonId+endAt.
+ALTER TABLE "Auction" ADD COLUMN "auctionOnlyId" TEXT;
+
+CREATE UNIQUE INDEX "Auction_auctionOnlyId_key" ON "Auction"("auctionOnlyId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1269,6 +1269,10 @@ model Auction {
   winnerAt           DateTime?
   endingSoonNotified Boolean       @default(false)
   isFeatured         Boolean       @default(false)
+  // Back-reference to the AuctionOnly listing that activated into this Auction
+  // (set at activation time in server/cron/sync-guild-members.js). Nullable/not a
+  // FK since the AuctionOnly row can later be deleted while this Auction lives on.
+  auctionOnlyId      String?       @unique
 
   userCtoon     UserCtoon @relation(fields: [userCtoonId], references: [id])
   creator       User?     @relation("AuctionsCreated", fields: [creatorId], references: [id])

--- a/server/api/admin/auction-only/[id].delete.js
+++ b/server/api/admin/auction-only/[id].delete.js
@@ -1,8 +1,23 @@
 // server/api/admin/auction-only/[id].delete.js
 import { defineEventHandler, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { logAuctionOnlyError } from '@/server/utils/auctionOnlyErrorLog'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { cancelAuctionClose } from '@/server/utils/queues'
 
 export default defineEventHandler(async (event) => {
+  try {
+    return await handleRemove(event)
+  } catch (err) {
+    const statusCode = err?.statusCode || 500
+    if (statusCode >= 500) {
+      await logAuctionOnlyError('removal', err, event.context.params?.id || null)
+    }
+    throw err
+  }
+})
+
+async function handleRemove(event) {
   const cookie = getRequestHeader(event, 'cookie') || ''
   let me
   try {
@@ -17,13 +32,133 @@ export default defineEventHandler(async (event) => {
 
   const existing = await prisma.auctionOnly.findUnique({
     where: { id },
-    select: { id: true, startsAt: true, isStarted: true }
+    select: {
+      id: true,
+      startsAt: true,
+      endsAt: true,
+      isStarted: true,
+      pricePoints: true,
+      isFeatured: true,
+      userCtoonId: true,
+      userCtoon: {
+        select: {
+          id: true,
+          userId: true,
+          mintNumber: true,
+          user: { select: { username: true } },
+          ctoon: { select: { name: true } }
+        }
+      }
+    }
   })
   if (!existing) throw createError({ statusCode: 404, statusMessage: 'Auction not found' })
-  if (existing.isStarted || existing.startsAt <= new Date()) {
-    throw createError({ statusCode: 400, statusMessage: 'Auction already started' })
+
+  // Correlate to a live/created Auction. Prefer the direct FK (set at activation
+  // time); fall back to a heuristic match for legacy rows created before the
+  // auctionOnlyId column existed, and refuse to guess if it's ambiguous.
+  let auction = await prisma.auction.findUnique({
+    where: { auctionOnlyId: id },
+    select: {
+      id: true,
+      status: true,
+      highestBidderId: true,
+      winnerId: true,
+      highestBid: true,
+      _count: { select: { bids: true, autoBids: true } }
+    }
+  })
+
+  if (!auction && existing.isStarted) {
+    const candidates = await prisma.auction.findMany({
+      where: { userCtoonId: existing.userCtoonId, endAt: existing.endsAt, auctionOnlyId: null },
+      select: {
+        id: true,
+        status: true,
+        highestBidderId: true,
+        winnerId: true,
+        highestBid: true,
+        _count: { select: { bids: true, autoBids: true } }
+      }
+    })
+    if (candidates.length > 1) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: `Cannot safely identify the resulting auction: found ${candidates.length} legacy Auction rows matching this listing's cToon and end time (ids: ${candidates.map(c => c.id).join(', ')}). Resolve manually before removing.`
+      })
+    }
+    auction = candidates[0] || null
   }
 
-  await prisma.auctionOnly.delete({ where: { id } })
+  // Decide whether removal is safe. Real transaction history (bids, autobids,
+  // a closed/cancelled status) blocks removal — the admin must resolve those
+  // manually first rather than silently destroying paid-for state.
+  if (auction) {
+    const hasBids = auction._count.bids > 0 || auction._count.autoBids > 0 || !!auction.highestBidderId
+    if (auction.status !== 'ACTIVE') {
+      throw createError({
+        statusCode: 400,
+        statusMessage: `Cannot remove: the resulting auction (id ${auction.id}) is already ${auction.status.toLowerCase()}${auction.winnerId ? ' with a winner assigned' : ''}. This listing has real transaction history and must be handled manually.`
+      })
+    }
+    if (hasBids) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: `Cannot remove: the resulting auction (id ${auction.id}) has ${auction._count.bids} bid(s) and ${auction._count.autoBids} max-bid setting(s) from real users (highest bid ${auction.highestBid} pts). Resolve/refund those manually before deleting.`
+      })
+    }
+
+    // Safe to touch the Auction — but not if its BullMQ auto-close job is
+    // actively being processed right now.
+    const jobState = await cancelAuctionClose(auction.id)
+    if (jobState.active) {
+      throw createError({ statusCode: 409, statusMessage: 'The auction-close job for this listing is currently processing. Try again in a moment.' })
+    }
+  }
+
+  const snapshot = {
+    ctoonName: existing.userCtoon?.ctoon?.name || null,
+    mintNumber: existing.userCtoon?.mintNumber ?? null,
+    pricePoints: existing.pricePoints,
+    startsAt: existing.startsAt,
+    endsAt: existing.endsAt,
+    isFeatured: existing.isFeatured,
+    isStarted: existing.isStarted,
+    hadAuction: !!auction,
+    auctionId: auction?.id || null,
+    auctionStatus: auction?.status || null
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      if (auction) {
+        await tx.auctionAutoBid.deleteMany({ where: { auctionId: auction.id } })
+        await tx.bid.deleteMany({ where: { auctionId: auction.id } })
+        const delAuction = await tx.auction.deleteMany({ where: { id: auction.id, status: 'ACTIVE' } })
+        if (delAuction.count !== 1) {
+          throw createError({ statusCode: 409, statusMessage: 'Auction changed concurrently (e.g. a bid just landed or it closed). Refresh and try again.' })
+        }
+        await tx.userCtoon.updateMany({ where: { id: existing.userCtoonId }, data: { isTradeable: true } })
+      }
+
+      const delAuctionOnly = await tx.auctionOnly.deleteMany({ where: { id, isStarted: existing.isStarted } })
+      if (delAuctionOnly.count !== 1) {
+        throw createError({ statusCode: 409, statusMessage: 'This listing changed concurrently (e.g. it just went live). Refresh and try again.' })
+      }
+    })
+  } catch (err) {
+    if (err?.statusCode) throw err
+    throw createError({ statusCode: 500, statusMessage: `Removal failed: ${err?.message || String(err)}` })
+  }
+
+  await logAdminChange(prisma, {
+    userId: me.id,
+    area: 'AuctionOnly',
+    key: 'delete',
+    prevValue: snapshot,
+    newValue: null,
+    targetUserId: existing.userCtoon?.userId || null,
+    targetUsername: existing.userCtoon?.user?.username || null
+  })
+
   return { ok: true }
-})
+}

--- a/server/api/admin/auction-only/bulk.delete.js
+++ b/server/api/admin/auction-only/bulk.delete.js
@@ -1,0 +1,98 @@
+// server/api/admin/auction-only/bulk.delete.js
+// Removes every currently-listed "upcoming" AuctionOnly (isStarted=false,
+// startsAt in the future) — the exact set shown on the main manage-auctions
+// list. None of these have activated yet, so there's never a correlated
+// Auction/bids/isTradeable lock to clean up; each deletion still gets its
+// own AdminChangeLog entry so the audit trail matches single-item removal.
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { logAuctionOnlyError } from '@/server/utils/auctionOnlyErrorLog'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+
+export default defineEventHandler(async (event) => {
+  try {
+    return await handleBulkRemove(event)
+  } catch (err) {
+    const statusCode = err?.statusCode || 500
+    if (statusCode >= 500) {
+      await logAuctionOnlyError('removal', err, null)
+    }
+    throw err
+  }
+})
+
+async function handleBulkRemove(event) {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const now = new Date()
+  const targets = await prisma.auctionOnly.findMany({
+    where: { isStarted: false, startsAt: { gt: now } },
+    select: {
+      id: true,
+      pricePoints: true,
+      startsAt: true,
+      endsAt: true,
+      isFeatured: true,
+      userCtoonId: true,
+      userCtoon: {
+        select: {
+          mintNumber: true,
+          userId: true,
+          user: { select: { username: true } },
+          ctoon: { select: { name: true } }
+        }
+      }
+    }
+  })
+
+  if (!targets.length) return { ok: true, removed: 0 }
+
+  let removed = 0
+  const failures = []
+
+  for (const t of targets) {
+    try {
+      const del = await prisma.auctionOnly.deleteMany({ where: { id: t.id, isStarted: false } })
+      if (del.count !== 1) continue // started concurrently between the read and delete — skip, not a failure
+
+      removed++
+      await logAdminChange(prisma, {
+        userId: me.id,
+        area: 'AuctionOnly',
+        key: 'delete',
+        prevValue: {
+          ctoonName: t.userCtoon?.ctoon?.name || null,
+          mintNumber: t.userCtoon?.mintNumber ?? null,
+          pricePoints: t.pricePoints,
+          startsAt: t.startsAt,
+          endsAt: t.endsAt,
+          isFeatured: t.isFeatured,
+          isStarted: false,
+          hadAuction: false,
+          removedVia: 'bulk'
+        },
+        newValue: null,
+        targetUserId: t.userCtoon?.userId || null,
+        targetUsername: t.userCtoon?.user?.username || null
+      })
+    } catch (err) {
+      failures.push({ id: t.id, ctoonName: t.userCtoon?.ctoon?.name || t.id, error: err?.message || String(err) })
+    }
+  }
+
+  if (failures.length) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: `Removed ${removed} of ${targets.length}. Failed: ${failures.map(f => `${f.ctoonName} (${f.error})`).join('; ')}`
+    })
+  }
+
+  return { ok: true, removed }
+}

--- a/server/api/admin/auction-only/history.get.js
+++ b/server/api/admin/auction-only/history.get.js
@@ -1,0 +1,134 @@
+// server/api/admin/auction-only/history.get.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const now = new Date()
+  const weekAgo = new Date(now.getTime() - 7 * 86400000)
+
+  const rows = await prisma.auctionOnly.findMany({
+    where: { startsAt: { gte: weekAgo, lte: now } },
+    orderBy: { startsAt: 'desc' },
+    include: {
+      userCtoon: {
+        select: {
+          mintNumber: true,
+          user: { select: { username: true } },
+          ctoon: { select: { id: true, name: true, rarity: true, assetPath: true } }
+        }
+      }
+    }
+  })
+
+  if (!rows.length) return []
+
+  // Direct correlation via the auctionOnlyId FK (set at activation time for
+  // anything activated after that column shipped).
+  const directAuctions = await prisma.auction.findMany({
+    where: { auctionOnlyId: { in: rows.map(r => r.id) } },
+    select: {
+      id: true,
+      auctionOnlyId: true,
+      status: true,
+      highestBidderId: true,
+      winnerId: true,
+      highestBid: true,
+      _count: { select: { bids: true, autoBids: true } }
+    }
+  })
+  const byAuctionOnlyId = new Map(directAuctions.map(a => [a.auctionOnlyId, a]))
+
+  // Legacy fallback for rows activated before the FK existed: match on
+  // userCtoonId + endAt (copied verbatim from AuctionOnly.endsAt at activation).
+  const needLegacyMatch = rows.filter(r => r.isStarted && !byAuctionOnlyId.has(r.id))
+  let legacyAuctions = []
+  if (needLegacyMatch.length) {
+    legacyAuctions = await prisma.auction.findMany({
+      where: {
+        auctionOnlyId: null,
+        OR: needLegacyMatch.map(r => ({ userCtoonId: r.userCtoonId, endAt: r.endsAt }))
+      },
+      select: {
+        id: true,
+        userCtoonId: true,
+        endAt: true,
+        status: true,
+        highestBidderId: true,
+        winnerId: true,
+        highestBid: true,
+        _count: { select: { bids: true, autoBids: true } }
+      }
+    })
+  }
+
+  return rows.map(r => {
+    let auction = byAuctionOnlyId.get(r.id) || null
+    let ambiguous = false
+    if (!auction && r.isStarted) {
+      const matches = legacyAuctions.filter(
+        a => a.userCtoonId === r.userCtoonId && a.endAt.getTime() === r.endsAt.getTime()
+      )
+      if (matches.length === 1) auction = matches[0]
+      else if (matches.length > 1) ambiguous = true
+    }
+
+    const hasBids =
+      !!auction && (auction._count.bids > 0 || auction._count.autoBids > 0 || !!auction.highestBidderId)
+
+    let status
+    let removable = true
+    let blockedReason = null
+
+    if (ambiguous) {
+      status = 'unknown'
+      removable = false
+      blockedReason = 'Multiple matching Auction records found for this legacy listing; cannot safely identify which one to remove.'
+    } else if (!auction) {
+      status = r.isStarted ? 'live_untracked' : (r.startsAt <= now ? 'stuck' : 'pending')
+    } else if (auction.status !== 'ACTIVE') {
+      status = auction.status.toLowerCase()
+      removable = false
+      blockedReason = `Auction already ${auction.status.toLowerCase()}${auction.winnerId ? ' with a winner assigned' : ''}; has real transaction history.`
+    } else if (hasBids) {
+      status = 'live_with_bids'
+      removable = false
+      blockedReason = `Has ${auction._count.bids} bid(s) and ${auction._count.autoBids} max-bid setting(s) from real users.`
+    } else {
+      status = 'live_no_bids'
+    }
+
+    return {
+      id: r.id,
+      pricePoints: r.pricePoints,
+      startsAt: r.startsAt,
+      endsAt: r.endsAt,
+      isFeatured: r.isFeatured,
+      isStarted: r.isStarted,
+      mintNumber: r.userCtoon?.mintNumber ?? null,
+      ownerUsername: r.userCtoon?.user?.username || null,
+      ctoon: r.userCtoon?.ctoon || null,
+      auction: auction
+        ? {
+            id: auction.id,
+            status: auction.status,
+            bidCount: auction._count.bids,
+            autoBidCount: auction._count.autoBids,
+            highestBid: auction.highestBid,
+            hasWinner: !!auction.winnerId
+          }
+        : null,
+      status,
+      removable,
+      blockedReason
+    }
+  })
+})

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -794,6 +794,7 @@ async function startDueAuctions() {
               endAt: new Date(fresh.endsAt),
               creatorId: row.userCtoon?.creatorId,
               isFeatured: fresh.isFeatured,        // ← carry flag onto Auction
+              auctionOnlyId: fresh.id,
             },
             select: { id: true }
           })

--- a/server/utils/auctionOnlyErrorLog.js
+++ b/server/utils/auctionOnlyErrorLog.js
@@ -3,7 +3,7 @@ import { prisma } from '../prisma.js'
 /**
  * Best-effort error log entry for AuctionOnly scheduling/activation failures,
  * surfaced on the "Manage Auction Only" admin page. Never throws.
- * @param {'schedule'|'activation'} context
+ * @param {'schedule'|'activation'|'removal'} context
  * @param {unknown} err
  * @param {string|null} auctionOnlyId
  */

--- a/server/utils/queues.js
+++ b/server/utils/queues.js
@@ -69,6 +69,26 @@ export async function scheduleAuctionClose(auctionId, endAt) {
   await auctionCloseQueue.add('close', { auctionId }, { jobId: auctionId, delay })
 }
 
+/**
+ * Cancel the pending auto-close job for an auction that's about to be deleted.
+ * Returns { active: true } without removing anything if the job is currently
+ * being processed — callers should treat that as "not safe to delete yet"
+ * rather than deleting the Auction row out from under an in-flight close.
+ * @param {string} auctionId
+ */
+export async function cancelAuctionClose(auctionId) {
+  const existing = await auctionCloseQueue.getJob(auctionId)
+  if (!existing) return { active: false, removed: false }
+  const state = await existing.getState()
+  if (state === 'active') return { active: true, removed: false }
+  try {
+    await existing.remove()
+    return { active: false, removed: true }
+  } catch (err) {
+    return { active: false, removed: false, error: err?.message || String(err) }
+  }
+}
+
 // Queue for closing time-based mint windows at their mintEndDate
 export const mintEndQueue = new Queue(
   process.env.MINT_END_QUEUE_KEY || 'mintEndQueue',


### PR DESCRIPTION
- Move Error Log into a modal opened by a top button; add a History modal
  listing AuctionOnly listings scheduled in the last 7 days with per-row
  status and a Remove action.
- Generalize the AuctionOnly delete endpoint to safely remove listings that
  never went live, are stuck (isStarted=false past startsAt), or activated
  with no bids yet - restoring UserCtoon.isTradeable, cleaning up the
  correlated Auction/Bid/AuctionAutoBid rows and BullMQ close job, and
  blocking removal with a detailed reason when real bids/winners exist.
- Add Auction.auctionOnlyId (unique) so removal can reliably find the
  Auction a listing activated into instead of guessing.
- Log every removal to AdminChangeLog and 5xx failures to the existing
  AuctionOnly error log.
- Add a bulk "Remove All" action (with confirmation modal) for the
  upcoming/not-yet-started listings shown on the page.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KquUecPGDYq3zgwQsVy2dL