### PR TITLE
Add cZone warning to auction modal

### DIFF
--- a/components/newsite/AuctionModal.vue
+++ b/components/newsite/AuctionModal.vue
@@ -32,6 +32,13 @@
             </div>
           </div>
 
+          <!-- cZone warning -->
+          <div v-if="inCzone" class="am-warning">
+            This cToon is in one of your cZone layouts. If the auction sells, it won't be
+            removed automatically — pull it out of your cZone yourself, or it'll keep
+            showing there even after you no longer own it.
+          </div>
+
           <hr class="am-divider" />
 
           <!-- Initial bid -->
@@ -155,6 +162,7 @@ const sending        = ref(false)
 const recentAuctions = ref([])
 const suggestion     = ref(null)
 const loadingSuggestion = ref(true)
+const inCzone        = ref(false)
 const toast          = reactive({ message: '', type: 'success' })
 
 onMounted(async () => {
@@ -167,6 +175,7 @@ onMounted(async () => {
     })
     recentAuctions.value = Array.isArray(res?.sales) ? res.sales : []
     suggestion.value     = res?.suggestion ?? null
+    inCzone.value        = !!res?.inCzone
   } catch {
     recentAuctions.value = []
     suggestion.value     = null
@@ -429,6 +438,17 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
 .am-input:focus { border-color: var(--OrbitLightBlue); }
 
 .am-error { font-size: 0.62rem; color: #fca5a5; }
+
+/* ── cZone warning ── */
+.am-warning {
+  font-size: 0.68rem;
+  line-height: 1.4;
+  color: #fde68a;
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.35);
+  border-radius: 6px;
+  padding: 7px 9px;
+}
 
 /* ── Presets ── */
 .am-presets { display: flex; flex-wrap: wrap; gap: 4px; }

--- a/server/api/ctoon/[id]/getRecentAuctions.get.js
+++ b/server/api/ctoon/[id]/getRecentAuctions.get.js
@@ -122,6 +122,10 @@ export default defineEventHandler(async (event) => {
   // encoded id is unsigned and forgeable, so an unverified one would let anyone
   // probe whether a given (user, cToon, mint) exists.
   let mintNumber = null
+  // Whether this exact UserCtoon is currently placed in the caller's cZone
+  // layout — surfaced so the "Send to Auction" modal can warn that selling it
+  // won't pull it out of the layout automatically.
+  let inCzone = false
   const rawUserCtoonId = Array.isArray(query.userCtoonId) ? query.userCtoonId[0] : query.userCtoonId
   if (rawUserCtoonId) {
     const resolvedId = await resolveUserCtoonId(String(rawUserCtoonId))
@@ -132,6 +136,17 @@ export default defineEventHandler(async (event) => {
       })
       if (owned && owned.userId === me.id && owned.ctoonId === id && !owned.burnedAt) {
         mintNumber = owned.mintNumber
+
+        const cZone = await prisma.cZone.findUnique({
+          where: { userId: me.id },
+          select: { layoutData: true }
+        })
+        const zones = cZone?.layoutData && typeof cZone.layoutData === 'object'
+          ? cZone.layoutData.zones
+          : null
+        if (Array.isArray(zones)) {
+          inCzone = zones.some(z => Array.isArray(z?.toons) && z.toons.some(t => t?.id === resolvedId))
+        }
       }
     }
   }
@@ -152,6 +167,7 @@ export default defineEventHandler(async (event) => {
 
   return {
     sales: sales.slice(0, DISPLAY_COUNT).map(toDisplay),
-    suggestion
+    suggestion,
+    inCzone
   }
 })


### PR DESCRIPTION
## Summary
Added a warning message to the "Send to Auction" modal that alerts users when a cToon is currently placed in one of their cZone layouts. This helps prevent confusion about why the cToon won't be automatically removed from the layout after the auction sells.

## Key Changes
- **Frontend (AuctionModal.vue)**:
  - Added `inCzone` reactive ref to track whether the cToon is in a cZone layout
  - Display a warning message when `inCzone` is true, informing users they must manually remove the cToon from their cZone layout
  - Added `.am-warning` CSS styling with yellow/amber color scheme to match the warning tone

- **Backend (getRecentAuctions.get.js)**:
  - Query the user's cZone layout data when a UserCtoon ID is provided
  - Check if the cToon exists in any of the zones within the layout
  - Return `inCzone` boolean flag in the API response

## Implementation Details
- The backend checks the cZone's `layoutData.zones` array to determine if the resolved UserCtoon ID matches any toon in the layout
- The warning is only displayed when the user owns the cToon and it's currently placed in their cZone
- The warning styling uses a subtle amber background with matching border to indicate a cautionary message without being alarming

https://claude.ai/code/session_01Qzh6HMEbv57rbFEES33Jh8