### PR TITLE
Fix import path in economyValuation utility

### DIFF
--- a/server/utils/economyValuation.js
+++ b/server/utils/economyValuation.js
@@ -1,6 +1,6 @@
 // server/utils/economyValuation.js
 // Shared valuation helpers for the Economy page (pages/newsite/economy.vue).
-import { prisma } from '@/server/prisma'
+import { prisma } from '../prisma.js'
 import { Prisma } from '@prisma/client'
 
 // Minimum number of distinct transactions required before an aggregate is


### PR DESCRIPTION
## Summary
Fixed an incorrect import path in the economyValuation utility module to use a relative path instead of an alias-based path.

## Changes
- Updated the prisma import statement in `server/utils/economyValuation.js` from `'@/server/prisma'` to `'../prisma.js'`
  - Changed from alias-based import to relative path import
  - This ensures the module correctly resolves the prisma client from its actual location relative to the utility file

## Details
The import path was using an alias (`@/`) that may not be properly configured or available in the context where this utility is used. Using a relative path (`../prisma.js`) provides a more reliable and explicit reference to the prisma module location.

https://claude.ai/code/session_01Ai8QEgRXLqrvzGyT4SRyTX