### PR TITLE
Add Alt Account Investigator and fix spoofable IP evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
 node_modules
 .env
+# Other env files (.env.local, .env.production) were not covered and are
+# committable as-is; the template is kept deliberately.
+.env.*
+!.env.template
+# Anti-cheat / alt-account investigation output contains player identity
+# evidence (IPs, device fingerprints, emails). Never commit it.
+*.report.json
+*.report.txt
+/reports/
 .nuxt
 .DS_Store
 .output

--- a/components/newsite/AdminAltFinder.vue
+++ b/components/newsite/AdminAltFinder.vue
@@ -1,0 +1,323 @@
+<template>
+  <div>
+    <!-- Search -->
+    <div class="bg-white border rounded shadow p-2 mb-2">
+      <div class="flex flex-col sm:flex-row gap-2">
+        <div class="flex-1">
+          <label class="block text-[11px] font-medium text-gray-600 mb-0.5">Banned account to investigate</label>
+          <input
+            v-model.trim="suspect"
+            type="text"
+            placeholder="e.g. ZenVikingGuru"
+            class="w-full border border-gray-300 rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            @keydown.enter.prevent="run()"
+          />
+        </div>
+        <div class="flex-1">
+          <label class="block text-[11px] font-medium text-gray-600 mb-0.5">
+            Known alts <span class="font-normal text-gray-400">(comma separated — widens the net a lot)</span>
+          </label>
+          <input
+            v-model.trim="knownAlts"
+            type="text"
+            placeholder="LoopyWarriorWarrior, GalaxyJumperDruid"
+            class="w-full border border-gray-300 rounded px-1.5 py-0.5 text-xs focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            @keydown.enter.prevent="run()"
+          />
+        </div>
+        <div class="flex items-end gap-1">
+          <button
+            type="button"
+            class="min-h-[32px] px-3 py-1 text-xs font-medium rounded bg-indigo-600 text-white disabled:opacity-50"
+            :disabled="loading || !suspect"
+            @click="run()"
+          >
+            {{ loading ? 'Investigating…' : 'Investigate' }}
+          </button>
+          <button
+            type="button"
+            class="min-h-[32px] px-2 py-1 text-[11px] rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+            :disabled="loading || !report"
+            title="Ignore the cached result and recompute"
+            @click="run(true)"
+          >
+            Recompute
+          </button>
+        </div>
+      </div>
+      <p v-if="error" class="mt-1 text-[11px] text-red-600">{{ error }}</p>
+    </div>
+
+    <div v-if="loading" class="text-gray-500 py-6 text-center">Gathering evidence…</div>
+
+    <template v-else-if="report">
+      <!-- Suspect summary -->
+      <div class="bg-white border rounded shadow p-2 mb-2">
+        <div class="flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
+          <h2 class="font-semibold text-xs">{{ report.suspect.username }}</h2>
+          <span class="text-[10px]" :class="report.suspect.banned ? 'text-red-600' : 'text-gray-500'">
+            {{ report.suspect.banned ? 'banned' : 'not banned' }}
+          </span>
+          <span class="text-[10px] text-gray-500">
+            ban recorded: {{ report.suspect.banAt ? formatDate(report.suspect.banAt) : 'unknown' }}
+          </span>
+          <span class="text-[10px] text-gray-500">
+            {{ formatNumber(report.candidatesConsidered) }} candidates scored of {{ formatNumber(report.userCount) }} users
+          </span>
+        </div>
+        <p v-if="report.suspect.knownAlts?.length" class="mt-0.5 text-[10px] text-gray-500">
+          Seed cluster: {{ [report.suspect.username, ...report.suspect.knownAlts].join(', ') }}
+        </p>
+        <p v-if="!report.suspect.banAt" class="mt-1 text-[10px] text-amber-700 bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5">
+          No ban note found for this account, so every date-relative signal is disabled. Record the ban in
+          Manage Users to sharpen the results.
+        </p>
+      </div>
+
+      <!-- Coverage: absence of evidence is not evidence of absence -->
+      <div class="bg-white border rounded shadow p-2 mb-2">
+        <h3 class="font-semibold text-[11px] mb-1">Evidence available for the seed cluster</h3>
+        <div class="flex flex-wrap gap-1">
+          <span
+            v-for="c in report.coverage"
+            :key="c.key"
+            class="text-[10px] px-1.5 py-0.5 rounded border"
+            :class="c.available
+              ? 'bg-gray-50 border-gray-200 text-gray-600'
+              : 'bg-amber-50 border-amber-300 text-amber-800'"
+          >
+            {{ c.label }}: {{ c.available ? formatNumber(c.rows) + ' rows' : 'no data' }}
+          </span>
+        </div>
+        <p v-if="missingCoverage.length" class="mt-1 text-[10px] text-amber-800">
+          No data for {{ missingCoverage.join(', ') }} — a zero score on
+          {{ missingCoverage.length > 1 ? 'those channels' : 'that channel' }} means nothing was recorded,
+          not that the accounts differ.
+        </p>
+      </div>
+
+      <!-- No results is a real answer -->
+      <div
+        v-if="!items.length"
+        class="bg-white border rounded shadow p-4 text-center"
+      >
+        <p class="text-xs font-medium text-gray-700">No account met the evidence threshold.</p>
+        <p class="mt-1 text-[11px] text-gray-500">
+          This is a result, not a failure — the evidence does not support naming anyone.
+          Adding known alts above, or waiting for more activity, may change it.
+        </p>
+      </div>
+
+      <!-- Ranked candidates -->
+      <div v-else class="space-y-2">
+        <div
+          v-for="(item, idx) in items"
+          :key="item.userId"
+          class="bg-white border rounded shadow p-2"
+        >
+          <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0">
+              <div class="flex items-baseline gap-1.5 flex-wrap">
+                <span class="text-[10px] text-gray-400">#{{ (page - 1) * limit + idx + 1 }}</span>
+                <h3 class="font-semibold text-xs truncate">{{ item.username }}</h3>
+                <span
+                  class="text-[10px] px-1.5 py-0.5 rounded font-medium"
+                  :class="tierClass(item.tier)"
+                >{{ tierLabel(item.tier) }}</span>
+              </div>
+              <div class="mt-0.5 text-[10px] text-gray-500">
+                {{ item.bits }} bits &middot; {{ item.corroboratingChannels }} independent
+                {{ item.corroboratingChannels === 1 ? 'channel' : 'channels' }}
+                <span v-if="item.surfacedBy?.length"> &middot; surfaced by {{ item.surfacedBy.join(', ') }}</span>
+              </div>
+            </div>
+            <div class="flex flex-col items-end gap-1 shrink-0">
+              <button
+                type="button"
+                class="min-h-[32px] px-2 py-0.5 text-[11px] rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                @click="toggle(item.userId)"
+              >
+                {{ expanded[item.userId] ? 'Hide' : 'Why?' }}
+              </button>
+            </div>
+          </div>
+
+          <!-- Evidence breakdown -->
+          <div v-if="expanded[item.userId]" class="mt-2 border-t pt-2 space-y-1.5">
+            <div v-for="(data, channel) in item.channels" :key="channel">
+              <div class="flex items-baseline gap-1.5">
+                <span class="text-[10px] font-semibold uppercase tracking-wide text-gray-500">{{ channel }}</span>
+                <span class="text-[10px]" :class="data.bits >= 0 ? 'text-gray-600' : 'text-green-700'">
+                  {{ data.bits >= 0 ? '+' : '' }}{{ data.bits }} bits
+                </span>
+              </div>
+              <ul class="mt-0.5 space-y-0.5">
+                <li v-for="sig in data.signals" :key="sig.key" class="text-[11px]">
+                  <span
+                    class="font-mono"
+                    :class="sig.bits >= 0 ? 'text-gray-800' : 'text-green-700'"
+                  >{{ sig.bits >= 0 ? '+' : '' }}{{ sig.bits }}</span>
+                  <span class="ml-1 text-gray-700">{{ sig.label }}</span>
+                  <p v-if="sig.caveat" class="ml-5 text-[10px] text-amber-700">⚠ {{ sig.caveat }}</p>
+                  <p v-if="sig.detail" class="ml-5 text-[10px] text-gray-500 break-words">
+                    {{ summarize(sig) }}
+                  </p>
+                </li>
+              </ul>
+            </div>
+
+            <!-- Hand off to the existing enforcement tools; this tool never acts -->
+            <div class="pt-1 border-t flex flex-wrap gap-2">
+              <NuxtLink
+                :to="`/admin/check-cheating?target=${encodeURIComponent(item.username)}&sources=${encodeURIComponent(report.suspect.username)}`"
+                class="text-[11px] text-indigo-600 hover:underline"
+              >Quantify in Check Cheating →</NuxtLink>
+              <NuxtLink
+                to="/newsite/admin/manageUsers"
+                class="text-[11px] text-indigo-600 hover:underline"
+              >Manage Users →</NuxtLink>
+              <NuxtLink
+                to="/newsite/admin/deviceFingerprints"
+                class="text-[11px] text-indigo-600 hover:underline"
+              >Browser Fingerprints →</NuxtLink>
+            </div>
+          </div>
+        </div>
+
+        <!-- Pagination -->
+        <div v-if="total > limit" class="flex items-center justify-between">
+          <div class="text-[11px] text-gray-600">Page {{ page }} of {{ totalPages }}</div>
+          <div class="space-x-1">
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page <= 1" @click="go(page - 1)">Prev</button>
+            <button class="px-2 py-0.5 border rounded text-[11px]" :disabled="page >= totalPages" @click="go(page + 1)">Next</button>
+          </div>
+        </div>
+      </div>
+
+      <p class="mt-2 text-[10px] text-gray-500 leading-relaxed">
+        Scores are log2 likelihood ratios: 20 bits is roughly a million to one against coincidence.
+        Negative signals argue <em>against</em> a match. A high score is a reason to review the
+        evidence, never a substitute for doing so — browser fingerprints in particular are supplied
+        by the client and can be forged.
+      </p>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, reactive } from 'vue'
+
+const suspect = ref('')
+const knownAlts = ref('')
+const loading = ref(false)
+const error = ref('')
+const report = ref(null)
+const items = ref([])
+const total = ref(0)
+const page = ref(1)
+const limit = 50
+const expanded = reactive({})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / limit)))
+const missingCoverage = computed(() =>
+  (report.value?.coverage || []).filter((c) => !c.available).map((c) => c.label.toLowerCase())
+)
+
+const TIER_LABELS = {
+  compelling: 'Compelling',
+  strong: 'Strong',
+  possible: 'Possible',
+  weak: 'Weak',
+  noise: 'Not significant'
+}
+function tierLabel(t) {
+  return TIER_LABELS[t] || t
+}
+function tierClass(t) {
+  if (t === 'compelling') return 'bg-red-100 text-red-800'
+  if (t === 'strong') return 'bg-orange-100 text-orange-800'
+  if (t === 'possible') return 'bg-amber-100 text-amber-800'
+  return 'bg-gray-100 text-gray-600'
+}
+
+function formatDate(d) {
+  if (!d) return '—'
+  return new Date(d).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+}
+function formatNumber(n) {
+  if (n == null) return '—'
+  return Number(n).toLocaleString('en-US')
+}
+
+// Render the per-signal detail without ever printing a raw identifier.
+function summarize(sig) {
+  const d = sig.detail || {}
+  if (d.ips) return d.ips.map((i) => `${i.ip} (shared by ${i.sharedBy}${i.vpn ? ', VPN exit' : ''})`).join(', ')
+  if (d.subnets) return d.subnets.map((s) => `${s.subnet} (${s.sharedBy} users)`).join(', ')
+  if (d.fingerprints) return d.fingerprints.map((f) => `${f.prefix}… (${f.sharedBy} accounts)`).join(', ')
+  if (d.contacts) return d.contacts.map((c) => `${c.username} ×${c.interactions}`).join(', ')
+  if (d.items && d.totalItems) return `${d.totalItems} item(s): ` + d.items.map((i) => `${i.name} #${i.mintNumber}`).join(', ')
+  if (d.barcodes) return d.barcodes.map((b) => `${b.label} (${b.scannedBy} scanners)`).join(', ')
+  if (d.partners) return d.partners.map((p) => p.username).join(', ')
+  if (d.sharedCards) return `${d.sharedCount} cards in common`
+  if (d.daysAfterBan != null) return `Discord account created ${d.daysAfterBan} days after the ban`
+  if (d.yearsBeforeBan != null) return `Discord account created ${d.yearsBeforeBan} years before the ban`
+  if (d.rate != null) return `active together in ${d.concurrentWindows}/${d.comparableWindows} windows`
+  if (d.match) return `match: ${d.match}`
+  return ''
+}
+
+function toggle(id) {
+  expanded[id] = !expanded[id]
+}
+
+function go(p) {
+  page.value = p
+  fetchPage()
+}
+
+async function run(force = false) {
+  page.value = 1
+  await fetchPage(force)
+}
+
+async function fetchPage(force = false) {
+  if (!suspect.value) return
+  loading.value = true
+  error.value = ''
+  try {
+    const params = new URLSearchParams({
+      username: suspect.value,
+      page: String(page.value),
+      limit: String(limit)
+    })
+    if (knownAlts.value) params.set('knownAlts', knownAlts.value)
+    if (force) params.set('force', '1')
+
+    const res = await fetch(`/api/admin/alt-finder/investigate?${params.toString()}`, {
+      credentials: 'include'
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      error.value = body?.statusMessage || body?.message || `Request failed (${res.status})`
+      report.value = null
+      items.value = []
+      total.value = 0
+      return
+    }
+    const data = await res.json()
+    report.value = data
+    items.value = data.items || []
+    total.value = data.total || 0
+    if (data.page) page.value = data.page
+  } catch (e) {
+    console.error('Alt finder request failed', e)
+    error.value = 'Request failed.'
+    report.value = null
+    items.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/components/newsite/AdminCheatFinder.vue
+++ b/components/newsite/AdminCheatFinder.vue
@@ -434,6 +434,17 @@
         </template>
       </div>
 
+      <!-- Alt Account Finder tab -->
+      <!--
+        The other two tabs scan the world for groups that share an IP or an ASN.
+        This one works the other way round: it starts from one banned account and
+        expands outward, which is the only shape that works when the suspect is
+        behind a VPN and on a fresh browser and Discord account.
+      -->
+      <div v-else-if="activeTab === 'altFinder'">
+        <AdminAltFinder />
+      </div>
+
       <!-- Placeholder tabs -->
       <div v-else class="text-gray-500 py-8 text-center">
         Placeholder
@@ -464,7 +475,7 @@ import { ref, reactive, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 const tabs = [
   { id: 'duplicateIps', label: 'Duplicate IPs' },
   { id: 'duplicateVpn', label: 'Duplicate VPN' },
-  { id: 'placeholder-2', label: 'Placeholder' },
+  { id: 'altFinder', label: 'Alt Account Finder' },
   { id: 'placeholder-3', label: 'Placeholder' },
   { id: 'placeholder-4', label: 'Placeholder' },
   { id: 'placeholder-5', label: 'Placeholder' }

--- a/prisma/alt-finder.js
+++ b/prisma/alt-finder.js
@@ -1,0 +1,202 @@
+// prisma/alt-finder.js
+//
+// Alt Account Investigator, command line edition. Given a banned account (and
+// optionally its already-known alts), ranks other accounts by how much evidence
+// says they are the same person.
+//
+// Usage:
+//   node --env-file=.env prisma/alt-finder.js --suspect ZenVikingGuru
+//   node --env-file=.env prisma/alt-finder.js --suspect ZenVikingGuru \
+//        --known-alts LoopyWarriorWarrior,GalaxyJumperDruid --limit 25
+//   node --env-file=.env prisma/alt-finder.js --suspect ZenVikingGuru --json --out ~/report.json
+//
+// Output is masked by default (no full IPs, no emails, no raw fingerprints).
+// The tool refuses to write a report anywhere inside the repository so a
+// `git add .` can never publish player identity data.
+
+import { PrismaClient } from '@prisma/client'
+import { writeFileSync } from 'fs'
+import { resolve, sep } from 'path'
+import { gatherEvidence } from '../server/utils/altAccountEvidence.js'
+
+const prisma = new PrismaClient()
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(`--${name}`)
+  if (i === -1) return fallback
+  const v = process.argv[i + 1]
+  return v && !v.startsWith('--') ? v : true
+}
+
+const suspect = arg('suspect')
+const knownAlts = String(arg('known-alts', '') || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean)
+const limit = Number.parseInt(arg('limit', '25'), 10) || 25
+const asJson = !!arg('json', false)
+const outPath = arg('out', null)
+const calibrate = !!arg('calibrate', false)
+
+if (!suspect) {
+  console.error('Usage: node --env-file=.env prisma/alt-finder.js --suspect <username> [--known-alts a,b,c] [--limit N] [--json] [--out FILE] [--calibrate]')
+  console.error('')
+  console.error('  --calibrate  Seed with the suspect ALONE and report where the accounts')
+  console.error('               passed via --known-alts actually rank. Use this to check the')
+  console.error('               scoring weights against accounts you already know are guilty')
+  console.error('               before trusting a number about an account you do not.')
+  process.exit(1)
+}
+
+// A report is full of player identity evidence. Writing it into the working
+// tree is how that ends up on GitHub.
+function assertSafeOutputPath(p) {
+  const abs = resolve(String(p))
+  const repoRoot = resolve(new URL('..', import.meta.url).pathname)
+  if (abs === repoRoot || abs.startsWith(repoRoot + sep)) {
+    console.error(`\nRefusing to write inside the repository: ${abs}`)
+    console.error('Pick a path outside the working tree (e.g. ~/alt-report.json).')
+    process.exit(1)
+  }
+  return abs
+}
+
+const TIER_LABEL = {
+  compelling: 'COMPELLING',
+  strong: 'STRONG',
+  possible: 'POSSIBLE',
+  weak: 'weak',
+  noise: '-'
+}
+
+function renderText(report) {
+  const lines = []
+  const s = report.suspect
+  lines.push('')
+  lines.push(`Alt Account Investigation — ${s.username}`)
+  lines.push('='.repeat(60))
+  lines.push(`Banned:            ${s.banned ? 'yes' : 'no'}`)
+  lines.push(`Ban recorded:      ${s.banAt ? new Date(s.banAt).toISOString() : 'unknown (no ban note)'}`)
+  if (s.banReason) lines.push(`Ban reason:        ${s.banReason}`)
+  lines.push(`Seed cluster:      ${[s.username, ...s.knownAlts].join(', ')}`)
+  lines.push(`Users on site:     ${report.userCount}`)
+  lines.push(`Candidates scored: ${report.candidatesConsidered}`)
+  lines.push('')
+
+  lines.push('Evidence coverage for the seed cluster')
+  lines.push('-'.repeat(60))
+  for (const c of report.coverage) {
+    const state = c.available ? `${c.rows} rows` : 'NO DATA — absence here is not exoneration'
+    lines.push(`  ${c.label.padEnd(24)} ${state}`)
+  }
+  lines.push('')
+
+  if (!report.results.length) {
+    lines.push('No candidate met the evidence threshold.')
+    lines.push('This is a real result: it means the evidence does not support naming anyone.')
+    lines.push('')
+    return lines.join('\n')
+  }
+
+  lines.push(`Ranked candidates (top ${Math.min(limit, report.results.length)} of ${report.results.length})`)
+  lines.push('-'.repeat(60))
+  for (const [i, r] of report.results.slice(0, limit).entries()) {
+    lines.push('')
+    lines.push(`${String(i + 1).padStart(2)}. ${r.username}  —  ${r.bits} bits  [${TIER_LABEL[r.tier] || r.tier}]`)
+    lines.push(`    channels corroborating: ${r.corroboratingChannels}`)
+    lines.push(`    surfaced by: ${r.surfacedBy.join(', ') || 'n/a'}`)
+    for (const [channel, data] of Object.entries(r.channels)) {
+      lines.push(`    [${channel}] ${data.bits} bits`)
+      for (const sig of data.signals) {
+        lines.push(`        ${sig.bits >= 0 ? '+' : ''}${sig.bits}  ${sig.label}`)
+        if (sig.caveat) lines.push(`               ! ${sig.caveat}`)
+      }
+    }
+  }
+  lines.push('')
+  lines.push('Bits are log2 likelihood ratios: 20 bits ~ a million to one against coincidence.')
+  lines.push('Negative signals argue AGAINST a match. Review evidence before acting.')
+  lines.push('')
+  return lines.join('\n')
+}
+
+/**
+ * Calibration: seed with the suspect alone and see where accounts we ALREADY
+ * know are alts land in the ranking. If known-guilty accounts don't reach the
+ * top tiers, the weights are wrong — and shipping a number about an unknown
+ * account would be guesswork dressed up as arithmetic.
+ */
+function renderCalibration(report, expected) {
+  const lines = []
+  lines.push('')
+  lines.push(`Calibration — seeded with ${report.suspect.username} alone`)
+  lines.push('='.repeat(60))
+  lines.push(`Scored ${report.candidatesConsidered} candidates.`)
+  lines.push('')
+
+  const rankByName = new Map()
+  report.results.forEach((r, i) => rankByName.set(r.username, { rank: i + 1, ...r }))
+
+  let found = 0
+  let topTier = 0
+  for (const name of expected) {
+    const hit = rankByName.get(name)
+    if (!hit) {
+      lines.push(`  MISS      ${name} — not surfaced as a candidate at all`)
+      continue
+    }
+    found++
+    const strong = hit.tier === 'compelling' || hit.tier === 'strong'
+    if (strong) topTier++
+    lines.push(
+      `  ${(strong ? 'OK  ' : 'WEAK').padEnd(9)} ${name.padEnd(26)} rank #${String(hit.rank).padStart(3)}  ${String(hit.bits).padStart(7)} bits  [${hit.tier}]`
+    )
+  }
+
+  lines.push('')
+  lines.push(`Recall:    ${found}/${expected.length} known alts surfaced as candidates`)
+  lines.push(`Precision: ${topTier}/${expected.length} reached the Strong or Compelling tier`)
+  if (found < expected.length) {
+    lines.push('')
+    lines.push('Known alts that were not surfaced mean candidate generation is too narrow —')
+    lines.push('the same blind spot would hide a new alt. Investigate before trusting results.')
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+try {
+  const report = await gatherEvidence(prisma, {
+    username: suspect,
+    // In calibration mode the known alts are the answer key, not an input.
+    extraUsernames: calibrate ? [] : knownAlts
+  })
+  if (!report) {
+    console.error(`No user found with username: ${suspect}`)
+    process.exit(1)
+  }
+
+  if (calibrate && !knownAlts.length) {
+    console.error('--calibrate needs --known-alts: the accounts you already know are alts.')
+    process.exit(1)
+  }
+
+  const output = asJson
+    ? JSON.stringify(report, null, 2)
+    : calibrate
+      ? renderCalibration(report, knownAlts)
+      : renderText(report)
+
+  if (outPath && outPath !== true) {
+    const abs = assertSafeOutputPath(outPath)
+    writeFileSync(abs, output, { mode: 0o600 })
+    console.log(`Report written to ${abs} (mode 0600). It contains player identity evidence — delete it when done.`)
+  } else {
+    console.log(output)
+  }
+} catch (err) {
+  console.error('Investigation failed:', err?.message || err)
+  process.exitCode = 1
+} finally {
+  await prisma.$disconnect()
+}

--- a/prisma/migrations/20260804000000_alt_account_investigator_indexes/migration.sql
+++ b/prisma/migrations/20260804000000_alt_account_investigator_indexes/migration.sql
@@ -1,0 +1,32 @@
+-- Indexes required by the Alt Account Investigator. Each one also fixes a
+-- sequential scan that already exists in production today.
+
+-- LoginLog only had [ip] and [createdAt]. Every "which IPs did this user log in
+-- from" lookup was a seq scan, and server/middleware/login-log.js runs a
+-- (userId, ip, createdAt) findFirst on EVERY non-hot-path request — it was
+-- riding LoginLog_ip_idx, which degrades exactly when an IP is shared (CGNAT,
+-- a school, a VPN exit), i.e. precisely the population being investigated.
+CREATE INDEX IF NOT EXISTS "LoginLog_userId_createdAt_idx" ON "LoginLog"("userId", "createdAt");
+
+-- UserIP had [userId] and unique(userId, ip), both leading with userId, so the
+-- reverse lookup ("who else ever used this IP") was a seq scan.
+CREATE INDEX IF NOT EXISTS "UserIP_ip_idx" ON "UserIP"("ip");
+
+-- Bid had NO indexes beyond its primary key. Any bidder-overlap query, and
+-- server/utils/suspiciousActivityMetrics.js:293, scan the whole table.
+CREATE INDEX IF NOT EXISTS "Bid_userId_createdAt_idx" ON "Bid"("userId", "createdAt");
+CREATE INDEX IF NOT EXISTS "Bid_auctionId_idx" ON "Bid"("auctionId");
+
+-- Visit had NO indexes at all, and server/api/points/visit.post.js counts by
+-- userId on every single cZone visit.
+CREATE INDEX IF NOT EXISTS "Visit_userId_createdAt_idx" ON "Visit"("userId", "createdAt");
+CREATE INDEX IF NOT EXISTS "Visit_zoneOwnerId_createdAt_idx" ON "Visit"("zoneOwnerId", "createdAt");
+
+-- CtoonOwnerLog indexed [userId, createdAt] but not counterpartyUserId, so
+-- "what flowed to/from this account" only worked in one direction.
+CREATE INDEX IF NOT EXISTS "CtoonOwnerLog_counterpartyUserId_createdAt_idx"
+  ON "CtoonOwnerLog"("counterpartyUserId", "createdAt");
+
+-- NOTE: barcode-scan overlap (the most VPN-resistant signal in the tool) needs
+-- no new index — UserBarcodeScan and UserScan both already carry
+-- @@index([mappingId]), which is what the reverse lookup joins on.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -624,6 +624,9 @@ model UserIP {
 
   @@unique([userId, ip])
   @@index([userId])
+  // Reverse lookup: "who else has ever used this IP". Both existing indexes
+  // lead with userId, so this direction was a sequential scan.
+  @@index([ip])
 }
 
 model Friend {
@@ -726,6 +729,11 @@ model Visit {
   createdAt   DateTime @default(now())
 
   user User @relation(fields: [userId], references: [id])
+
+  // Previously unindexed entirely, despite server/api/points/visit.post.js
+  // counting by userId on every cZone visit.
+  @@index([userId, createdAt])
+  @@index([zoneOwnerId, createdAt])
 }
 
 model TradeRoom {
@@ -842,6 +850,10 @@ model LoginLog {
 
   @@index([ip])
   @@index([createdAt])
+  // "which IPs did this user log in from" — and the (userId, ip, createdAt)
+  // dedupe in server/middleware/login-log.js, which runs on nearly every
+  // request — previously had no usable index and rode LoginLog_ip_idx.
+  @@index([userId, createdAt])
 }
 
 model DeviceFingerprintLog {
@@ -1442,6 +1454,11 @@ model Bid {
 
   auction Auction @relation(fields: [auctionId], references: [id])
   user    User    @relation(fields: [userId], references: [id])
+
+  // This table had no indexes at all beyond its primary key, so every
+  // per-user bid history and every bidder/seller overlap query scanned it whole.
+  @@index([userId, createdAt])
+  @@index([auctionId])
 }
 
 // ── Economy page ─────────────────────────────────────────────────
@@ -1921,6 +1938,9 @@ model CtoonOwnerLog {
   @@index([userCtoonId, createdAt])
   @@index([ctoonId, createdAt])
   @@index([userId, createdAt])
+  // Without this, "what flowed to/from this account" only worked in the
+  // owner direction; the counterparty direction was a sequential scan.
+  @@index([counterpartyUserId, createdAt])
 }
 
 // ── Holiday feature ─────────────────────────────────────────────

--- a/server/api/admin/alt-finder/investigate.get.js
+++ b/server/api/admin/alt-finder/investigate.get.js
@@ -1,0 +1,175 @@
+/**
+ * Alt Account Investigator — admin endpoint.
+ *
+ * Given one banned account (optionally plus its already-known alts), ranks
+ * other accounts by how much evidence says they are the same person, and
+ * returns per-signal reasoning.
+ *
+ * Read-only by design. It deliberately does NOT ban, seize, or dissolve — an
+ * admin reviews the evidence and hands off to the existing enforcement tools.
+ */
+
+import { defineEventHandler, getQuery, createError, setHeader } from 'h3'
+import { prisma } from '@/server/prisma'
+import { redis } from '@/server/utils/redis'
+import { gatherEvidence } from '@/server/utils/altAccountEvidence'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { createHash } from 'crypto'
+
+// Short TTL: these feed ban decisions, and an admin who bans an alt and re-runs
+// must not be shown a stale ranking. The Recompute button (force=1) bypasses it.
+const CACHE_TTL_SECONDS = 300
+const LOCK_TTL_SECONDS = 120
+const RATE_LIMIT_WINDOW_SEC = 60
+const RATE_LIMIT_MAX = 10
+
+// Bumped whenever the scoring or payload shape changes, so a deploy can never
+// serve an old-shaped blob into new code.
+const SCHEMA_VERSION = 'v1'
+
+const UUID_RE = /^[0-9a-f-]{36}$/i
+
+function firstValue(v) {
+  return Array.isArray(v) ? v[0] : v
+}
+
+export default defineEventHandler(async (event) => {
+  // Read the admin flags straight from the DB rather than via an internal
+  // $fetch('/api/auth/me'): it avoids an HTTP round-trip through the whole
+  // middleware stack (including an outbound Discord call) and, unlike an
+  // isAdmin-only check, refuses a suspended or deactivated admin.
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  const me = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, username: true, isAdmin: true, banned: true, active: true }
+  })
+  if (!me?.isAdmin || me.banned || me.active === false) {
+    throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+  }
+
+  // This endpoint is expensive and returns bulk identity evidence — rate limit
+  // it per admin.
+  const rlKey = `admin:alt-finder:rl:${me.id}`
+  const hits = await redis.incr(rlKey)
+  if (hits === 1) await redis.expire(rlKey, RATE_LIMIT_WINDOW_SEC)
+  if (hits > RATE_LIMIT_MAX) {
+    throw createError({ statusCode: 429, statusMessage: 'Too many investigations — slow down.' })
+  }
+
+  const query = getQuery(event)
+  const rawUsername = String(firstValue(query.username) || '').trim()
+  const rawUserId = String(firstValue(query.userId) || '').trim()
+  if (!rawUsername && !rawUserId) {
+    throw createError({ statusCode: 400, statusMessage: 'username or userId is required' })
+  }
+  if (rawUserId && !UUID_RE.test(rawUserId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid userId' })
+  }
+
+  const page = Math.max(parseInt(firstValue(query.page) || '1', 10) || 1, 1)
+  const limit = Math.min(Math.max(parseInt(firstValue(query.limit) || '50', 10) || 50, 1), 200)
+  const force = String(firstValue(query.force) || '') === '1'
+
+  // Known alts widen the seed cluster. Scoring against the whole cluster is
+  // what makes this work on someone who changed IP, browser and Discord
+  // account — he cannot also abandon the network he came back for.
+  const extraUsernames = String(firstValue(query.knownAlts) || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, 25)
+
+  // Resolve to a real user BEFORE building any cache key, so the key can never
+  // contain raw user input.
+  const suspect = await prisma.user.findFirst({
+    where: rawUserId ? { id: rawUserId } : { username: rawUsername },
+    select: { id: true }
+  })
+  // Uniform 404 — don't leak whether a username exists.
+  if (!suspect) throw createError({ statusCode: 404, statusMessage: 'Not found' })
+
+  const paramHash = createHash('sha256')
+    .update(JSON.stringify({ extra: [...extraUsernames].sort() }))
+    .digest('hex')
+    .slice(0, 16)
+  const cacheKey = `admin:alt-finder:${SCHEMA_VERSION}:${suspect.id}:${paramHash}`
+  const lockKey = `${cacheKey}:lock`
+
+  // Never let a browser or intermediary retain identity evidence.
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  let report
+  if (!force) {
+    try {
+      const hit = await redis.get(cacheKey)
+      if (hit) {
+        const parsed = JSON.parse(hit)
+        // Validate the shape rather than trusting whatever is in Redis.
+        if (parsed && Array.isArray(parsed.results) && parsed.suspect) report = parsed
+      }
+    } catch {}
+  }
+
+  if (!report) {
+    // Single-flight: two admins opening the page together shouldn't both run
+    // the full investigation.
+    let gotLock = false
+    try {
+      gotLock = (await redis.set(lockKey, me.id, 'EX', LOCK_TTL_SECONDS, 'NX')) === 'OK'
+    } catch {
+      gotLock = true // Redis down — degrade to computing rather than failing
+    }
+    if (!gotLock) {
+      throw createError({
+        statusCode: 202,
+        statusMessage: 'An investigation for this account is already running — retry shortly.'
+      })
+    }
+
+    try {
+      report = await gatherEvidence(prisma, {
+        userId: suspect.id,
+        extraUsernames
+      })
+      if (!report) throw createError({ statusCode: 404, statusMessage: 'Not found' })
+      try {
+        await redis.set(cacheKey, JSON.stringify(report), 'EX', CACHE_TTL_SECONDS)
+      } catch {}
+    } finally {
+      try { await redis.del(lockKey) } catch {}
+    }
+  }
+
+  // Audit the access — this is a bulk identity-evidence surface, so who ran it
+  // and against whom should be attributable. Counts only: never write the
+  // evidence itself into a permanent, un-TTL'd table that lands in every
+  // nightly pg_dump.
+  await logAdminChange(prisma, {
+    userId: me.id,
+    area: 'Admin:AltFinder',
+    key: 'investigate',
+    prevValue: null,
+    newValue: {
+      resultCount: report.results.length,
+      topBits: report.results[0]?.bits ?? 0,
+      candidatesConsidered: report.candidatesConsidered,
+      knownAltsSupplied: extraUsernames.length
+    },
+    targetUserId: report.suspect.id,
+    targetUsername: report.suspect.username
+  })
+
+  const total = report.results.length
+  const start = (page - 1) * limit
+  return {
+    suspect: report.suspect,
+    coverage: report.coverage,
+    candidatesConsidered: report.candidatesConsidered,
+    userCount: report.userCount,
+    items: report.results.slice(start, start + limit),
+    total,
+    page,
+    limit
+  }
+})

--- a/server/api/auth/device-fingerprint.post.js
+++ b/server/api/auth/device-fingerprint.post.js
@@ -12,14 +12,12 @@ import {
 } from 'h3'
 import { prisma } from '@/server/prisma'
 import { encryptIp } from '@/server/utils/ip-encrypt'
+import { getTrustedClientIp } from '@/server/utils/requestIp'
 
 function getRequestIP(event) {
-  return (
-    event.node.req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
-    event.node.req.connection?.remoteAddress ||
-    event.node.req.socket?.remoteAddress ||
-    ''
-  )
+  // Right-to-left XFF parsing; see server/utils/requestIp.js for why the
+  // leftmost entry must never be trusted.
+  return getTrustedClientIp(event) || ''
 }
 
 // Derive a compact, human-readable device summary from a User-Agent string.

--- a/server/api/auth/discord/callback.get.js
+++ b/server/api/auth/discord/callback.get.js
@@ -1,5 +1,7 @@
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/server/prisma'
+import { encryptIp } from '@/server/utils/ip-encrypt'
+import { getTrustedClientIp } from '@/server/utils/requestIp'
 
 // Utility: parse a Discord “snowflake” ID into its creation Date
 function parseDiscordSnowflake(snowflake) {
@@ -9,12 +11,9 @@ function parseDiscordSnowflake(snowflake) {
 }
 
 function getRequestIP(event) {
-  return (
-    event.node.req.headers['x-forwarded-for']?.split(',')[0] ||
-    event.node.req.connection?.remoteAddress ||
-    event.node.req.socket?.remoteAddress ||
-    null
-  )
+  // Right-to-left XFF parsing; see server/utils/requestIp.js for why the
+  // leftmost entry must never be trusted.
+  return getTrustedClientIp(event)
 }
 
 async function getRoleIdByName(guildId, roleName, botToken) {
@@ -146,13 +145,22 @@ export default defineEventHandler(async (event) => {
   })
 
   // 4.1 Save IP
+  //
+  // MUST be stored encrypted. This previously wrote the raw plaintext IP while
+  // server/middleware/login-log.js wrote ciphertext into the same column, so
+  // the @@unique([userId, ip]) constraint never deduped: one IP existed twice
+  // in two encodings, splitting it across two buckets and halving every
+  // IP-overlap count the anti-cheat tooling produces.
   const ip = getRequestIP(event)
   if (ip) {
-    await prisma.userIP.upsert({
-      where: { userId_ip: { userId: result.user.id, ip } },
-      update: {},
-      create: { userId: result.user.id, ip }
-    })
+    const encryptedIp = encryptIp(ip)
+    if (encryptedIp) {
+      await prisma.userIP.upsert({
+        where: { userId_ip: { userId: result.user.id, ip: encryptedIp } },
+        update: {},
+        create: { userId: result.user.id, ip: encryptedIp }
+      })
+    }
   }
 
   // 5) Session cookie

--- a/server/middleware/login-log.js
+++ b/server/middleware/login-log.js
@@ -4,6 +4,7 @@ import { prisma } from '@/server/prisma'
 import { isPrivateIp } from '@/server/utils/vpn-check'
 import { encryptIp } from '@/server/utils/ip-encrypt'
 import { enqueueVpnCheck } from '@/server/utils/vpn-queue'
+import { getTrustedClientIp } from '@/server/utils/requestIp'
 import { isHotPath } from '@/server/utils/hotPaths'
 
 export default defineEventHandler(async (event) => {
@@ -15,7 +16,7 @@ export default defineEventHandler(async (event) => {
   const userId = event.context?.userId
   if (!userId) return
 
-  const ip = getRequestIP(event)
+  const ip = getTrustedClientIp(event)
   if (!ip) return
 
   const encryptedLoginIp = encryptIp(ip)
@@ -62,12 +63,3 @@ export default defineEventHandler(async (event) => {
   }
 })
 
-function getRequestIP(event) {
-  const headers = event.node.req.headers
-  const forwarded = headers['x-forwarded-for']
-  if (forwarded) {
-    const firstIp = forwarded.split(',')[0].trim()
-    if (firstIp) return firstIp
-  }
-  return event.node.req.socket?.remoteAddress || null
-}

--- a/server/utils/altAccountEvidence.js
+++ b/server/utils/altAccountEvidence.js
@@ -1,0 +1,678 @@
+/**
+ * Alt Account Investigator — evidence gathering.
+ *
+ * Takes a Prisma client as an argument rather than importing one, so the Nitro
+ * endpoint and the CLI in prisma/ can both use it.
+ *
+ * Two phases:
+ *   1. CANDIDATE GENERATION — several independent, individually capped
+ *      generators, each stamping provenance onto the candidates it surfaced.
+ *      Scoring every user on the site against every signal is neither
+ *      affordable nor useful; scoring ~500 plausible ones is both.
+ *   2. SCORING — a bounded set of aggregate queries over the candidate set
+ *      only. Never per-candidate queries in a loop.
+ *
+ * Deliberately NOT here: VPN ASN grouping as a candidate generator. The suspect
+ * is known to use a VPN, and a commercial VPN ASN is shared by every
+ * privacy-minded player, so it produces thousands of strangers and then the cap
+ * silently truncates the true positives the precise generators found. VpnLog is
+ * used only to DISCOUNT IP matches (see vpnIps below).
+ */
+
+import { encryptIp, decryptIp } from './ip-encrypt.js'
+import { normalizeIp, isNonIdentifyingIp, subnetPrefix, maskIp } from './requestIp.js'
+import { rankCandidates, buildCoverage } from './altAccountScoring.js'
+
+// Caps per generator. Generous enough not to lose real leads, tight enough that
+// phase 2 stays a fixed number of indexed aggregates.
+const CAPS = {
+  ip: 300,
+  subnet: 300,
+  fingerprint: 150,
+  cluster: 250,
+  provenance: 200,
+  recall: 200,
+  physical: 150,
+  total: 600
+}
+
+// Only enumerate this many distinct /24s. Each costs 256 encrypt calls.
+const MAX_SUBNETS = 12
+
+/**
+ * Resolve the seed cluster: the banned account plus any accounts already known
+ * to belong to it. Scoring against the whole cluster rather than one username
+ * is what makes the tool work on someone who knows he was caught — he can
+ * change his IP, browser and Discord account, but reconnecting with his network
+ * and his items is the entire reason he came back.
+ */
+export async function resolveSeedCluster(prisma, { username, userId, extraUsernames = [] }) {
+  const where = userId ? { id: userId } : { username }
+  const primary = await prisma.user.findFirst({
+    where,
+    select: {
+      id: true,
+      username: true,
+      email: true,
+      discordId: true,
+      discordCreatedAt: true,
+      createdAt: true,
+      banned: true
+    }
+  })
+  if (!primary) return null
+
+  const extras = extraUsernames.length
+    ? await prisma.user.findMany({
+        where: { username: { in: extraUsernames } },
+        select: { id: true, username: true }
+      })
+    : []
+
+  // Ban time anchors every temporal signal. Prefer the ban note over any
+  // last-activity heuristic: a banned user holding a valid 30-day JWT keeps
+  // writing LoginLog rows, because only /api/auth/me checks the banned flag.
+  const banNote = await prisma.userBanNote.findFirst({
+    where: { userId: primary.id, action: 'BAN' },
+    orderBy: { createdAt: 'desc' },
+    select: { createdAt: true, reason: true }
+  })
+
+  return {
+    primary,
+    seedIds: [primary.id, ...extras.map((e) => e.id)],
+    seedUsernames: [primary.username, ...extras.map((e) => e.username)],
+    knownAlts: extras,
+    banAt: banNote?.createdAt || null,
+    banReason: banNote?.reason || null
+  }
+}
+
+/**
+ * Every stored form of the seed cluster's IPs.
+ *
+ * Returns plaintext addresses plus the set of stored representations to match
+ * against. Both encodings are included because UserIP historically received
+ * plaintext from the OAuth callback while the login middleware wrote
+ * ciphertext — matching on one form alone silently halves the overlap count.
+ */
+async function loadSeedIps(prisma, seedIds) {
+  const [userIps, loginIps, fpIps] = await Promise.all([
+    prisma.userIP.findMany({ where: { userId: { in: seedIds } }, select: { ip: true } }),
+    prisma.loginLog.findMany({
+      where: { userId: { in: seedIds } },
+      select: { ip: true },
+      distinct: ['ip']
+    }),
+    prisma.deviceFingerprintLog.findMany({
+      where: { userId: { in: seedIds } },
+      select: { ip: true },
+      distinct: ['ip']
+    })
+  ])
+
+  const plaintext = new Set()
+  for (const row of [...userIps, ...loginIps, ...fpIps]) {
+    // decryptIp passes non-hex values through unchanged, which normalizes the
+    // legacy plaintext rows onto the same footing as encrypted ones.
+    const ip = normalizeIp(decryptIp(row.ip))
+    if (ip && !isNonIdentifyingIp(ip)) plaintext.add(ip)
+  }
+
+  return { plaintext: [...plaintext], storedForms: storedFormsFor([...plaintext]) }
+}
+
+/**
+ * Every representation an IP may have been stored under.
+ *
+ * Three variants exist in the data, and matching on one alone loses history:
+ *   - ciphertext (what server/middleware/login-log.js writes),
+ *   - plaintext (what the OAuth callback wrote until this was fixed),
+ *   - the IPv4-mapped IPv6 form `::ffff:1.2.3.4`, which is what Node reports
+ *     for a socket peer and which predates normalization.
+ */
+function storedFormsFor(ips) {
+  const forms = new Set()
+  for (const ip of ips) {
+    const variants = [ip]
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(ip)) variants.push(`::ffff:${ip}`)
+    for (const v of variants) {
+      forms.add(v)
+      const enc = encryptIp(v)
+      if (enc) forms.add(enc)
+    }
+  }
+  return [...forms]
+}
+
+/**
+ * Subnet matching without decrypting the world.
+ *
+ * IPs are encrypted as whole strings with a deterministic key, so there is no
+ * SQL prefix match — the obvious implementation is to SELECT every LoginLog row
+ * and decrypt it in Node, which is seconds of blocked event loop and hundreds
+ * of megabytes of heap. Instead: decrypt only the SEED's addresses, enumerate
+ * the 256 addresses of each of its /24s, encrypt those, and hand the result to
+ * an ordinary indexed `IN`. Bounded work, no table scan.
+ *
+ * IPv4 only — a /64 has 2^64 addresses, so IPv6 seeds fall back to exact match.
+ */
+function enumerateSubnetForms(plaintextIps) {
+  const prefixes = new Set()
+  for (const ip of plaintextIps) {
+    const prefix = subnetPrefix(ip)
+    if (prefix && prefix.includes('.')) prefixes.add(prefix)
+  }
+
+  const limited = [...prefixes].slice(0, MAX_SUBNETS)
+  const forms = []
+  const byForm = new Map()
+  for (const prefix of limited) {
+    for (let octet = 0; octet < 256; octet++) {
+      const ip = `${prefix}.${octet}`
+      const enc = encryptIp(ip)
+      forms.push(ip)
+      byForm.set(ip, prefix)
+      if (enc) {
+        forms.push(enc)
+        byForm.set(enc, prefix)
+      }
+    }
+  }
+  return { forms, byForm, prefixes: limited }
+}
+
+/** Distinct-user count per stored IP form, used for rarity weighting. */
+async function ipUserCounts(prisma, storedForms) {
+  if (!storedForms.length) return new Map()
+  const rows = await prisma.userIP.findMany({
+    where: { ip: { in: storedForms } },
+    select: { ip: true, userId: true }
+  })
+  const byIp = new Map()
+  for (const row of rows) {
+    if (!byIp.has(row.ip)) byIp.set(row.ip, new Set())
+    byIp.get(row.ip).add(row.userId)
+  }
+  return byIp
+}
+
+/** Phase 1 — candidate generation. */
+async function generateCandidates(prisma, seed, seedIps, banAt) {
+  const seedSet = new Set(seed.seedIds)
+  const surfaced = new Map() // userId -> Set<generator>
+
+  const add = (userId, generator, cap, counter) => {
+    if (!userId || seedSet.has(userId)) return
+    if (counter.n >= cap && !surfaced.has(userId)) return
+    if (!surfaced.has(userId)) {
+      surfaced.set(userId, new Set())
+      counter.n++
+    }
+    surfaced.get(userId).add(generator)
+  }
+
+  const subnet = enumerateSubnetForms(seedIps.plaintext)
+
+  const [
+    ipRows,
+    loginRows,
+    subnetRows,
+    fpRows,
+    clusterRows,
+    barcodeRows
+  ] = await Promise.all([
+    // Exact IP overlap
+    seedIps.storedForms.length
+      ? prisma.userIP.findMany({
+          where: { ip: { in: seedIps.storedForms }, userId: { notIn: seed.seedIds } },
+          select: { userId: true, ip: true }
+        })
+      : [],
+    seedIps.storedForms.length
+      ? prisma.loginLog.findMany({
+          where: { ip: { in: seedIps.storedForms }, userId: { notIn: seed.seedIds } },
+          select: { userId: true, ip: true },
+          distinct: ['userId', 'ip']
+        })
+      : [],
+    // /24 overlap
+    subnet.forms.length
+      ? prisma.userIP.findMany({
+          where: { ip: { in: subnet.forms }, userId: { notIn: seed.seedIds } },
+          select: { userId: true, ip: true }
+        })
+      : [],
+    // Shared browser fingerprint
+    (async () => {
+      const seedFps = await prisma.deviceFingerprintLog.findMany({
+        where: { userId: { in: seed.seedIds } },
+        select: { visitorId: true },
+        distinct: ['visitorId']
+      })
+      const ids = seedFps.map((f) => f.visitorId).filter(Boolean)
+      if (!ids.length) return []
+      return prisma.deviceFingerprintLog.findMany({
+        where: { visitorId: { in: ids }, userId: { notIn: seed.seedIds } },
+        select: { userId: true, visitorId: true },
+        distinct: ['userId', 'visitorId']
+      })
+    })(),
+    // Anyone who transacted with the cluster, in either direction
+    prisma.ctoonOwnerLog.findMany({
+      where: {
+        OR: [
+          { userId: { in: seed.seedIds }, counterpartyUserId: { notIn: seed.seedIds } },
+          { counterpartyUserId: { in: seed.seedIds }, userId: { notIn: seed.seedIds } }
+        ]
+      },
+      select: { userId: true, counterpartyUserId: true, createdAt: true }
+    }),
+    // Same physical barcodes
+    (async () => {
+      const seedScans = await prisma.userBarcodeScan.findMany({
+        where: { userId: { in: seed.seedIds } },
+        select: { mappingId: true },
+        distinct: ['mappingId']
+      })
+      const ids = seedScans.map((s) => s.mappingId)
+      if (!ids.length) return []
+      return prisma.userBarcodeScan.findMany({
+        where: { mappingId: { in: ids }, userId: { notIn: seed.seedIds } },
+        select: { userId: true, mappingId: true }
+      })
+    })()
+  ])
+
+  const counters = {
+    ip: { n: 0 },
+    subnet: { n: 0 },
+    fingerprint: { n: 0 },
+    cluster: { n: 0 },
+    physical: { n: 0 },
+    recall: { n: 0 }
+  }
+
+  const exactForms = new Set(seedIps.storedForms)
+  for (const r of ipRows) add(r.userId, 'sharedIp', CAPS.ip, counters.ip)
+  for (const r of loginRows) add(r.userId, 'sharedIp', CAPS.ip, counters.ip)
+  for (const r of subnetRows) {
+    if (exactForms.has(r.ip)) continue // already counted as an exact match
+    add(r.userId, 'sharedSubnet', CAPS.subnet, counters.subnet)
+  }
+  for (const r of fpRows) add(r.userId, 'sharedFingerprint', CAPS.fingerprint, counters.fingerprint)
+  for (const r of clusterRows) {
+    const other = seedSet.has(r.userId) ? r.counterpartyUserId : r.userId
+    add(other, 'clusterContact', CAPS.cluster, counters.cluster)
+  }
+  for (const r of barcodeRows) add(r.userId, 'sharedBarcode', CAPS.physical, counters.physical)
+
+  // Recall floor: accounts created in the window after the ban. Without this,
+  // an alt that shares nothing measurable with the seed is never even scored.
+  if (banAt) {
+    const windowStart = new Date(banAt)
+    const windowEnd = new Date(new Date(banAt).getTime() + 120 * 86400000)
+    const fresh = await prisma.user.findMany({
+      where: { createdAt: { gte: windowStart, lte: windowEnd }, id: { notIn: seed.seedIds } },
+      select: { id: true },
+      take: CAPS.recall
+    })
+    for (const u of fresh) add(u.id, 'createdAfterBan', CAPS.recall, counters.recall)
+  }
+
+  return surfaced
+}
+
+/**
+ * Phase 2 — gather per-candidate evidence with a fixed number of aggregate
+ * queries scoped to the candidate set.
+ */
+export async function gatherEvidence(prisma, options = {}) {
+  const seed = await resolveSeedCluster(prisma, options)
+  if (!seed) return null
+
+  const banAt = options.banAt || seed.banAt
+  const seedIps = await loadSeedIps(prisma, seed.seedIds)
+
+  const surfaced = await generateCandidates(prisma, seed, seedIps, banAt)
+  let candidateIds = [...surfaced.keys()].slice(0, CAPS.total)
+  if (!candidateIds.length) {
+    return emptyResult(seed, banAt, prisma)
+  }
+
+  const subnet = enumerateSubnetForms(seedIps.plaintext)
+  const seedFingerprints = await prisma.deviceFingerprintLog.findMany({
+    where: { userId: { in: seed.seedIds } },
+    select: { visitorId: true, deviceType: true },
+    distinct: ['visitorId']
+  })
+  const seedVisitorIds = seedFingerprints.map((f) => f.visitorId).filter(Boolean)
+  const seedDeviceTypes = [...new Set(seedFingerprints.map((f) => f.deviceType).filter(Boolean))]
+
+  const [
+    userCount,
+    users,
+    candidateUserIps,
+    candidateLoginIps,
+    candidateFps,
+    ipCounts,
+    vpnRows,
+    clusterLogs,
+    seedOwned,
+    candidateBarcodes,
+    seedBarcodes,
+    candidateWishlist,
+    seedWishlist
+  ] = await Promise.all([
+    prisma.user.count(),
+    prisma.user.findMany({
+      where: { id: { in: candidateIds } },
+      select: {
+        id: true,
+        username: true,
+        email: true,
+        discordCreatedAt: true,
+        createdAt: true,
+        banned: true,
+        active: true,
+        isAdmin: true,
+        lastLogin: true
+      }
+    }),
+    prisma.userIP.findMany({
+      where: { userId: { in: candidateIds } },
+      select: { userId: true, ip: true }
+    }),
+    prisma.loginLog.findMany({
+      where: { userId: { in: candidateIds }, ip: { in: seedIps.storedForms } },
+      select: { userId: true, ip: true },
+      distinct: ['userId', 'ip']
+    }),
+    seedVisitorIds.length
+      ? prisma.deviceFingerprintLog.findMany({
+          where: { userId: { in: candidateIds } },
+          select: { userId: true, visitorId: true, deviceType: true },
+          distinct: ['userId', 'visitorId']
+        })
+      : [],
+    ipUserCounts(prisma, [...seedIps.storedForms, ...subnet.forms]),
+    prisma.vpnLog.findMany({
+      where: { ip: { in: seedIps.storedForms }, isVpn: true },
+      select: { ip: true },
+      distinct: ['ip']
+    }),
+    prisma.ctoonOwnerLog.findMany({
+      where: {
+        OR: [
+          { userId: { in: seed.seedIds }, counterpartyUserId: { in: candidateIds } },
+          { counterpartyUserId: { in: seed.seedIds }, userId: { in: candidateIds } }
+        ]
+      },
+      select: { userId: true, counterpartyUserId: true, createdAt: true }
+    }),
+    prisma.ctoonOwnerLog.findMany({
+      where: { userId: { in: seed.seedIds }, userCtoonId: { not: null } },
+      select: { userCtoonId: true },
+      distinct: ['userCtoonId']
+    }),
+    prisma.userBarcodeScan.findMany({
+      where: { userId: { in: candidateIds } },
+      select: { userId: true, mappingId: true }
+    }),
+    prisma.userBarcodeScan.findMany({
+      where: { userId: { in: seed.seedIds } },
+      select: { mappingId: true },
+      distinct: ['mappingId']
+    }),
+    prisma.wishlistItem.findMany({
+      where: { userId: { in: candidateIds } },
+      select: { userId: true, ctoonId: true }
+    }),
+    prisma.wishlistItem.findMany({
+      where: { userId: { in: seed.seedIds } },
+      select: { ctoonId: true },
+      distinct: ['ctoonId']
+    })
+  ])
+
+  // Items the cluster once owned that a candidate now holds — the strongest
+  // "he came back for his stuff" signal. Bounded by the seed's own history.
+  const seedOwnedIds = seedOwned.map((r) => r.userCtoonId).filter(Boolean)
+  const reacquired = seedOwnedIds.length
+    ? await prisma.ctoonOwnerLog.findMany({
+        where: {
+          userCtoonId: { in: seedOwnedIds },
+          userId: { in: candidateIds },
+          ...(banAt ? { createdAt: { gte: new Date(banAt) } } : {})
+        },
+        select: {
+          userId: true,
+          mintNumber: true,
+          createdAt: true,
+          ctoon: { select: { name: true, rarity: true } }
+        }
+      })
+    : []
+
+  // Barcode rarity: how many distinct users scanned each shared product.
+  const seedMappingIds = seedBarcodes.map((b) => b.mappingId)
+  const barcodeCounts = new Map()
+  if (seedMappingIds.length) {
+    const rows = await prisma.userBarcodeScan.findMany({
+      where: { mappingId: { in: seedMappingIds } },
+      select: { mappingId: true, userId: true }
+    })
+    for (const r of rows) {
+      if (!barcodeCounts.has(r.mappingId)) barcodeCounts.set(r.mappingId, new Set())
+      barcodeCounts.get(r.mappingId).add(r.userId)
+    }
+  }
+
+  // Wishlist rarity: how many users want each shared cToon.
+  const seedWishIds = seedWishlist.map((w) => w.ctoonId)
+  const wishCounts = new Map()
+  if (seedWishIds.length) {
+    const grouped = await prisma.wishlistItem.groupBy({
+      by: ['ctoonId'],
+      where: { ctoonId: { in: seedWishIds } },
+      _count: { _all: true }
+    })
+    for (const g of grouped) wishCounts.set(g.ctoonId, g._count._all)
+  }
+
+  // Degree of each seed account: a mule who deals with three people makes
+  // contact far more meaningful than a hub who deals with three hundred.
+  const seedDegrees = new Map()
+  {
+    const rows = await prisma.ctoonOwnerLog.findMany({
+      where: { userId: { in: seed.seedIds }, counterpartyUserId: { not: null } },
+      select: { userId: true, counterpartyUserId: true }
+    })
+    for (const r of rows) {
+      if (!seedDegrees.has(r.userId)) seedDegrees.set(r.userId, new Set())
+      seedDegrees.get(r.userId).add(r.counterpartyUserId)
+    }
+  }
+
+  // ── Fold everything into per-candidate evidence objects ────────────────────
+  const seedUsernameById = new Map(
+    [{ id: seed.primary.id, username: seed.primary.username }, ...seed.knownAlts].map((u) => [
+      u.id,
+      u.username
+    ])
+  )
+  const vpnIpForms = new Set(vpnRows.map((r) => r.ip))
+  const exactForms = new Set(seedIps.storedForms)
+  const subnetByForm = subnet.byForm
+
+  const byUser = new Map()
+  const ensure = (userId) => {
+    if (!byUser.has(userId)) {
+      byUser.set(userId, {
+        userId,
+        sharedIps: [],
+        sharedSubnets: [],
+        sharedVisitorIds: [],
+        clusterContacts: [],
+        reacquiredMints: [],
+        sharedBarcodes: [],
+        sharedWishlist: [],
+        deviceTypes: [],
+        surfacedBy: [...(surfaced.get(userId) || [])]
+      })
+    }
+    return byUser.get(userId)
+  }
+
+  const dfFor = (form) => (ipCounts.get(form)?.size ?? 2)
+
+  const seenIp = new Set()
+  for (const row of [...candidateUserIps, ...candidateLoginIps]) {
+    const key = `${row.userId}|${row.ip}`
+    if (seenIp.has(key)) continue
+    seenIp.add(key)
+    const ev = ensure(row.userId)
+    if (exactForms.has(row.ip)) {
+      const plain = normalizeIp(decryptIp(row.ip))
+      ev.sharedIps.push({ ip: row.ip, df: dfFor(row.ip), masked: maskIp(plain) })
+    } else if (subnetByForm.has(row.ip)) {
+      ev.sharedSubnets.push({ subnet: subnetByForm.get(row.ip), df: dfFor(row.ip) })
+    }
+  }
+
+  const seedVisitorSet = new Set(seedVisitorIds)
+  const fpUserCounts = new Map()
+  for (const row of candidateFps) {
+    if (!seedVisitorSet.has(row.visitorId)) continue
+    if (!fpUserCounts.has(row.visitorId)) fpUserCounts.set(row.visitorId, new Set())
+    fpUserCounts.get(row.visitorId).add(row.userId)
+  }
+  for (const row of candidateFps) {
+    const ev = ensure(row.userId)
+    if (row.deviceType && !ev.deviceTypes.includes(row.deviceType)) ev.deviceTypes.push(row.deviceType)
+    if (!seedVisitorSet.has(row.visitorId)) continue
+    ev.sharedVisitorIds.push({
+      visitorId: row.visitorId,
+      df: (fpUserCounts.get(row.visitorId)?.size ?? 1) + seed.seedIds.length
+    })
+  }
+
+  const contactTally = new Map()
+  for (const log of clusterLogs) {
+    const seedSide = seedUsernameById.has(log.userId) ? log.userId : log.counterpartyUserId
+    const otherSide = seedUsernameById.has(log.userId) ? log.counterpartyUserId : log.userId
+    if (!otherSide || !seedUsernameById.has(seedSide)) continue
+    const key = `${otherSide}|${seedSide}`
+    contactTally.set(key, (contactTally.get(key) || 0) + 1)
+  }
+  for (const [key, interactions] of contactTally) {
+    const [otherSide, seedSide] = key.split('|')
+    ensure(otherSide).clusterContacts.push({
+      username: seedUsernameById.get(seedSide),
+      interactions,
+      partnerDegree: seedDegrees.get(seedSide)?.size ?? 1
+    })
+  }
+
+  for (const row of reacquired) {
+    ensure(row.userId).reacquiredMints.push({
+      name: row.ctoon?.name || 'unknown',
+      rarity: row.ctoon?.rarity || null,
+      mintNumber: row.mintNumber,
+      lowMint: Number.isFinite(row.mintNumber) && row.mintNumber <= 10,
+      circulation: 50,
+      acquiredAt: row.createdAt
+    })
+  }
+
+  const seedMappingSet = new Set(seedMappingIds)
+  for (const row of candidateBarcodes) {
+    if (!seedMappingSet.has(row.mappingId)) continue
+    ensure(row.userId).sharedBarcodes.push({
+      label: `barcode ${String(row.mappingId).slice(0, 8)}`,
+      df: barcodeCounts.get(row.mappingId)?.size ?? 2
+    })
+  }
+
+  const seedWishSet = new Set(seedWishIds)
+  for (const row of candidateWishlist) {
+    if (!seedWishSet.has(row.ctoonId)) continue
+    ensure(row.userId).sharedWishlist.push({
+      name: row.ctoonId,
+      wantedBy: wishCounts.get(row.ctoonId) ?? 2
+    })
+  }
+
+  for (const u of users) {
+    const ev = ensure(u.id)
+    ev.username = u.username
+    ev.email = u.email
+    ev.discordCreatedAt = u.discordCreatedAt
+    ev.firstSeenAt = u.createdAt
+    ev.banned = u.banned
+    ev.active = u.active
+    ev.isAdmin = u.isAdmin
+    ev.activeBeforeBanDays =
+      banAt && u.createdAt < new Date(banAt)
+        ? Math.floor((new Date(banAt) - u.createdAt) / 86400000)
+        : 0
+  }
+
+  const context = {
+    userCount,
+    banAt,
+    suspectEmail: seed.primary.email,
+    suspectDevices: seedDeviceTypes,
+    vpnIps: vpnIpForms
+  }
+
+  const ranked = rankCandidates([...byUser.values()], context)
+
+  const coverage = await suspectCoverage(prisma, seed.seedIds)
+
+  return {
+    suspect: {
+      id: seed.primary.id,
+      username: seed.primary.username,
+      banned: seed.primary.banned,
+      banAt,
+      banReason: seed.banReason,
+      knownAlts: seed.knownAlts.map((a) => a.username)
+    },
+    coverage,
+    candidatesConsidered: candidateIds.length,
+    userCount,
+    results: ranked
+  }
+}
+
+/** Row counts behind each channel, so "no match" is distinguishable from "no data". */
+async function suspectCoverage(prisma, seedIds) {
+  const [loginLogs, fingerprints, survey, trades, barcodes] = await Promise.all([
+    prisma.loginLog.count({ where: { userId: { in: seedIds } } }),
+    prisma.deviceFingerprintLog.count({ where: { userId: { in: seedIds } } }),
+    prisma.surveyAnswers.count({ where: { userId: { in: seedIds } } }),
+    prisma.ctoonOwnerLog.count({ where: { userId: { in: seedIds } } }),
+    prisma.userBarcodeScan.count({ where: { userId: { in: seedIds } } })
+  ])
+  return buildCoverage({ loginLogs, fingerprints, survey, trades, barcodes })
+}
+
+async function emptyResult(seed, banAt, prisma) {
+  return {
+    suspect: {
+      id: seed.primary.id,
+      username: seed.primary.username,
+      banned: seed.primary.banned,
+      banAt,
+      banReason: seed.banReason,
+      knownAlts: seed.knownAlts.map((a) => a.username)
+    },
+    coverage: await suspectCoverage(prisma, seed.seedIds),
+    candidatesConsidered: 0,
+    userCount: await prisma.user.count(),
+    results: []
+  }
+}
+
+export { CAPS }

--- a/server/utils/altAccountScoring.js
+++ b/server/utils/altAccountScoring.js
@@ -1,0 +1,703 @@
+/**
+ * Alt Account Investigator — scoring engine.
+ *
+ * Pure and DB-free on purpose: it takes plain evidence objects in and returns
+ * scores out, so the Nitro endpoint, the CLI in prisma/, and tests/ can all
+ * share it without Nitro's `@/` alias resolution or a Prisma client.
+ *
+ * ── Why bits, not a 0-100 score ──────────────────────────────────────────────
+ * Every observation is scored as a log-likelihood ratio:
+ *
+ *     bits = log2( P(observation | same person) / P(observation | strangers) )
+ *
+ * Summing bits across INDEPENDENT channels gives an interpretable total: 20
+ * bits means the evidence is ~1,000,000x more likely under "same person" than
+ * under coincidence. Two properties matter more than the interpretability:
+ *
+ *   1. Rarity falls out automatically. Sharing an IP that only two accounts
+ *      have ever used is strong; sharing a carrier-grade NAT address that
+ *      3,000 accounts have used is nearly worthless. A flat weighted sum
+ *      cannot express that difference and will rank households and school
+ *      networks at the top.
+ *   2. Evidence can be NEGATIVE. A weighted sum floors at zero, so it always
+ *      produces a #1 suspect — even when the banned user never came back. That
+ *      is the failure mode that gets an innocent player banned. Bits let
+ *      "these two accounts were repeatedly active in the same minute" or "this
+ *      Discord account predates the ban by two years" subtract.
+ *
+ * ── Channels ────────────────────────────────────────────────────────────────
+ * Bits may only be summed across channels that fail independently. The obvious
+ * grouping (network / device / behaviour) is wrong: exact IP, /24, ASN, ISP and
+ * country are five views of ONE observation, and UserIP / LoginLog / VpnLog
+ * store the same IP written by the same middleware. Summing those lets a single
+ * data point corroborate itself into a false conviction. Channels here are
+ * independent causal paths, and within a channel we take the MAX, not the sum.
+ */
+
+// Channel identifiers. Corroboration is counted across these.
+export const CHANNELS = {
+  NETWORK: 'network', // how packets reach us
+  DEVICE: 'device', // the browser/hardware
+  IDENTITY: 'identity', // external identity: Discord, email
+  CONTENT: 'content', // text the user authored
+  ECONOMY: 'economy', // in-game economic + social graph
+  PHYSICAL: 'physical' // real-world objects (barcodes)
+}
+
+// Per-channel ceilings. No single channel may on its own push a candidate into
+// the top tier — a spoofable client-supplied fingerprint must not read as
+// proof. See DEVICE especially: visitorId is an unauthenticated string from the
+// browser (server/api/auth/device-fingerprint.post.js accepts any 8-128 chars).
+export const CHANNEL_CAPS = {
+  [CHANNELS.NETWORK]: 14,
+  [CHANNELS.DEVICE]: 10,
+  [CHANNELS.IDENTITY]: 12,
+  [CHANNELS.CONTENT]: 6,
+  [CHANNELS.ECONOMY]: 18,
+  [CHANNELS.PHYSICAL]: 16
+}
+
+// Tiers are deliberately conservative, and every tier above LOW additionally
+// requires corroboration from independent channels (see tierFor).
+export const TIERS = [
+  { id: 'compelling', label: 'Compelling', minBits: 30, minChannels: 3 },
+  { id: 'strong', label: 'Strong', minBits: 20, minChannels: 2 },
+  { id: 'possible', label: 'Possible', minBits: 12, minChannels: 2 },
+  { id: 'weak', label: 'Weak', minBits: 6, minChannels: 1 },
+  { id: 'noise', label: 'Not significant', minBits: -Infinity, minChannels: 0 }
+]
+
+/**
+ * Bits of evidence from sharing a feature, given how many distinct users have
+ * that feature. This is the workhorse: it converts "they share X" into "how
+ * surprising is it that they share X".
+ *
+ * With `df` users carrying the feature out of `n` total, the chance that a
+ * random stranger also carries it is df/n, so the evidence is log2(n/df).
+ * A feature only two accounts share is worth a lot; one that a third of the
+ * site shares is worth ~1.5 bits.
+ *
+ * @param {number} df    distinct users carrying the feature (including both parties)
+ * @param {number} n     total users in the population
+ * @param {number} cap   maximum bits this single feature may contribute
+ */
+export function rarityBits(df, n, cap = 12) {
+  if (!Number.isFinite(df) || !Number.isFinite(n) || df <= 0 || n <= 0) return 0
+  // A feature nobody else shares still can't be worth more than the population
+  // can justify; and df is never meaningfully below 2 for a *shared* feature.
+  const effectiveDf = Math.max(df, 2)
+  if (effectiveDf >= n) return 0
+  return Math.min(cap, Math.log2(n / effectiveDf))
+}
+
+/**
+ * Diminishing returns for repeated observations of the same kind.
+ *
+ * Sharing five IPs is stronger than sharing one, but not five times stronger —
+ * they are correlated (same house, same trip, same ISP reassignment). The k-th
+ * additional observation contributes 1/k of a full unit.
+ */
+export function diminishing(values) {
+  const sorted = [...values].filter((v) => v > 0).sort((a, b) => b - a)
+  let total = 0
+  for (let i = 0; i < sorted.length; i++) total += sorted[i] / (i + 1)
+  return total
+}
+
+function clampChannel(channel, bits) {
+  const cap = CHANNEL_CAPS[channel] ?? 12
+  // Negative evidence is not capped by the positive ceiling — being able to
+  // rule someone out decisively is the point.
+  return bits > 0 ? Math.min(bits, cap) : bits
+}
+
+/**
+ * Normalize a Gmail-style local part: strip dots and +suffix, lowercase.
+ * `Zen.Viking+alt@gmail.com` and `zenviking@gmail.com` are one inbox, and
+ * reusing the underlying account is a common evader mistake. Only Google
+ * treats dots as insignificant, so restrict that part to Gmail domains.
+ */
+export function normalizeEmail(email) {
+  if (!email || typeof email !== 'string') return null
+  const trimmed = email.trim().toLowerCase()
+  const at = trimmed.lastIndexOf('@')
+  if (at <= 0) return null
+  let local = trimmed.slice(0, at)
+  const domain = trimmed.slice(at + 1)
+  const plus = local.indexOf('+')
+  if (plus !== -1) local = local.slice(0, plus)
+  if (domain === 'gmail.com' || domain === 'googlemail.com') local = local.replace(/\./g, '')
+  if (!local) return null
+  return { local, domain, normalized: `${local}@${domain}` }
+}
+
+/**
+ * Jaccard-style overlap that returns the shared members, so callers can show
+ * the admin *what* matched rather than just a coefficient.
+ */
+export function overlap(aSet, bSet) {
+  const a = aSet instanceof Set ? aSet : new Set(aSet || [])
+  const b = bSet instanceof Set ? bSet : new Set(bSet || [])
+  const shared = []
+  for (const v of a) if (b.has(v)) shared.push(v)
+  const unionSize = a.size + b.size - shared.length
+  return { shared, jaccard: unionSize > 0 ? shared.length / unionSize : 0, aSize: a.size, bSize: b.size }
+}
+
+/**
+ * ── Signal builders ─────────────────────────────────────────────────────────
+ * Each returns { channel, key, label, bits, detail } or null when it has
+ * nothing to say. `detail` is rendered to the admin as the "why".
+ */
+
+/** Shared IP addresses, rarity-weighted, with VPN/datacenter exits discounted. */
+export function ipSignal({ sharedIps = [], userCount, vpnIps = new Set() }) {
+  if (!sharedIps.length || !userCount) return null
+
+  const perIp = []
+  const evidence = []
+  for (const entry of sharedIps) {
+    const { ip, df, masked } = entry
+    // Two accounts behind the same commercial VPN exit is not evidence — that
+    // is what a VPN is for, and the suspect is known to use one. Discount to
+    // near-zero rather than dropping it, so it still shows in the UI.
+    const isVpn = vpnIps.has(ip)
+    const raw = rarityBits(df, userCount, 12)
+    const bits = isVpn ? Math.min(raw, 0.5) : raw
+    perIp.push(bits)
+    evidence.push({ ip: masked, sharedBy: df, bits: round(bits), vpn: isVpn })
+  }
+
+  const bits = diminishing(perIp)
+  if (bits <= 0) return null
+  return {
+    channel: CHANNELS.NETWORK,
+    key: 'sharedIp',
+    label: 'Shared IP address',
+    bits,
+    detail: { ips: evidence.sort((a, b) => b.bits - a.bits).slice(0, 10) }
+  }
+}
+
+/**
+ * Shared /24 (or IPv6 /64). Strictly weaker than a shared exact IP and NESTED
+ * inside it — same IP implies same subnet. The caller must pass only subnets
+ * where no exact IP already matched, and the combiner takes the max within the
+ * channel, so this can never stack on top of ipSignal.
+ */
+export function subnetSignal({ sharedSubnets = [], userCount }) {
+  if (!sharedSubnets.length || !userCount) return null
+  const per = sharedSubnets.map(({ df }) => rarityBits(df, userCount, 8) * 0.6)
+  const bits = diminishing(per)
+  if (bits <= 0) return null
+  return {
+    channel: CHANNELS.NETWORK,
+    key: 'sharedSubnet',
+    label: 'Shared subnet',
+    bits,
+    detail: {
+      subnets: sharedSubnets
+        .map((s) => ({ subnet: `${s.subnet}.0/24`, sharedBy: s.df }))
+        .slice(0, 10)
+    }
+  }
+}
+
+/**
+ * Shared browser fingerprint. High signal when honest, but the visitorId is a
+ * client-supplied string with no integrity check, so it is both trivially
+ * randomized (evasion) and trivially replayed (framing an innocent user).
+ * Capped hard and always flagged as rebuttable.
+ */
+export function fingerprintSignal({ sharedVisitorIds = [], userCount }) {
+  if (!sharedVisitorIds.length || !userCount) return null
+  const per = sharedVisitorIds.map(({ df }) => rarityBits(df, userCount, 10))
+  const bits = diminishing(per)
+  if (bits <= 0) return null
+  return {
+    channel: CHANNELS.DEVICE,
+    key: 'sharedFingerprint',
+    label: 'Shared browser fingerprint',
+    bits,
+    caveat: 'visitorId is supplied by the client and can be randomized or replayed — treat as corroborating, never conclusive.',
+    detail: {
+      fingerprints: sharedVisitorIds.map((f) => ({
+        // Never expose the full visitorId: it is a replayable credential for
+        // manufacturing a device match against any account.
+        prefix: String(f.visitorId || '').slice(0, 8),
+        sharedBy: f.df
+      }))
+    }
+  }
+}
+
+/** Same underlying email inbox, after Gmail normalization. */
+export function emailSignal({ suspectEmail, candidateEmail }) {
+  const a = normalizeEmail(suspectEmail)
+  const b = normalizeEmail(candidateEmail)
+  if (!a || !b) return null
+
+  if (a.normalized === b.normalized) {
+    return {
+      channel: CHANNELS.IDENTITY,
+      key: 'sameEmail',
+      label: 'Same email inbox',
+      bits: 12,
+      detail: { match: 'exact-after-normalization', domain: a.domain }
+    }
+  }
+  // Same local part on a different provider — someone reusing a handle.
+  if (a.local === b.local && a.local.length >= 5) {
+    return {
+      channel: CHANNELS.IDENTITY,
+      key: 'sameEmailLocal',
+      label: 'Same email handle, different provider',
+      bits: 7,
+      detail: { match: 'local-part', domains: [a.domain, b.domain] }
+    }
+  }
+  return null
+}
+
+/**
+ * Discord account created in the window between the suspect's ban and this
+ * account's first login.
+ *
+ * Note this is NOT "the Discord account is new" — in a Discord-OAuth-only game
+ * most new players have young Discord accounts, so that alone is near-zero
+ * evidence. What matters is a fresh account appearing right after the ban.
+ * An account that predates the ban by a long stretch is evidence AGAINST.
+ */
+export function discordTimingSignal({ banAt, discordCreatedAt, firstSeenAt }) {
+  if (!banAt || !discordCreatedAt) return null
+  const ban = new Date(banAt).getTime()
+  const created = new Date(discordCreatedAt).getTime()
+  if (!Number.isFinite(ban) || !Number.isFinite(created)) return null
+
+  const DAY = 86400000
+  const daysAfterBan = (created - ban) / DAY
+
+  if (daysAfterBan >= 0 && daysAfterBan <= 45) {
+    // Tightest right after the ban, decaying across the window.
+    const bits = 6 * (1 - daysAfterBan / 45) + 1
+    return {
+      channel: CHANNELS.IDENTITY,
+      key: 'discordCreatedAfterBan',
+      label: 'Discord account created shortly after the ban',
+      bits,
+      detail: { daysAfterBan: round(daysAfterBan), discordCreatedAt, firstSeenAt }
+    }
+  }
+
+  // Created well before the ban and therefore not made for this purpose.
+  // Weak exculpatory evidence — an aged account can still be bought or borrowed.
+  if (daysAfterBan < -365) {
+    return {
+      channel: CHANNELS.IDENTITY,
+      key: 'discordPredatesBan',
+      label: 'Discord account long predates the ban',
+      bits: -3,
+      detail: { yearsBeforeBan: round(-daysAfterBan / 365, 2), discordCreatedAt }
+    }
+  }
+  return null
+}
+
+/** Near-duplicate survey text — catches literal copy-paste between accounts. */
+export function surveyDuplicateSignal({ minhashSimilarity, aiScore }) {
+  const signals = []
+  if (Number.isFinite(minhashSimilarity) && minhashSimilarity >= 0.6) {
+    signals.push({
+      channel: CHANNELS.CONTENT,
+      key: 'surveyNearDuplicate',
+      label: 'Near-duplicate survey answers',
+      bits: Math.min(6, (minhashSimilarity - 0.5) * 12),
+      detail: { similarity: round(minhashSimilarity, 3) }
+    })
+  }
+  // Not identity evidence on its own, but a returning evader pasting LLM text
+  // to dodge stylometry is itself worth flagging to the admin.
+  if (Number.isFinite(aiScore) && aiScore >= 0.85) {
+    signals.push({
+      channel: CHANNELS.CONTENT,
+      key: 'surveyAiGenerated',
+      label: 'Survey answers look AI-generated',
+      bits: 1,
+      detail: { aiScore: round(aiScore, 3) }
+    })
+  }
+  return signals
+}
+
+/**
+ * Contact with the banned user's known cluster (the account itself plus any
+ * previously-confirmed alts/mules).
+ *
+ * This is the signal an evader cannot avoid without abandoning the network and
+ * the loot he came back for. Weighted by how selective each contact is: trading
+ * with a hub who deals with 300 people means little; trading with a mule who
+ * has dealt with 3 means a lot.
+ */
+export function clusterContactSignal({ contacts = [], userCount }) {
+  if (!contacts.length || !userCount) return null
+
+  const per = contacts.map(({ partnerDegree, interactions }) => {
+    const base = rarityBits(partnerDegree, userCount, 10)
+    // Repeated dealings are more than a one-off.
+    const volume = Math.min(2, Math.log2(1 + (interactions || 1)))
+    return base + volume
+  })
+
+  let bits = diminishing(per)
+  // Touching two or more separate known-bad accounts is far harder to explain
+  // as coincidence than touching one.
+  if (contacts.length >= 2) bits += 4
+  if (contacts.length >= 3) bits += 3
+
+  return {
+    channel: CHANNELS.ECONOMY,
+    key: 'knownClusterContact',
+    label: 'Traded with the banned account or its known alts',
+    bits,
+    detail: {
+      contacts: contacts.map((c) => ({
+        username: c.username,
+        interactions: c.interactions,
+        partnerDegree: c.partnerDegree
+      }))
+    }
+  }
+}
+
+/**
+ * Reacquiring specific mint-numbered items the banned account used to own.
+ * Every UserCtoon is globally unique (@@unique([ctoonId, mintNumber])) and
+ * CtoonOwnerLog survives both ban and dissolve, so the trail persists.
+ */
+export function mintProvenanceSignal({ reacquiredMints = [], userCount }) {
+  if (!reacquiredMints.length) return null
+
+  const per = reacquiredMints.map((m) => {
+    // A rare or low-mint item is a much stronger draw than a common one.
+    const rarityBonus = m.lowMint ? 3 : 0
+    const scarcity = rarityBits(m.circulation || 50, userCount || 1000, 6)
+    return 2 + scarcity + rarityBonus
+  })
+
+  return {
+    channel: CHANNELS.ECONOMY,
+    key: 'mintProvenance',
+    label: "Reacquired the banned account's former items",
+    bits: diminishing(per),
+    detail: {
+      items: reacquiredMints.slice(0, 15).map((m) => ({
+        name: m.name,
+        mintNumber: m.mintNumber,
+        rarity: m.rarity,
+        acquiredAt: m.acquiredAt
+      })),
+      totalItems: reacquiredMints.length
+    }
+  }
+}
+
+/** Shared trade counterparties beyond the known cluster, rarity-weighted. */
+export function counterpartySignal({ sharedPartners = [], userCount }) {
+  if (!sharedPartners.length || !userCount) return null
+  const per = sharedPartners.map(({ degree }) => rarityBits(degree, userCount, 7))
+  const bits = diminishing(per) * 0.7
+  if (bits <= 0) return null
+  return {
+    channel: CHANNELS.ECONOMY,
+    key: 'sharedCounterparties',
+    label: 'Shared trading partners',
+    bits,
+    detail: {
+      partners: sharedPartners.slice(0, 12).map((p) => ({ username: p.username, degree: p.degree }))
+    }
+  }
+}
+
+/**
+ * Overlapping wishlist / trade-list entries. A wishlist is aspirational and
+ * self-selected, so it is far more idiosyncratic than a collection (which is
+ * mostly determined by which packs were on sale when you joined).
+ */
+export function wishlistSignal({ sharedItems = [], userCount }) {
+  if (sharedItems.length < 2 || !userCount) return null
+  const per = sharedItems.map(({ wantedBy }) => rarityBits(wantedBy, userCount, 6))
+  const bits = diminishing(per) * 0.6
+  if (bits <= 0) return null
+  return {
+    channel: CHANNELS.ECONOMY,
+    key: 'wishlistOverlap',
+    label: 'Overlapping wishlists',
+    bits,
+    detail: { items: sharedItems.slice(0, 12).map((i) => ({ name: i.name, wantedBy: i.wantedBy })) }
+  }
+}
+
+/** Deck composition — players rebuild their pet deck on a new account. */
+export function deckSignal({ sharedCards = [], userCount, deckSize }) {
+  if (sharedCards.length < 3 || !userCount) return null
+  const per = sharedCards.map(({ playedBy }) => rarityBits(playedBy, userCount, 5))
+  let bits = diminishing(per) * 0.6
+  // Near-identical decks are much more telling than a few shared staples.
+  if (deckSize && sharedCards.length / deckSize >= 0.75) bits += 3
+  if (bits <= 0) return null
+  return {
+    channel: CHANNELS.ECONOMY,
+    key: 'deckSimilarity',
+    label: 'Similar Clash deck composition',
+    bits,
+    detail: { sharedCards: sharedCards.slice(0, 12).map((c) => c.name), sharedCount: sharedCards.length }
+  }
+}
+
+/**
+ * Scanned the same physical barcodes.
+ *
+ * The most evasion-resistant signal available: a VPN, a fresh browser and a new
+ * Discord account do nothing here, because it requires physically owning
+ * different objects. IDF-weighted — a Coca-Cola can is worthless, a specific
+ * niche product is close to conclusive.
+ */
+export function barcodeSignal({ sharedBarcodes = [], userCount }) {
+  if (!sharedBarcodes.length || !userCount) return null
+  const per = sharedBarcodes.map(({ df }) => rarityBits(df, userCount, 14))
+  const bits = diminishing(per)
+  if (bits <= 0) return null
+  return {
+    channel: CHANNELS.PHYSICAL,
+    key: 'sharedBarcodes',
+    label: 'Scanned the same physical barcodes',
+    bits,
+    detail: {
+      barcodes: sharedBarcodes
+        .map((b) => ({ label: b.label || 'unknown product', scannedBy: b.df }))
+        .slice(0, 10)
+    }
+  }
+}
+
+/**
+ * ── Negative evidence ───────────────────────────────────────────────────────
+ * Without these, the household/sibling case is indistinguishable from an alt:
+ * siblings max out network, device, social AND economic similarity at once.
+ */
+
+/**
+ * Repeated simultaneous activity. Two people in one house are frequently active
+ * in the same few minutes; one person alternating between accounts almost never
+ * is. This is the single best household discriminator.
+ */
+export function coActivitySignal({ concurrentWindows = 0, comparableWindows = 0 }) {
+  if (!comparableWindows || comparableWindows < 20) return null
+  const rate = concurrentWindows / comparableWindows
+  if (rate < 0.02) {
+    // Never online together despite plenty of overlap in active periods —
+    // mildly consistent with one person switching accounts.
+    return {
+      channel: CHANNELS.NETWORK,
+      key: 'neverConcurrent',
+      label: 'Never active at the same time',
+      bits: 2,
+      detail: { concurrentWindows, comparableWindows }
+    }
+  }
+  if (rate >= 0.15) {
+    const bits = -Math.min(14, 6 + rate * 20)
+    return {
+      channel: CHANNELS.NETWORK,
+      key: 'frequentlyConcurrent',
+      label: 'Frequently active at the same time — likely two different people',
+      bits,
+      detail: { concurrentWindows, comparableWindows, rate: round(rate, 3) }
+    }
+  }
+  return null
+}
+
+/** Disjoint device classes, e.g. iOS-only vs Windows-only. */
+export function deviceMismatchSignal({ suspectDevices = [], candidateDevices = [] }) {
+  if (!suspectDevices.length || !candidateDevices.length) return null
+  const { shared } = overlap(new Set(suspectDevices), new Set(candidateDevices))
+  if (shared.length === 0) {
+    return {
+      channel: CHANNELS.DEVICE,
+      key: 'deviceMismatch',
+      label: 'No device platform in common',
+      bits: -4,
+      detail: { suspectDevices, candidateDevices }
+    }
+  }
+  return null
+}
+
+/** The candidate was already active well before the ban, alongside the suspect. */
+export function precedesBanSignal({ candidateFirstSeen, banAt, activeBeforeBanDays = 0 }) {
+  if (!candidateFirstSeen || !banAt) return null
+  const first = new Date(candidateFirstSeen).getTime()
+  const ban = new Date(banAt).getTime()
+  if (!Number.isFinite(first) || !Number.isFinite(ban) || first >= ban) return null
+  if (activeBeforeBanDays < 60) return null
+  return {
+    channel: CHANNELS.IDENTITY,
+    key: 'activeBeforeBan',
+    label: 'Was already active long before the ban',
+    bits: -5,
+    detail: { candidateFirstSeen, activeBeforeBanDays }
+  }
+}
+
+/**
+ * Combine signals into a scored candidate.
+ *
+ * Within a channel we take the maximum positive signal plus diminished
+ * contributions from the rest, because same-channel signals are correlated
+ * views of one underlying fact. Negative evidence always applies in full.
+ */
+export function combineSignals(signals) {
+  const byChannel = new Map()
+  for (const sig of signals.filter(Boolean)) {
+    if (!byChannel.has(sig.channel)) byChannel.set(sig.channel, [])
+    byChannel.get(sig.channel).push(sig)
+  }
+
+  const channelScores = {}
+  let totalBits = 0
+  let corroboratingChannels = 0
+
+  for (const [channel, sigs] of byChannel) {
+    const positives = sigs.filter((s) => s.bits > 0).map((s) => s.bits)
+    const negatives = sigs.filter((s) => s.bits < 0).reduce((a, s) => a + s.bits, 0)
+
+    const positiveBits = clampChannel(channel, diminishing(positives))
+    const channelBits = positiveBits + negatives
+
+    channelScores[channel] = {
+      bits: round(channelBits),
+      signals: sigs.map((s) => ({
+        key: s.key,
+        label: s.label,
+        bits: round(s.bits),
+        caveat: s.caveat || null,
+        detail: s.detail || null
+      }))
+    }
+    totalBits += channelBits
+    // A channel only counts toward corroboration if it contributes real weight
+    // on its own — otherwise three trivial signals would fake a strong case.
+    if (positiveBits >= 3) corroboratingChannels++
+  }
+
+  return {
+    bits: round(totalBits),
+    channels: channelScores,
+    corroboratingChannels,
+    tier: tierFor(totalBits, corroboratingChannels)
+  }
+}
+
+/**
+ * Map bits + corroboration onto a tier. The channel requirement is what stops a
+ * single spoofable signal from reading as proof: 30 bits of fingerprint match
+ * and nothing else cannot reach "Compelling".
+ */
+export function tierFor(bits, corroboratingChannels) {
+  for (const tier of TIERS) {
+    if (bits >= tier.minBits && corroboratingChannels >= tier.minChannels) return tier.id
+  }
+  return 'noise'
+}
+
+/**
+ * Describe what evidence was actually available, so "no match" can be
+ * distinguished from "no data". A suspect with zero DeviceFingerprintLog rows
+ * scores 0 on device the same way a genuine non-match does, and an admin must
+ * not read that silence as exculpatory. DeviceFingerprintLog, SurveyAnswers and
+ * VpnLog all shipped in late May 2026, so for anyone banned soon after there
+ * may be only weeks of history.
+ */
+export function buildCoverage(suspectCounts = {}) {
+  const checks = [
+    { key: 'loginLogs', channel: CHANNELS.NETWORK, label: 'Login/IP history' },
+    { key: 'fingerprints', channel: CHANNELS.DEVICE, label: 'Browser fingerprints' },
+    { key: 'survey', channel: CHANNELS.CONTENT, label: 'Survey answers' },
+    { key: 'trades', channel: CHANNELS.ECONOMY, label: 'Trade history' },
+    { key: 'barcodes', channel: CHANNELS.PHYSICAL, label: 'Barcode scans' }
+  ]
+  return checks.map((c) => ({
+    ...c,
+    rows: suspectCounts[c.key] ?? 0,
+    available: (suspectCounts[c.key] ?? 0) > 0
+  }))
+}
+
+function round(n, places = 2) {
+  if (!Number.isFinite(n)) return 0
+  const f = 10 ** places
+  return Math.round(n * f) / f
+}
+
+/**
+ * Score one candidate against the suspect cluster.
+ * `evidence` is assembled by server/utils/altAccountEvidence.js (or the CLI).
+ */
+export function scoreCandidate(evidence, context) {
+  const { userCount, banAt } = context
+  const signals = [
+    ipSignal({ sharedIps: evidence.sharedIps, userCount, vpnIps: context.vpnIps }),
+    subnetSignal({ sharedSubnets: evidence.sharedSubnets, userCount }),
+    fingerprintSignal({ sharedVisitorIds: evidence.sharedVisitorIds, userCount }),
+    emailSignal({ suspectEmail: context.suspectEmail, candidateEmail: evidence.email }),
+    discordTimingSignal({
+      banAt,
+      discordCreatedAt: evidence.discordCreatedAt,
+      firstSeenAt: evidence.firstSeenAt
+    }),
+    ...surveyDuplicateSignal({
+      minhashSimilarity: evidence.minhashSimilarity,
+      aiScore: evidence.aiScore
+    }),
+    clusterContactSignal({ contacts: evidence.clusterContacts, userCount }),
+    mintProvenanceSignal({ reacquiredMints: evidence.reacquiredMints, userCount }),
+    counterpartySignal({ sharedPartners: evidence.sharedPartners, userCount }),
+    wishlistSignal({ sharedItems: evidence.sharedWishlist, userCount }),
+    deckSignal({
+      sharedCards: evidence.sharedDeckCards,
+      userCount,
+      deckSize: evidence.deckSize
+    }),
+    barcodeSignal({ sharedBarcodes: evidence.sharedBarcodes, userCount }),
+    coActivitySignal({
+      concurrentWindows: evidence.concurrentWindows,
+      comparableWindows: evidence.comparableWindows
+    }),
+    deviceMismatchSignal({
+      suspectDevices: context.suspectDevices,
+      candidateDevices: evidence.deviceTypes
+    }),
+    precedesBanSignal({
+      candidateFirstSeen: evidence.firstSeenAt,
+      banAt,
+      activeBeforeBanDays: evidence.activeBeforeBanDays
+    })
+  ]
+
+  const combined = combineSignals(signals)
+  return {
+    userId: evidence.userId,
+    username: evidence.username,
+    ...combined,
+    surfacedBy: evidence.surfacedBy || []
+  }
+}
+
+/** Score and rank a candidate set. */
+export function rankCandidates(candidates, context) {
+  return candidates
+    .map((c) => scoreCandidate(c, context))
+    .filter((c) => c.bits > 0)
+    .sort((a, b) => b.bits - a.bits)
+}

--- a/server/utils/ip-encrypt.js
+++ b/server/utils/ip-encrypt.js
@@ -8,15 +8,26 @@
  */
 import { createCipheriv, createDecipheriv, createHash } from 'crypto'
 
+// Memoized per key value. This runs on a per-request hot path via
+// server/middleware/login-log.js, and the alt-account investigator encrypts a
+// few thousand addresses per run to do subnet matching — re-deriving the buffer
+// and re-running SHA-256 on every call was pure overhead.
+let cachedKeyHex = null
+let cachedKeyAndIV = null
+
 function getKeyAndIV() {
   const keyHex = process.env.IP_ENCRYPTION_KEY
   if (!keyHex || keyHex.length !== 64) {
     throw new Error('IP_ENCRYPTION_KEY env var must be a 64-character hex string (32 bytes)')
   }
+  if (keyHex === cachedKeyHex) return cachedKeyAndIV
+
   const key = Buffer.from(keyHex, 'hex')
   // Derive a fixed 16-byte IV from the key deterministically
   const iv = createHash('sha256').update(key).digest().slice(0, 16)
-  return { key, iv }
+  cachedKeyHex = keyHex
+  cachedKeyAndIV = { key, iv }
+  return cachedKeyAndIV
 }
 
 /**

--- a/server/utils/requestIp.js
+++ b/server/utils/requestIp.js
@@ -1,0 +1,162 @@
+/**
+ * Trusted client-IP derivation.
+ *
+ * Every IP-based anti-cheat signal (LoginLog, UserIP, DeviceFingerprintLog,
+ * VpnLog) is only as trustworthy as this function. The previous implementation
+ * took the LEFTMOST X-Forwarded-For entry, which is attacker-supplied: nginx's
+ * standard `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`
+ * APPENDS the real peer, so a client that sends its own XFF header keeps that
+ * forged value in first position. That let anyone
+ *
+ *   a) evade IP linkage entirely by sending a random XFF per session, and
+ *   b) FRAME another account by sending a victim's IP, manufacturing shared-IP
+ *      evidence that the Cheat Finder / Alt Account Investigator would then
+ *      report as a near-certain match.
+ *
+ * The header is therefore read RIGHT-TO-LEFT. The rightmost entry is the one
+ * appended by our own reverse proxy — the peer address it actually observed —
+ * and each additional trusted proxy in front of it adds one more entry to skip.
+ *
+ * Env:
+ *   TRUSTED_PROXY_HOPS  number of proxies that append to XFF (default 1).
+ *                       1 = a single nginx. 2 = CDN in front of nginx.
+ *                       0 = no proxy; XFF is ignored entirely.
+ */
+
+const IPV4_RE = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+// Loose IPv6 check — we only need to reject junk, not validate every RFC form.
+const IPV6_RE = /^[0-9a-f:]+$/i
+
+/**
+ * Strip an IPv4-mapped IPv6 prefix and any zone/port decoration.
+ *
+ * Node hands back `::ffff:203.0.113.5` for the same peer that XFF reports as
+ * `203.0.113.5`. Left unnormalized those encrypt to two different ciphertexts,
+ * which silently splits one IP into two buckets and halves every overlap count.
+ */
+export function normalizeIp(raw) {
+  if (!raw) return null
+  let ip = String(raw).trim()
+  if (!ip) return null
+
+  // Some proxies quote entries, e.g. `"203.0.113.5"`.
+  if (ip.startsWith('"') && ip.endsWith('"')) ip = ip.slice(1, -1).trim()
+
+  // `[2001:db8::1]:443` → `2001:db8::1`
+  if (ip.startsWith('[')) {
+    const close = ip.indexOf(']')
+    if (close !== -1) ip = ip.slice(1, close)
+  }
+
+  // IPv6 zone index: `fe80::1%eth0` → `fe80::1`
+  const pct = ip.indexOf('%')
+  if (pct !== -1) ip = ip.slice(0, pct)
+
+  // IPv4-mapped IPv6
+  const lower = ip.toLowerCase()
+  if (lower.startsWith('::ffff:') && IPV4_RE.test(ip.slice(7))) ip = ip.slice(7)
+
+  // `203.0.113.5:51234` → `203.0.113.5` (only when it's unambiguously IPv4)
+  if (ip.includes(':') && !lower.includes('::') && ip.split(':').length === 2) {
+    const [host] = ip.split(':')
+    if (IPV4_RE.test(host)) ip = host
+  }
+
+  return isValidIp(ip) ? ip : null
+}
+
+export function isValidIp(ip) {
+  if (!ip) return false
+  const m = IPV4_RE.exec(ip)
+  if (m) return m.slice(1).every((o) => Number(o) <= 255 && String(Number(o)) === String(Number(o)))
+  return ip.includes(':') && IPV6_RE.test(ip)
+}
+
+function trustedHops() {
+  const raw = process.env.TRUSTED_PROXY_HOPS
+  if (raw === undefined || raw === '') return 1
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n >= 0 ? n : 1
+}
+
+/**
+ * Derive the client IP for the current request.
+ *
+ * @param {object} event  h3 event
+ * @returns {string|null} normalized IP, or null when nothing trustworthy exists
+ */
+export function getTrustedClientIp(event) {
+  const req = event?.node?.req
+  if (!req) return null
+
+  const socketIp = normalizeIp(req.socket?.remoteAddress || req.connection?.remoteAddress)
+  const hops = trustedHops()
+
+  // No proxy in front of us: the socket peer is the only trustworthy source and
+  // XFF is pure client input.
+  if (hops === 0) return socketIp
+
+  const rawHeader = req.headers['x-forwarded-for']
+  if (!rawHeader) return socketIp
+
+  // The header may legitimately appear multiple times; Node joins repeats into
+  // an array. Concatenate in order so the rightmost entry is still ours.
+  const header = Array.isArray(rawHeader) ? rawHeader.join(',') : String(rawHeader)
+  const parts = header.split(',').map((p) => p.trim()).filter(Boolean)
+  if (!parts.length) return socketIp
+
+  // Walk right-to-left, skipping the entries our own trusted proxies appended.
+  const idx = parts.length - hops
+  if (idx < 0) {
+    // Fewer entries than configured hops — the chain is shorter than expected
+    // (direct hit on the origin, or a misconfigured proxy). Trust the socket.
+    return socketIp
+  }
+
+  return normalizeIp(parts[idx]) || socketIp
+}
+
+/**
+ * IPs that must never be treated as identifying, because many unrelated people
+ * share them. Extends the private-range check with carrier-grade NAT, which is
+ * the dominant false-positive source for a mobile-heavy player base: one
+ * 100.64.0.0/10 egress address can front thousands of unrelated subscribers.
+ */
+const NON_IDENTIFYING_RE =
+  /^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|0\.|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.|::1$|fc|fd|fe80)/i
+
+export function isNonIdentifyingIp(ip) {
+  if (!ip) return true
+  return NON_IDENTIFYING_RE.test(ip)
+}
+
+/**
+ * IPv4 /24 (or IPv6 /64) prefix, used for subnet-level correlation.
+ * Returns null for addresses we refuse to correlate on.
+ */
+export function subnetPrefix(ip) {
+  if (!ip || isNonIdentifyingIp(ip)) return null
+  if (IPV4_RE.test(ip)) return ip.split('.').slice(0, 3).join('.')
+  if (ip.includes(':')) {
+    // Expand only far enough to take the first four hextets (/64).
+    const [head] = ip.split('::')
+    const hextets = head.split(':').filter(Boolean)
+    if (ip.includes('::') || hextets.length < 4) return null
+    return hextets.slice(0, 4).join(':').toLowerCase()
+  }
+  return null
+}
+
+/**
+ * Mask an IP for display. The investigator UI shows these instead of full
+ * addresses so a routine review isn't a bulk PII export.
+ */
+export function maskIp(ip) {
+  if (!ip) return null
+  if (IPV4_RE.test(ip)) return `${ip.split('.').slice(0, 3).join('.')}.xxx`
+  if (ip.includes(':')) {
+    const hextets = ip.split(':').filter(Boolean)
+    return `${hextets.slice(0, 3).join(':')}::/48`
+  }
+  return 'unknown'
+}

--- a/tests/altAccountScoring.test.js
+++ b/tests/altAccountScoring.test.js
@@ -1,0 +1,389 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  CHANNELS,
+  CHANNEL_CAPS,
+  rarityBits,
+  diminishing,
+  normalizeEmail,
+  overlap,
+  ipSignal,
+  fingerprintSignal,
+  emailSignal,
+  discordTimingSignal,
+  clusterContactSignal,
+  barcodeSignal,
+  coActivitySignal,
+  deviceMismatchSignal,
+  precedesBanSignal,
+  combineSignals,
+  tierFor,
+  buildCoverage,
+  scoreCandidate,
+  rankCandidates
+} from '../server/utils/altAccountScoring.js'
+
+const POP = 5000
+
+// ── rarityBits ────────────────────────────────────────────────────────────────
+
+test('rarityBits: a feature shared by few users is worth far more than a common one', () => {
+  const rare = rarityBits(2, POP)
+  const common = rarityBits(1500, POP)
+  assert.ok(rare > common * 3, `expected rare(${rare}) >> common(${common})`)
+})
+
+test('rarityBits: carrier-grade NAT scale sharing is near worthless', () => {
+  // ~3000 of 5000 users behind one egress address
+  assert.ok(rarityBits(3000, POP) < 1)
+})
+
+test('rarityBits: respects the cap and handles degenerate input', () => {
+  assert.equal(rarityBits(2, 10 ** 9, 12), 12)
+  assert.equal(rarityBits(0, POP), 0)
+  assert.equal(rarityBits(5, 0), 0)
+  assert.equal(rarityBits(POP, POP), 0, 'a feature everyone has carries no information')
+})
+
+// ── diminishing ───────────────────────────────────────────────────────────────
+
+test('diminishing: repeated observations add sublinearly', () => {
+  const single = diminishing([10])
+  const five = diminishing([10, 10, 10, 10, 10])
+  assert.equal(single, 10)
+  assert.ok(five < 50, 'five identical observations must not be worth 5x one')
+  assert.ok(five > 10)
+})
+
+test('diminishing: ignores non-positive values', () => {
+  assert.equal(diminishing([]), 0)
+  assert.equal(diminishing([0, -5]), 0)
+})
+
+// ── email normalization ───────────────────────────────────────────────────────
+
+test('normalizeEmail: gmail dots and +suffix collapse to one inbox', () => {
+  const a = normalizeEmail('Zen.Viking+reorbit@gmail.com')
+  const b = normalizeEmail('zenviking@gmail.com')
+  assert.equal(a.normalized, b.normalized)
+})
+
+test('normalizeEmail: dots are significant outside gmail', () => {
+  const a = normalizeEmail('zen.viking@outlook.com')
+  const b = normalizeEmail('zenviking@outlook.com')
+  assert.notEqual(a.normalized, b.normalized)
+})
+
+test('normalizeEmail: rejects malformed input', () => {
+  assert.equal(normalizeEmail(null), null)
+  assert.equal(normalizeEmail('not-an-email'), null)
+  assert.equal(normalizeEmail('@gmail.com'), null)
+})
+
+test('emailSignal: exact inbox match outranks a shared handle', () => {
+  const exact = emailSignal({
+    suspectEmail: 'zen.viking@gmail.com',
+    candidateEmail: 'zenviking+alt@gmail.com'
+  })
+  const handle = emailSignal({
+    suspectEmail: 'zenviking@gmail.com',
+    candidateEmail: 'zenviking@proton.me'
+  })
+  assert.equal(exact.channel, CHANNELS.IDENTITY)
+  assert.ok(exact.bits > handle.bits)
+  assert.equal(emailSignal({ suspectEmail: 'a@b.com', candidateEmail: 'c@d.com' }), null)
+})
+
+// ── overlap ───────────────────────────────────────────────────────────────────
+
+test('overlap: reports shared members and a jaccard coefficient', () => {
+  const r = overlap(['a', 'b', 'c'], ['b', 'c', 'd'])
+  assert.deepEqual(r.shared.sort(), ['b', 'c'])
+  assert.equal(r.jaccard, 0.5)
+})
+
+// ── IP signal ─────────────────────────────────────────────────────────────────
+
+test('ipSignal: a VPN exit node is discounted to near zero', () => {
+  const shared = [{ ip: 'enc1', df: 2, masked: '203.0.113.xxx' }]
+  const clean = ipSignal({ sharedIps: shared, userCount: POP, vpnIps: new Set() })
+  const vpn = ipSignal({ sharedIps: shared, userCount: POP, vpnIps: new Set(['enc1']) })
+  assert.ok(clean.bits > 10)
+  assert.ok(vpn.bits <= 0.5, 'sharing a commercial VPN exit is not evidence')
+})
+
+test('ipSignal: returns null with no shared IPs', () => {
+  assert.equal(ipSignal({ sharedIps: [], userCount: POP }), null)
+})
+
+test('ipSignal: exposes only masked addresses', () => {
+  const sig = ipSignal({
+    sharedIps: [{ ip: 'ciphertext', df: 2, masked: '203.0.113.xxx' }],
+    userCount: POP
+  })
+  const serialized = JSON.stringify(sig)
+  assert.ok(serialized.includes('203.0.113.xxx'))
+  assert.ok(!serialized.includes('ciphertext'), 'raw IP ciphertext must never reach the payload')
+})
+
+// ── fingerprint ───────────────────────────────────────────────────────────────
+
+test('fingerprintSignal: truncates the visitorId and carries a spoofing caveat', () => {
+  const sig = fingerprintSignal({
+    sharedVisitorIds: [{ visitorId: 'abcdefghijklmnop', df: 2 }],
+    userCount: POP
+  })
+  assert.equal(sig.detail.fingerprints[0].prefix, 'abcdefgh')
+  assert.ok(!JSON.stringify(sig).includes('abcdefghijklmnop'))
+  assert.match(sig.caveat, /client/i)
+})
+
+// ── discord timing ────────────────────────────────────────────────────────────
+
+test('discordTimingSignal: a Discord account made right after the ban is incriminating', () => {
+  const banAt = new Date('2026-06-30T00:00:00Z')
+  const soon = discordTimingSignal({
+    banAt,
+    discordCreatedAt: new Date('2026-07-02T00:00:00Z')
+  })
+  const later = discordTimingSignal({
+    banAt,
+    discordCreatedAt: new Date('2026-08-10T00:00:00Z')
+  })
+  assert.ok(soon.bits > later.bits)
+  assert.ok(soon.bits > 0 && later.bits > 0)
+})
+
+test('discordTimingSignal: an account years older than the ban is exculpatory', () => {
+  const sig = discordTimingSignal({
+    banAt: new Date('2026-06-30T00:00:00Z'),
+    discordCreatedAt: new Date('2021-01-01T00:00:00Z')
+  })
+  assert.ok(sig.bits < 0, 'a long-established Discord account is evidence against')
+})
+
+// ── cluster contact ───────────────────────────────────────────────────────────
+
+test('clusterContactSignal: touching several known mules escalates sharply', () => {
+  const one = clusterContactSignal({
+    contacts: [{ username: 'LoopyWarriorWarrior', partnerDegree: 4, interactions: 2 }],
+    userCount: POP
+  })
+  const three = clusterContactSignal({
+    contacts: [
+      { username: 'LoopyWarriorWarrior', partnerDegree: 4, interactions: 2 },
+      { username: 'GalaxyJumperDruid', partnerDegree: 5, interactions: 3 },
+      { username: 'RockinBotSuperstar', partnerDegree: 3, interactions: 1 }
+    ],
+    userCount: POP
+  })
+  assert.ok(three.bits > one.bits + 6)
+})
+
+test('clusterContactSignal: trading with a hub counts for little', () => {
+  const hub = clusterContactSignal({
+    contacts: [{ username: 'PopularTrader', partnerDegree: 2000, interactions: 1 }],
+    userCount: POP
+  })
+  const niche = clusterContactSignal({
+    contacts: [{ username: 'QuietMule', partnerDegree: 3, interactions: 1 }],
+    userCount: POP
+  })
+  assert.ok(niche.bits > hub.bits * 2)
+})
+
+// ── barcodes ──────────────────────────────────────────────────────────────────
+
+test('barcodeSignal: an obscure product beats a ubiquitous one', () => {
+  const obscure = barcodeSignal({
+    sharedBarcodes: [{ label: 'niche board game', df: 2 }],
+    userCount: POP
+  })
+  const ubiquitous = barcodeSignal({
+    sharedBarcodes: [{ label: 'Coca-Cola can', df: 1200 }],
+    userCount: POP
+  })
+  assert.ok(obscure.bits > ubiquitous.bits * 4)
+  assert.equal(obscure.channel, CHANNELS.PHYSICAL)
+})
+
+// ── negative evidence ─────────────────────────────────────────────────────────
+
+test('coActivitySignal: constant simultaneous activity is strong evidence AGAINST', () => {
+  const sig = coActivitySignal({ concurrentWindows: 90, comparableWindows: 200 })
+  assert.ok(sig.bits < -6, 'two people online together is a household, not an alt')
+})
+
+test('coActivitySignal: never overlapping is mildly supportive', () => {
+  const sig = coActivitySignal({ concurrentWindows: 0, comparableWindows: 300 })
+  assert.ok(sig.bits > 0)
+})
+
+test('coActivitySignal: stays silent without enough samples', () => {
+  assert.equal(coActivitySignal({ concurrentWindows: 0, comparableWindows: 5 }), null)
+})
+
+test('deviceMismatchSignal: disjoint platforms subtract', () => {
+  const sig = deviceMismatchSignal({
+    suspectDevices: ['Mobile · iOS · Safari'],
+    candidateDevices: ['Desktop · Windows · Chrome']
+  })
+  assert.ok(sig.bits < 0)
+  assert.equal(
+    deviceMismatchSignal({
+      suspectDevices: ['Desktop · Windows · Chrome'],
+      candidateDevices: ['Desktop · Windows · Chrome']
+    }),
+    null
+  )
+})
+
+test('precedesBanSignal: a long-established player is evidence against', () => {
+  const sig = precedesBanSignal({
+    candidateFirstSeen: new Date('2025-01-01T00:00:00Z'),
+    banAt: new Date('2026-06-30T00:00:00Z'),
+    activeBeforeBanDays: 400
+  })
+  assert.ok(sig.bits < 0)
+})
+
+// ── combination and tiers ─────────────────────────────────────────────────────
+
+test('combineSignals: same-channel signals do not stack linearly', () => {
+  const combined = combineSignals([
+    { channel: CHANNELS.NETWORK, key: 'a', label: 'a', bits: 10 },
+    { channel: CHANNELS.NETWORK, key: 'b', label: 'b', bits: 10 },
+    { channel: CHANNELS.NETWORK, key: 'c', label: 'c', bits: 10 }
+  ])
+  assert.ok(
+    combined.bits < 30,
+    'exact IP / subnet / ASN are views of one observation and must not self-corroborate'
+  )
+})
+
+test('combineSignals: respects per-channel caps', () => {
+  const combined = combineSignals([
+    { channel: CHANNELS.DEVICE, key: 'a', label: 'a', bits: 100 }
+  ])
+  assert.equal(combined.bits, CHANNEL_CAPS[CHANNELS.DEVICE])
+})
+
+test('combineSignals: negative evidence is applied in full and can zero a case', () => {
+  const combined = combineSignals([
+    { channel: CHANNELS.NETWORK, key: 'ip', label: 'ip', bits: 12 },
+    { channel: CHANNELS.NETWORK, key: 'concurrent', label: 'concurrent', bits: -14 }
+  ])
+  assert.ok(combined.bits < 0)
+  assert.equal(combined.tier, 'noise')
+})
+
+test('tierFor: a single uncorroborated channel cannot reach the top tier', () => {
+  assert.equal(tierFor(60, 1), 'weak', 'one spoofable signal must never read as proof')
+  assert.equal(tierFor(60, 3), 'compelling')
+  assert.equal(tierFor(22, 2), 'strong')
+})
+
+test('combineSignals: trivial signals across channels do not fake corroboration', () => {
+  const combined = combineSignals([
+    { channel: CHANNELS.NETWORK, key: 'a', label: 'a', bits: 1 },
+    { channel: CHANNELS.DEVICE, key: 'b', label: 'b', bits: 1 },
+    { channel: CHANNELS.ECONOMY, key: 'c', label: 'c', bits: 1 }
+  ])
+  assert.equal(combined.corroboratingChannels, 0)
+})
+
+// ── coverage ──────────────────────────────────────────────────────────────────
+
+test('buildCoverage: distinguishes "no data" from "no match"', () => {
+  const coverage = buildCoverage({ loginLogs: 40, fingerprints: 0, trades: 12 })
+  const device = coverage.find((c) => c.key === 'fingerprints')
+  const network = coverage.find((c) => c.key === 'loginLogs')
+  assert.equal(device.available, false, 'zero fingerprint rows is missing data, not exoneration')
+  assert.equal(network.available, true)
+})
+
+// ── end to end ────────────────────────────────────────────────────────────────
+
+const CONTEXT = {
+  userCount: POP,
+  banAt: new Date('2026-06-30T00:00:00Z'),
+  suspectEmail: 'zenviking@gmail.com',
+  suspectDevices: ['Desktop · Windows · Chrome'],
+  vpnIps: new Set()
+}
+
+test('scoreCandidate: a returning alt behind a VPN is still caught by durable signals', () => {
+  // No IP or fingerprint overlap at all — the VPN and a fresh browser did their
+  // job. What gives him away is the network, the loot, and the physical world.
+  const result = scoreCandidate(
+    {
+      userId: 'u-alt',
+      username: 'MegaOtterSage',
+      discordCreatedAt: new Date('2026-07-05T00:00:00Z'),
+      firstSeenAt: new Date('2026-07-06T00:00:00Z'),
+      clusterContacts: [
+        { username: 'LoopyWarriorWarrior', partnerDegree: 4, interactions: 3 },
+        { username: 'GalaxyJumperDruid', partnerDegree: 6, interactions: 2 }
+      ],
+      reacquiredMints: [
+        { name: 'Rare Toon', mintNumber: 3, rarity: 'Crazy Rare', lowMint: true, circulation: 8 }
+      ],
+      sharedBarcodes: [{ label: 'niche cereal', df: 2 }]
+    },
+    CONTEXT
+  )
+  assert.ok(result.bits >= 20, `expected a strong case, got ${result.bits}`)
+  assert.ok(['strong', 'compelling'].includes(result.tier))
+  assert.ok(result.corroboratingChannels >= 2)
+})
+
+test('scoreCandidate: a sibling on the same connection is not ranked as an alt', () => {
+  const result = scoreCandidate(
+    {
+      userId: 'u-sibling',
+      username: 'HappyKoalaScout',
+      // Same house: same IP, same subnet, overlapping social circle.
+      sharedIps: [{ ip: 'enc-home', df: 2, masked: '192.0.2.xxx' }],
+      sharedPartners: [{ username: 'SomeFriend', degree: 20 }],
+      // But they play at the same time constantly, and were here long before.
+      concurrentWindows: 140,
+      comparableWindows: 300,
+      firstSeenAt: new Date('2025-03-01T00:00:00Z'),
+      activeBeforeBanDays: 400,
+      deviceTypes: ['Mobile · Android · Chrome']
+    },
+    CONTEXT
+  )
+  assert.ok(
+    result.tier === 'noise' || result.tier === 'weak',
+    `a co-active long-standing sibling must not rank as an alt (got ${result.tier}, ${result.bits} bits)`
+  )
+})
+
+test('rankCandidates: orders by bits and drops non-positive cases', () => {
+  const ranked = rankCandidates(
+    [
+      { userId: 'a', username: 'A', sharedBarcodes: [{ label: 'x', df: 2 }] },
+      { userId: 'b', username: 'B' },
+      {
+        userId: 'c',
+        username: 'C',
+        clusterContacts: [
+          { username: 'm1', partnerDegree: 3, interactions: 5 },
+          { username: 'm2', partnerDegree: 3, interactions: 5 }
+        ],
+        sharedBarcodes: [{ label: 'y', df: 2 }]
+      }
+    ],
+    CONTEXT
+  )
+  assert.equal(ranked[0].userId, 'c')
+  assert.ok(!ranked.some((r) => r.userId === 'b'), 'candidates with no evidence are dropped')
+  for (let i = 1; i < ranked.length; i++) assert.ok(ranked[i - 1].bits >= ranked[i].bits)
+})
+
+test('rankCandidates: an empty investigation ranks nobody', () => {
+  const ranked = rankCandidates([{ userId: 'x', username: 'X' }], CONTEXT)
+  assert.equal(ranked.length, 0, 'the tool must be able to say the alt is not here')
+})


### PR DESCRIPTION
Adds a target-anchored tool for the case the existing Cheat Finder can't handle: one banned account, behind a VPN and a fresh browser, coming back on an alt. The existing tabs scan the world for groups sharing an IP or an ASN; this one starts from a banned account and expands outward.

Motivated by the ZenVikingGuru case. `prisma/audit-zen-trading.js` (already in the repo) names seven accounts from the original investigation, and the tool accepts them as extra seeds — he can change IP, browser and Discord account, but not the network he came back for.

## Read this part even if you skim the rest

`server/middleware/login-log.js` trusted the **leftmost** `X-Forwarded-For` entry, which is client-supplied — nginx's standard `$proxy_add_x_forwarded_for` *appends* the real peer, so a forged value stays in first position. Two live consequences:

1. Any alt evades all IP linkage by rotating the header per session.
2. Anyone who knows a victim's IP can log in with `X-Forwarded-For: <victim ip>` and **manufacture shared-IP evidence against them** — and `cheating-tool-apply` seizes items and deactivates accounts on that basis.

Fixed via `server/utils/requestIp.js`, which parses right-to-left skipping `TRUSTED_PROXY_HOPS` (default 1).

**Operational consequence: IP evidence collected before this deploy is not trustworthy, including everything currently in Cheat Finder.**

Two related data bugs fixed alongside it:

- `discord/callback.get.js` wrote **plaintext** IPs into `UserIP` while the login middleware wrote ciphertext, so `@@unique([userId, ip])` never deduped — one IP existed twice in two encodings and every IP-overlap count has been silently halved. Worth re-running `prisma/encrypt-existing-ips.js` after merge.
- `getKeyAndIV()` re-derived the key and ran a fresh SHA-256 on every call, on a per-request hot path. Now memoized.

## Scoring: bits, not 0–100

Each observation is scored as a log-likelihood ratio and summed across independent channels. Two properties drove the choice:

- **Rarity is automatic.** Sharing a carrier-grade NAT address is worth ~1 bit; sharing a residential IP only two accounts have used is worth ~11. A flat weighted sum can't express that and ranks households and school networks at the top.
- **Evidence can be negative.** A weighted sum floors at zero, so it always produces a #1 suspect even when the banned user never came back. That's the failure mode that bans an innocent kid. The tool can now say "no account met the threshold," and the UI presents that as a real answer.

Tiers additionally require corroboration from ≥2 independent channels, so a single spoofable signal can't read as proof.

## Signals, chosen for evasion resistance

**Dropped** as noise or actively misleading:

| Signal | Why |
|---|---|
| VPN ASN/ISP/country | The suspect is *known* to use a VPN; a commercial VPN ASN is shared by every privacy-minded player. Likelihood ratio ≈ 1. Now used *negatively* — a VPN exit IP discounts an IP match to near zero. |
| Username similarity | `set-username.post.js` restricts usernames to a closed 100×100×100 vocabulary, and the signup page has a randomize button. ~3% of all users share a token with any given name by chance. |
| Survey embedding cosine | Measures topic, not authorship — every answer is "played Cartoon Orbit as a kid." MinHash (literal copy-paste) kept. |
| Email domain | ~90% gmail. Replaced with normalized local-part matching (strips dots and `+suffix`), which catches a common evader mistake. |

**Added** — the signals a VPN and a fresh browser don't erase: shared physical barcode scans (users scan real UPCs off objects in their home), reacquisition of the banned account's specific mint numbers, contact with its known cluster, deck and wishlist composition.

Household false positives are suppressed by negative evidence, chiefly repeated simultaneous activity — that's what separates two siblings on one connection from one person alternating accounts.

## Safety and scope

- **Read-only.** Ranks and explains, then deep-links to the existing enforcement tools. No ban/seize path.
- Coverage is reported per channel so "no data" is never misread as exoneration — `DeviceFingerprintLog`, `SurveyAnswers` and `VpnLog` all shipped in late May 2026, so a user banned soon after may have only weeks of history.
- The list ships masked IPs, truncated fingerprint prefixes and an email match *type* — never raw identifiers. Redis caches slim payloads under a versioned per-suspect key with a 300s TTL, behind a rate limit and a single-flight lock. Access is audited to `AdminChangeLog` with counts only.
- The CLI masks by default and refuses to write a report anywhere inside the repo; `.gitignore` extended with `.env.*` and report globs.

## Indexes

Each fixes an existing sequential scan, not just new queries: **`Bid` and `Visit` had no indexes at all**, and `LoginLog` had no `userId` index despite the login middleware querying by it on nearly every request.

Subnet matching deliberately avoids the obvious implementation (decrypt every `LoginLog` row in Node — seconds of blocked event loop, hundreds of MB of heap). Instead it decrypts only the seed's addresses, enumerates the 256 addresses of each /24, encrypts those, and hands the result to an indexed `IN`.

## Validation

Run this before trusting any number:

```bash
node --env-file=.env prisma/alt-finder.js --suspect ZenVikingGuru \
  --known-alts LoopyWarriorWarrior,GalaxyJumperDruid,RockinBotSuperstar,GroovyOtterWizard,UltraGoblinWarrior,ChillSquirrelAgent,GlitchyPixelArchitect \
  --calibrate
```

Seeds with Zen alone and reports where the seven known-guilty accounts actually rank. If they don't reach the top tiers, the weights are wrong.

34 new tests pass (`tests/altAccountScoring.test.js`), including that a VPN-evading alt is still caught and that a co-active long-standing sibling is not. One **pre-existing** failure in `monsterBattleEngine.test.js` — confirmed failing on a clean tree, unrelated to this branch.

## Known issue left alone

`CheatFinderConfirmation.groupKey` is computed from sorted *usernames*, so a rename silently invalidates dismissals and can collide one onto a different set. Real bug, but fixing it changes every existing key and resurfaces previously-dismissed groups — wants its own migration rather than a quiet ride-along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018T36FL7AhuVbgKqyzAjqiJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018T36FL7AhuVbgKqyzAjqiJ)_