### PR TITLE
Auto-schedule dissolve queue entries from inactivity cron

### DIFF
--- a/prisma/migrations/20260805000000_add_dissolve_schedule_config/migration.sql
+++ b/prisma/migrations/20260805000000_add_dissolve_schedule_config/migration.sql
@@ -1,0 +1,6 @@
+-- Persisted default cadence for scheduling DissolveAuctionQueue entries, so the
+-- automatic 9-month inactivity dissolve cron can schedule newly-queued priority
+-- entries without requiring an admin to manually apply a schedule first.
+ALTER TABLE "GlobalGameConfig" ADD COLUMN IF NOT EXISTS "dissolveScheduleCadenceDays"        INTEGER DEFAULT 7;
+ALTER TABLE "GlobalGameConfig" ADD COLUMN IF NOT EXISTS "dissolveScheduleFeaturedPerCadence" INTEGER DEFAULT 2;
+ALTER TABLE "GlobalGameConfig" ADD COLUMN IF NOT EXISTS "dissolveScheduleOtherPerCadence"    INTEGER DEFAULT 10;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1301,6 +1301,13 @@ model GlobalGameConfig {
   featuredDissolveRarities   Json     @default("[]")
   featuredDissolveSeries     Json     @default("[]")
   featuredDissolveSets       Json     @default("[]")
+  // Default cadence for scheduling DissolveAuctionQueue entries, set via the
+  // "Reschedule All" form on /admin/dissolve-queue and reused automatically by
+  // the 9-month inactivity dissolve cron so newly-queued priority entries get
+  // scheduledFor set without needing an admin to visit the page.
+  dissolveScheduleCadenceDays        Int @default(7)
+  dissolveScheduleFeaturedPerCadence Int @default(2)
+  dissolveScheduleOtherPerCadence    Int @default(10)
   // Site favicon / meta-icon set, uploaded from Admin > Manage Homepage > Favicon.
   // faviconVersion is bumped on every upload and appended as a cache-busting
   // query string to every icon URL rendered in pages/index.vue's useHead.

--- a/server/api/admin/dissolve-queue/schedule.post.js
+++ b/server/api/admin/dissolve-queue/schedule.post.js
@@ -1,8 +1,7 @@
 // server/api/admin/dissolve-queue/schedule.post.js
 // Reschedule all (or unscheduled) dissolve-queue entries from the management page.
 import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
-import { prisma } from '@/server/prisma'
-import { scheduleDissolveAuctionLaunch, cancelDissolveAuctionLaunch } from '@/server/utils/queues'
+import { applyDissolveSchedule, saveDissolveScheduleConfig } from '@/server/utils/dissolveSchedule'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -24,54 +23,14 @@ export default defineEventHandler(async (event) => {
   } = body
 
   if (!startAtUtc) throw createError({ statusCode: 400, statusMessage: 'startAtUtc required' })
-  const startMs = new Date(startAtUtc).getTime()
-  if (isNaN(startMs)) throw createError({ statusCode: 400, statusMessage: 'Invalid startAtUtc' })
+  if (isNaN(new Date(startAtUtc).getTime())) throw createError({ statusCode: 400, statusMessage: 'Invalid startAtUtc' })
   if (!cadenceDays || Number(cadenceDays) < 1) throw createError({ statusCode: 400, statusMessage: 'cadenceDays must be >= 1' })
 
-  const perCategory = {
-    FEATURED: Number(featuredPerCadence) || 0,
-    OTHER:    Number(otherPerCadence)    || 0,
-  }
+  // Persist as the default cadence so the automatic 9-month inactivity dissolve
+  // cron can keep scheduling new entries the same way going forward.
+  await saveDissolveScheduleConfig({ cadenceDays, featuredPerCadence, otherPerCadence })
 
-  // Fetch entries to schedule
-  const entries = await prisma.dissolveAuctionQueue.findMany({
-    where: reschedule ? {} : { scheduledFor: null },
-    orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
-    select: { id: true, category: true, scheduledFor: true }
-  })
-
-  if (!entries.length) return { scheduled: 0 }
-
-  // If rescheduling, cancel existing BullMQ jobs first
-  if (reschedule) {
-    for (const e of entries) {
-      if (e.scheduledFor) {
-        await cancelDissolveAuctionLaunch(e.id)
-      }
-    }
-  }
-
-  // Group by category
-  const grouped = { FEATURED: [], OTHER: [] }
-  for (const e of entries) grouped[e.category]?.push(e.id)
-
-  let scheduled = 0
-
-  for (const [cat, ids] of Object.entries(grouped)) {
-    const countPerCadence = perCategory[cat]
-    if (!countPerCadence || !ids.length) continue
-    const intervalMs = (Number(cadenceDays) * 24 * 3600 * 1000) / countPerCadence
-
-    for (let i = 0; i < ids.length; i++) {
-      const scheduledFor = new Date(startMs + i * intervalMs)
-      await prisma.dissolveAuctionQueue.update({
-        where: { id: ids[i] },
-        data:  { scheduledFor }
-      })
-      await scheduleDissolveAuctionLaunch(ids[i], scheduledFor)
-      scheduled++
-    }
-  }
+  const scheduled = await applyDissolveSchedule({ startAtUtc, cadenceDays, featuredPerCadence, otherPerCadence, reschedule })
 
   return { scheduled }
 })

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -12,6 +12,7 @@ import { syncWordleResults } from '../../server/utils/wordle.js'
 import { checkAndCreateWeeklyCZoneContest } from './create-weekly-czone-contest.js'
 import { runEconomyAggregate } from './economy-aggregate.js'
 import { getFeaturedDissolveConfig, isCtoonFeatured } from '../utils/featuredDissolveConfig.js'
+import { applyDissolveSchedule, getDissolveScheduleConfig } from '../utils/dissolveSchedule.js'
 import { logAuctionOnlyError } from '../utils/auctionOnlyErrorLog.js'
 import { activateAuctionOnlyRow, AUCTION_ONLY_ROW_INCLUDE } from '../utils/auctionOnlyActivate.js'
 import { logCronError } from '../utils/cronErrorLog.js'
@@ -592,6 +593,7 @@ async function enforceDormantAccounts() {
   })
 
   const featuredConfig = await getFeaturedDissolveConfig()
+  let anyQueued = false
 
   for (const u of batch) {
     // DM best-effort
@@ -665,11 +667,31 @@ async function enforceDormantAccounts() {
           update: { priority: true, fromInactive: true, sourceUsername: u.username },
           create: { userCtoonId: uc.id, category, isFeatured, priority: true, fromInactive: true, sourceUsername: u.username }
         })
+        anyQueued = true
       }
 
       // 3.3 disable account
       await tx.user.update({ where: { id: u.id }, data: { active: false } })
     })
+  }
+
+  // 3.4 auto-schedule the queue so these priority entries actually launch
+  // instead of sitting as "unscheduled" until an admin visits the dissolve
+  // queue page. Recomputes every entry (reschedule: true) so the new
+  // priority ones jump ahead of already-scheduled non-priority entries.
+  if (anyQueued) {
+    try {
+      const { cadenceDays, featuredPerCadence, otherPerCadence } = await getDissolveScheduleConfig()
+      await applyDissolveSchedule({
+        startAtUtc: new Date(),
+        cadenceDays,
+        featuredPerCadence,
+        otherPerCadence,
+        reschedule: true
+      })
+    } catch (err) {
+      console.error('[enforceDormantAccounts] Failed to auto-schedule dissolve queue:', err)
+    }
   }
 }
 

--- a/server/utils/dissolveSchedule.js
+++ b/server/utils/dissolveSchedule.js
@@ -1,0 +1,102 @@
+// server/utils/dissolveSchedule.js
+// Shared scheduling logic for the DissolveAuctionQueue, used by both the admin
+// "Reschedule All" endpoint and the automatic 9-month inactivity dissolve cron
+// job. Assigns evenly-spaced `scheduledFor` times per category (FEATURED /
+// OTHER), ordered priority-first (inactivity dissolves jump the queue ahead of
+// admin-initiated dissolves), then by creation order.
+import { prisma } from '../prisma.js'
+import { scheduleDissolveAuctionLaunch, cancelDissolveAuctionLaunch } from './queues.js'
+
+const CONFIG_ID = 'singleton'
+
+// Persisted cadence defaults, read/written to GlobalGameConfig so the
+// inactivity-dissolve cron can reuse whatever an admin last configured via
+// the "Reschedule All" form on /admin/dissolve-queue.
+export async function getDissolveScheduleConfig() {
+  const config = await prisma.globalGameConfig.findUnique({
+    where: { id: CONFIG_ID },
+    select: {
+      dissolveScheduleCadenceDays:        true,
+      dissolveScheduleFeaturedPerCadence: true,
+      dissolveScheduleOtherPerCadence:    true,
+    }
+  })
+  return {
+    cadenceDays:        config?.dissolveScheduleCadenceDays        ?? 7,
+    featuredPerCadence: config?.dissolveScheduleFeaturedPerCadence ?? 2,
+    otherPerCadence:    config?.dissolveScheduleOtherPerCadence    ?? 10,
+  }
+}
+
+export async function saveDissolveScheduleConfig({ cadenceDays, featuredPerCadence, otherPerCadence }) {
+  await prisma.globalGameConfig.upsert({
+    where:  { id: CONFIG_ID },
+    update: {
+      dissolveScheduleCadenceDays:        Number(cadenceDays),
+      dissolveScheduleFeaturedPerCadence: Number(featuredPerCadence),
+      dissolveScheduleOtherPerCadence:    Number(otherPerCadence),
+    },
+    create: {
+      id: CONFIG_ID,
+      dissolveScheduleCadenceDays:        Number(cadenceDays),
+      dissolveScheduleFeaturedPerCadence: Number(featuredPerCadence),
+      dissolveScheduleOtherPerCadence:    Number(otherPerCadence),
+    }
+  })
+}
+
+/**
+ * Assign scheduledFor times to DissolveAuctionQueue entries and schedule their
+ * BullMQ launch jobs.
+ * @param {object} opts
+ * @param {Date|string} opts.startAtUtc
+ * @param {number} opts.cadenceDays
+ * @param {number} opts.featuredPerCadence
+ * @param {number} opts.otherPerCadence
+ * @param {boolean} [opts.reschedule] - if true, recompute every entry (not just unscheduled ones)
+ * @returns {Promise<number>} number of entries scheduled
+ */
+export async function applyDissolveSchedule({ startAtUtc, cadenceDays, featuredPerCadence, otherPerCadence, reschedule = false }) {
+  const startMs = new Date(startAtUtc).getTime()
+  if (isNaN(startMs)) throw new Error('Invalid startAtUtc')
+
+  const perCategory = {
+    FEATURED: Number(featuredPerCadence) || 0,
+    OTHER:    Number(otherPerCadence)    || 0,
+  }
+
+  const entries = await prisma.dissolveAuctionQueue.findMany({
+    where: reschedule ? {} : { scheduledFor: null },
+    orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
+    select: { id: true, category: true, scheduledFor: true }
+  })
+  if (!entries.length) return 0
+
+  if (reschedule) {
+    for (const e of entries) {
+      if (e.scheduledFor) await cancelDissolveAuctionLaunch(e.id)
+    }
+  }
+
+  const grouped = { FEATURED: [], OTHER: [] }
+  for (const e of entries) grouped[e.category]?.push(e.id)
+
+  let scheduled = 0
+  for (const [cat, ids] of Object.entries(grouped)) {
+    const countPerCadence = perCategory[cat]
+    if (!countPerCadence || !ids.length) continue
+    const intervalMs = (Number(cadenceDays) * 24 * 3600 * 1000) / countPerCadence
+
+    for (let i = 0; i < ids.length; i++) {
+      const scheduledFor = new Date(startMs + i * intervalMs)
+      await prisma.dissolveAuctionQueue.update({
+        where: { id: ids[i] },
+        data:  { scheduledFor }
+      })
+      await scheduleDissolveAuctionLaunch(ids[i], scheduledFor)
+      scheduled++
+    }
+  }
+
+  return scheduled
+}


### PR DESCRIPTION
## Summary
Refactors dissolve queue scheduling logic into a reusable utility module and enables the 9-month inactivity cron job to automatically schedule newly-queued priority entries without requiring manual admin intervention.

## Key Changes
- **New utility module** (`server/utils/dissolveSchedule.js`): Extracted shared scheduling logic that was previously only in the admin endpoint, including:
  - `getDissolveScheduleConfig()` - retrieves persisted cadence defaults from database
  - `saveDissolveScheduleConfig()` - persists admin-configured cadence settings
  - `applyDissolveSchedule()` - core scheduling algorithm that assigns evenly-spaced times per category with priority-first ordering

- **Admin endpoint refactor** (`server/api/admin/dissolve-queue/schedule.post.js`): Simplified to use the new utility functions and now persists the configured cadence as defaults for the cron job

- **Inactivity cron enhancement** (`server/cron/sync-guild-members.js`): Added auto-scheduling logic in `enforceDormantAccounts()` that:
  - Detects when priority entries are queued from inactivity detection
  - Automatically applies the saved schedule configuration to those entries
  - Reschedules all entries so new priority items jump ahead of already-scheduled ones
  - Includes error handling to prevent cron failures

- **Database schema** (`prisma/schema.prisma` + migration): Added three new fields to `GlobalGameConfig` to persist the dissolve schedule cadence:
  - `dissolveScheduleCadenceDays` (default: 7)
  - `dissolveScheduleFeaturedPerCadence` (default: 2)
  - `dissolveScheduleOtherPerCadence` (default: 10)

## Implementation Details
- The scheduling algorithm maintains priority-first ordering (inactivity dissolves jump ahead) followed by creation order
- Entries are grouped by category (FEATURED/OTHER) and assigned evenly-spaced times within each cadence period
- The cron job gracefully handles scheduling failures without disrupting the account deactivation process
- Default cadence values ensure the system works out-of-the-box even if no admin has configured the schedule yet

https://claude.ai/code/session_01CEx1stFNfyXb6mBsx28zr9