### PR TITLE
Fix blackjack Cash Out and Reset Chips sending GET instead of POST

### DIFF
--- a/pages/newsite/blackjack.vue
+++ b/pages/newsite/blackjack.vue
@@ -252,10 +252,19 @@
         </div>
 
         <!-- Out of chips -->
+        <!-- "Below the minimum bet" is not the same as "out of chips": a player sitting on a
+             few chips they cannot bet still has points to collect, and telling them they are
+             out is both wrong and points them away from the one thing left to do. -->
         <div v-if="outOfChips" class="bj-broke">
           <template v-if="isGamble">
-            <span>Out of chips.</span>
-            <button class="bj-link" :disabled="buyInLeft < rules.minBet" @click="openBuyIn">
+            <span v-if="chips > 0">
+              {{ chips.toLocaleString() }} chips left — under the {{ rules.minBet }} minimum bet.
+            </span>
+            <span v-else>Out of chips.</span>
+            <button v-if="chips > 0" class="bj-link" @click="showCashOut = true">
+              Cash out {{ chips.toLocaleString() }}
+            </button>
+            <button v-else class="bj-link" :disabled="buyInLeft < rules.minBet" @click="openBuyIn">
               {{ buyInLeft >= rules.minBet ? `Buy in again (${buyInLeft} left today)` : 'Done for today' }}
             </button>
           </template>
@@ -707,11 +716,11 @@ function applyView (view) {
   if (typeof view.autoCashedOut === 'number') autoCashedOut.value = view.autoCashedOut
 }
 
-async function call (url, body) {
+async function request (url, options) {
   busy.value = true
   error.value = ''
   try {
-    return await $fetch(url, body ? { method: 'POST', body } : {})
+    return await $fetch(url, options)
   } catch (e) {
     error.value = e?.data?.statusMessage || e?.statusMessage || 'Something went wrong. Try again.'
     setTimeout(() => { error.value = '' }, 4000)
@@ -721,8 +730,26 @@ async function call (url, body) {
   }
 }
 
+/**
+ * Calls one of the game's mutating endpoints.
+ *
+ * Always POST, even with nothing to send. Deriving the method from whether a body happened to
+ * be passed meant `call('/cashout')` and `call('/reset')` — which need no arguments — went out
+ * as GETs and never matched their POST-only handlers, so Cash Out and Reset Chips failed for
+ * everyone. A player left holding chips below the minimum bet could then neither cash out nor
+ * leave, because leaving with chips routes through the cash-out sheet.
+ */
+function call (url, body) {
+  return request(url, { method: 'POST', body: body ?? {} })
+}
+
+/** The one read-only endpoint. */
+function fetchStatus () {
+  return request('/api/game/blackjack/status', { method: 'GET' })
+}
+
 async function refresh () {
-  const view = await call('/api/game/blackjack/status')
+  const view = await fetchStatus()
   if (!view) return
   applyView(view)
   // A session left open from a previous visit drops the player straight back at the table.

--- a/tests/blackjackClientRoutes.test.js
+++ b/tests/blackjackClientRoutes.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// Guards the one blackjack failure that endpoint tests structurally cannot catch.
+//
+// Every handler under server/api/game/blackjack is method-specific by filename: status.get.js
+// answers GET, the rest answer POST only. The page's helper derived its method from whether a
+// body happened to be passed, so the two calls that need no arguments — cash out and practice
+// reset — went out as GETs and 404'd. Both endpoints passed their own tests the whole time,
+// because `curl -X POST` was always sending the right verb; only the browser sent the wrong
+// one. A player left holding chips under the minimum bet could then neither cash out nor
+// leave, because leaving with chips routes through the cash-out sheet.
+//
+// This checks the page's calls against the handlers on disk, which needs no server and no
+// browser.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = join(here, '..')
+const PAGE = join(root, 'pages/newsite/blackjack.vue')
+const API_DIR = join(root, 'server/api/game/blackjack')
+
+const source = readFileSync(PAGE, 'utf8')
+
+/** Route names the page references, e.g. 'cashout'. */
+function referencedRoutes () {
+  return [...source.matchAll(/'\/api\/game\/blackjack\/([a-z]+)'/g)].map(m => m[1])
+}
+
+test('every blackjack route the page calls exists as a handler', () => {
+  const routes = [...new Set(referencedRoutes())]
+  assert.ok(routes.length >= 5, `expected the page to call several routes, saw ${routes.length}`)
+
+  for (const route of routes) {
+    const isGet = existsSync(join(API_DIR, `${route}.get.js`))
+    const isPost = existsSync(join(API_DIR, `${route}.post.js`))
+    assert.ok(isGet || isPost, `page calls /api/game/blackjack/${route}, which has no handler`)
+  }
+})
+
+test('the POST helper cannot silently fall back to GET', () => {
+  // The bug in one line: `body ? { method: 'POST', body } : {}` — no body meant no method,
+  // and $fetch defaults to GET.
+  const helper = source.match(/function call \(url, body\) \{[\s\S]*?\n\}/)
+  assert.ok(helper, 'expected a call() helper in the page')
+
+  assert.ok(
+    /method:\s*'POST'/.test(helper[0]),
+    'call() must always set method POST'
+  )
+  // Rejects the ternary `body ? ... : ...` while allowing the nullish default `body ?? {}`.
+  assert.ok(
+    !/body\s*\?(?!\?)/.test(helper[0]),
+    'call() must not choose its HTTP method based on whether a body was passed'
+  )
+})
+
+test('the read-only route is fetched with GET and the rest with POST', () => {
+  // Anything reached through call() must be a POST handler.
+  const viaCall = [...source.matchAll(/\bcall\(\s*'\/api\/game\/blackjack\/([a-z]+)'/g)].map(m => m[1])
+  assert.ok(viaCall.length >= 4, `expected several call() routes, saw ${viaCall.join(',') || 'none'}`)
+
+  for (const route of new Set(viaCall)) {
+    assert.ok(
+      existsSync(join(API_DIR, `${route}.post.js`)),
+      `call() is POST-only, but /api/game/blackjack/${route} has no .post.js handler`
+    )
+  }
+
+  // ...and the GET handler must not be reached through it.
+  assert.ok(
+    !viaCall.includes('status'),
+    'status is a GET route and must not go through the POST helper'
+  )
+  assert.ok(
+    /fetchStatus\s*\(\)/.test(source),
+    'expected a dedicated fetchStatus() for the one read-only route'
+  )
+})
+
+test('no mutating route is reachable without a body-independent method', () => {
+  // Belt and braces: no bare $fetch to a game route anywhere in the page, which would bypass
+  // the helpers and reintroduce the same ambiguity.
+  const bare = [...source.matchAll(/\$fetch\(\s*'\/api\/game\/blackjack\/[a-z]+'/g)]
+  assert.equal(
+    bare.length, 0,
+    'call $fetch through request()/call()/fetchStatus() so the method is always explicit'
+  )
+})


### PR DESCRIPTION
Fixes the reported case: a player could not cash out 5 chips or leave the table after losing 295 of a 300 buy-in.

**This affects every player, not just that one.** Cash Out has never worked from the UI.

## Cause

The page's request helper picked its HTTP method from whether a body happened to be passed:

```js
$fetch(url, body ? { method: 'POST', body } : {})
```

Cash out and practice reset take no arguments, so both went out as **GET**. Every handler under `server/api/game/blackjack` is method-specific by filename, and both are POST-only — so neither route matched anything. The browser was getting `404 GET /api/game/blackjack/cashout`.

Leaving a table that still holds chips deliberately routes through the cash-out sheet, so **Main Menu was blocked by the same fault**. A player holding chips under the minimum bet had no legal move at all: they could not bet (below the minimum), cash out, or leave.

## Fix

The helper always sends POST; the one read-only route gets its own `fetchStatus()` instead of sharing a helper that infers the verb.

Also fixed the message in this state — with chips remaining but under the minimum bet, the table said *"Out of chips"*, which is untrue and points away from the only useful action. It now reports the real balance and offers to cash it out.

## Why this got through, and what stops it recurring

The endpoints were tested directly with `curl -X POST`, which always sent the correct verb, and the browser tests never clicked these two particular buttons. **Endpoint tests structurally cannot catch a client calling them with the wrong method** — both endpoints passed their own tests the entire time.

`tests/blackjackClientRoutes.test.js` closes that gap by checking the page's calls against the handlers on disk. No server or browser needed, so it runs in the normal `node --test` suite. Confirmed it **fails on the previous code** (2 failures) and passes on this one.

## Verification

Drove a real browser against the reported state (300 in, 295 lost, 5 stranded), on a 390×844 phone:

| | before | after |
|---|---|---|
| Cash out 5 chips | `404 GET cashout`, chips stuck at 5 | points +5, session closed |
| Main Menu | blocked | reaches the menu |
| Practice Reset Chips | `404 GET`, stack unchanged | restores 1000 |

## Note on the affected player

Their 5 points are still held in an open session and are not lost. Once this deploys they can cash out normally. Failing that, the 8pm CST reset already force-settles stale sessions and returns the chips automatically, so they recover either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_015YTiAREB8ffyW191kbSmtr)_