### PR TITLE
Add manual Start Now for stuck AuctionOnly listings, harden cron against crashes

### DIFF
--- a/pages/admin/manage-auctions.vue
+++ b/pages/admin/manage-auctions.vue
@@ -225,31 +225,59 @@
         <template v-else>
           <div v-if="history.length" class="bg-gray-50 rounded-lg border divide-y">
             <div v-for="h in history" :key="h.id" class="p-3 sm:p-4">
-              <div class="flex flex-col sm:flex-row sm:items-center gap-3">
-                <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex flex-col gap-3">
+                <div class="flex items-start gap-3 min-w-0 flex-wrap">
                   <img
                     v-if="h.ctoon?.assetPath"
                     :src="h.ctoon.assetPath"
                     class="w-12 h-12 rounded object-cover border shrink-0"
                     alt="cToon"
                   />
-                  <div class="min-w-0">
+                  <div class="min-w-0 flex-1 basis-40">
                     <div class="font-medium truncate">{{ h.ctoon?.name || 'Unknown cToon' }}</div>
-                    <div class="text-xs text-gray-500 truncate">
+                    <div class="text-xs text-gray-500 break-words">
                       <span v-if="h.mintNumber !== null && h.mintNumber !== undefined">Mint #{{ h.mintNumber }} • </span>
                       <span v-if="h.ownerUsername">{{ h.ownerUsername }} • </span>
                       {{ fmtCST(h.startsAt) }}
                     </div>
                   </div>
-                </div>
-
-                <div class="flex items-center gap-2 sm:shrink-0">
                   <span
-                    class="px-2 py-1 rounded text-xs font-medium border-l-4"
+                    class="px-2 py-1 rounded text-xs font-medium border-l-4 shrink-0 whitespace-nowrap"
                     :class="historyStatusBadgeClass(h.status)"
                   >
                     {{ historyStatusLabel(h.status) }}
                   </span>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-2">
+                  <button
+                    v-if="h.status === 'stuck' && confirmingStartId !== h.id"
+                    type="button"
+                    class="px-3 py-1.5 text-sm rounded border border-green-600 text-green-700 hover:bg-green-50 min-h-[40px]"
+                    :disabled="startingId === h.id"
+                    @click="confirmingStartId = h.id"
+                  >
+                    Start Now
+                  </button>
+
+                  <template v-else-if="confirmingStartId === h.id">
+                    <button
+                      type="button"
+                      class="px-3 py-1.5 text-sm rounded bg-green-600 text-white hover:bg-green-700 min-h-[40px] disabled:opacity-50"
+                      :disabled="startingId === h.id"
+                      @click="startHistoryItem(h)"
+                    >
+                      {{ startingId === h.id ? 'Starting…' : 'Confirm Start' }}
+                    </button>
+                    <button
+                      type="button"
+                      class="px-3 py-1.5 text-sm rounded border min-h-[40px]"
+                      :disabled="startingId === h.id"
+                      @click="confirmingStartId = null"
+                    >
+                      Cancel
+                    </button>
+                  </template>
 
                   <button
                     v-if="h.removable && confirmingId !== h.id"
@@ -280,7 +308,12 @@
                     </button>
                   </template>
 
-                  <span v-else class="text-xs text-gray-400 italic">Not removable</span>
+                  <span
+                    v-if="h.status !== 'stuck' && !h.removable && confirmingId !== h.id"
+                    class="text-xs text-gray-400 italic"
+                  >
+                    Not removable
+                  </span>
                 </div>
               </div>
 
@@ -330,6 +363,8 @@ const historyError = ref('')
 const historyLoading = ref(false)
 const confirmingId = ref(null)
 const removingId = ref(null)
+const confirmingStartId = ref(null)
+const startingId = ref(null)
 const historyErrors = ref({})
 
 const editing = ref(null)
@@ -375,12 +410,14 @@ function formatPts(n) {
 function errorContextLabel(context) {
   if (context === 'activation') return 'Go-live'
   if (context === 'removal') return 'Removal'
+  if (context === 'process') return 'Process Crash'
   return 'Scheduling'
 }
 
 function errorContextBadgeClass(context) {
   if (context === 'activation') return 'bg-orange-100 text-orange-800'
   if (context === 'removal') return 'bg-red-100 text-red-800'
+  if (context === 'process') return 'bg-red-200 text-red-900'
   return 'bg-purple-100 text-purple-800'
 }
 
@@ -460,6 +497,7 @@ function closeModal() {
   editing.value = null
   editError.value = ''
   confirmingId.value = null
+  confirmingStartId.value = null
   removeAllError.value = ''
 }
 
@@ -628,6 +666,27 @@ async function loadHistory() {
     historyError.value = e.message
   } finally {
     historyLoading.value = false
+  }
+}
+
+async function startHistoryItem(h) {
+  historyErrors.value = { ...historyErrors.value, [h.id]: '' }
+  startingId.value = h.id
+  try {
+    const res = await fetch(`/api/admin/auction-only/${h.id}/start`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.message || err.statusMessage || `Start failed (status ${res.status})`)
+    }
+    confirmingStartId.value = null
+    await loadHistory()
+  } catch (e) {
+    historyErrors.value = { ...historyErrors.value, [h.id]: e.message }
+  } finally {
+    startingId.value = null
   }
 }
 

--- a/server/api/admin/auction-only/[id]/start.post.js
+++ b/server/api/admin/auction-only/[id]/start.post.js
@@ -1,0 +1,66 @@
+// server/api/admin/auction-only/[id]/start.post.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { logAuctionOnlyError } from '@/server/utils/auctionOnlyErrorLog'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { activateAuctionOnlyRow, AUCTION_ONLY_ROW_INCLUDE } from '@/server/utils/auctionOnlyActivate'
+
+export default defineEventHandler(async (event) => {
+  try {
+    return await handleStart(event)
+  } catch (err) {
+    const statusCode = err?.statusCode || 500
+    if (statusCode >= 500) {
+      await logAuctionOnlyError('activation', err, event.context.params?.id || null)
+    }
+    throw err
+  }
+})
+
+async function handleStart(event) {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const id = event.context.params?.id
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing id' })
+
+  const row = await prisma.auctionOnly.findUnique({
+    where: { id },
+    include: AUCTION_ONLY_ROW_INCLUDE
+  })
+  if (!row) throw createError({ statusCode: 404, statusMessage: 'Auction not found' })
+  if (row.isStarted) throw createError({ statusCode: 400, statusMessage: 'This listing has already gone live.' })
+
+  let result
+  try {
+    result = await activateAuctionOnlyRow(row)
+  } catch (err) {
+    await logAuctionOnlyError('activation', err, id)
+    throw createError({ statusCode: 500, statusMessage: `Failed to start auction: ${err?.message || String(err)}` })
+  }
+
+  if (!result) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: 'This listing changed concurrently (it already went live, or an active auction already exists for this cToon). Refresh and try again.'
+    })
+  }
+
+  await logAdminChange(prisma, {
+    userId: me.id,
+    area: 'AuctionOnly',
+    key: 'manualStart',
+    prevValue: { isStarted: false, startsAt: row.startsAt },
+    newValue: { isStarted: true, auctionId: result.auctionId },
+    targetUserId: null,
+    targetUsername: null
+  })
+
+  return { ok: true, auctionId: result.auctionId }
+}

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -13,6 +13,7 @@ import { checkAndCreateWeeklyCZoneContest } from './create-weekly-czone-contest.
 import { runEconomyAggregate } from './economy-aggregate.js'
 import { getFeaturedDissolveConfig, isCtoonFeatured } from '../utils/featuredDissolveConfig.js'
 import { logAuctionOnlyError } from '../utils/auctionOnlyErrorLog.js'
+import { activateAuctionOnlyRow, AUCTION_ONLY_ROW_INCLUDE } from '../utils/auctionOnlyActivate.js'
 
 const BOT_TOKEN   = process.env.BOT_TOKEN
 const ANNOUNCEMENTS_BOT_TOKEN = process.env.DISCORD_ANNOUNCEMENTS_BOT_TOKEN || BOT_TOKEN
@@ -26,6 +27,23 @@ const baseDir = process.env.NODE_ENV === 'production'
 const announcementsDir = (process.env.PUBLIC_BASE_URL || process.env.NODE_ENV === 'production')
   ? join(baseDir, 'cartoon-reorbit-images', 'announcements')
   : join(baseDir, 'public', 'announcements')
+
+// This process runs many unrelated cron jobs (Discord sync, achievements,
+// AuctionOnly activation, tournament scheduling, ...) back to back at startup
+// and hourly. Without these handlers, an unhandled rejection thrown by any one
+// of them (e.g. a transient DB blip in a job unrelated to auctions) crashes the
+// whole process — silently killing AuctionOnly activation (startDueAuctions)
+// along with everything else, with nothing written to AuctionOnlyErrorLog
+// since the crash never touches that code path. Keep the process alive and
+// record it so it's visible in the admin Error Log instead.
+process.on('unhandledRejection', (reason) => {
+  console.error('[guild-checker] Unhandled rejection (process kept alive):', reason)
+  logAuctionOnlyError('process', reason instanceof Error ? reason : new Error(String(reason)), null).catch(() => {})
+})
+process.on('uncaughtException', (err) => {
+  console.error('[guild-checker] Uncaught exception (process kept alive):', err)
+  logAuctionOnlyError('process', err, null).catch(() => {})
+})
 
 async function sleep(ms) { return new Promise(r => setTimeout(r, ms)) }
 
@@ -726,114 +744,18 @@ async function syncGuildMembers() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 async function startDueAuctions() {
-  const rarityFloor = (r) => {
-    const s = (r || '').trim().toLowerCase()
-    if (s === 'common') return 25
-    if (s === 'uncommon') return 50
-    if (s === 'rare') return 100
-    if (s === 'very rare') return 187
-    if (s === 'crazy rare') return 312
-    return 50
-  }
-
   try {
     const now = new Date()
 
     const due = await prisma.auctionOnly.findMany({
       where: { isStarted: false, startsAt: { lte: now } },
       orderBy: { startsAt: 'asc' },
-      include: {
-        userCtoon: {
-          select: {
-            id: true,
-            mintNumber: true,
-            ctoon: { select: { id: true, name: true, rarity: true, assetPath: true } }
-          }
-        }
-      }
+      include: AUCTION_ONLY_ROW_INCLUDE
     })
 
     for (const row of due) {
       try {
-        // Transaction: double-check state, create auction, lock tradeability, mark started
-        const result = await prisma.$transaction(async (tx) => {
-          const fresh = await tx.auctionOnly.findUnique({
-            where: { id: row.id },
-            select: {
-              id: true,
-              isStarted: true,
-              userCtoonId: true,
-              pricePoints: true,
-              startsAt: true,
-              endsAt: true,
-              isFeatured: true
-            }
-          })
-          if (!fresh || fresh.isStarted) return null
-
-          const active = await tx.auction.findFirst({
-            where: { userCtoonId: fresh.userCtoonId, status: 'ACTIVE' },
-            select: { id: true }
-          })
-          if (active) {
-            await tx.auctionOnly.update({ where: { id: fresh.id }, data: { isStarted: true } })
-            return null
-          }
-
-          const floor = rarityFloor(row.userCtoon?.ctoon?.rarity)
-          const initialBet = Math.max(Number(fresh.pricePoints || 0), floor)
-
-          const ms = new Date(fresh.endsAt).getTime() - new Date(fresh.startsAt).getTime()
-          const durationDays = Math.max(1, Math.min(5, Math.round(ms / 86400000) || 1))
-
-          const created = await tx.auction.create({
-            data: {
-              userCtoonId: fresh.userCtoonId,
-              initialBet,
-              duration: durationDays,
-              endAt: new Date(fresh.endsAt),
-              creatorId: row.userCtoon?.creatorId,
-              isFeatured: fresh.isFeatured,        // ← carry flag onto Auction
-              auctionOnlyId: fresh.id,
-            },
-            select: { id: true }
-          })
-
-          await tx.userCtoon.update({
-            where: { id: fresh.userCtoonId },
-            data: { isTradeable: false }
-          })
-
-          await tx.auctionOnly.update({
-            where: { id: fresh.id },
-            data: { isStarted: true }
-          })
-
-          return {
-            auctionId: created.id,
-            endAt: new Date(fresh.endsAt),
-            initialBet,
-            durationDays,
-            ctoon: row.userCtoon.ctoon,
-            mintNumber: row.userCtoon.mintNumber,
-            ctoonId: row.userCtoon.ctoon.id,
-            isFeatured: fresh.isFeatured,        // optional, if you ever need it downstream
-          }
-        })
-
-        if (!result) continue
-
-        // Schedule the BullMQ job that will close this auction at endAt
-        await scheduleAuctionClose(result.auctionId, result.endAt)
-
-        // Holiday flag for messaging
-        const isHolidayItem = !!(await prisma.holidayEventItem.findFirst({
-          where: { ctoonId: result.ctoonId },
-          select: { id: true }
-        }))
-
-        // Discord notification (best effort)
-        await sendAuctionDiscordAnnouncement(result, isHolidayItem)
+        await activateAuctionOnlyRow(row)
       } catch (e2) {
         console.error('[startDueAuctions] failed to activate AuctionOnly', row.id, e2)
         await logAuctionOnlyError('activation', e2, row.id)

--- a/server/utils/auctionOnlyActivate.js
+++ b/server/utils/auctionOnlyActivate.js
@@ -1,0 +1,182 @@
+// server/utils/auctionOnlyActivate.js
+//
+// Shared "activate an AuctionOnly listing into a live Auction" logic, used by
+// both the hourly cron job (server/cron/sync-guild-members.js) and the manual
+// admin "Start Now" endpoint (server/api/admin/auction-only/[id]/start.post.js)
+// so the two paths can never drift apart.
+import fetch from 'node-fetch'
+import { prisma } from '../prisma.js'
+import { scheduleAuctionClose } from './queues.js'
+
+const DISCORD_API = 'https://discord.com/api/v10'
+
+export function auctionOnlyRarityFloor(r) {
+  const s = (r || '').trim().toLowerCase()
+  if (s === 'common') return 25
+  if (s === 'uncommon') return 50
+  if (s === 'rare') return 100
+  if (s === 'very rare') return 187
+  if (s === 'crazy rare') return 312
+  return 50
+}
+
+export async function sendAuctionOnlyDiscordAnnouncement(result, isHolidayItem = false) {
+  try {
+    const botToken = process.env.DISCORD_ANNOUNCEMENTS_BOT_TOKEN || process.env.BOT_TOKEN
+    const guildId = process.env.DISCORD_GUILD_ID
+
+    if (!botToken || !guildId) {
+      console.error('Missing DISCORD_ANNOUNCEMENTS_BOT_TOKEN/BOT_TOKEN or DISCORD_GUILD_ID env vars.')
+      return
+    }
+
+    const authHeader = botToken.startsWith('Bot ') ? botToken : `Bot ${botToken}`
+
+    const channelsRes = await fetch(`${DISCORD_API}/guilds/${guildId}/channels`, {
+      method: 'GET',
+      headers: { Authorization: authHeader }
+    })
+    if (!channelsRes.ok) {
+      console.error('Failed to fetch guild channels:', channelsRes.status, channelsRes.statusText)
+      return
+    }
+
+    const channels = await channelsRes.json()
+    const targetChannel = channels.find((ch) => ch.type === 0 && ch.name === 'cmart-alerts')
+    if (!targetChannel) {
+      console.error('No channel named "cmart-alerts" found in the guild.')
+      return
+    }
+
+    const channelId = targetChannel.id
+    const baseUrl =
+      process.env.PUBLIC_BASE_URL ||
+      (process.env.NODE_ENV === 'production'
+        ? 'https://www.cartoonreorbit.com'
+        : `http://localhost:${process.env.SOCKET_PORT || 3000}`)
+
+    const { name, rarity, assetPath } = result.ctoon || {}
+    const auctionLink = `${baseUrl}/auction/${result.auctionId}`
+    const rawImageUrl = assetPath ? (assetPath.startsWith('http') ? assetPath : `${baseUrl}${assetPath}`) : null
+    const imageUrl = rawImageUrl ? encodeURI(rawImageUrl) : null
+
+    const lines = [
+      `**Rarity:** ${rarity ?? 'N/A'}`,
+      ...(!isHolidayItem ? [`**Mint #:** ${result.mintNumber ?? 'N/A'}`] : []),
+      `**Starting Bid:** ${result.initialBet} pts`,
+      `**Duration:** ${result.durationDays} day(s)`
+    ]
+
+    const payload = {
+      content: `A scheduled auction is now live.`,
+      embeds: [{
+        title: name ?? 'cToon',
+        url: auctionLink,
+        description: lines.join('\n'),
+        ...(imageUrl ? { image: { url: imageUrl } } : {})
+      }]
+    }
+
+    await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+      method: 'POST',
+      headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+  } catch (e1) {
+    // best-effort only
+  }
+}
+
+export const AUCTION_ONLY_ROW_INCLUDE = {
+  userCtoon: {
+    select: {
+      id: true,
+      mintNumber: true,
+      creatorId: true,
+      ctoon: { select: { id: true, name: true, rarity: true, assetPath: true } }
+    }
+  }
+}
+
+// Activates a single AuctionOnly row (id + userCtoon include as above) into a
+// live Auction. Returns the created-auction summary, or null if the row was
+// already started / already has a live Auction by the time the transaction runs.
+export async function activateAuctionOnlyRow(row) {
+  const result = await prisma.$transaction(async (tx) => {
+    const fresh = await tx.auctionOnly.findUnique({
+      where: { id: row.id },
+      select: {
+        id: true,
+        isStarted: true,
+        userCtoonId: true,
+        pricePoints: true,
+        startsAt: true,
+        endsAt: true,
+        isFeatured: true
+      }
+    })
+    if (!fresh || fresh.isStarted) return null
+
+    const active = await tx.auction.findFirst({
+      where: { userCtoonId: fresh.userCtoonId, status: 'ACTIVE' },
+      select: { id: true }
+    })
+    if (active) {
+      await tx.auctionOnly.update({ where: { id: fresh.id }, data: { isStarted: true } })
+      return null
+    }
+
+    const floor = auctionOnlyRarityFloor(row.userCtoon?.ctoon?.rarity)
+    const initialBet = Math.max(Number(fresh.pricePoints || 0), floor)
+
+    const ms = new Date(fresh.endsAt).getTime() - new Date(fresh.startsAt).getTime()
+    const durationDays = Math.max(1, Math.min(5, Math.round(ms / 86400000) || 1))
+
+    const created = await tx.auction.create({
+      data: {
+        userCtoonId: fresh.userCtoonId,
+        initialBet,
+        duration: durationDays,
+        endAt: new Date(fresh.endsAt),
+        creatorId: row.userCtoon?.creatorId,
+        isFeatured: fresh.isFeatured,
+        auctionOnlyId: fresh.id
+      },
+      select: { id: true }
+    })
+
+    await tx.userCtoon.update({
+      where: { id: fresh.userCtoonId },
+      data: { isTradeable: false }
+    })
+
+    await tx.auctionOnly.update({
+      where: { id: fresh.id },
+      data: { isStarted: true }
+    })
+
+    return {
+      auctionId: created.id,
+      endAt: new Date(fresh.endsAt),
+      initialBet,
+      durationDays,
+      ctoon: row.userCtoon.ctoon,
+      mintNumber: row.userCtoon.mintNumber,
+      ctoonId: row.userCtoon.ctoon.id,
+      isFeatured: fresh.isFeatured
+    }
+  })
+
+  if (!result) return null
+
+  await scheduleAuctionClose(result.auctionId, result.endAt)
+
+  const isHolidayItem = !!(await prisma.holidayEventItem.findFirst({
+    where: { ctoonId: result.ctoonId },
+    select: { id: true }
+  }))
+
+  await sendAuctionOnlyDiscordAnnouncement(result, isHolidayItem)
+
+  return result
+}


### PR DESCRIPTION
The AuctionOnly go-live cron (startDueAuctions) runs hourly inside a single
process (guild-checker) alongside many unrelated jobs. Since none of those
top-level awaits were guarded against unhandledRejection/uncaughtException,
a transient failure in any one of them could crash the whole process and
silently stop the auction cron from ever running again — with nothing
written to AuctionOnlyErrorLog, since the crash never touched auction code.
Add process-level handlers that keep the process alive and log the failure
under a new 'process' context so it's visible in the admin Error Log.

Also extract the single-row activation logic (previously inlined in
startDueAuctions) into server/utils/auctionOnlyActivate.js so it can be
reused by a new admin endpoint, POST /api/admin/auction-only/:id/start,
which lets an admin manually force a stuck listing live from the History
modal's "Start Now" button instead of waiting on the next cron tick.

Also restructure the history modal rows to stack on mobile instead of
relying on horizontal space for the status badge and action buttons.