### PR TITLE
Remove VIEWNEWDESIGN feature flag and make newsite default

### DIFF
--- a/components/Nav.vue
+++ b/components/Nav.vue
@@ -28,7 +28,7 @@
       <!-- logo: right on small, centered on md+ -->
       <NuxtLink
         v-if="!hasAdUrl"
-        to="/dashboard"
+        to="/newsite/home"
         class="absolute inset-y-0 left-1/2 -translate-x-1/2 right-auto flex items-center gap-3"
       >
         <img :src="currentAdSrc || '/images/newlogo.gif'" alt="Cartoon ReOrbit logo" class="max-h-20 max-w-[300px] w-auto h-auto object-contain md:h-20 md:max-h-none md:max-w-none" />
@@ -251,8 +251,8 @@ const q = ref('')
 
 /* main links */
 const mainLinks = [
-  { label: 'Showcase', to: '/dashboard' },
-  { label: 'My cZone', to: user.value?.username ? `/czone/${user.value.username}` : '/dashboard' },
+  { label: 'Showcase', to: '/newsite/home' },
+  { label: 'My cZone', to: user.value?.username ? `/czone/${user.value.username}` : '/newsite/home' },
   { label: 'Collection', to: '/collection' },
   { label: 'Achievements', to: '/achievements' },
   { label: 'cMart', to: '/cmart' },

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -8,9 +8,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     if (user.value?.active === false) return navigateTo('/join-discord?inactive=1')
     if (user.value?.needsSetup) return navigateTo('/setup-username')
     if (user.value) {
-      const { public: { viewNewDesign } } = useRuntimeConfig()
-      if (viewNewDesign === '1') return navigateTo('/newsite/home')
-      return navigateTo('/dashboard')
+      return navigateTo('/newsite/home')
     }
     return
   }
@@ -39,7 +37,6 @@ export default defineNuxtRouteMiddleware(async (to) => {
   }
 
   if (to.path === '/dashboard') {
-    const { public: { viewNewDesign } } = useRuntimeConfig()
-    if (viewNewDesign === '1') return navigateTo('/newsite/home')
+    return navigateTo('/newsite/home')
   }
 })

--- a/middleware/home-redirect.global.js
+++ b/middleware/home-redirect.global.js
@@ -6,8 +6,6 @@ export default defineNuxtRouteMiddleware( async (to) => {
   if (user.value?.active === false) return navigateTo('/join-discord?inactive=1')
   if (user.value?.needsSetup) return navigateTo('/setup-username')
   if (user.value) {
-    const { public: { viewNewDesign } } = useRuntimeConfig()
-    if (viewNewDesign === '1') return navigateTo('/newsite/home')
-    return navigateTo('/dashboard')
+    return navigateTo('/newsite/home')
   }
 })

--- a/middleware/newsite.js
+++ b/middleware/newsite.js
@@ -1,13 +1,6 @@
 // middleware/newsite.js
-// Gates all /newsite/* pages behind the VIEWNEWDESIGN flag and auth.
+// Gates all /newsite/* pages behind auth.
 export default defineNuxtRouteMiddleware(async (to) => {
-  const { public: { viewNewDesign } } = useRuntimeConfig()
-
-  // If the flag is off, redirect away from newsite pages
-  if (viewNewDesign !== '1') {
-    return navigateTo('/dashboard')
-  }
-
   // Require authentication
   const { user, fetchSelf } = useAuth()
   if (!user.value) {

--- a/pages/admin/manage-ads.vue
+++ b/pages/admin/manage-ads.vue
@@ -37,7 +37,7 @@
                 {{ img.url }}
               </a>
             </p>
-            <p v-else class="mt-1 text-gray-500"><strong>URL:</strong> /dashboard (default)</p>
+            <p v-else class="mt-1 text-gray-500"><strong>URL:</strong> /newsite/home (default)</p>
           </div>
           <div class="p-3 pt-0 flex justify-end gap-2">
             <button
@@ -80,7 +80,7 @@
                 placeholder="https://example.com"
                 class="w-full border rounded px-3 py-2"
               />
-              <p class="text-xs text-gray-500 mt-1">Leave blank to link to /dashboard</p>
+              <p class="text-xs text-gray-500 mt-1">Leave blank to link to /newsite/home</p>
             </div>
             <div v-if="uploadError" class="text-red-600 text-sm">{{ uploadError }}</div>
           </div>

--- a/pages/join-discord.vue
+++ b/pages/join-discord.vue
@@ -57,7 +57,7 @@
           const data = await res.json()
           if (data.inGuild) {
             if (checkInterval) clearInterval(checkInterval)
-            router.push('/dashboard')
+            router.push('/newsite/home')
           }
         }
       } catch (err) {

--- a/pages/setup-username.vue
+++ b/pages/setup-username.vue
@@ -205,7 +205,7 @@ part3.value = sample(wordLists[2])
 /* ── Lifecycle ──────────────────────────────────────────────────────── */
 onMounted(async () => {
   if (!user.value) return navigateTo('/')
-  if (!user.value.needsSetup) return navigateTo('/dashboard')
+  if (!user.value.needsSetup) return navigateTo('/newsite/home')
 
   if (user.value.username) {
     step.value = 2 // username already set

--- a/pages/submit-ctoon.vue
+++ b/pages/submit-ctoon.vue
@@ -469,7 +469,7 @@ async function submitAll() {
   submitting.value = false
   if (allOk) {
     showToast('All cToons submitted! You\'ll be notified on Discord when reviewed.', 'success')
-    setTimeout(() => router.push('/dashboard'), 2000)
+    setTimeout(() => router.push('/newsite/home'), 2000)
   }
 }
 

--- a/server/api/auth/discord.get.js
+++ b/server/api/auth/discord.get.js
@@ -16,7 +16,7 @@ export default defineEventHandler(async (event) => {
         const payload = jwt.verify(token, config.jwtSecret)
         userId = payload.sub
         event.context.userId = userId // make it available to downstream handlers
-        return sendRedirect(event, '/dashboard', 302)
+        return sendRedirect(event, '/newsite/home', 302)
       } catch {
         const params = new URLSearchParams({
           client_id: config.discord.clientId,
@@ -42,7 +42,7 @@ export default defineEventHandler(async (event) => {
       return sendRedirect(event, discordAuthUrl, 302)
     }
   } else {
-    return sendRedirect(event, '/dashboard', 302)
+    return sendRedirect(event, '/newsite/home', 302)
   }
 
   // if (!userId) {


### PR DESCRIPTION
## Summary
This PR removes the `VIEWNEWDESIGN` feature flag and makes the new site design the default experience for all authenticated users. All references to the flag have been removed, and all redirect logic now points to `/newsite/home` instead of `/dashboard`.

## Key Changes
- **Removed feature flag checks**: Eliminated all `viewNewDesign` runtime config checks from middleware and components
- **Updated authentication flows**: Modified `auth.js`, `newsite.js`, and `home-redirect.global.js` middleware to always redirect authenticated users to `/newsite/home`
- **Updated navigation links**: Changed all `/dashboard` links to `/newsite/home` in the Nav component and admin pages
- **Updated redirect endpoints**: Changed Discord OAuth callback and post-signup redirects to point to `/newsite/home`
- **Updated user-facing text**: Changed placeholder text in admin ads management to reference `/newsite/home` as the default

## Implementation Details
- The `newsite.js` middleware now only enforces authentication, removing the feature flag gate
- All authenticated user redirects (login, setup completion, ad clicks) now consistently point to `/newsite/home`
- The new design is now the permanent default experience with no option to revert to the old dashboard

https://claude.ai/code/session_01XpEWMKbGtm11u3cCboDaMH