### PR TITLE
Fix unreadable white text in cMoon admin UI

### DIFF
--- a/components/CMoonSelectModal.vue
+++ b/components/CMoonSelectModal.vue
@@ -31,7 +31,7 @@
           <div v-if="!cmoons.length" class="cms-empty">No cMoons are available yet.</div>
         </div>
 
-        <div v-if="error" class="cms-error">{{ error }}</div>
+        <div v-if="error" class="cms-error" role="alert">{{ error }}</div>
 
         <div class="cms-footer">
           <button class="cms-confirm-btn" :disabled="!choice || submitting" @click="confirm">
@@ -235,15 +235,22 @@ onBeforeUnmount(() => {
   min-height: 46px;
   border: none;
   border-radius: 8px;
-  background: #2e8b57;
+  /* #2e8b57 gave white text only 4.25:1; this clears the 4.5:1 minimum. */
+  background: #256e45;
   color: #fff;
   font-weight: 700;
   cursor: pointer;
 }
 
 .cms-confirm-btn:disabled {
-  background: rgba(255, 255, 255, 0.15);
-  color: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.10);
+  color: rgba(255, 255, 255, 0.62);
   cursor: not-allowed;
+}
+
+.cms-option:focus-visible,
+.cms-confirm-btn:focus-visible {
+  outline: 3px solid #ffd75e;
+  outline-offset: 2px;
 }
 </style>

--- a/components/newsite/AdminCMoon.vue
+++ b/components/newsite/AdminCMoon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="admin-cmoon bg-gray-50 p-3 text-sm">
+  <div class="admin-cmoon bg-gray-50 p-3 text-sm text-gray-900">
     <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
       <h1 class="text-base font-bold">cMoons</h1>
     </div>
@@ -10,42 +10,47 @@
         <input type="checkbox" v-model="flagEnabled" :disabled="flagSaving" @change="toggleFlag" />
         <span class="font-medium">cMoons enabled</span>
       </label>
-      <p class="text-xs text-gray-500 mt-1">
+      <p class="text-xs text-gray-600 mt-1">
         Off by default. Turning this on starts a 3-day window for existing players to pick a
         cMoon before they're auto-assigned to whichever has the fewest members; new players
         always get 3 days from when they join.
       </p>
-      <p v-if="cMoonEnabledAt" class="text-xs text-gray-500 mt-1">
+      <p v-if="cMoonEnabledAt" class="text-xs text-gray-600 mt-1">
         Launched {{ formatDate(cMoonEnabledAt) }} · existing-player deadline {{ formatDate(cMoonSelectionDeadlineAt) }}
       </p>
     </div>
 
-    <div v-if="loading" class="text-gray-500">Loading…</div>
+    <div v-if="loading" class="text-gray-600">Loading…</div>
     <template v-else>
       <!-- Existing cMoons -->
       <div class="space-y-3 mb-4">
         <div v-for="c in cmoons" :key="c.id" class="bg-white rounded border p-3">
-          <div class="flex items-center gap-2 mb-2">
-            <span class="inline-block w-4 h-4 rounded-full border" :style="{ background: c.color }"></span>
-            <span class="font-semibold">{{ c.name }}</span>
-            <span class="text-xs text-gray-500">{{ c.memberCount }} member{{ c.memberCount === 1 ? '' : 's' }}</span>
-            <button class="ml-auto text-xs text-indigo-600 hover:underline" @click="startEdit(c)">Edit</button>
-            <button
-              class="text-xs text-red-600 hover:underline disabled:opacity-40"
-              :disabled="c.memberCount > 0"
-              :title="c.memberCount > 0 ? 'Reassign members before deleting' : ''"
-              @click="remove(c)"
-            >Delete</button>
+          <div class="flex items-center flex-wrap gap-x-2 gap-y-1 mb-2">
+            <span class="inline-block w-4 h-4 rounded-full border flex-shrink-0" :style="{ background: safeColor(c.color) }"></span>
+            <span class="font-semibold break-words min-w-0">{{ c.name }}</span>
+            <span class="text-xs text-gray-600">{{ c.memberCount }} member{{ c.memberCount === 1 ? '' : 's' }}</span>
+            <!-- Kept together so they travel as a unit when the row wraps on narrow screens. -->
+            <div class="ml-auto flex items-center gap-3 flex-shrink-0">
+              <button class="cm-tap text-xs text-indigo-600 hover:underline" @click="startEdit(c)">Edit</button>
+              <button
+                class="cm-tap text-xs text-red-600 hover:underline disabled:opacity-40"
+                :disabled="c.memberCount > 0"
+                @click="remove(c)"
+              >Delete</button>
+            </div>
           </div>
-          <div class="text-xs text-gray-500">
+          <div class="text-xs text-gray-600 break-words">
             Captains: {{ c.captains.map(cap => cap.username).join(', ') || 'none' }}
           </div>
-          <div class="text-xs text-gray-500">
+          <div class="text-xs text-gray-600 break-words">
             Prize cToons: {{ c.prizeCtoons.map(p => `${p.name} ×${p.quantity}`).join(', ') || 'none' }}
           </div>
-          <div class="text-xs text-gray-500">Discord role ID: {{ c.discordRoleId || 'none' }}</div>
+          <div class="text-xs text-gray-600 break-words">Discord role ID: {{ c.discordRoleId || 'none' }}</div>
+          <p v-if="c.memberCount > 0" class="text-xs text-gray-600 mt-1">
+            Reassign members before this cMoon can be deleted.
+          </p>
         </div>
-        <div v-if="!cmoons.length" class="text-gray-500">No cMoons yet — create one below.</div>
+        <div v-if="!cmoons.length" class="text-gray-600">No cMoons yet — create one below.</div>
       </div>
 
       <!-- Create / edit form -->
@@ -57,16 +62,23 @@
             <input v-model="form.name" class="w-full border rounded px-2 py-1" style="font-size:16px" />
           </div>
           <div>
-            <label class="block text-xs font-medium mb-1">Color (text color)</label>
+            <label class="block text-xs font-medium mb-1">Color (badge background)</label>
             <div class="flex items-center gap-2">
-              <input v-model="form.color" class="w-full border rounded px-2 py-1" style="font-size:16px" placeholder="#3366ff" />
-              <span class="inline-block w-6 h-6 rounded-full border flex-shrink-0" :style="{ background: safeColor(form.color) }"></span>
+              <input v-model="form.color" class="w-full min-w-0 border rounded px-2 py-1" style="font-size:16px" placeholder="#3366ff" autocapitalize="none" autocorrect="off" spellcheck="false" />
+              <!-- Native picker is the one control that is easier on a phone than typing hex. -->
+              <input v-model="colorPicker" type="color" class="cm-color-swatch flex-shrink-0" aria-label="Pick color" />
             </div>
             <p v-if="form.color && !isValidColor(form.color)" class="text-xs text-red-600 mt-1">Must be a hex color like #3366ff</p>
+            <p v-else-if="isValidColor(form.color)" class="text-xs mt-1 flex items-center gap-2 flex-wrap">
+              <span class="cm-preview-pill" :style="cMoonPillStyle(form.color)">{{ form.name || 'Preview' }}</span>
+              <span :class="colorContrast >= 4.5 ? 'text-gray-600' : 'text-red-600'">
+                Badge contrast {{ colorContrast.toFixed(1) }}:1{{ colorContrast >= 4.5 ? '' : ' — below the 4.5:1 minimum, pick a darker or lighter color' }}
+              </span>
+            </p>
           </div>
           <div>
             <label class="block text-xs font-medium mb-1">Discord Role ID (optional)</label>
-            <input v-model="form.discordRoleId" class="w-full border rounded px-2 py-1" style="font-size:16px" placeholder="123456789012345678" />
+            <input v-model="form.discordRoleId" class="w-full border rounded px-2 py-1" style="font-size:16px" inputmode="numeric" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="123456789012345678" />
           </div>
         </div>
 
@@ -76,27 +88,52 @@
             <button
               v-for="a in admins" :key="a.id"
               type="button"
-              class="px-2 py-1 rounded-full border text-xs"
+              class="cm-chip px-3 rounded-full border text-xs"
               :class="form.captainIds.includes(a.id) ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white text-gray-700'"
+              :aria-pressed="form.captainIds.includes(a.id)"
               @click="toggleCaptain(a.id)"
-            >{{ a.username || a.id }}</button>
+            >
+              <span aria-hidden="true">{{ form.captainIds.includes(a.id) ? '✓' : '+' }}</span>
+              {{ a.username || a.id }}
+            </button>
           </div>
         </div>
 
         <div class="mt-3">
           <label class="block text-xs font-medium mb-1">Prize cToons (granted when a user joins)</label>
-          <div class="flex gap-2 items-center">
-            <datalist id="cmoon-ctoon-list">
-              <option v-for="c in filteredCtoons(prizeCtoonSearch)" :key="c.id" :value="c.name" />
-            </datalist>
-            <input v-model="prizeCtoonSearch" list="cmoon-ctoon-list" class="border rounded px-2 py-1 flex-1" style="font-size:16px" placeholder="Type 3+ characters" />
-            <input v-model.number="prizeCtoonQty" type="number" min="1" class="w-20 border rounded px-2 py-1" style="font-size:16px" />
-            <button type="button" class="px-3 py-1 border rounded" @click="addPrizeCtoon">Add</button>
+          <!-- Stacks on phones so the search field gets full width and Add stays a big target. -->
+          <div class="flex flex-col sm:flex-row gap-2 sm:items-center">
+            <input
+              v-model="prizeCtoonSearch"
+              class="cm-field w-full sm:flex-1 min-w-0 border rounded px-2 py-1"
+              style="font-size:16px"
+              placeholder="Type 3+ characters"
+              autocapitalize="none"
+              autocorrect="off"
+              spellcheck="false"
+              role="combobox"
+              :aria-expanded="ctoonSuggestions.length > 0"
+              aria-controls="cmoon-ctoon-suggestions"
+            />
+            <div class="flex gap-2">
+              <input v-model.number="prizeCtoonQty" type="number" min="1" inputmode="numeric" class="cm-field w-20 flex-shrink-0 border rounded px-2 py-1" style="font-size:16px" aria-label="Quantity" />
+              <button type="button" class="cm-tap flex-1 sm:flex-none px-4 border rounded bg-white" @click="addPrizeCtoon">Add</button>
+            </div>
+          </div>
+          <!-- Rendered list rather than <datalist>: datalist is unreliable on iOS and forced an
+               exact string match, which made this picker unusable on a phone. -->
+          <div v-if="ctoonSuggestions.length" id="cmoon-ctoon-suggestions" class="mt-2 border rounded divide-y bg-white max-h-56 overflow-y-auto">
+            <button
+              v-for="c in ctoonSuggestions" :key="c.id"
+              type="button"
+              class="cm-tap w-full text-left px-3 text-xs hover:bg-gray-100"
+              @click="selectCtoon(c)"
+            >{{ c.name }}</button>
           </div>
           <div v-if="form.prizeCtoons.length" class="mt-2 space-y-1">
             <div v-for="(p, i) in form.prizeCtoons" :key="p.ctoonId" class="flex items-center gap-2 text-xs">
-              <span>{{ nameForCtoon(p.ctoonId) }} × {{ p.quantity }}</span>
-              <button type="button" class="text-red-600" @click="form.prizeCtoons.splice(i, 1)">Remove</button>
+              <span class="break-words min-w-0">{{ nameForCtoon(p.ctoonId) }} × {{ p.quantity }}</span>
+              <button type="button" class="cm-tap ml-auto flex-shrink-0 text-red-600" @click="form.prizeCtoons.splice(i, 1)">Remove</button>
             </div>
           </div>
         </div>
@@ -115,6 +152,8 @@
 </template>
 
 <script setup>
+import { cMoonPillStyle, isSafeCMoonColor, cMoonContrastRatio } from '~/utils/cmoonColor'
+
 const loading = ref(false)
 const saving = ref(false)
 const formError = ref('')
@@ -132,8 +171,18 @@ const form = reactive(emptyForm())
 const prizeCtoonSearch = ref('')
 const prizeCtoonQty = ref(1)
 
-function isValidColor(c) { return /^#[0-9a-fA-F]{6}$/.test(c || '') }
+// Share the validation/contrast helpers with the player-facing badges so the admin
+// preview here matches exactly what renders on leaderboards and cZones.
+function isValidColor(c) { return isSafeCMoonColor(c) }
 function safeColor(c) { return isValidColor(c) ? c : '#cccccc' }
+
+const colorContrast = computed(() => cMoonContrastRatio(form.color))
+
+// Two-way bridge to <input type="color">, which only ever holds a valid lowercase hex.
+const colorPicker = computed({
+  get: () => (isValidColor(form.color) ? form.color : '#3366ff'),
+  set: (v) => { form.color = v },
+})
 
 function formatDate(d) {
   if (!d) return ''
@@ -158,15 +207,32 @@ function toggleCaptain(id) {
   else form.captainIds.push(id)
 }
 
-function addPrizeCtoon() {
-  const match = ctoons.value.find(c => c.name === prizeCtoonSearch.value)
+const ctoonSuggestions = computed(() => filteredCtoons(prizeCtoonSearch.value))
+
+function selectCtoon(c) {
+  prizeCtoonSearch.value = c.name
+  addPrizeCtoon(c)
+}
+
+function addPrizeCtoon(preselected) {
+  // Tolerate case and stray whitespace, and accept a lone suggestion — mobile
+  // keyboards autocapitalize, which used to make the exact match impossible to hit.
+  const typed = String(prizeCtoonSearch.value || '').trim().toLowerCase()
+  const match = preselected
+    || ctoons.value.find(c => c.name?.trim().toLowerCase() === typed)
+    || (ctoonSuggestions.value.length === 1 ? ctoonSuggestions.value[0] : null)
   if (!match) {
-    formError.value = 'Select a valid cToon from suggestions.'
+    formError.value = 'Select a valid cToon from the suggestions below.'
+    return
+  }
+  if (form.prizeCtoons.find(p => p.ctoonId === match.id)) {
+    formError.value = `${match.name} is already a prize for this cMoon.`
+    prizeCtoonSearch.value = ''
     return
   }
   formError.value = ''
-  if (form.prizeCtoons.find(p => p.ctoonId === match.id)) return
-  form.prizeCtoons.push({ ctoonId: match.id, quantity: Math.max(1, Number(prizeCtoonQty.value || 1)) })
+  const qty = Math.floor(Number(prizeCtoonQty.value))
+  form.prizeCtoons.push({ ctoonId: match.id, quantity: Math.min(100, Math.max(1, Number.isFinite(qty) ? qty : 1)) })
   prizeCtoonSearch.value = ''
   prizeCtoonQty.value = 1
 }
@@ -264,3 +330,69 @@ async function remove(c) {
 
 onMounted(load)
 </script>
+
+<style scoped>
+/* The newsite layout sets `color: #ffffff` on <body>, which every admin section has
+   to opt out of. Without this the whole panel renders white-on-white. */
+.admin-cmoon {
+  width: 100%;
+  min-height: 100%;
+  color: #111;
+  /* Keeps the UA from painting checkboxes, number spinners and placeholders in
+     dark-mode colors on iOS/macOS, which would reintroduce unreadable controls. */
+  color-scheme: light;
+}
+
+/* Checkboxes and radios are excluded on purpose: painting a background over a
+   native checkbox suppresses its tick on WebKit/Blink. Buttons are excluded so
+   the Tailwind text-* utilities already on them keep winning. */
+.admin-cmoon input:not([type='checkbox']):not([type='radio']):not([type='color']),
+.admin-cmoon select,
+.admin-cmoon textarea {
+  color: #111;
+  background: #fff;
+  -webkit-text-fill-color: #111;
+}
+
+.admin-cmoon input::placeholder {
+  color: #6b7280;
+  -webkit-text-fill-color: #6b7280;
+  opacity: 1;
+}
+
+/* 44px minimum touch target without changing the visual text size. */
+.cm-tap {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.cm-chip {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.cm-field {
+  min-height: 44px;
+}
+
+.cm-color-swatch {
+  width: 44px;
+  height: 44px;
+  padding: 2px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.cm-preview-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+</style>

--- a/components/newsite/Leaderboards.vue
+++ b/components/newsite/Leaderboards.vue
@@ -380,7 +380,7 @@ function cMoonForRow(row) {
   margin-top: 1px;
   padding: 0 4px;
   border-radius: 3px;
-  font-size: 0.58rem;
+  font-size: 0.68rem;
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -1332,7 +1332,7 @@ defineExpose({ save, clearZone })
   padding: 0 5px;
   border-radius: 3px;
   font-weight: 600;
-  font-size: 0.56rem;
+  font-size: 0.68rem;
   line-height: 1.4;
 }
 

--- a/utils/cmoonColor.js
+++ b/utils/cmoonColor.js
@@ -1,26 +1,53 @@
 // utils/cmoonColor.js
 // cMoon colors are admin-chosen hex values with no guaranteed contrast against
 // any particular background. Render them as a small pill (color as background,
-// not text) with black/white text picked by relative luminance, so an
-// arbitrarily dark or light admin choice always stays readable.
+// not text) with black/white text picked by whichever actually contrasts more,
+// so an arbitrarily dark or light admin choice always stays readable.
 const HEX_RE = /^#[0-9a-fA-F]{6}$/
+
+const DARK_TEXT = '#000000'
+const LIGHT_TEXT = '#ffffff'
+const FALLBACK_BG = '#3a4a63'
 
 export function isSafeCMoonColor(color) {
   return typeof color === 'string' && HEX_RE.test(color)
 }
 
-function contrastTextColor(hex) {
-  const r = parseInt(hex.slice(1, 3), 16) / 255
-  const g = parseInt(hex.slice(3, 5), 16) / 255
-  const b = parseInt(hex.slice(5, 7), 16) / 255
+function relativeLuminance(hex) {
+  const channels = [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16) / 255)
   const lin = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4))
-  const luminance = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
-  return luminance > 0.5 ? '#0a1830' : '#ffffff'
+  const [r, g, b] = channels.map(lin)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function contrast(l1, l2) {
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05)
+}
+
+// Compare both candidates rather than guessing from a luminance threshold. A
+// fixed threshold mispicks across a wide band of ordinary mid-tone colors —
+// e.g. #b8860b and #808080 got white text at ~3.3:1 and ~3.9:1.
+function contrastTextColor(hex) {
+  const bg = relativeLuminance(hex)
+  const dark = contrast(relativeLuminance(DARK_TEXT), bg)
+  const light = contrast(relativeLuminance(LIGHT_TEXT), bg)
+  return dark >= light ? DARK_TEXT : LIGHT_TEXT
+}
+
+// Contrast ratio the pill will actually render at, so the admin form can warn
+// before an unreadable color reaches leaderboards and cZones.
+export function cMoonContrastRatio(color) {
+  const hex = isSafeCMoonColor(color) ? color : FALLBACK_BG
+  const bg = relativeLuminance(hex)
+  return Math.max(
+    contrast(relativeLuminance(DARK_TEXT), bg),
+    contrast(relativeLuminance(LIGHT_TEXT), bg),
+  )
 }
 
 // Returns a style object safe to bind with :style — never a raw string, so an
 // admin-entered value can't smuggle extra CSS declarations.
 export function cMoonPillStyle(color) {
-  if (!isSafeCMoonColor(color)) return { background: '#3a4a63', color: '#ffffff' }
+  if (!isSafeCMoonColor(color)) return { background: FALLBACK_BG, color: LIGHT_TEXT }
   return { background: color, color: contrastTextColor(color) }
 }


### PR DESCRIPTION
## Problem

The cMoon admin panel rendered white-on-white — headings, field labels, and input text were invisible.

`layouts/newsite-template.vue:14` sets `color: #ffffff` on `<body>`, so every admin section has to explicitly opt out of it. `AdminCMoon.vue` was the only cMoon file with no `<style>` block, so it inherited white. The `text-gray-500` helper text stayed visible, which is why the panel looked half-rendered rather than blank.

## The same bug elsewhere in the feature

`utils/cmoonColor.js` chose badge text color from a `luminance > 0.5` threshold. That threshold isn't derived from the contrast formula, so a wide band of ordinary mid-tone colors got white text anyway:

| Color | Was | Ratio | Now |
|---|---|---|---|
| `#48cce1` | white | **1.91:1** | black, 11.0:1 |
| `#b8860b` | white | **3.25:1** | black, 6.45:1 |
| `#808080` | white | **3.95:1** | black, 5.32:1 |

Same unreadable-white-text bug, on the player-facing badges in leaderboards and cZones. It now compares both candidates rather than guessing from a threshold. A sweep of the hex space puts the worst case at **4.58:1**, so any color an admin can pick clears WCAG AA.

## Changes

**Readability**
- Scoped root color rule on `.admin-cmoon`, matching the pattern in the other admin sections, plus `color-scheme: light` so iOS/macOS dark appearance can't repaint the checkbox, number spinners, and placeholders into dark-on-dark. Checkboxes, radios, and buttons are deliberately excluded from the control rule — painting a background over a native checkbox suppresses its tick on WebKit/Blink, and excluding buttons lets the existing Tailwind `text-*` utilities keep winning.
- Contrast-comparison fix in `cmoonColor.js`, with a new `cMoonContrastRatio()` export.
- Live badge preview and contrast ratio in the admin form, so an unreadable color can't reach leaderboards or cZones.
- Badge font size on leaderboards and cZones raised from ~9px to ~11px.
- Selection modal: confirm button was `#fff` on `#2e8b57` = 4.25:1, below AA — darkened to `#256e45`. Disabled state and focus rings also raised.
- Helper text `text-gray-500` → `text-gray-600` (4.63:1 → 6.7:1 on the card background).

**Mobile**
- Prize-cToon row stacks on narrow screens so the search field gets full width.
- 44px touch targets on buttons and captain chips; Edit separated from the destructive Delete, which previously sat 8px away.
- Long cMoon names, captain lists, and 18-digit role IDs now wrap instead of blowing out the card.
- `inputmode="numeric"` on the numeric fields; native color picker alongside the hex input.
- Replaced the `<datalist>` prize picker with a rendered suggestion list — it required an exact case-sensitive match, which mobile autocapitalize makes near-impossible to satisfy, and `<datalist>` support is unreliable on iOS.

**Accessibility**
- `aria-pressed` and a ✓/+ glyph on captain chips, which previously conveyed selection by color alone.
- Delete-disabled reason moved from a `title` attribute to visible text.
- `role="alert"` on the modal's error message.

## Verification

- `nuxi build` passes.
- Rendered the fix in headless Chromium against the inherited-white body: heading, label, and input text all compute to `rgb(17, 17, 17)`; the checkbox keeps its native rendering.
- Swept the hex space for the contrast picker — minimum 4.58:1.

## Noted, not changed

- `components/newsite/AdminEdRpsLogs.vue` has the identical white-on-white bug (no style block, no root color). Left alone as it's outside the cMoon feature; it's a one-line fix.
- Pre-existing, unrelated to readability: prize `quantity` is unbounded server-side in `cmoons.post.js:33` and `cmoons/[id].put.js:39`, so a large value would enqueue that many mint jobs per joining user, and a non-numeric value silently grants nothing. This PR clamps the client to 1–100, but the server is the real gate.
- Pre-existing: cMoon delete is guarded by the denormalized `memberCount` while `User.cMoon` is `onDelete: SetNull`. If that counter drifts to 0 with real members, deleting frees them to select again and collect a second cMoon's prizes.

Authorization on the admin and user cMoon endpoints, IDOR on `/api/cmoon/select`, the prize double-grant race, and server-side hex validation were all reviewed and are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017k5QWwoMcVxzxieTwakPpt)_