### PR TITLE
Normalize rarity filter values to title case

### DIFF
--- a/server/api/auctions/all.get.js
+++ b/server/api/auctions/all.get.js
@@ -141,7 +141,7 @@ export default defineEventHandler(async (event) => {
   if (sets.length) ctoonWhere.set = { in: sets }
   if (gtoonsOnly) ctoonWhere.isGtoon = true
   if (series.length) ctoonWhere.series = { in: series }
-  if (rarities.length) ctoonWhere.rarity = { in: rarities }
+  if (rarities.length) ctoonWhere.rarity = { in: rarities.map(toTitleCase) }
   if (search) {
     const characterValues = buildCharacterMatches(search)
     ctoonWhere.OR = [


### PR DESCRIPTION
## Summary
Fixed rarity filter matching by normalizing input values to title case before querying the database.

## Changes
- Modified the rarity filter in the auctions API endpoint to apply `toTitleCase()` transformation to rarity values before passing them to the database query
- This ensures that rarity filter inputs are normalized to match the expected format stored in the database (e.g., "rare" → "Rare")

## Details
The rarity filter was not matching records because the input values were not being normalized to the same case format as the stored database values. By applying the `toTitleCase()` function to the rarities array, the filter now correctly matches auction records regardless of the input case.

https://claude.ai/code/session_01PLhcihLsGjarKEeq5xnxsL