### PR TITLE
Fix Prisma error breaking auction-only go-live

### DIFF
--- a/server/utils/auctionOnlyActivate.js
+++ b/server/utils/auctionOnlyActivate.js
@@ -92,7 +92,7 @@ export const AUCTION_ONLY_ROW_INCLUDE = {
     select: {
       id: true,
       mintNumber: true,
-      creatorId: true,
+      userId: true,
       ctoon: { select: { id: true, name: true, rarity: true, assetPath: true } }
     }
   }
@@ -138,7 +138,7 @@ export async function activateAuctionOnlyRow(row) {
         initialBet,
         duration: durationDays,
         endAt: new Date(fresh.endsAt),
-        creatorId: row.userCtoon?.creatorId,
+        creatorId: row.userCtoon?.userId,
         isFeatured: fresh.isFeatured,
         auctionOnlyId: fresh.id
       },


### PR DESCRIPTION
UserCtoon has no creatorId field (only userId), so the include/select
in AUCTION_ONLY_ROW_INCLUDE threw PrismaClientValidationError whenever
an auction-only listing tried to activate. This hit both the manual
admin "Go Live" action and the sync-guild-members cron job that starts
scheduled listings, which is why auction-only auctions were getting
stuck. Use userCtoon.userId for the Auction's creatorId instead.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016KfkrEr7SwbpJfQ7HUat4K