### PR TITLE
Give form fields a readable default text colour

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,0 +1,44 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  /*
+   * Readable text in form controls, everywhere.
+   *
+   * Tailwind's preflight sets `color: inherit` on button/input/optgroup/select/
+   * textarea. The newsite layout sets `color: var(--text-color)` (#ffffff) on
+   * html and body. So any field that does not name its own colour inherits
+   * white — and since almost every field sits on a white or near-white
+   * background, the text you type is invisible. Roughly 1,300 of the ~1,335
+   * text fields in this app name no colour of their own, so this belongs in
+   * one base rule rather than in 1,300 templates.
+   *
+   * This lives in `@layer base` deliberately. Tailwind's layer order means any
+   * utility class (`text-white`, `text-gray-700`) and any component's scoped
+   * CSS still wins, so the fields that intentionally render white on a dark
+   * panel — the cToon filter, the cZone editor and sidebar search boxes, the
+   * admin rail filter — keep their explicit `color: #fff` and are unaffected.
+   *
+   * Note this sets `color` only, never `-webkit-text-fill-color`: in WebKit the
+   * fill colour beats `color`, so setting it here would override those same
+   * dark-panel inputs, which set `color` but not the fill property.
+   */
+  input,
+  select,
+  textarea {
+    color: #111827; /* gray-900 */
+  }
+
+  /*
+   * Dropdown items are drawn by the OS using the select's own colours, so a
+   * white-on-dark select renders an unreadable white-on-white popup list on
+   * Windows and Linux. Pin both so the list is legible regardless of how the
+   * select itself is styled.
+   */
+  option,
+  optgroup {
+    color: #111827;
+    background-color: #ffffff;
+  }
+}

--- a/tests/formFieldContrast.test.js
+++ b/tests/formFieldContrast.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execSync } from 'node:child_process'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const read = p => readFileSync(join(root, p), 'utf8')
+
+const TAILWIND_ENTRY = 'assets/css/tailwind.css'
+
+// Tailwind's preflight sets `color: inherit` on form controls, and the newsite
+// layout sets `color: #ffffff` on html/body. Without an explicit default, every
+// field that does not name its own colour renders white on a white background
+// and the text you type is invisible.
+
+test('the tailwind entry exists and still emits all three layers', () => {
+  assert.ok(existsSync(join(root, TAILWIND_ENTRY)), `${TAILWIND_ENTRY} is the module's cssPath; deleting it silently drops these base rules`)
+  const css = read(TAILWIND_ENTRY)
+  for (const directive of ['@tailwind base', '@tailwind components', '@tailwind utilities']) {
+    assert.ok(css.includes(directive), `${TAILWIND_ENTRY} must keep ${directive}`)
+  }
+})
+
+test('form controls get a readable default colour in the base layer', () => {
+  const css = read(TAILWIND_ENTRY)
+  const base = css.slice(css.indexOf('@layer base'))
+  assert.ok(base.length, 'no @layer base block')
+
+  const rule = base.match(/input\s*,\s*select\s*,\s*textarea\s*\{[^}]*\}/)
+  assert.ok(rule, 'no input/select/textarea rule in @layer base')
+  assert.match(rule[0], /color:\s*#[0-9a-f]{6}/i, 'the rule must set an explicit colour')
+  assert.doesNotMatch(rule[0], /color:\s*(inherit|#fff(fff)?|white)\b/i, 'the default must not be white or inherit')
+})
+
+test('the default is in @layer base so utilities and scoped CSS still win', () => {
+  const css = read(TAILWIND_ENTRY)
+  const i = css.indexOf('@layer base')
+  const j = css.search(/input\s*,\s*select\s*,\s*textarea\s*\{/)
+  assert.ok(i > -1 && j > i, 'the rule must live inside @layer base, not at top level')
+})
+
+test('the rule does not set -webkit-text-fill-color', () => {
+  // In WebKit the fill colour beats `color`. Setting it here would override the
+  // fields that intentionally render white on a dark panel (the cToon filter,
+  // cZone editor and sidebar search boxes), which set `color` but not the fill.
+  const css = read(TAILWIND_ENTRY)
+  const base = css.slice(css.indexOf('@layer base'))
+  const rule = base.match(/input\s*,\s*select\s*,\s*textarea\s*\{[^}]*\}/)
+  assert.doesNotMatch(rule[0], /-webkit-text-fill-color/, 'would override dark-panel inputs')
+})
+
+test('buttons are deliberately excluded from the default', () => {
+  // Buttons commonly rely on inheriting white over a coloured background
+  // (bg-blue-600 with no text-white). Forcing them dark would break those.
+  const css = read(TAILWIND_ENTRY)
+  const base = css.slice(css.indexOf('@layer base'))
+  const rule = base.match(/(^|\n)\s*(button\s*,\s*)?input\s*,\s*select\s*,\s*textarea\s*\{/)
+  assert.ok(rule, 'rule not found')
+  assert.ok(!/button/.test(rule[0]), 'button must not be in the form-control colour rule')
+})
+
+// The base default is only safe because nothing depends on a field inheriting
+// white. If someone adds a dark-background field without naming its colour,
+// this catches it — that field would render dark-on-dark.
+test('no field relies on inheriting white text', () => {
+  const files = execSync("find pages components layouts -name '*.vue'", { cwd: root })
+    .toString().trim().split('\n')
+
+  const DARK_BG = /bg-(?:black|slate-[6789]|gray-[6789]|zinc-[6789]|neutral-[6789]|stone-[6789]|blue-[6789]|indigo-[6789])\d*/
+  const HAS_COLOR = /\btext-(?:white|black|slate|gray|grey|zinc|neutral|stone|red|blue|green|indigo|purple|amber|yellow|emerald|teal|cyan|sky|violet|fuchsia|pink|rose|orange|lime)-?\d*\b/
+  const SKIP_TYPES = /type=["'](?:hidden|checkbox|radio|file|range|color|submit|button|image)["']/
+
+  const offenders = []
+  for (const f of files) {
+    const src = readFileSync(join(root, f), 'utf8')
+    for (const tag of src.match(/<(?:input|select|textarea)\b[^>]*>/gs) || []) {
+      if (SKIP_TYPES.test(tag)) continue
+      if (HAS_COLOR.test(tag)) continue
+      if (DARK_BG.test(tag)) offenders.push(`${f}: ${tag.replace(/\s+/g, ' ').slice(0, 100)}`)
+    }
+  }
+  assert.deepEqual(offenders, [], 'these fields sit on a dark background but name no text colour, so they will render dark-on-dark')
+})


### PR DESCRIPTION
Typed text was invisible in most admin forms — white on white. Reported for **Create cToon** and **Create Code**, but it affected fields across the site.

## Cause

Tailwind's preflight sets `color: inherit` on `button/input/optgroup/select/textarea` (`node_modules/tailwindcss/src/css/preflight.css:60`), and `layouts/newsite-template.vue:14` sets `color: var(--text-color)` — `#ffffff` — on `html` and `body`.

So any field that doesn't name its own colour inherits white, and nearly every field sits on a white or near-white background. The legacy admin tools previously rendered under `layouts/admin.vue`, which has no white base colour; moving them into the console at `/newsite/admin` is what exposed this.

## Fix

**1,302 of the ~1,335 text fields in the app name no colour of their own**, so this is one base rule rather than 1,302 template edits:

```css
@layer base {
  input, select, textarea { color: #111827; }
}
```

`@layer base` is load-bearing. Tailwind's layer order means every utility class and every component's scoped CSS still wins, so fields that intentionally render white on a dark panel keep their explicit colour — the cToon filter, cZone editor and All-cToons sidebar search boxes, and the admin rail filter all set `color: #fff` in scoped CSS and are unaffected. I verified there is no field anywhere that depends on *inheriting* white, which is the only thing that would make this rule wrong.

Also pins `option`/`optgroup` to dark-on-white: dropdown items are drawn by the OS from the select's own colours, so a white-on-dark select renders an unreadable white-on-white popup list on Windows and Linux.

## Two deliberate exclusions

- **`button` is not in the rule.** Buttons commonly rely on inherited white over a coloured background (`bg-blue-600` with no `text-white`), so forcing them dark would break those. Buttons aren't enterable fields, so they're out of scope here — but the same root cause applies to any button with a light or transparent background, if you want that looked at separately.
- **The rule sets `color` only, never `-webkit-text-fill-color`.** In WebKit the fill colour beats `color`, so setting it would override those same dark-panel inputs, which set `color` but not the fill property. `components/newsite/AdminCMoon.vue:351` had already hit this bug and patched it locally with `-webkit-text-fill-color`; that workaround still works and is left alone.

## A note on the new file

This adds `assets/css/tailwind.css`, which is `@nuxtjs/tailwindcss`'s default `cssPath`. The module was previously falling back to its own built-in entry. The new file keeps all three `@tailwind` directives and only appends the base layer — the build log confirms `Using Tailwind CSS from ~/assets/css/tailwind.css`.

## Verification

- `npm run build` passes. I checked the compiled output rather than assuming: in the inlined global stylesheet, preflight's `color:inherit` is at offset 2805 and the override `input,select,textarea{color:#111827}` at 4804 — after preflight, before the utilities layer. Cascade order is right.
- `npm test`: **280/281**. The single failure (`monsterBattleEngine`, "attack-vs-attack KO prevents counterattack") is pre-existing on `dev` and unrelated.
- New `tests/formFieldContrast.test.js` (6 tests): the entry keeps its three directives, the rule sits inside `@layer base` with a non-white colour, buttons stay excluded, the fill property stays unset, and — the useful one — no field anywhere sits on a dark background without naming a text colour, which would regress the moment someone adds one.

**Not verified in a browser.** The cascade is confirmed from the built CSS, but I haven't loaded a page. Worth a quick look at Create cToon and Create Code to confirm, plus one dark-panel search box (the cToon filter or cZone editor sidebar) to confirm those are still white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYvaLzwcKab3nczqgjk9oe

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYvaLzwcKab3nczqgjk9oe)_