### PR TITLE
Add per-entry reschedule functionality to dissolve queue admin

### DIFF
--- a/pages/admin/dissolve-queue.vue
+++ b/pages/admin/dissolve-queue.vue
@@ -58,11 +58,26 @@
               <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 shrink-0">
                 <div class="hidden sm:block text-xs text-gray-600">{{ fmtCST(entry.scheduledFor) }}</div>
                 <button
+                  @click="openReschedule(entry)"
+                  class="text-xs text-blue-600 hover:text-blue-800"
+                >Reschedule</button>
+                <button
                   @click="cancelEntry(entry.id)"
                   class="text-xs text-red-500 hover:text-red-700"
                   :disabled="cancellingId === entry.id"
                 >{{ cancellingId === entry.id ? '…' : 'Unschedule' }}</button>
               </div>
+            </div>
+            <div v-if="reschedulingId === entry.id" class="mt-3 flex flex-wrap items-center gap-2 pl-0 sm:pl-[52px]">
+              <input v-model="rescheduleLocal" type="datetime-local"
+                     class="text-xs border rounded px-2 py-1.5" />
+              <button
+                @click="saveReschedule(entry.id)"
+                :disabled="reschedulingSaving"
+                class="px-3 py-1.5 text-xs rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+              >{{ reschedulingSaving ? 'Saving…' : 'Save' }}</button>
+              <button @click="cancelReschedule" class="px-3 py-1.5 text-xs rounded-md border border-gray-300 hover:bg-gray-50">Cancel</button>
+              <div v-if="rescheduleError" class="text-xs text-red-600 w-full">{{ rescheduleError }}</div>
             </div>
           </div>
         </div>
@@ -182,13 +197,28 @@
                   {{ entry.scheduledFor ? fmtCST(entry.scheduledFor) : 'Not scheduled' }}
                 </div>
               </div>
-              <div class="shrink-0">
+              <div class="shrink-0 flex flex-col items-end gap-1">
+                <button
+                  @click="openReschedule(entry)"
+                  class="text-xs text-blue-600 hover:text-blue-800"
+                >Reschedule</button>
                 <button
                   @click="cancelEntry(entry.id)"
                   class="text-xs text-red-500 hover:text-red-700"
                   :disabled="cancellingId === entry.id"
                 >{{ cancellingId === entry.id ? '…' : (entry.scheduledFor ? 'Unschedule' : 'Remove') }}</button>
               </div>
+            </div>
+            <div v-if="reschedulingId === entry.id" class="mt-3 flex flex-wrap items-center gap-2 pl-0 sm:pl-[52px]">
+              <input v-model="rescheduleLocal" type="datetime-local"
+                     class="text-xs border rounded px-2 py-1.5" />
+              <button
+                @click="saveReschedule(entry.id)"
+                :disabled="reschedulingSaving"
+                class="px-3 py-1.5 text-xs rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+              >{{ reschedulingSaving ? 'Saving…' : 'Save' }}</button>
+              <button @click="cancelReschedule" class="px-3 py-1.5 text-xs rounded-md border border-gray-300 hover:bg-gray-50">Cancel</button>
+              <div v-if="rescheduleError" class="text-xs text-red-600 w-full">{{ rescheduleError }}</div>
             </div>
           </div>
         </div>
@@ -533,6 +563,62 @@ async function applySchedule() {
     scheduleError.value = e?.data?.statusMessage || 'Failed to apply schedule.'
   } finally {
     scheduling.value = false
+  }
+}
+
+// Per-entry reschedule
+const reschedulingId      = ref(null)
+const rescheduleLocal     = ref('')
+const reschedulingSaving  = ref(false)
+const rescheduleError     = ref('')
+
+function toDatetimeLocal(iso) {
+  const d = iso ? new Date(iso) : new Date()
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function openReschedule(entry) {
+  rescheduleError.value = ''
+  reschedulingId.value  = entry.id
+  rescheduleLocal.value = toDatetimeLocal(entry.scheduledFor)
+}
+
+function cancelReschedule() {
+  reschedulingId.value  = null
+  rescheduleLocal.value = ''
+  rescheduleError.value = ''
+}
+
+function updateEntryInLists(id, patch) {
+  const apply = (list) => {
+    const idx = list.findIndex(e => e.id === id)
+    if (idx !== -1) list[idx] = { ...list[idx], ...patch }
+  }
+  apply(upcoming.value)
+  apply(allEntries.value)
+}
+
+async function saveReschedule(id) {
+  rescheduleError.value = ''
+  if (!rescheduleLocal.value) {
+    rescheduleError.value = 'Please choose a date/time.'
+    return
+  }
+  reschedulingSaving.value = true
+  try {
+    const scheduledForUtc = new Date(rescheduleLocal.value).toISOString()
+    await $fetch(`/api/admin/dissolve-queue/${id}`, {
+      method: 'PATCH',
+      body: { scheduledForUtc }
+    })
+    updateEntryInLists(id, { scheduledFor: scheduledForUtc })
+    cancelReschedule()
+    await loadData()
+  } catch (e) {
+    rescheduleError.value = e?.data?.statusMessage || 'Failed to reschedule entry.'
+  } finally {
+    reschedulingSaving.value = false
   }
 }
 

--- a/server/api/admin/dissolve-queue/[id].patch.js
+++ b/server/api/admin/dissolve-queue/[id].patch.js
@@ -1,0 +1,33 @@
+// server/api/admin/dissolve-queue/[id].patch.js
+// Reschedule a single dissolve-queue entry to a new date/time.
+import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { scheduleDissolveAuctionLaunch } from '@/server/utils/queues'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const { id } = event.context.params || {}
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing id' })
+
+  const body = await readBody(event) || {}
+  const { scheduledForUtc } = body
+  if (!scheduledForUtc) throw createError({ statusCode: 400, statusMessage: 'scheduledForUtc required' })
+  const scheduledFor = new Date(scheduledForUtc)
+  if (isNaN(scheduledFor.getTime())) throw createError({ statusCode: 400, statusMessage: 'Invalid scheduledForUtc' })
+
+  const entry = await prisma.dissolveAuctionQueue.findUnique({ where: { id } })
+  if (!entry) throw createError({ statusCode: 404, statusMessage: 'Queue entry not found' })
+
+  await prisma.dissolveAuctionQueue.update({ where: { id }, data: { scheduledFor } })
+  await scheduleDissolveAuctionLaunch(id, scheduledFor)
+
+  return { ok: true, scheduledFor }
+})


### PR DESCRIPTION
## Summary
This PR adds the ability to reschedule individual dissolve queue entries to a new date/time, providing more granular control over scheduled auctions without having to cancel and recreate entries.

## Key Changes
- **Frontend UI**: Added "Reschedule" button next to each queue entry in both the upcoming and all entries sections
- **Reschedule Modal**: Implemented an inline datetime picker that appears when rescheduling is initiated, with save/cancel options and error handling
- **Backend API**: Created new `PATCH /api/admin/dissolve-queue/[id]` endpoint to update the scheduled time for a queue entry
- **State Management**: Added reactive state variables (`reschedulingId`, `rescheduleLocal`, `reschedulingSaving`, `rescheduleError`) to manage the reschedule UI flow
- **Helper Functions**: 
  - `toDatetimeLocal()`: Converts ISO datetime to HTML5 datetime-local format
  - `openReschedule()`: Initializes reschedule UI with current scheduled time
  - `saveReschedule()`: Validates input and persists changes via API
  - `updateEntryInLists()`: Syncs updated entry across both upcoming and allEntries lists

## Implementation Details
- The reschedule UI uses a native HTML5 `datetime-local` input for better UX across devices
- The backend validates admin authorization and entry existence before updating
- After successful reschedule, the queue job is re-scheduled via `scheduleDissolveAuctionLaunch()`
- Both list views (upcoming and all entries) are updated in-place and then fully reloaded to ensure consistency
- Error messages are displayed inline within the reschedule form

https://claude.ai/code/session_019YCf3vY4u2TpqM3SiRHLdM