### PR TITLE
Add cMoon faction feature, gated behind an off-by-default admin flag

### DIFF
--- a/components/CMoonSelectModal.vue
+++ b/components/CMoonSelectModal.vue
@@ -1,0 +1,249 @@
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="cms-overlay">
+      <div class="cms-modal">
+        <div class="cms-header">
+          <h2 class="cms-title">Choose your cMoon</h2>
+          <p class="cms-sub">
+            Pick a faction to represent. This can't be changed later, so choose carefully.
+          </p>
+          <p v-if="deadlineText" class="cms-deadline">Choose by {{ deadlineText }} or you'll be auto-assigned.</p>
+        </div>
+
+        <div v-if="loading" class="cms-loading">Loading cMoons…</div>
+        <div v-else class="cms-body">
+          <button
+            v-for="c in cmoons" :key="c.id"
+            type="button"
+            class="cms-option"
+            :class="{ 'cms-option-selected': choice === c.id }"
+            role="radio"
+            :aria-checked="choice === c.id"
+            @click="choice = c.id"
+          >
+            <span class="cms-swatch" :style="{ background: safeColor(c.color) }"></span>
+            <span class="cms-option-body">
+              <span class="cms-option-name">{{ c.name }}</span>
+              <span class="cms-option-count">{{ c.memberCount }} member{{ c.memberCount === 1 ? '' : 's' }}</span>
+            </span>
+            <span class="cms-option-check" aria-hidden="true">{{ choice === c.id ? '●' : '○' }}</span>
+          </button>
+          <div v-if="!cmoons.length" class="cms-empty">No cMoons are available yet.</div>
+        </div>
+
+        <div v-if="error" class="cms-error">{{ error }}</div>
+
+        <div class="cms-footer">
+          <button class="cms-confirm-btn" :disabled="!choice || submitting" @click="confirm">
+            {{ submitting ? 'Joining…' : 'Confirm cMoon' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+const visible = ref(false)
+const loading = ref(false)
+const submitting = ref(false)
+const error = ref('')
+const cmoons = ref([])
+const choice = ref(null)
+const deadline = ref(null)
+
+function safeColor(color) {
+  return /^#[0-9a-fA-F]{6}$/.test(color || '') ? color : '#3a4a63'
+}
+
+const deadlineText = computed(() => {
+  if (!deadline.value) return ''
+  const d = new Date(deadline.value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }).format(d)
+})
+
+async function checkStatus() {
+  try {
+    const status = await $fetch('/api/cmoon/status')
+    if (!status?.cMoonEnabled || !status.canChoose) return
+    deadline.value = status.deadline || null
+    loading.value = true
+    visible.value = true
+    const list = await $fetch('/api/cmoons')
+    cmoons.value = list?.cmoons || []
+  } catch {
+    // Not logged in, or feature off — silently skip.
+  } finally {
+    loading.value = false
+  }
+}
+
+async function confirm() {
+  if (!choice.value || submitting.value) return
+  submitting.value = true
+  error.value = ''
+  try {
+    await $fetch('/api/cmoon/select', { method: 'POST', body: { cMoonId: choice.value } })
+    visible.value = false
+  } catch (e) {
+    error.value = e?.data?.statusMessage || 'Unable to join that cMoon. Please try again.'
+  } finally {
+    submitting.value = false
+  }
+}
+
+watch(visible, (v) => {
+  if (typeof document === 'undefined') return
+  document.body.style.overflow = v ? 'hidden' : ''
+})
+
+onMounted(checkStatus)
+onBeforeUnmount(() => {
+  if (typeof document !== 'undefined') document.body.style.overflow = ''
+})
+</script>
+
+<style scoped>
+.cms-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.cms-modal {
+  width: 100%;
+  max-width: 420px;
+  max-height: 85vh;
+  max-height: 85dvh;
+  background: #0a1830;
+  border: 2px solid #1a5a9a;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding-bottom: env(safe-area-inset-bottom);
+  color: #fff;
+  font-family: 'Nunito', sans-serif;
+}
+
+.cms-header {
+  padding: 16px 16px 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.cms-title {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.cms-sub {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.cms-deadline {
+  margin: 6px 0 0;
+  font-size: 0.7rem;
+  color: #ffd75e;
+  font-weight: 600;
+}
+
+.cms-loading, .cms-empty {
+  padding: 20px 16px;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.cms-body {
+  padding: 12px 16px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cms-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 48px;
+  padding: 8px 12px;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #fff;
+  text-align: left;
+  cursor: pointer;
+}
+
+.cms-option-selected {
+  border-color: #ffd75e;
+  background: rgba(255, 215, 94, 0.12);
+}
+
+.cms-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.cms-option-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.cms-option-name {
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.cms-option-count {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.cms-option-check {
+  flex: 0 0 auto;
+  color: #ffd75e;
+}
+
+.cms-error {
+  padding: 0 16px;
+  font-size: 0.72rem;
+  color: #ff8a8a;
+}
+
+.cms-footer {
+  padding: 12px 16px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.cms-confirm-btn {
+  width: 100%;
+  min-height: 46px;
+  border: none;
+  border-radius: 8px;
+  background: #2e8b57;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.cms-confirm-btn:disabled {
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.4);
+  cursor: not-allowed;
+}
+</style>

--- a/components/newsite/AdminCMoon.vue
+++ b/components/newsite/AdminCMoon.vue
@@ -1,0 +1,266 @@
+<template>
+  <div class="admin-cmoon bg-gray-50 p-3 text-sm">
+    <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+      <h1 class="text-base font-bold">cMoons</h1>
+    </div>
+
+    <!-- Feature flag -->
+    <div class="bg-white rounded border p-3 mb-4">
+      <label class="flex items-center gap-2">
+        <input type="checkbox" v-model="flagEnabled" :disabled="flagSaving" @change="toggleFlag" />
+        <span class="font-medium">cMoons enabled</span>
+      </label>
+      <p class="text-xs text-gray-500 mt-1">
+        Off by default. Turning this on starts a 3-day window for existing players to pick a
+        cMoon before they're auto-assigned to whichever has the fewest members; new players
+        always get 3 days from when they join.
+      </p>
+      <p v-if="cMoonEnabledAt" class="text-xs text-gray-500 mt-1">
+        Launched {{ formatDate(cMoonEnabledAt) }} · existing-player deadline {{ formatDate(cMoonSelectionDeadlineAt) }}
+      </p>
+    </div>
+
+    <div v-if="loading" class="text-gray-500">Loading…</div>
+    <template v-else>
+      <!-- Existing cMoons -->
+      <div class="space-y-3 mb-4">
+        <div v-for="c in cmoons" :key="c.id" class="bg-white rounded border p-3">
+          <div class="flex items-center gap-2 mb-2">
+            <span class="inline-block w-4 h-4 rounded-full border" :style="{ background: c.color }"></span>
+            <span class="font-semibold">{{ c.name }}</span>
+            <span class="text-xs text-gray-500">{{ c.memberCount }} member{{ c.memberCount === 1 ? '' : 's' }}</span>
+            <button class="ml-auto text-xs text-indigo-600 hover:underline" @click="startEdit(c)">Edit</button>
+            <button
+              class="text-xs text-red-600 hover:underline disabled:opacity-40"
+              :disabled="c.memberCount > 0"
+              :title="c.memberCount > 0 ? 'Reassign members before deleting' : ''"
+              @click="remove(c)"
+            >Delete</button>
+          </div>
+          <div class="text-xs text-gray-500">
+            Captains: {{ c.captains.map(cap => cap.username).join(', ') || 'none' }}
+          </div>
+          <div class="text-xs text-gray-500">
+            Prize cToons: {{ c.prizeCtoons.map(p => `${p.name} ×${p.quantity}`).join(', ') || 'none' }}
+          </div>
+          <div class="text-xs text-gray-500">Discord role ID: {{ c.discordRoleId || 'none' }}</div>
+        </div>
+        <div v-if="!cmoons.length" class="text-gray-500">No cMoons yet — create one below.</div>
+      </div>
+
+      <!-- Create / edit form -->
+      <div class="bg-white rounded border p-3">
+        <h2 class="font-semibold mb-2">{{ editId ? 'Edit cMoon' : 'Create cMoon' }}</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label class="block text-xs font-medium mb-1">Name</label>
+            <input v-model="form.name" class="w-full border rounded px-2 py-1" style="font-size:16px" />
+          </div>
+          <div>
+            <label class="block text-xs font-medium mb-1">Color (text color)</label>
+            <div class="flex items-center gap-2">
+              <input v-model="form.color" class="w-full border rounded px-2 py-1" style="font-size:16px" placeholder="#3366ff" />
+              <span class="inline-block w-6 h-6 rounded-full border flex-shrink-0" :style="{ background: safeColor(form.color) }"></span>
+            </div>
+            <p v-if="form.color && !isValidColor(form.color)" class="text-xs text-red-600 mt-1">Must be a hex color like #3366ff</p>
+          </div>
+          <div>
+            <label class="block text-xs font-medium mb-1">Discord Role ID (optional)</label>
+            <input v-model="form.discordRoleId" class="w-full border rounded px-2 py-1" style="font-size:16px" placeholder="123456789012345678" />
+          </div>
+        </div>
+
+        <div class="mt-3">
+          <label class="block text-xs font-medium mb-1">Captains (from admins)</label>
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="a in admins" :key="a.id"
+              type="button"
+              class="px-2 py-1 rounded-full border text-xs"
+              :class="form.captainIds.includes(a.id) ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white text-gray-700'"
+              @click="toggleCaptain(a.id)"
+            >{{ a.username || a.id }}</button>
+          </div>
+        </div>
+
+        <div class="mt-3">
+          <label class="block text-xs font-medium mb-1">Prize cToons (granted when a user joins)</label>
+          <div class="flex gap-2 items-center">
+            <datalist id="cmoon-ctoon-list">
+              <option v-for="c in filteredCtoons(prizeCtoonSearch)" :key="c.id" :value="c.name" />
+            </datalist>
+            <input v-model="prizeCtoonSearch" list="cmoon-ctoon-list" class="border rounded px-2 py-1 flex-1" style="font-size:16px" placeholder="Type 3+ characters" />
+            <input v-model.number="prizeCtoonQty" type="number" min="1" class="w-20 border rounded px-2 py-1" style="font-size:16px" />
+            <button type="button" class="px-3 py-1 border rounded" @click="addPrizeCtoon">Add</button>
+          </div>
+          <div v-if="form.prizeCtoons.length" class="mt-2 space-y-1">
+            <div v-for="(p, i) in form.prizeCtoons" :key="p.ctoonId" class="flex items-center gap-2 text-xs">
+              <span>{{ nameForCtoon(p.ctoonId) }} × {{ p.quantity }}</span>
+              <button type="button" class="text-red-600" @click="form.prizeCtoons.splice(i, 1)">Remove</button>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="formError" class="text-xs text-red-600 mt-2">{{ formError }}</div>
+
+        <div class="mt-3 flex gap-2">
+          <button class="px-3 py-1.5 bg-indigo-600 text-white rounded" @click="save" :disabled="saving">
+            {{ saving ? 'Saving…' : (editId ? 'Save Changes' : 'Create cMoon') }}
+          </button>
+          <button v-if="editId" type="button" class="px-3 py-1.5 border rounded" @click="resetForm">Cancel</button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+const loading = ref(false)
+const saving = ref(false)
+const formError = ref('')
+const cmoons = ref([])
+const admins = ref([])
+const ctoons = ref([])
+const flagEnabled = ref(false)
+const flagSaving = ref(false)
+const cMoonEnabledAt = ref(null)
+const cMoonSelectionDeadlineAt = ref(null)
+
+const editId = ref('')
+const emptyForm = () => ({ name: '', color: '', discordRoleId: '', captainIds: [], prizeCtoons: [] })
+const form = reactive(emptyForm())
+const prizeCtoonSearch = ref('')
+const prizeCtoonQty = ref(1)
+
+function isValidColor(c) { return /^#[0-9a-fA-F]{6}$/.test(c || '') }
+function safeColor(c) { return isValidColor(c) ? c : '#cccccc' }
+
+function formatDate(d) {
+  if (!d) return ''
+  const dt = new Date(d)
+  if (Number.isNaN(dt.getTime())) return ''
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' }).format(dt)
+}
+
+function filteredCtoons(input) {
+  const v = String(input || '').trim().toLowerCase()
+  if (v.length < 3) return []
+  return ctoons.value.filter(c => c.name?.toLowerCase().includes(v)).slice(0, 20)
+}
+
+function nameForCtoon(id) {
+  return ctoons.value.find(c => c.id === id)?.name || id
+}
+
+function toggleCaptain(id) {
+  const i = form.captainIds.indexOf(id)
+  if (i >= 0) form.captainIds.splice(i, 1)
+  else form.captainIds.push(id)
+}
+
+function addPrizeCtoon() {
+  const match = ctoons.value.find(c => c.name === prizeCtoonSearch.value)
+  if (!match) {
+    formError.value = 'Select a valid cToon from suggestions.'
+    return
+  }
+  formError.value = ''
+  if (form.prizeCtoons.find(p => p.ctoonId === match.id)) return
+  form.prizeCtoons.push({ ctoonId: match.id, quantity: Math.max(1, Number(prizeCtoonQty.value || 1)) })
+  prizeCtoonSearch.value = ''
+  prizeCtoonQty.value = 1
+}
+
+function startEdit(c) {
+  editId.value = c.id
+  Object.assign(form, {
+    name: c.name,
+    color: c.color,
+    discordRoleId: c.discordRoleId || '',
+    captainIds: c.captains.map(cap => cap.userId),
+    prizeCtoons: c.prizeCtoons.map(p => ({ ctoonId: p.ctoonId, quantity: p.quantity })),
+  })
+  formError.value = ''
+}
+
+function resetForm() {
+  Object.assign(form, emptyForm())
+  editId.value = ''
+  formError.value = ''
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const [data, adminsData, ctoonsData] = await Promise.all([
+      $fetch('/api/admin/cmoons'),
+      $fetch('/api/admin/cmoon-admins'),
+      $fetch('/api/admin/list-ctoons'),
+    ])
+    cmoons.value = data.cmoons || []
+    flagEnabled.value = !!data.cMoonEnabled
+    cMoonEnabledAt.value = data.cMoonEnabledAt
+    cMoonSelectionDeadlineAt.value = data.cMoonSelectionDeadlineAt
+    admins.value = adminsData || []
+    ctoons.value = ctoonsData || []
+  } catch (e) {
+    formError.value = e?.data?.statusMessage || 'Failed to load cMoons'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function toggleFlag() {
+  flagSaving.value = true
+  try {
+    const res = await $fetch('/api/admin/cmoon-settings', { method: 'POST', body: { cMoonEnabled: flagEnabled.value } })
+    cMoonEnabledAt.value = res.cMoonEnabledAt
+    cMoonSelectionDeadlineAt.value = res.cMoonSelectionDeadlineAt
+  } catch (e) {
+    flagEnabled.value = !flagEnabled.value
+    alert(e?.data?.statusMessage || 'Failed to update flag')
+  } finally {
+    flagSaving.value = false
+  }
+}
+
+async function save() {
+  if (!form.name.trim()) { formError.value = 'Name is required'; return }
+  if (!isValidColor(form.color)) { formError.value = 'Color must be a hex value like #3366ff'; return }
+  formError.value = ''
+  saving.value = true
+  try {
+    const body = {
+      name: form.name.trim(),
+      color: form.color,
+      discordRoleId: form.discordRoleId.trim(),
+      captainIds: form.captainIds,
+      prizeCtoons: form.prizeCtoons,
+    }
+    if (!editId.value) {
+      await $fetch('/api/admin/cmoons', { method: 'POST', body })
+    } else {
+      await $fetch(`/api/admin/cmoons/${editId.value}`, { method: 'PUT', body })
+    }
+    resetForm()
+    await load()
+  } catch (e) {
+    formError.value = e?.data?.statusMessage || 'Save failed'
+  } finally {
+    saving.value = false
+  }
+}
+
+async function remove(c) {
+  if (c.memberCount > 0) return
+  if (!confirm(`Delete cMoon "${c.name}"?`)) return
+  try {
+    await $fetch(`/api/admin/cmoons/${c.id}`, { method: 'DELETE' })
+    await load()
+  } catch (e) {
+    alert(e?.data?.statusMessage || 'Delete failed')
+  }
+}
+
+onMounted(load)
+</script>

--- a/components/newsite/AdminNav.vue
+++ b/components/newsite/AdminNav.vue
@@ -51,6 +51,7 @@ const menus = [
       { id: 'manageUsers',   label: 'Manage Users', to: '/newsite/admin/manageUsers' },
       { id: 'czoneContest',  label: 'cZone Contest', to: '/newsite/admin/czoneContest' },
       { id: 'manageSales',   label: 'Manage Sales', to: '/newsite/admin/manageSales' },
+      { id: 'cMoon',         label: 'cMoons',       to: '/newsite/admin/cMoon' },
       { id: 'core-placeholder-3', label: 'Placeholder', to: null },
       { id: 'core-placeholder-4', label: 'Placeholder', to: null },
       { id: 'core-placeholder-5', label: 'Placeholder', to: null },

--- a/components/newsite/Leaderboards.vue
+++ b/components/newsite/Leaderboards.vue
@@ -26,7 +26,10 @@
             >
               <span class="lb-rank">{{ row.rank }}</span>
               <img class="lb-avatar" :src="`/avatars/${row.avatar || 'default.png'}`" alt="" />
-              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <div class="lb-user-col">
+                <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+                <span v-if="cMoonForRow(row)" class="lb-cmoon" :style="cMoonPillStyle(cMoonForRow(row).color)">{{ cMoonForRow(row).name }}</span>
+              </div>
               <span class="lb-value">{{ board.formatValue(row) }}</span>
             </li>
             <li v-if="!board.rows?.length" class="lb-empty">No data yet</li>
@@ -62,7 +65,10 @@
             >
               <span class="lb-rank">{{ row.rank }}</span>
               <img class="lb-avatar" :src="`/avatars/${row.avatar || 'default.png'}`" alt="" />
-              <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+              <div class="lb-user-col">
+                <NuxtLink :to="`/newsite/czone/${row.username}`" class="lb-username">{{ row.username }}</NuxtLink>
+                <span v-if="cMoonForRow(row)" class="lb-cmoon" :style="cMoonPillStyle(cMoonForRow(row).color)">{{ cMoonForRow(row).name }}</span>
+              </div>
               <span class="lb-value">{{ board.formatValue(row) }}</span>
             </li>
             <li v-if="!board.rows?.length" class="lb-empty">No scores yet</li>
@@ -183,6 +189,30 @@ const gamesBoards = computed(() => [
     formatValue: gameValueLabel.value
   },
 ])
+
+// cMoon badges: one batched lookup per visible row set instead of joining
+// cMoon into every one of the ~10 separate leaderboard endpoints above.
+const cMoonBadges = ref({})
+const fetchedUsernames = new Set()
+
+async function loadCMoonBadges(usernames) {
+  const toFetch = usernames.filter(u => u && !fetchedUsernames.has(u))
+  if (!toFetch.length) return
+  toFetch.forEach(u => fetchedUsernames.add(u))
+  try {
+    const map = await $fetch('/api/leaderboard/cmoon-badges', { method: 'POST', body: { usernames: toFetch } })
+    cMoonBadges.value = { ...cMoonBadges.value, ...map }
+  } catch {}
+}
+
+watch([usersBoards, gamesBoards], ([users, games]) => {
+  const names = [...users, ...games].flatMap(b => (b.rows || []).map(r => r.username))
+  if (names.length) loadCMoonBadges(names)
+}, { immediate: true })
+
+function cMoonForRow(row) {
+  return cMoonBadges.value[row.username] || null
+}
 </script>
 
 <style scoped>
@@ -326,9 +356,16 @@ const gamesBoards = computed(() => [
   background: rgba(255, 255, 255, 0.08);
 }
 
-.lb-username {
+.lb-user-col {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  line-height: 1.15;
+}
+
+.lb-username {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -337,6 +374,19 @@ const gamesBoards = computed(() => [
   font-weight: 600;
 }
 .lb-username:hover { color: #b3e0ff; text-decoration: underline; }
+
+.lb-cmoon {
+  align-self: flex-start;
+  margin-top: 1px;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 0.58rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
 
 .lb-value {
   flex-shrink: 0;

--- a/components/newsite/MyAchievements.vue
+++ b/components/newsite/MyAchievements.vue
@@ -28,6 +28,7 @@
             <div class="ma-card-footer">
               <span class="ma-achievers">{{ a.achievers }} achiever{{ a.achievers !== 1 ? 's' : '' }}</span>
               <span v-if="hasRewards(a)" class="ma-has-reward">★ Reward</span>
+              <span v-else-if="a.isClaimable" class="ma-has-reward">★ Choose reward</span>
             </div>
           </div>
         </div>
@@ -90,6 +91,49 @@
                 </div>
               </div>
             </template>
+
+            <!-- Claimable reward: pick one of up to 4 options -->
+            <template v-else-if="selected.isClaimable">
+              <div class="ma-reward-heading">Choose your reward</div>
+
+              <div v-if="!selected.achieved" class="ma-no-reward">Unlock this achievement to choose a reward.</div>
+
+              <div v-else-if="selected.claimedOptionId" class="ma-claim-done">
+                You claimed: <strong>{{ claimedOptionLabel(selected) }}</strong>
+              </div>
+
+              <div v-else class="ma-claim-options" role="radiogroup" aria-label="Reward options">
+                <button
+                  v-for="opt in selected.claimOptions" :key="opt.id"
+                  type="button"
+                  class="ma-claim-option"
+                  :class="{ 'ma-claim-option-selected': claimChoice === opt.id }"
+                  role="radio"
+                  :aria-checked="claimChoice === opt.id"
+                  @click="claimChoice = opt.id"
+                >
+                  <img v-if="opt.ctoonImagePath" :src="opt.ctoonImagePath" class="ma-claim-option-img" :alt="opt.label" />
+                  <div class="ma-claim-option-body">
+                    <div class="ma-claim-option-label">{{ opt.label }}</div>
+                    <div class="ma-claim-option-detail">
+                      <span v-if="opt.ctoonName">{{ opt.ctoonName }} × {{ opt.quantity }}</span>
+                      <span v-if="opt.points"> {{ opt.ctoonName ? '+ ' : '' }}{{ opt.points.toLocaleString() }} pts</span>
+                    </div>
+                  </div>
+                  <span class="ma-claim-option-check" aria-hidden="true">{{ claimChoice === opt.id ? '●' : '○' }}</span>
+                </button>
+
+                <button
+                  class="ma-claim-confirm-btn"
+                  :disabled="!claimChoice || claiming"
+                  @click="confirmClaim(selected)"
+                >
+                  {{ claiming ? 'Claiming…' : 'Confirm reward' }}
+                </button>
+                <div v-if="claimError" class="ma-claim-error">{{ claimError }}</div>
+              </div>
+            </template>
+
             <div v-else class="ma-no-reward">No rewards for this achievement.</div>
           </div>
 
@@ -108,6 +152,15 @@
 const achievements = ref([])
 const loading      = ref(false)
 const selected     = ref(null)
+const claimChoice  = ref(null)
+const claiming     = ref(false)
+const claimError   = ref('')
+
+watch(selected, () => {
+  claimChoice.value = null
+  claiming.value = false
+  claimError.value = ''
+})
 
 onMounted(loadAchievements)
 
@@ -124,6 +177,28 @@ async function loadAchievements() {
 
 function hasRewards(a) {
   return a.rewards?.points || a.rewards?.ctoons?.length || a.rewards?.backgrounds?.length
+}
+
+function claimedOptionLabel(a) {
+  const opt = a.claimOptions?.find(o => o.id === a.claimedOptionId)
+  return opt?.label || 'a reward'
+}
+
+async function confirmClaim(a) {
+  if (!claimChoice.value || claiming.value) return
+  claiming.value = true
+  claimError.value = ''
+  try {
+    await $fetch(`/api/achievements/${a.id}/claim`, {
+      method: 'POST',
+      body: { optionId: claimChoice.value },
+    })
+    a.claimedOptionId = claimChoice.value
+  } catch (e) {
+    claimError.value = e?.data?.statusMessage || 'Unable to claim reward. Please try again.'
+  } finally {
+    claiming.value = false
+  }
 }
 </script>
 
@@ -281,10 +356,12 @@ function hasRewards(a) {
   width: 100%;
   max-width: 480px;
   max-height: 85vh;
+  max-height: 85dvh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .ma-modal-header {
@@ -436,6 +513,92 @@ function hasRewards(a) {
   font-size: 0.7rem;
   color: rgba(255,255,255,0.35);
   font-style: italic;
+}
+
+.ma-claim-done {
+  font-size: 0.8rem;
+  color: #7fd3ff;
+  background: rgba(255,255,255,0.06);
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+
+.ma-claim-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ma-claim-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 10px;
+  background: rgba(255,255,255,0.05);
+  border: 2px solid rgba(255,255,255,0.15);
+  border-radius: 8px;
+  color: #fff;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ma-claim-option-selected {
+  border-color: #ffd75e;
+  background: rgba(255,215,94,0.12);
+}
+
+.ma-claim-option-img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.ma-claim-option-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ma-claim-option-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.ma-claim-option-detail {
+  font-size: 0.68rem;
+  color: rgba(255,255,255,0.6);
+}
+
+.ma-claim-option-check {
+  flex: 0 0 auto;
+  font-size: 1rem;
+  color: #ffd75e;
+}
+
+.ma-claim-confirm-btn {
+  min-height: 44px;
+  margin-top: 4px;
+  padding: 10px 14px;
+  border: none;
+  border-radius: 6px;
+  background: #2e8b57;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ma-claim-confirm-btn:disabled {
+  background: rgba(255,255,255,0.15);
+  color: rgba(255,255,255,0.4);
+  cursor: not-allowed;
+}
+
+.ma-claim-error {
+  font-size: 0.7rem;
+  color: #ff8a8a;
 }
 
 .ma-modal-footer {

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -50,7 +50,11 @@
             <img :src="`/avatars/${viewedOwner.avatar || 'default.png'}`" class="cz-owner-avatar" />
             <div class="cz-owner-label">
               <div><span class="cz-owner-prefix">Owner</span> {{ viewedOwner.username }}</div>
-              <div v-if="lastOnlineText" class="cz-owner-lastseen">{{ lastOnlineText }}</div>
+              <div v-if="lastOnlineText || viewedOwner.cMoon" class="cz-owner-lastseen">
+                <span v-if="lastOnlineText">{{ lastOnlineText }}</span>
+                <span v-if="lastOnlineText && viewedOwner.cMoon"> · </span>
+                <span v-if="viewedOwner.cMoon" class="cz-owner-cmoon" :style="cMoonPillStyle(viewedOwner.cMoon.color)">{{ viewedOwner.cMoon.name }}</span>
+              </div>
             </div>
           </template>
         </div>
@@ -811,7 +815,7 @@ async function loadZone(username) {
     cz.value.zones       = data.cZone.zones
     const firstActive    = data.cZone.zones.findIndex(z => z.toons.length > 0)
     cz.value.activeZone  = firstActive >= 0 ? firstActive : 0
-    viewedOwner.value    = { username: data.ownerName, avatar: data.avatar, lastActivity: data.lastActivity ?? null }
+    viewedOwner.value    = { username: data.ownerName, avatar: data.avatar, lastActivity: data.lastActivity ?? null, cMoon: data.cMoon ?? null }
     loadCzoneSearchItems()
     eagerLoadMissingDimensions()
 
@@ -1323,6 +1327,14 @@ defineExpose({ save, clearZone })
 .cz-owner-label  { font-size: 0.68rem; color: #fff; white-space: nowrap; }
 .cz-owner-prefix  { font-size: 0.6rem; text-transform: uppercase; color: rgba(255,255,255,0.55); margin-right: 3px; }
 .cz-owner-lastseen { font-size: 0.58rem; color: rgba(255,255,255,0.5); white-space: nowrap; }
+.cz-owner-cmoon {
+  display: inline-block;
+  padding: 0 5px;
+  border-radius: 3px;
+  font-weight: 600;
+  font-size: 0.56rem;
+  line-height: 1.4;
+}
 
 /* ── Skeleton placeholders (shown while a new cZone is loading) ── */
 .cz-skeleton {

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -274,6 +274,7 @@ html.newsite-active body {
     />
   </div>
   <Onboarding />
+  <CMoonSelectModal />
 </template>
 
 <script setup>

--- a/pages/admin/achievements.vue
+++ b/pages/admin/achievements.vue
@@ -225,6 +225,47 @@
               </button>
             </div>
           </div>
+
+          <h3 class="text-lg font-semibold mt-6">Claimable Reward (optional)</h3>
+          <div class="flex items-center gap-2">
+            <input type="checkbox" v-model="form.isClaimable" id="isClaimable" />
+            <label for="isClaimable">User picks 1 of up to 4 reward options instead of auto-granting the Rewards above</label>
+          </div>
+          <div v-if="form.isClaimable" class="mt-2 space-y-3">
+            <div v-for="(opt, i) in form.claimOptions" :key="i" class="border rounded p-2 grid grid-cols-1 md:grid-cols-4 gap-2 items-end">
+              <div>
+                <label class="block text-xs">Label</label>
+                <input v-model="opt.label" class="w-full border rounded px-2 py-1" placeholder="Option name" />
+              </div>
+              <div>
+                <label class="block text-xs">Points</label>
+                <input v-model.number="opt.points" type="number" min="0" class="w-full border rounded px-2 py-1" />
+              </div>
+              <div>
+                <label class="block text-xs">cToon</label>
+                <datalist :id="`claim-ctoon-list-${i}`">
+                  <option v-for="c in filteredCtoons(opt.ctoonName)" :key="c.id" :value="c.name" />
+                </datalist>
+                <input
+                  v-model="opt.ctoonName"
+                  :list="`claim-ctoon-list-${i}`"
+                  class="w-full border rounded px-2 py-1"
+                  placeholder="Type 3+ chars"
+                  @change="setClaimOptionCtoon(opt, opt.ctoonName)"
+                />
+              </div>
+              <div class="flex items-end gap-2">
+                <div class="flex-1">
+                  <label class="block text-xs">Qty</label>
+                  <input v-model.number="opt.quantity" type="number" min="1" class="w-full border rounded px-2 py-1" />
+                </div>
+                <button type="button" class="text-red-600 px-2 py-1" @click="removeClaimOption(i)">Remove</button>
+              </div>
+            </div>
+            <button v-if="form.claimOptions.length < 4" type="button" class="px-3 py-1 border rounded" @click="addClaimOption">
+              Add option ({{ form.claimOptions.length }}/4)
+            </button>
+          </div>
           </div>
           <div class="px-4 py-3 border-t flex gap-3 justify-end">
             <button type="button" class="px-4 py-2 border rounded" @click="closeForm">Cancel</button>
@@ -321,7 +362,9 @@ const emptyForm = () => ({
     ctoonsRequired: [],
     userCreatedBefore: null
   },
-  rewards: { points: 0, ctoons: [], backgrounds: [] }
+  rewards: { points: 0, ctoons: [], backgrounds: [] },
+  isClaimable: false,
+  claimOptions: []
 })
 const form = reactive(emptyForm())
 const queuing = ref(false)
@@ -445,6 +488,21 @@ function addCtoon() {
   ctoonSelection.value = { name: '', qty: 1 }
 }
 
+const claimOptionCtoonInput = ref('')
+function addClaimOption() {
+  if (form.claimOptions.length >= 4) return
+  form.claimOptions.push({ label: '', points: 0, ctoonId: '', ctoonName: '', quantity: 1 })
+}
+function removeClaimOption(i) {
+  form.claimOptions.splice(i, 1)
+}
+function setClaimOptionCtoon(opt, name) {
+  const match = ctoons.value.find(c => c.name === name)
+  if (!match) return
+  opt.ctoonId = match.id
+  opt.ctoonName = match.name
+}
+
 function toggleBg(id) {
   const i = bgSelection.value.indexOf(id)
   if (i >= 0) bgSelection.value.splice(i, 1)
@@ -481,7 +539,9 @@ function startEdit(a) {
       points: a.rewards?.points || 0,
       ctoons: (a.rewards?.ctoons || []).map(r => ({ ctoonId: r.ctoonId, quantity: r.quantity })),
       backgrounds: (a.rewards?.backgrounds || []).map(r => ({ backgroundId: r.backgroundId }))
-    }
+    },
+    isClaimable: !!a.isClaimable,
+    claimOptions: (a.claimOptions || []).map(o => ({ label: o.label, points: o.points || 0, ctoonId: o.ctoonId || '', ctoonName: o.ctoonName || '', quantity: o.quantity || 1 }))
   })
   bgSelection.value = form.rewards.backgrounds.map(b => b.backgroundId)
   if (imageInput.value) imageInput.value.value = ''

--- a/pages/newsite/admin/[[section]].vue
+++ b/pages/newsite/admin/[[section]].vue
@@ -27,6 +27,7 @@
       <AdminSetAnalytics v-else-if="section === 'setAnalytics'" />
       <AdminCzoneContest v-else-if="section === 'czoneContest'" />
       <AdminErrorLogs v-else-if="section === 'errorLogs'" />
+      <AdminCMoon v-else-if="section === 'cMoon'" />
       <div v-else class="newsite-admin-placeholder">
         <h1 class="newsite-admin-title">Unknown section</h1>
       </div>

--- a/prisma/migrations/20260809164117_add_cmoon_and_achievement_claims/migration.sql
+++ b/prisma/migrations/20260809164117_add_cmoon_and_achievement_claims/migration.sql
@@ -1,0 +1,146 @@
+/*
+  Warnings:
+
+  - Made the column `dissolveScheduleCadenceDays` on table `GlobalGameConfig` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `dissolveScheduleFeaturedPerCadence` on table `GlobalGameConfig` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `dissolveScheduleOtherPerCadence` on table `GlobalGameConfig` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Achievement" ADD COLUMN     "isClaimable" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "GlobalGameConfig" ADD COLUMN     "cMoonEnabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "cMoonEnabledAt" TIMESTAMP(3),
+ADD COLUMN     "cMoonSelectionDeadlineAt" TIMESTAMP(3),
+ALTER COLUMN "dissolveScheduleCadenceDays" SET NOT NULL,
+ALTER COLUMN "dissolveScheduleFeaturedPerCadence" SET NOT NULL,
+ALTER COLUMN "dissolveScheduleOtherPerCadence" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "cMoonAutoAssigned" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "cMoonId" TEXT,
+ADD COLUMN     "cMoonRoleGrantedAt" TIMESTAMP(3),
+ADD COLUMN     "cMoonSelectedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "AchievementClaimOption" (
+    "id" TEXT NOT NULL,
+    "achievementId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "points" INTEGER NOT NULL DEFAULT 0,
+    "ctoonId" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "AchievementClaimOption_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AchievementClaim" (
+    "id" TEXT NOT NULL,
+    "achievementId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "optionId" TEXT NOT NULL,
+    "claimedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AchievementClaim_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CMoon" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "discordRoleId" TEXT,
+    "memberCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CMoon_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CMoonCaptain" (
+    "id" TEXT NOT NULL,
+    "cMoonId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "CMoonCaptain_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CMoonPrizeCtoon" (
+    "id" TEXT NOT NULL,
+    "cMoonId" TEXT NOT NULL,
+    "ctoonId" TEXT NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+
+    CONSTRAINT "CMoonPrizeCtoon_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AchievementClaimOption_achievementId_sortOrder_idx" ON "AchievementClaimOption"("achievementId", "sortOrder");
+
+-- CreateIndex
+CREATE INDEX "AchievementClaim_userId_idx" ON "AchievementClaim"("userId");
+
+-- CreateIndex
+CREATE INDEX "AchievementClaim_optionId_idx" ON "AchievementClaim"("optionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AchievementClaim_achievementId_userId_key" ON "AchievementClaim"("achievementId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CMoon_name_key" ON "CMoon"("name");
+
+-- CreateIndex
+CREATE INDEX "CMoon_memberCount_idx" ON "CMoon"("memberCount");
+
+-- CreateIndex
+CREATE INDEX "CMoonCaptain_userId_idx" ON "CMoonCaptain"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CMoonCaptain_cMoonId_userId_key" ON "CMoonCaptain"("cMoonId", "userId");
+
+-- CreateIndex
+CREATE INDEX "CMoonPrizeCtoon_ctoonId_idx" ON "CMoonPrizeCtoon"("ctoonId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CMoonPrizeCtoon_cMoonId_ctoonId_key" ON "CMoonPrizeCtoon"("cMoonId", "ctoonId");
+
+-- CreateIndex
+CREATE INDEX "User_cMoonId_idx" ON "User"("cMoonId");
+
+-- CreateIndex
+CREATE INDEX "User_cMoonId_cMoonRoleGrantedAt_idx" ON "User"("cMoonId", "cMoonRoleGrantedAt");
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_cMoonId_fkey" FOREIGN KEY ("cMoonId") REFERENCES "CMoon"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AchievementClaimOption" ADD CONSTRAINT "AchievementClaimOption_achievementId_fkey" FOREIGN KEY ("achievementId") REFERENCES "Achievement"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AchievementClaimOption" ADD CONSTRAINT "AchievementClaimOption_ctoonId_fkey" FOREIGN KEY ("ctoonId") REFERENCES "Ctoon"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AchievementClaim" ADD CONSTRAINT "AchievementClaim_achievementId_fkey" FOREIGN KEY ("achievementId") REFERENCES "Achievement"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AchievementClaim" ADD CONSTRAINT "AchievementClaim_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AchievementClaim" ADD CONSTRAINT "AchievementClaim_optionId_fkey" FOREIGN KEY ("optionId") REFERENCES "AchievementClaimOption"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CMoonCaptain" ADD CONSTRAINT "CMoonCaptain_cMoonId_fkey" FOREIGN KEY ("cMoonId") REFERENCES "CMoon"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CMoonCaptain" ADD CONSTRAINT "CMoonCaptain_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CMoonPrizeCtoon" ADD CONSTRAINT "CMoonPrizeCtoon_cMoonId_fkey" FOREIGN KEY ("cMoonId") REFERENCES "CMoon"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CMoonPrizeCtoon" ADD CONSTRAINT "CMoonPrizeCtoon_ctoonId_fkey" FOREIGN KEY ("ctoonId") REFERENCES "Ctoon"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -295,6 +295,10 @@ model Ctoon {
   // Achievements back‑relations
   achievementRewardCtoons    AchievementRewardCtoon[]
   achievementRequiredCtoons  AchievementRequiredCtoon[]
+  achievementClaimOptions    AchievementClaimOption[]
+
+  // cMoon back-relation
+  cMoonPrizeRows CMoonPrizeCtoon[]
 
   cZoneSearchPrizeRows   CZoneSearchPrize[]
   cZoneSearchAppearances CZoneSearchAppearance[]
@@ -407,6 +411,15 @@ model User {
   additionalCzones                  Int       @default(0)
   usernameChangedAt                 DateTime?
   vpnDetected                       Boolean   @default(false)
+
+  // cMoon (faction) membership
+  cMoonId           String?
+  cMoon             CMoon?    @relation(fields: [cMoonId], references: [id], onDelete: SetNull)
+  cMoonSelectedAt   DateTime?
+  cMoonAutoAssigned Boolean   @default(false)
+  // Set once the daily Discord sync grants this user's cMoon role, so the job
+  // only touches never-synced members instead of re-checking everyone daily.
+  cMoonRoleGrantedAt DateTime?
 
   cZones                    CZone[]
   clashDecks                ClashDeck[]
@@ -550,7 +563,13 @@ model User {
   fruitSamuraiScores FruitSamuraiScore[]
   fruitSamuraiPlays  FruitSamuraiPlay[]
 
+  // cMoon (faction) relations
+  cMoonCaptainOf    CMoonCaptain[]
+  achievementClaims AchievementClaim[]
+
   @@unique([discordId, active]) // at most one active user per Discord ID
+  @@index([cMoonId])
+  @@index([cMoonId, cMoonRoleGrantedAt])
 }
 
 model CtoonUserSuggestion {
@@ -1084,33 +1103,33 @@ model GameConfig {
   // but only this many per day write a score row and award points. Everything else is a
   // difficulty/scoring/power-up knob mirrored in lib/asteroidSim.js DEFAULT_CONFIG, which is
   // the single source of truth for the defaults and the clamp ranges.
-  asteroidRankedPlaysPerPeriod Int     @default(3)
-  asteroidPointsPerGame        Int     @default(50)
-  asteroidStartingLives        Int     @default(3)
-  asteroidStartAsteroids       Int     @default(4)
-  asteroidAsteroidsPerWave     Int     @default(1)
-  asteroidAsteroidSpeed        Float   @default(1.15)
-  asteroidWaveSpeedGrowth      Float   @default(0.06)
-  asteroidMaxSpeedMultiplier   Float   @default(2.2)
-  asteroidTurnRate             Int     @default(6)
-  asteroidThrustAccel          Float   @default(0.145)
-  asteroidMaxShipSpeed         Float   @default(5.6)
-  asteroidShipDrag             Float   @default(0.992)
-  asteroidFireIntervalTicks    Int     @default(13)
-  asteroidExtraLifeScore       Int     @default(10000)
+  asteroidRankedPlaysPerPeriod Int   @default(3)
+  asteroidPointsPerGame        Int   @default(50)
+  asteroidStartingLives        Int   @default(3)
+  asteroidStartAsteroids       Int   @default(4)
+  asteroidAsteroidsPerWave     Int   @default(1)
+  asteroidAsteroidSpeed        Float @default(1.15)
+  asteroidWaveSpeedGrowth      Float @default(0.06)
+  asteroidMaxSpeedMultiplier   Float @default(2.2)
+  asteroidTurnRate             Int   @default(6)
+  asteroidThrustAccel          Float @default(0.145)
+  asteroidMaxShipSpeed         Float @default(5.6)
+  asteroidShipDrag             Float @default(0.992)
+  asteroidFireIntervalTicks    Int   @default(13)
+  asteroidExtraLifeScore       Int   @default(10000)
   // physics / geometry (world units; durations in 60Hz ticks)
-  asteroidShipRadius           Float   @default(13)
+  asteroidShipRadius           Float @default(13)
   // DEPRECATED: superseded by the per-ship weapon columns below. Firing is now resolved from
   // the ship the player picked, so these are no longer read. Kept to avoid a destructive
   // migration; not exposed in the admin panel.
-  asteroidBulletSpeed          Float   @default(6.2)
-  asteroidBulletLifeTicks      Int     @default(66)
-  asteroidRespawnInvulnTicks   Int     @default(96)
-  asteroidPowerupRadius        Float   @default(13)
-  asteroidPowerupLifeTicks     Int     @default(600)
-  asteroidLargeRadius          Float   @default(34)
-  asteroidMediumRadius         Float   @default(20)
-  asteroidSmallRadius          Float   @default(11)
+  asteroidBulletSpeed          Float @default(6.2)
+  asteroidBulletLifeTicks      Int   @default(66)
+  asteroidRespawnInvulnTicks   Int   @default(96)
+  asteroidPowerupRadius        Float @default(13)
+  asteroidPowerupLifeTicks     Int   @default(600)
+  asteroidLargeRadius          Float @default(34)
+  asteroidMediumRadius         Float @default(20)
+  asteroidSmallRadius          Float @default(11)
 
   // — Per-ship weapons —
   // Each selectable ship is a weapon profile. Defaults mirror the `weapon` blocks in
@@ -1296,31 +1315,37 @@ model GlobalGameConfig {
   gameTileGuessctoonImagePath    String?
   gameTileAsteroidImagePath      String?
 
-  gameTileFlappyImagePath       String?
-  gameTileBlackjackImagePath    String?
-  gameTileEdrpsImagePath        String?
-  gameTileFruitsamuraiImagePath String?
+  gameTileFlappyImagePath            String?
+  gameTileBlackjackImagePath         String?
+  gameTileEdrpsImagePath             String?
+  gameTileFruitsamuraiImagePath      String?
   // Account-dissolve "featured auction" rules: cToons matching any of these
   // rarities/series/sets are marked isFeatured when an account is dissolved.
   // Each is a JSON array of strings, edited via the "Edit Featured" modal on
   // /admin/dissolve-queue.
-  featuredDissolveRarities   Json     @default("[]")
-  featuredDissolveSeries     Json     @default("[]")
-  featuredDissolveSets       Json     @default("[]")
+  featuredDissolveRarities           Json      @default("[]")
+  featuredDissolveSeries             Json      @default("[]")
+  featuredDissolveSets               Json      @default("[]")
   // Default cadence for scheduling DissolveAuctionQueue entries, set via the
   // "Reschedule All" form on /admin/dissolve-queue and reused automatically by
   // the 9-month inactivity dissolve cron so newly-queued priority entries get
   // scheduledFor set without needing an admin to visit the page.
-  dissolveScheduleCadenceDays        Int @default(7)
-  dissolveScheduleFeaturedPerCadence Int @default(2)
-  dissolveScheduleOtherPerCadence    Int @default(10)
+  dissolveScheduleCadenceDays        Int       @default(7)
+  dissolveScheduleFeaturedPerCadence Int       @default(2)
+  dissolveScheduleOtherPerCadence    Int       @default(10)
   // Site favicon / meta-icon set, uploaded from Admin > Manage Homepage > Favicon.
   // faviconVersion is bumped on every upload and appended as a cache-busting
   // query string to every icon URL rendered in pages/index.vue's useHead.
-  faviconVersion             BigInt?
-  faviconSourcePath          String? // original master upload, retained for re-generation/audit
-  createdAt                  DateTime @default(now())
-  updatedAt                  DateTime @updatedAt
+  faviconVersion                     BigInt?
+  faviconSourcePath                  String? // original master upload, retained for re-generation/audit
+  // cMoon (faction) feature — off by default, easy to disable without losing data.
+  // When flipped false -> true, cMoonEnabledAt is set to now and cMoonSelectionDeadlineAt
+  // to now + 3 days (the window existing users get to pick a cMoon before auto-assignment).
+  cMoonEnabled                       Boolean   @default(false)
+  cMoonEnabledAt                     DateTime?
+  cMoonSelectionDeadlineAt           DateTime?
+  createdAt                          DateTime  @default(now())
+  updatedAt                          DateTime  @updatedAt
 }
 
 model WishlistItem {
@@ -2418,12 +2443,49 @@ model Achievement {
   setsRequired                String[] // complete ALL sets in this array
   userCreatedBefore           DateTime? // user must have signed up before this date (strictly earlier)
   discordRoleName             String?
+  // When true, unlocking this achievement does NOT auto-grant `rewards` —
+  // instead the user picks exactly one of `claimOptions` (up to 4) via the claim UI.
+  isClaimable                 Boolean   @default(false)
   createdAt                   DateTime  @default(now())
   updatedAt                   DateTime  @updatedAt
 
   rewards        AchievementReward[]
   users          AchievementUser[]
   requiredCtoons AchievementRequiredCtoon[]
+  claimOptions   AchievementClaimOption[]
+  claims         AchievementClaim[]
+}
+
+model AchievementClaimOption {
+  id            String  @id @default(uuid())
+  achievementId String
+  label         String
+  points        Int     @default(0)
+  ctoonId       String?
+  quantity      Int     @default(1)
+  sortOrder     Int     @default(0)
+
+  achievement Achievement        @relation(fields: [achievementId], references: [id], onDelete: Cascade)
+  ctoon       Ctoon?             @relation(fields: [ctoonId], references: [id], onDelete: Restrict)
+  claims      AchievementClaim[]
+
+  @@index([achievementId, sortOrder])
+}
+
+model AchievementClaim {
+  id            String   @id @default(uuid())
+  achievementId String
+  userId        String
+  optionId      String
+  claimedAt     DateTime @default(now())
+
+  achievement Achievement            @relation(fields: [achievementId], references: [id], onDelete: Cascade)
+  user        User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  option      AchievementClaimOption @relation(fields: [optionId], references: [id], onDelete: Restrict)
+
+  @@unique([achievementId, userId])
+  @@index([userId])
+  @@index([optionId])
 }
 
 model AchievementUser {
@@ -2500,6 +2562,49 @@ model AchievementRewardBackground {
 
   @@unique([rewardId, backgroundId])
   @@index([backgroundId])
+}
+
+// cMoon — admin-managed factions. Off by default via GlobalGameConfig.cMoonEnabled.
+model CMoon {
+  id            String   @id @default(uuid())
+  name          String   @unique
+  color         String // "#RRGGBB", validated server-side; used as text color
+  discordRoleId String? // Discord role snowflake granted to members (add-only sync)
+  // Denormalized to avoid COUNT(*) races/scans on every selection + the daily auto-assign job.
+  memberCount   Int      @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  members     User[]
+  captains    CMoonCaptain[]
+  prizeCtoons CMoonPrizeCtoon[]
+
+  @@index([memberCount])
+}
+
+model CMoonCaptain {
+  id      String @id @default(uuid())
+  cMoonId String
+  userId  String
+
+  cMoon CMoon @relation(fields: [cMoonId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([cMoonId, userId])
+  @@index([userId])
+}
+
+model CMoonPrizeCtoon {
+  id       String @id @default(uuid())
+  cMoonId  String
+  ctoonId  String
+  quantity Int    @default(1)
+
+  cMoon CMoon @relation(fields: [cMoonId], references: [id], onDelete: Cascade)
+  ctoon Ctoon @relation(fields: [ctoonId], references: [id], onDelete: Restrict)
+
+  @@unique([cMoonId, ctoonId])
+  @@index([ctoonId])
 }
 
 model AchievementRequiredCtoon {

--- a/server/api/achievements.get.js
+++ b/server/api/achievements.get.js
@@ -18,15 +18,22 @@ export default defineEventHandler(async (event) => {
           ctoons: { include: { ctoon: { select: { id: true, name: true, assetPath: true } } } },
           backgrounds: { include: { background: { select: { id: true, label: true, imagePath: true } } } }
         }
+      },
+      claimOptions: {
+        orderBy: { sortOrder: 'asc' },
+        include: { ctoon: { select: { id: true, name: true, assetPath: true } } }
       }
     }
   })
 
   const ids = list.map(a => a.id)
   const achievedSet = new Set()
+  const claimedMap = new Map()
   if (userId) {
     const rows = await db.achievementUser.findMany({ where: { userId, achievementId: { in: ids } }, select: { achievementId: true } })
     rows.forEach(r => achievedSet.add(r.achievementId))
+    const claims = await db.achievementClaim.findMany({ where: { userId, achievementId: { in: ids } }, select: { achievementId: true, optionId: true } })
+    claims.forEach(c => claimedMap.set(c.achievementId, c.optionId))
   }
 
   // Counts excluding inactive/banned users
@@ -47,6 +54,18 @@ export default defineEventHandler(async (event) => {
     imagePath: a.imagePath,
     achievers: countMap.get(a.id) || 0,
     achieved: userId ? achievedSet.has(a.id) : false,
+    isClaimable: a.isClaimable,
+    claimedOptionId: userId ? (claimedMap.get(a.id) || null) : null,
+    claimOptions: a.isClaimable
+      ? a.claimOptions.map(o => ({
+          id: o.id,
+          label: o.label,
+          points: o.points || 0,
+          ctoonName: o.ctoon?.name || null,
+          ctoonImagePath: o.ctoon?.assetPath || null,
+          quantity: o.quantity,
+        }))
+      : [],
     rewards: a.rewards?.[0]
       ? {
           points: a.rewards[0].points || 0,

--- a/server/api/achievements/[id]/claim.post.js
+++ b/server/api/achievements/[id]/claim.post.js
@@ -1,0 +1,30 @@
+// server/api/achievements/[id]/claim.post.js
+import { defineEventHandler, readBody, createError } from 'h3'
+import { claimAchievementReward, AchievementClaimError } from '@/server/utils/achievements'
+
+const ERROR_STATUS = {
+  NOT_UNLOCKED: { statusCode: 403, statusMessage: 'You have not unlocked this achievement' },
+  NOT_CLAIMABLE: { statusCode: 400, statusMessage: 'This achievement has no claimable reward' },
+  INVALID_OPTION: { statusCode: 400, statusMessage: 'Invalid reward option' },
+  ALREADY_CLAIMED: { statusCode: 409, statusMessage: 'You already claimed a reward for this achievement' },
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+
+  const achievementId = event.context.params?.id
+  const body = await readBody(event)
+  const optionId = typeof body?.optionId === 'string' ? body.optionId : ''
+  if (!optionId) throw createError({ statusCode: 400, statusMessage: 'optionId is required' })
+
+  try {
+    const result = await claimAchievementReward(userId, achievementId, optionId)
+    return { ok: true, ...result }
+  } catch (err) {
+    if (err instanceof AchievementClaimError) {
+      throw createError(ERROR_STATUS[err.code] || { statusCode: 400, statusMessage: 'Unable to claim reward' })
+    }
+    throw createError({ statusCode: 500, statusMessage: 'Unable to claim reward' })
+  }
+})

--- a/server/api/admin/achievements.get.js
+++ b/server/api/admin/achievements.get.js
@@ -17,7 +17,8 @@ export default defineEventHandler(async (event) => {
           backgrounds: { include: { background: { select: { id: true, label: true, imagePath: true } } } }
         }
       },
-      requiredCtoons: { include: { ctoon: { select: { id: true, name: true, assetPath: true } } } }
+      requiredCtoons: { include: { ctoon: { select: { id: true, name: true, assetPath: true } } } },
+      claimOptions: { orderBy: { sortOrder: 'asc' }, include: { ctoon: { select: { id: true, name: true } } } }
     }
   })
 
@@ -45,6 +46,8 @@ export default defineEventHandler(async (event) => {
     ctoonsRequired: (a.requiredCtoons || []).map(rc => ({ ctoonId: rc.ctoonId, name: rc.ctoon?.name || '', assetPath: rc.ctoon?.assetPath || null })),
     userCreatedBefore: a.userCreatedBefore,
     discordRoleName: a.discordRoleName,
+    isClaimable: a.isClaimable,
+    claimOptions: (a.claimOptions || []).map(o => ({ id: o.id, label: o.label, points: o.points, ctoonId: o.ctoonId, ctoonName: o.ctoon?.name || '', quantity: o.quantity })),
     rewards: a.rewards?.[0] ? {
       points: a.rewards[0].points || 0,
       ctoons: (a.rewards[0].ctoons || []).map(rc => ({ ctoonId: rc.ctoonId, quantity: rc.quantity, name: rc.ctoon?.name || '' })),

--- a/server/api/admin/achievements.post.js
+++ b/server/api/admin/achievements.post.js
@@ -41,11 +41,31 @@ export default defineEventHandler(async (event) => {
     isActive = true,
     notifyDiscord = false,
     discordRoleName = '',
+    isClaimable = false,
     criteria = {},
-    rewards = {}
+    rewards = {},
+    claimOptions = []
   } = payload || {}
 
   if (!String(title).trim()) throw createError({ statusCode: 400, statusMessage: 'Title is required' })
+
+  const claimOptionRows = (Array.isArray(claimOptions) ? claimOptions : [])
+    .slice(0, 4)
+    .filter(o => o && String(o.label || '').trim())
+    .map((o, i) => ({
+      label: String(o.label).trim(),
+      points: Math.max(0, Number(o.points || 0)) || 0,
+      ctoonId: o.ctoonId ? String(o.ctoonId) : null,
+      quantity: Math.max(1, Number(o.quantity || 1)),
+      sortOrder: i,
+    }))
+  const claimCtoonIds = claimOptionRows.map(o => o.ctoonId).filter(Boolean)
+  if (claimCtoonIds.length) {
+    const validCount = await db.ctoon.count({ where: { id: { in: [...new Set(claimCtoonIds)] } } })
+    if (validCount !== new Set(claimCtoonIds).size) {
+      throw createError({ statusCode: 400, statusMessage: 'One or more claim option cToons do not exist' })
+    }
+  }
   let slug = slugify(desiredSlug || title)
 
   // ensure unique slug
@@ -79,6 +99,7 @@ export default defineEventHandler(async (event) => {
       isActive: !!isActive,
       notifyDiscord: !!notifyDiscord,
       discordRoleName: roleName || null,
+      isClaimable: !!isClaimable,
       pointsGte:       criteria?.pointsGte       ?? null,
       totalCtoonsGte:  criteria?.totalCtoonsGte  ?? null,
       uniqueCtoonsGte: criteria?.uniqueCtoonsGte ?? null,
@@ -112,6 +133,9 @@ export default defineEventHandler(async (event) => {
               .map(r => ({ backgroundId: String(r.backgroundId) }))
           }
         }
+      },
+      claimOptions: {
+        create: claimOptionRows
       }
     }
   })

--- a/server/api/admin/achievements/[id].put.js
+++ b/server/api/admin/achievements/[id].put.js
@@ -52,9 +52,29 @@ export default defineEventHandler(async (event) => {
     isActive = ach.isActive,
     notifyDiscord = ach.notifyDiscord,
     discordRoleName = ach.discordRoleName,
+    isClaimable = ach.isClaimable,
     criteria = {},
-    rewards = {}
+    rewards = {},
+    claimOptions = []
   } = payload || {}
+
+  const claimOptionRows = (Array.isArray(claimOptions) ? claimOptions : [])
+    .slice(0, 4)
+    .filter(o => o && String(o.label || '').trim())
+    .map((o, i) => ({
+      label: String(o.label).trim(),
+      points: Math.max(0, Number(o.points || 0)) || 0,
+      ctoonId: o.ctoonId ? String(o.ctoonId) : null,
+      quantity: Math.max(1, Number(o.quantity || 1)),
+      sortOrder: i,
+    }))
+  const claimCtoonIds = claimOptionRows.map(o => o.ctoonId).filter(Boolean)
+  if (claimCtoonIds.length) {
+    const validCount = await db.ctoon.count({ where: { id: { in: [...new Set(claimCtoonIds)] } } })
+    if (validCount !== new Set(claimCtoonIds).size) {
+      throw createError({ statusCode: 400, statusMessage: 'One or more claim option cToons do not exist' })
+    }
+  }
 
   // Optional image replacement
   let imagePath = ach.imagePath
@@ -87,6 +107,7 @@ export default defineEventHandler(async (event) => {
       isActive: !!isActive,
       notifyDiscord: !!notifyDiscord,
       discordRoleName: roleName || null,
+      isClaimable: !!isClaimable,
       pointsGte:       criteria?.pointsGte       ?? null,
       totalCtoonsGte:  criteria?.totalCtoonsGte  ?? null,
       uniqueCtoonsGte: criteria?.uniqueCtoonsGte ?? null,
@@ -103,6 +124,19 @@ export default defineEventHandler(async (event) => {
       userCreatedBefore: criteria?.userCreatedBefore ? new Date(criteria.userCreatedBefore) : null,
     }
   })
+
+  // Claim options: replace, but never delete an option a user has already
+  // claimed against (AchievementClaim.optionId is onDelete: Restrict) — those
+  // are left as-is so past claims stay auditable; only never-claimed options
+  // are cleared before inserting the new set.
+  const claimedOptionIds = new Set(
+    (await db.achievementClaim.findMany({ where: { achievementId: id }, select: { optionId: true } })).map(c => c.optionId)
+  )
+  const deletableOptionIds = (await db.achievementClaimOption.findMany({ where: { achievementId: id }, select: { id: true } }))
+    .map(o => o.id)
+    .filter(oid => !claimedOptionIds.has(oid))
+  if (deletableOptionIds.length) await db.achievementClaimOption.deleteMany({ where: { id: { in: deletableOptionIds } } })
+  if (claimOptionRows.length) await db.achievementClaimOption.createMany({ data: claimOptionRows.map(o => ({ achievementId: id, ...o })) })
 
   // Required cToons: replace
   await db.achievementRequiredCtoon.deleteMany({ where: { achievementId: id } })

--- a/server/api/admin/cmoon-admins.get.js
+++ b/server/api/admin/cmoon-admins.get.js
@@ -1,0 +1,18 @@
+// server/api/admin/cmoon-admins.get.js
+// Lists admins eligible to be set as cMoon captains.
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const admins = await db.user.findMany({
+    where: { isAdmin: true, active: true },
+    select: { id: true, username: true },
+    orderBy: { username: 'asc' },
+  })
+  return admins
+})

--- a/server/api/admin/cmoon-settings.post.js
+++ b/server/api/admin/cmoon-settings.post.js
@@ -1,0 +1,53 @@
+// server/api/admin/cmoon-settings.post.js
+// Dedicated toggle for the cMoon feature flag, kept separate from the general
+// global-config endpoint so the whole feature can be ripped out later by
+// deleting this file + the cMoon-specific tables, without touching anything else.
+import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { invalidateGlobalConfigCache } from '@/server/utils/cmoon'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const body = await readBody(event)
+  const enabled = !!body?.cMoonEnabled
+
+  const existing = await db.globalGameConfig.findUnique({ where: { id: 'singleton' } })
+  const wasEnabled = !!existing?.cMoonEnabled
+
+  const data = { cMoonEnabled: enabled }
+  // Rising edge only: starting the feature (re)sets the launch timestamp and the
+  // 3-day window existing users get to pick before auto-assignment kicks in.
+  // Flipping it off never touches these — data/timers are preserved so turning
+  // it back on later doesn't reset anyone's clock unexpectedly.
+  if (enabled && !wasEnabled) {
+    const now = new Date()
+    data.cMoonEnabledAt = now
+    data.cMoonSelectionDeadlineAt = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000)
+  }
+
+  const updated = await db.globalGameConfig.upsert({
+    where: { id: 'singleton' },
+    create: { id: 'singleton', dailyPointLimit: 100, ...data },
+    update: data,
+  })
+  invalidateGlobalConfigCache()
+
+  await logAdminChange(db, {
+    userId: me.id,
+    area: 'cMoon',
+    key: 'cMoonEnabled',
+    prevValue: { cMoonEnabled: wasEnabled },
+    newValue: { cMoonEnabled: enabled, cMoonEnabledAt: updated.cMoonEnabledAt, cMoonSelectionDeadlineAt: updated.cMoonSelectionDeadlineAt },
+  })
+
+  return {
+    cMoonEnabled: updated.cMoonEnabled,
+    cMoonEnabledAt: updated.cMoonEnabledAt,
+    cMoonSelectionDeadlineAt: updated.cMoonSelectionDeadlineAt,
+  }
+})

--- a/server/api/admin/cmoons.get.js
+++ b/server/api/admin/cmoons.get.js
@@ -1,0 +1,36 @@
+// server/api/admin/cmoons.get.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const [cmoons, config] = await Promise.all([
+    db.cMoon.findMany({
+      orderBy: { createdAt: 'asc' },
+      include: {
+        captains: { include: { user: { select: { id: true, username: true } } } },
+        prizeCtoons: { include: { ctoon: { select: { id: true, name: true, assetPath: true } } } },
+      },
+    }),
+    db.globalGameConfig.findUnique({ where: { id: 'singleton' }, select: { cMoonEnabled: true, cMoonEnabledAt: true, cMoonSelectionDeadlineAt: true } }),
+  ])
+
+  return {
+    cMoonEnabled: !!config?.cMoonEnabled,
+    cMoonEnabledAt: config?.cMoonEnabledAt || null,
+    cMoonSelectionDeadlineAt: config?.cMoonSelectionDeadlineAt || null,
+    cmoons: cmoons.map(c => ({
+      id: c.id,
+      name: c.name,
+      color: c.color,
+      discordRoleId: c.discordRoleId,
+      memberCount: c.memberCount,
+      captains: c.captains.map(cap => ({ userId: cap.userId, username: cap.user?.username || '' })),
+      prizeCtoons: c.prizeCtoons.map(pc => ({ ctoonId: pc.ctoonId, quantity: pc.quantity, name: pc.ctoon?.name || '', assetPath: pc.ctoon?.assetPath || null })),
+    })),
+  }
+})

--- a/server/api/admin/cmoons.post.js
+++ b/server/api/admin/cmoons.post.js
@@ -1,0 +1,57 @@
+// server/api/admin/cmoons.post.js
+import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { isValidHexColor, isValidDiscordSnowflake } from '@/server/utils/cmoon'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const body = await readBody(event)
+  const name = typeof body?.name === 'string' ? body.name.trim() : ''
+  const color = typeof body?.color === 'string' ? body.color.trim() : ''
+  const discordRoleId = typeof body?.discordRoleId === 'string' ? body.discordRoleId.trim() : ''
+  const captainIds = Array.isArray(body?.captainIds) ? [...new Set(body.captainIds.filter(x => typeof x === 'string'))] : []
+  const prizeCtoons = Array.isArray(body?.prizeCtoons) ? body.prizeCtoons : []
+
+  if (!name) throw createError({ statusCode: 400, statusMessage: 'Name is required' })
+  if (!isValidHexColor(color)) throw createError({ statusCode: 400, statusMessage: 'Color must be a hex value like #3366ff' })
+  if (discordRoleId && !isValidDiscordSnowflake(discordRoleId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Discord Role ID must be a numeric snowflake' })
+  }
+
+  if (captainIds.length) {
+    const validAdmins = await db.user.count({ where: { id: { in: captainIds }, isAdmin: true } })
+    if (validAdmins !== captainIds.length) throw createError({ statusCode: 400, statusMessage: 'Captains must be existing admins' })
+  }
+
+  const prizeCtoonRows = prizeCtoons
+    .filter(p => p?.ctoonId && typeof p.ctoonId === 'string')
+    .map(p => ({ ctoonId: p.ctoonId, quantity: Math.max(1, Number(p.quantity || 1)) }))
+  if (prizeCtoonRows.length) {
+    const validCtoons = await db.ctoon.count({ where: { id: { in: prizeCtoonRows.map(p => p.ctoonId) } } })
+    if (validCtoons !== new Set(prizeCtoonRows.map(p => p.ctoonId)).size) {
+      throw createError({ statusCode: 400, statusMessage: 'One or more prize cToons do not exist' })
+    }
+  }
+
+  const existing = await db.cMoon.findUnique({ where: { name } })
+  if (existing) throw createError({ statusCode: 409, statusMessage: 'A cMoon with that name already exists' })
+
+  const created = await db.cMoon.create({
+    data: {
+      name,
+      color,
+      discordRoleId: discordRoleId || null,
+      captains: { create: captainIds.map(userId => ({ userId })) },
+      prizeCtoons: { create: prizeCtoonRows },
+    },
+  })
+
+  await logAdminChange(db, { userId: me.id, area: 'cMoon', key: `create:${created.id}`, prevValue: null, newValue: { id: created.id, name } })
+
+  return { id: created.id }
+})

--- a/server/api/admin/cmoons/[id].delete.js
+++ b/server/api/admin/cmoons/[id].delete.js
@@ -1,0 +1,24 @@
+// server/api/admin/cmoons/[id].delete.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const id = event.context.params?.id
+  const cmoon = await db.cMoon.findUnique({ where: { id } })
+  if (!cmoon) throw createError({ statusCode: 404, statusMessage: 'cMoon not found' })
+
+  if (cmoon.memberCount > 0) {
+    throw createError({ statusCode: 409, statusMessage: 'Cannot delete a cMoon that still has members — reassign them first' })
+  }
+
+  await db.cMoon.delete({ where: { id } })
+  await logAdminChange(db, { userId: me.id, area: 'cMoon', key: `delete:${id}`, prevValue: { name: cmoon.name }, newValue: null })
+
+  return { ok: true }
+})

--- a/server/api/admin/cmoons/[id].put.js
+++ b/server/api/admin/cmoons/[id].put.js
@@ -1,0 +1,71 @@
+// server/api/admin/cmoons/[id].put.js
+import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { isValidHexColor, isValidDiscordSnowflake } from '@/server/utils/cmoon'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const id = event.context.params?.id
+  const cmoon = await db.cMoon.findUnique({ where: { id } })
+  if (!cmoon) throw createError({ statusCode: 404, statusMessage: 'cMoon not found' })
+
+  const body = await readBody(event)
+  const name = typeof body?.name === 'string' ? body.name.trim() : cmoon.name
+  const color = typeof body?.color === 'string' ? body.color.trim() : cmoon.color
+  const discordRoleId = body?.discordRoleId === undefined ? cmoon.discordRoleId : (typeof body.discordRoleId === 'string' ? body.discordRoleId.trim() : '')
+  const captainIds = Array.isArray(body?.captainIds) ? [...new Set(body.captainIds.filter(x => typeof x === 'string'))] : null
+  const prizeCtoons = Array.isArray(body?.prizeCtoons) ? body.prizeCtoons : null
+
+  if (!name) throw createError({ statusCode: 400, statusMessage: 'Name is required' })
+  if (!isValidHexColor(color)) throw createError({ statusCode: 400, statusMessage: 'Color must be a hex value like #3366ff' })
+  if (discordRoleId && !isValidDiscordSnowflake(discordRoleId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Discord Role ID must be a numeric snowflake' })
+  }
+
+  if (captainIds && captainIds.length) {
+    const validAdmins = await db.user.count({ where: { id: { in: captainIds }, isAdmin: true } })
+    if (validAdmins !== captainIds.length) throw createError({ statusCode: 400, statusMessage: 'Captains must be existing admins' })
+  }
+
+  let prizeCtoonRows = null
+  if (prizeCtoons) {
+    prizeCtoonRows = prizeCtoons
+      .filter(p => p?.ctoonId && typeof p.ctoonId === 'string')
+      .map(p => ({ ctoonId: p.ctoonId, quantity: Math.max(1, Number(p.quantity || 1)) }))
+    if (prizeCtoonRows.length) {
+      const validCtoons = await db.ctoon.count({ where: { id: { in: prizeCtoonRows.map(p => p.ctoonId) } } })
+      if (validCtoons !== new Set(prizeCtoonRows.map(p => p.ctoonId)).size) {
+        throw createError({ statusCode: 400, statusMessage: 'One or more prize cToons do not exist' })
+      }
+    }
+  }
+
+  if (name !== cmoon.name) {
+    const dup = await db.cMoon.findUnique({ where: { name } })
+    if (dup && dup.id !== id) throw createError({ statusCode: 409, statusMessage: 'A cMoon with that name already exists' })
+  }
+
+  await db.$transaction(async (tx) => {
+    await tx.cMoon.update({
+      where: { id },
+      data: { name, color, discordRoleId: discordRoleId || null },
+    })
+    if (captainIds) {
+      await tx.cMoonCaptain.deleteMany({ where: { cMoonId: id } })
+      if (captainIds.length) await tx.cMoonCaptain.createMany({ data: captainIds.map(userId => ({ cMoonId: id, userId })), skipDuplicates: true })
+    }
+    if (prizeCtoonRows) {
+      await tx.cMoonPrizeCtoon.deleteMany({ where: { cMoonId: id } })
+      if (prizeCtoonRows.length) await tx.cMoonPrizeCtoon.createMany({ data: prizeCtoonRows.map(p => ({ cMoonId: id, ...p })), skipDuplicates: true })
+    }
+  })
+
+  await logAdminChange(db, { userId: me.id, area: 'cMoon', key: `update:${id}`, prevValue: { name: cmoon.name, color: cmoon.color }, newValue: { name, color } })
+
+  return { ok: true }
+})

--- a/server/api/cmoon/select.post.js
+++ b/server/api/cmoon/select.post.js
@@ -1,0 +1,30 @@
+// server/api/cmoon/select.post.js
+import { defineEventHandler, readBody, createError } from 'h3'
+import { selectCMoonForUser, CMoonError, CMOON_SELECT_ERRORS } from '@/server/utils/cmoon'
+
+const ERROR_STATUS = {
+  [CMOON_SELECT_ERRORS.DISABLED]: { statusCode: 403, statusMessage: 'cMoons are not currently enabled' },
+  [CMOON_SELECT_ERRORS.NOT_FOUND]: { statusCode: 404, statusMessage: 'cMoon not found' },
+  [CMOON_SELECT_ERRORS.ALREADY_ASSIGNED]: { statusCode: 409, statusMessage: 'You already belong to a cMoon' },
+  [CMOON_SELECT_ERRORS.DEADLINE_PASSED]: { statusCode: 409, statusMessage: 'Your selection window has passed' },
+}
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+
+  const body = await readBody(event)
+  const cMoonId = typeof body?.cMoonId === 'string' ? body.cMoonId : ''
+  if (!cMoonId) throw createError({ statusCode: 400, statusMessage: 'cMoonId is required' })
+
+  try {
+    const assigned = await selectCMoonForUser(userId, cMoonId)
+    return { ok: true, cMoonId: assigned }
+  } catch (err) {
+    if (err instanceof CMoonError) {
+      const mapped = ERROR_STATUS[err.code] || { statusCode: 400, statusMessage: 'Unable to select cMoon' }
+      throw createError(mapped)
+    }
+    throw createError({ statusCode: 500, statusMessage: 'Unable to select cMoon' })
+  }
+})

--- a/server/api/cmoon/status.get.js
+++ b/server/api/cmoon/status.get.js
@@ -1,0 +1,37 @@
+// server/api/cmoon/status.get.js
+// The logged-in user's cMoon selection state: what they're in (if anything),
+// whether they're still eligible to choose, and their personal deadline.
+import { defineEventHandler, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { getGlobalConfig, computeCMoonDeadline } from '@/server/utils/cmoon'
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+
+  const config = await getGlobalConfig()
+  if (!config?.cMoonEnabled) return { cMoonEnabled: false }
+
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: {
+      createdAt: true,
+      cMoonId: true,
+      cMoonSelectedAt: true,
+      cMoonAutoAssigned: true,
+      cMoon: { select: { id: true, name: true, color: true } },
+    },
+  })
+  if (!user) throw createError({ statusCode: 404, statusMessage: 'User not found' })
+
+  const deadline = computeCMoonDeadline(user, config)
+
+  return {
+    cMoonEnabled: true,
+    cMoon: user.cMoon,
+    cMoonSelectedAt: user.cMoonSelectedAt,
+    cMoonAutoAssigned: user.cMoonAutoAssigned,
+    canChoose: !user.cMoonId && (!deadline || new Date() <= deadline),
+    deadline,
+  }
+})

--- a/server/api/cmoons.get.js
+++ b/server/api/cmoons.get.js
@@ -1,0 +1,28 @@
+// server/api/cmoons.get.js
+// Public list of cMoons with live member counts, used by the selection UI,
+// cZone, and leaderboard. Cached briefly in-process — this is read on every
+// visit to pages that show cMoon data, and member counts don't need to be
+// millisecond-fresh.
+import { defineEventHandler } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { getGlobalConfig } from '@/server/utils/cmoon'
+
+let cachedList = null
+let cachedAt = 0
+const TTL_MS = 30_000
+
+export default defineEventHandler(async () => {
+  const config = await getGlobalConfig()
+  if (!config?.cMoonEnabled) return { cMoonEnabled: false, cmoons: [] }
+
+  const now = Date.now()
+  if (!cachedList || (now - cachedAt) >= TTL_MS) {
+    cachedList = await db.cMoon.findMany({
+      orderBy: { name: 'asc' },
+      select: { id: true, name: true, color: true, memberCount: true },
+    })
+    cachedAt = now
+  }
+
+  return { cMoonEnabled: true, cmoons: cachedList }
+})

--- a/server/api/czone/[username].get.js
+++ b/server/api/czone/[username].get.js
@@ -3,6 +3,7 @@
 import { defineEventHandler, createError } from 'h3'
 
 import { prisma } from '@/server/prisma'
+import { getGlobalConfig } from '@/server/utils/cmoon'
 
 function normalizeZones(layoutData, background, targetCount) {
   let zones = []
@@ -36,7 +37,8 @@ export default defineEventHandler(async (event) => {
   const user = await prisma.user.findUnique({
     where: { username },
     include: {
-      cZones: true
+      cZones: true,
+      cMoon: { select: { id: true, name: true, color: true } }
     }
   })
 
@@ -56,6 +58,9 @@ export default defineEventHandler(async (event) => {
   // everyone else from `ctoonId`, `mintNumber`, asset, etc.
   const viewerId = event.context.userId || event.context.user?.id || null
   const viewerIsOwner = !!viewerId && viewerId === user.id
+
+  const cMoonConfig = await getGlobalConfig()
+  const cMoonEnabled = !!cMoonConfig?.cMoonEnabled
 
   const config = await prisma.globalGameConfig.findUnique({
     where: { id: 'singleton' },
@@ -244,6 +249,7 @@ export default defineEventHandler(async (event) => {
     ownerName: user.username,
     isBooster: user.isBooster,
     lastActivity: user.lastActivity ?? null,
+    cMoon: (cMoonEnabled && user.cMoon) || null,
     cZone: {
       id: chosenZone.id,
       zones: enrichedZones,

--- a/server/api/leaderboard/cmoon-badges.post.js
+++ b/server/api/leaderboard/cmoon-badges.post.js
@@ -1,0 +1,33 @@
+// server/api/leaderboard/cmoon-badges.post.js
+// Batched cMoon lookup for the leaderboard: the leaderboard already fetches
+// ~10 separate per-board endpoints, so joining cMoon into each of those would
+// mean touching a dozen files. Instead the page collects all usernames it's
+// about to render and asks once here — a single indexed query, not one
+// request per row.
+import { defineEventHandler, readBody } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { getGlobalConfig } from '@/server/utils/cmoon'
+
+const MAX_USERNAMES = 500
+
+export default defineEventHandler(async (event) => {
+  const config = await getGlobalConfig()
+  if (!config?.cMoonEnabled) return {}
+
+  const body = await readBody(event)
+  const usernames = Array.isArray(body?.usernames)
+    ? [...new Set(body.usernames.filter(u => typeof u === 'string' && u))].slice(0, MAX_USERNAMES)
+    : []
+  if (!usernames.length) return {}
+
+  const rows = await db.user.findMany({
+    where: { username: { in: usernames } },
+    select: { username: true, cMoon: { select: { name: true, color: true } } },
+  })
+
+  const map = {}
+  for (const row of rows) {
+    if (row.cMoon) map[row.username] = row.cMoon
+  }
+  return map
+})

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -17,6 +17,7 @@ import { applyDissolveSchedule, getDissolveScheduleConfig } from '../utils/disso
 import { logAuctionOnlyError } from '../utils/auctionOnlyErrorLog.js'
 import { activateAuctionOnlyRow, AUCTION_ONLY_ROW_INCLUDE } from '../utils/auctionOnlyActivate.js'
 import { logCronError } from '../utils/cronErrorLog.js'
+import { autoAssignExpiredCMoonUsers } from '../utils/cmoon.js'
 
 const BOT_TOKEN   = process.env.BOT_TOKEN
 const ANNOUNCEMENTS_BOT_TOKEN = process.env.DISCORD_ANNOUNCEMENTS_BOT_TOKEN || BOT_TOKEN
@@ -500,6 +501,39 @@ async function syncVerifiedRoles() {
     if (!ok) continue
     try {
       await prisma.user.update({ where: { id: row.id }, data: { isVerified: true } })
+    } catch {}
+  }
+}
+
+// Grants each cMoon's Discord role to members who don't have it yet. Add-only —
+// never removes a role, matching every other role-grant job in this file.
+// Gated by User.cMoonRoleGrantedAt (set once a grant succeeds) instead of a live
+// "does the member already have this role" check, so this only ever touches
+// newly-joined/never-synced members instead of re-scanning the whole roster daily.
+async function syncCMoonDiscordRoles() {
+  let rows = []
+  try {
+    rows = await prisma.$queryRawUnsafe(`
+      SELECT u."id", u."discordId", m."discordRoleId"
+      FROM "User" u
+      JOIN "CMoon" m ON m."id" = u."cMoonId"
+      WHERE u."cMoonId" IS NOT NULL
+        AND u."cMoonRoleGrantedAt" IS NULL
+        AND m."discordRoleId" IS NOT NULL
+        AND u."discordId" IS NOT NULL
+        AND u."inGuild" = true
+        AND u."active" = true
+      LIMIT 300
+    `)
+  } catch {
+    return
+  }
+
+  for (const row of rows) {
+    const ok = await addRoleToMember(row.discordId, row.discordRoleId)
+    if (!ok) continue
+    try {
+      await prisma.user.update({ where: { id: row.id }, data: { cMoonRoleGrantedAt: new Date() } })
     } catch {}
   }
 }
@@ -1146,6 +1180,14 @@ await runJob('recordDailyActivity', recordDailyActivity)
 await runJob('syncVerifiedRoles', syncVerifiedRoles)
 cron.schedule('30 2 * * *', () => runJob('recordDailyActivity', recordDailyActivity), { timezone: 'America/Chicago' }) // 02:30 CST daily
 cron.schedule('35 2 * * *', () => runJob('syncVerifiedRoles', syncVerifiedRoles), { timezone: 'America/Chicago' }) // 02:35 CST daily
+
+// cMoon: auto-assign anyone past their pick-a-cMoon deadline, then grant Discord
+// role flair to newly-assigned/newly-selected members. Off by default via
+// GlobalGameConfig.cMoonEnabled — both jobs no-op immediately when disabled.
+await runJob('autoAssignExpiredCMoonUsers', autoAssignExpiredCMoonUsers)
+await runJob('syncCMoonDiscordRoles', syncCMoonDiscordRoles)
+cron.schedule('40 2 * * *', () => runJob('autoAssignExpiredCMoonUsers', autoAssignExpiredCMoonUsers), { timezone: 'America/Chicago' }) // 02:40 CST daily
+cron.schedule('45 2 * * *', () => runJob('syncCMoonDiscordRoles', syncCMoonDiscordRoles), { timezone: 'America/Chicago' }) // 02:45 CST daily
 
 await runJob('recomputeLastActivity', recomputeLastActivity)
 cron.schedule('0 4 * * *', () => runJob('recomputeLastActivity', recomputeLastActivity), { timezone: 'America/Chicago' })  // 04:00 CST daily

--- a/server/utils/achievements.js
+++ b/server/utils/achievements.js
@@ -195,6 +195,12 @@ export async function awardAchievementToUser(client, userId, achievement) {
     // console.log('[achievements] award: creating achievementUser', { userId, ach: achievement?.slug || achievement?.id })
     await tx.achievementUser.create({ data: { achievementId: achievement.id, userId } })
 
+    // Claimable achievements don't auto-grant a reward — the user picks one of
+    // up to 4 options via POST /api/achievements/:id/claim instead.
+    if (achievement.isClaimable) {
+      return { points: 0, ctoons: [], backgrounds: 0 }
+    }
+
     // Rewards
     const reward = await tx.achievementReward.findFirst({
       where: { achievementId: achievement.id },
@@ -324,4 +330,63 @@ export async function processAchievementsForUser(userId) {
 
   // console.log('[achievements] process: complete', { userId, awarded })
   return { awarded }
+}
+
+export class AchievementClaimError extends Error {
+  constructor(code) {
+    super(code)
+    this.code = code
+  }
+}
+
+// User picks exactly one of an achievement's claim options. The unique
+// constraint on AchievementClaim(achievementId, userId) is the atomic guard
+// against double-claiming (concurrent double-submit both racing to insert —
+// the second insert throws P2002 and is treated as ALREADY_CLAIMED here).
+export async function claimAchievementReward(userId, achievementId, optionId) {
+  const achieved = await prisma.achievementUser.findUnique({
+    where: { achievementId_userId: { achievementId, userId } },
+  })
+  if (!achieved) throw new AchievementClaimError('NOT_UNLOCKED')
+
+  const ach = await prisma.achievement.findUnique({ where: { id: achievementId }, select: { isClaimable: true } })
+  if (!ach?.isClaimable) throw new AchievementClaimError('NOT_CLAIMABLE')
+
+  const option = await prisma.achievementClaimOption.findUnique({
+    where: { id: optionId },
+    include: { ctoon: { select: { quantity: true, name: true } } },
+  })
+  if (!option || option.achievementId !== achievementId) throw new AchievementClaimError('INVALID_OPTION')
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.achievementClaim.create({ data: { achievementId, userId, optionId } })
+
+      const points = toIntOrNull(option.points)
+      if (points && points > 0) {
+        const up = await getOrCreateUserPoints(tx, userId)
+        const updated = await tx.userPoints.update({ where: { userId }, data: { points: { increment: points } } })
+        await tx.pointsLog.create({
+          data: { userId, points, total: updated.points, method: `achievementClaim:${achievementId}`, direction: 'increase' },
+        })
+      }
+    })
+  } catch (err) {
+    if (err?.code === 'P2002') throw new AchievementClaimError('ALREADY_CLAIMED')
+    throw err
+  }
+
+  // Minting is not transactional (queue add can't roll back), so it runs after
+  // the claim row has safely committed — same pattern as awardAchievementToUser.
+  if (option.ctoonId) {
+    const qty = Math.max(1, Number(option.quantity || 1))
+    const minted = await prisma.userCtoon.count({ where: { ctoonId: option.ctoonId } })
+    const lim = option.ctoon?.quantity
+    const canGive = lim == null ? qty : Math.max(0, Math.min(qty, lim - minted))
+    for (let i = 0; i < canGive; i++) {
+      await mintQueue.add('mintCtoon', { userId, ctoonId: option.ctoonId, isSpecial: true, method: 'ACHIEVEMENT_CLAIM' })
+    }
+  }
+
+  return { label: option.label, points: option.points, ctoonName: option.ctoon?.name || null }
 }

--- a/server/utils/cmoon.js
+++ b/server/utils/cmoon.js
@@ -1,0 +1,201 @@
+// server/utils/cmoon.js
+// Shared logic for the cMoon (faction) feature: eligibility/deadline math, atomic
+// self-selection, cron auto-assignment, and prize granting. Kept in one place so
+// the feature is easy to rip out later — see GlobalGameConfig.cMoonEnabled.
+import { prisma } from '../prisma.js'
+import { mintQueue } from './queues.js'
+
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000
+
+export const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
+export const DISCORD_SNOWFLAKE_RE = /^\d{17,20}$/
+
+export function isValidHexColor(value) {
+  return typeof value === 'string' && HEX_COLOR_RE.test(value)
+}
+
+export function isValidDiscordSnowflake(value) {
+  return typeof value === 'string' && DISCORD_SNOWFLAKE_RE.test(value)
+}
+
+// GlobalGameConfig is read on the selection page/API on every load; cache briefly
+// in-process to avoid hammering the singleton row (mirrors the pattern used by
+// other hot config reads in this codebase, e.g. server/middleware/daily-points.js).
+let cachedConfig = null
+let cachedConfigAt = 0
+const CONFIG_TTL_MS = 30_000
+
+export async function getGlobalConfig({ fresh = false } = {}) {
+  const now = Date.now()
+  if (!fresh && cachedConfig && (now - cachedConfigAt) < CONFIG_TTL_MS) return cachedConfig
+  const cfg = await prisma.globalGameConfig.findUnique({ where: { id: 'singleton' } })
+  cachedConfig = cfg
+  cachedConfigAt = now
+  return cfg
+}
+
+export function invalidateGlobalConfigCache() {
+  cachedConfig = null
+  cachedConfigAt = 0
+}
+
+// A user's personal deadline to pick a cMoon before they're auto-assigned:
+//  - joined on/after the feature's launch (cMoonEnabledAt): 3 days from their own join date
+//  - joined before launch (an "existing" user): the shared cMoonSelectionDeadlineAt
+// Returns null if the feature isn't enabled or the user already has a cMoon.
+export function computeCMoonDeadline(user, config) {
+  if (!config?.cMoonEnabled || !config.cMoonEnabledAt) return null
+  if (user.cMoonId) return null
+  const createdAt = new Date(user.createdAt)
+  const enabledAt = new Date(config.cMoonEnabledAt)
+  if (createdAt >= enabledAt) {
+    return new Date(createdAt.getTime() + THREE_DAYS_MS)
+  }
+  return config.cMoonSelectionDeadlineAt ? new Date(config.cMoonSelectionDeadlineAt) : null
+}
+
+export const CMOON_SELECT_ERRORS = {
+  DISABLED: 'CMOON_DISABLED',
+  NOT_FOUND: 'CMOON_NOT_FOUND',
+  ALREADY_ASSIGNED: 'CMOON_ALREADY_ASSIGNED',
+  DEADLINE_PASSED: 'CMOON_DEADLINE_PASSED',
+}
+
+class CMoonError extends Error {
+  constructor(code) {
+    super(code)
+    this.code = code
+  }
+}
+
+// Grants a cMoon's configured prize cToons to a user. Called only after the
+// selection/assignment transaction has committed (mint jobs are not
+// transactional, so they must never run inside a $transaction that might roll back).
+async function grantCMoonPrizes(userId, cMoonId) {
+  const prizes = await prisma.cMoonPrizeCtoon.findMany({ where: { cMoonId } })
+  for (const prize of prizes) {
+    const qty = Math.max(1, Number(prize.quantity || 1))
+    for (let i = 0; i < qty; i++) {
+      await mintQueue.add('mintCtoon', {
+        userId,
+        ctoonId: prize.ctoonId,
+        isSpecial: true,
+        method: 'CMOON_PRIZE',
+      })
+    }
+  }
+}
+
+// User-initiated selection. Atomic: the `updateMany({ where: { cMoonId: null } })`
+// clause is the concurrency gate — Postgres serializes concurrent writers on the
+// same row, and the second writer sees count===0 and is rejected. This prevents
+// double-selection (and the double prize grant that would follow it) under
+// concurrent double-submits.
+export async function selectCMoonForUser(userId, cMoonId) {
+  const config = await getGlobalConfig({ fresh: true })
+  if (!config?.cMoonEnabled) throw new CMoonError(CMOON_SELECT_ERRORS.DISABLED)
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, createdAt: true, cMoonId: true },
+  })
+  if (!user) throw new CMoonError(CMOON_SELECT_ERRORS.NOT_FOUND)
+  if (user.cMoonId) throw new CMoonError(CMOON_SELECT_ERRORS.ALREADY_ASSIGNED)
+
+  const deadline = computeCMoonDeadline(user, config)
+  if (deadline && new Date() > deadline) throw new CMoonError(CMOON_SELECT_ERRORS.DEADLINE_PASSED)
+
+  const cmoon = await prisma.cMoon.findUnique({ where: { id: cMoonId }, select: { id: true } })
+  if (!cmoon) throw new CMoonError(CMOON_SELECT_ERRORS.NOT_FOUND)
+
+  const assigned = await prisma.$transaction(async (tx) => {
+    const result = await tx.user.updateMany({
+      where: { id: userId, cMoonId: null },
+      data: { cMoonId: cmoon.id, cMoonSelectedAt: new Date(), cMoonAutoAssigned: false },
+    })
+    if (result.count === 0) throw new CMoonError(CMOON_SELECT_ERRORS.ALREADY_ASSIGNED)
+    await tx.cMoon.update({ where: { id: cmoon.id }, data: { memberCount: { increment: 1 } } })
+    return cmoon.id
+  })
+
+  await grantCMoonPrizes(userId, assigned)
+  return assigned
+}
+
+// Assigns one user to whatever cMoon currently has the fewest members.
+// `FOR UPDATE` on the chosen CMoon row serializes concurrent assignments so two
+// callers can't both read the same "smallest" moon before either commits.
+async function assignSmallestCMoonToUser(userId) {
+  return prisma.$transaction(async (tx) => {
+    const [smallest] = await tx.$queryRaw`
+      SELECT id FROM "CMoon" ORDER BY "memberCount" ASC, id ASC LIMIT 1 FOR UPDATE
+    `
+    if (!smallest) return null
+
+    const result = await tx.user.updateMany({
+      where: { id: userId, cMoonId: null },
+      data: { cMoonId: smallest.id, cMoonSelectedAt: new Date(), cMoonAutoAssigned: true },
+    })
+    if (result.count === 0) return null
+
+    await tx.cMoon.update({ where: { id: smallest.id }, data: { memberCount: { increment: 1 } } })
+    return smallest.id
+  })
+}
+
+// Daily cron entry point. Finds users whose personal deadline has passed and
+// haven't picked a cMoon, auto-assigns them to the smallest cMoon, and grants
+// that cMoon's prizes. Capped per run so a large backlog can't stall the shared
+// cron process or flood the mint queue in one shot; it drains across days.
+export async function autoAssignExpiredCMoonUsers({ batchLimit = 200, maxBatches = 5 } = {}) {
+  const config = await getGlobalConfig({ fresh: true })
+  if (!config?.cMoonEnabled || !config.cMoonEnabledAt) return { processed: 0 }
+
+  const cmoonCount = await prisma.cMoon.count()
+  if (cmoonCount === 0) return { processed: 0 }
+
+  const now = new Date()
+  const newUserCutoff = new Date(now.getTime() - THREE_DAYS_MS)
+  const enabledAt = new Date(config.cMoonEnabledAt)
+  const globalDeadlinePassed = !!(config.cMoonSelectionDeadlineAt && now > new Date(config.cMoonSelectionDeadlineAt))
+
+  const orClauses = [
+    { createdAt: { gte: enabledAt, lt: newUserCutoff } },
+  ]
+  if (globalDeadlinePassed) {
+    orClauses.push({ createdAt: { lt: enabledAt } })
+  }
+
+  let processed = 0
+  for (let batch = 0; batch < maxBatches; batch++) {
+    const candidates = await prisma.user.findMany({
+      where: {
+        cMoonId: null,
+        active: true,
+        banned: false,
+        OR: orClauses,
+      },
+      select: { id: true },
+      take: batchLimit,
+    })
+    if (candidates.length === 0) break
+
+    for (const { id: userId } of candidates) {
+      try {
+        const cMoonId = await assignSmallestCMoonToUser(userId)
+        if (cMoonId) {
+          await grantCMoonPrizes(userId, cMoonId)
+          processed++
+        }
+      } catch {
+        // one user's failure shouldn't stop the rest of the batch
+      }
+    }
+
+    if (candidates.length < batchLimit) break
+  }
+
+  return { processed }
+}
+
+export { CMoonError }

--- a/utils/cmoonColor.js
+++ b/utils/cmoonColor.js
@@ -1,0 +1,26 @@
+// utils/cmoonColor.js
+// cMoon colors are admin-chosen hex values with no guaranteed contrast against
+// any particular background. Render them as a small pill (color as background,
+// not text) with black/white text picked by relative luminance, so an
+// arbitrarily dark or light admin choice always stays readable.
+const HEX_RE = /^#[0-9a-fA-F]{6}$/
+
+export function isSafeCMoonColor(color) {
+  return typeof color === 'string' && HEX_RE.test(color)
+}
+
+function contrastTextColor(hex) {
+  const r = parseInt(hex.slice(1, 3), 16) / 255
+  const g = parseInt(hex.slice(3, 5), 16) / 255
+  const b = parseInt(hex.slice(5, 7), 16) / 255
+  const lin = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4))
+  const luminance = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+  return luminance > 0.5 ? '#0a1830' : '#ffffff'
+}
+
+// Returns a style object safe to bind with :style — never a raw string, so an
+// admin-entered value can't smuggle extra CSS declarations.
+export function cMoonPillStyle(color) {
+  if (!isSafeCMoonColor(color)) return { background: '#3a4a63', color: '#ffffff' }
+  return { background: color, color: contrastTextColor(color) }
+}


### PR DESCRIPTION
- Prisma: CMoon/CMoonCaptain/CMoonPrizeCtoon models, User.cMoonId/cMoonSelectedAt/
  cMoonAutoAssigned/cMoonRoleGrantedAt, GlobalGameConfig.cMoonEnabled/cMoonEnabledAt/
  cMoonSelectionDeadlineAt, and Achievement.isClaimable + AchievementClaimOption/
  AchievementClaim for the new "claim one of up to 4 rewards" achievement mechanic.
- server/utils/cmoon.js: deadline math (3 days from launch for existing users, 3 days
  from join date for new ones), atomic self-selection and cron auto-assignment to the
  smallest cMoon (row-locked to avoid double-assignment races), prize cToon granting.
- New user/admin API routes for selecting a cMoon, listing cMoons, and admin CRUD
  (name/color/Discord role/captains/prize cToons), plus a dedicated cMoonEnabled
  toggle endpoint kept separate from the general global-config route.
- Daily cron jobs (sync-guild-members.js): auto-assign expired users, and an add-only
  Discord role sync gated by cMoonRoleGrantedAt so it only touches never-synced members.
- UI: cMoon badge on cZone (folded into the existing Last Online line) and leaderboard
  (batched lookup, not per-row), a mobile-friendly select-then-confirm cMoon picker
  modal, an achievement claim-option picker, and a newsite admin page for managing
  cMoons and the feature flag.
- Colors are validated as hex and rendered via :style bindings (never string-concat
  CSS) with contrast-safe pill rendering; reward grants go through the existing
  mint-queue/points-log paths used by achievements.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013fYK8EyVQRbzwubpzD4VNJ