### PR TITLE
Update cZone auction warning and fix post-login redirect

### DIFF
--- a/components/newsite/AuctionModal.vue
+++ b/components/newsite/AuctionModal.vue
@@ -34,9 +34,8 @@
 
           <!-- cZone warning -->
           <div v-if="inCzone" class="am-warning">
-            This cToon is in one of your cZone layouts. If the auction sells, it won't be
-            removed automatically — pull it out of your cZone yourself, or it'll keep
-            showing there even after you no longer own it.
+            This cToon is in one of your cZone layouts. If the auction sells, it will be
+            removed automatically.
           </div>
 
           <hr class="am-divider" />

--- a/server/api/auth/discord/callback.get.js
+++ b/server/api/auth/discord/callback.get.js
@@ -164,5 +164,7 @@ export default defineEventHandler(async (event) => {
   })
 
   // 6) Redirect: new accounts go to username setup
-  return sendRedirect(event, result.isNew ? '/setup-username' : '/dashboard')
+  if (result.isNew) return sendRedirect(event, '/setup-username')
+  const destination = config.public.viewNewDesign === '1' ? '/newsite/home' : '/dashboard'
+  return sendRedirect(event, destination)
 })

--- a/server/api/auth/discord/callback.get.js
+++ b/server/api/auth/discord/callback.get.js
@@ -165,6 +165,5 @@ export default defineEventHandler(async (event) => {
 
   // 6) Redirect: new accounts go to username setup
   if (result.isNew) return sendRedirect(event, '/setup-username')
-  const destination = config.public.viewNewDesign === '1' ? '/newsite/home' : '/dashboard'
-  return sendRedirect(event, destination)
+  return sendRedirect(event, '/newsite/home')
 })


### PR DESCRIPTION
## Summary
This PR updates user-facing messaging and corrects the post-authentication redirect flow.

## Key Changes
- **cZone auction warning**: Updated the warning message to reflect that cToons will now be removed automatically from cZone layouts when their auction sells, removing the previous manual intervention requirement
- **Discord auth redirect**: Fixed the post-login redirect to send existing users to `/newsite/home` instead of `/dashboard`, ensuring consistent navigation to the new site

## Implementation Details
- The cZone warning message was simplified to accurately communicate the new automatic removal behavior
- The Discord callback handler now explicitly checks `result.isNew` and redirects new users to the username setup flow, while all other users are directed to the new home page

https://claude.ai/code/session_012uM9gXrb5fs13F6nQGu8vg