### PR TITLE
Add worker-content-analyzer BullMQ worker configuration

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -16,6 +16,7 @@
  *   worker-dissolve               – BullMQ worker: account dissolution
  *   worker-dissolve-auction-launch – BullMQ worker: dissolve auction launch
  *   worker-achieve                – BullMQ worker: daily achievements
+ *   worker-content-analyzer       – BullMQ worker: survey content analysis
  *   guild-checker                 – Cron: Discord guild member sync
  *
  * Workers run as single fork-mode instances to prevent double-processing of jobs.
@@ -148,6 +149,16 @@ module.exports = {
     {
       name:      'worker-achieve',
       script:    'server/workers/achievements.worker.js',
+      exec_mode: 'fork',
+      instances: 1,
+      env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
+    },
+
+    // ── BullMQ worker: survey content analysis ─────────────────────────────
+    {
+      name:      'worker-content-analyzer',
+      script:    'server/workers/content-analyzer.worker.js',
       exec_mode: 'fork',
       instances: 1,
       env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },


### PR DESCRIPTION
## Summary
Added configuration for a new BullMQ worker process that handles survey content analysis.

## Changes
- Added `worker-content-analyzer` to the PM2 ecosystem configuration
- Configured the worker to run the `server/workers/content-analyzer.worker.js` script
- Set up fork-mode execution with a single instance to prevent duplicate job processing
- Configured environment variables for both production and development environments

## Implementation Details
- The worker follows the same pattern as other BullMQ workers in the configuration (e.g., `worker-dissolve`, `worker-achieve`)
- Runs in fork mode with a single instance, consistent with the project's worker architecture
- Supports separate environment configurations for production and development environments with the `OFFICIAL_USERNAME` variable

https://claude.ai/code/session_018irXuzYt9DixEBpxmJbhw3