### PR TITLE
Fix: swiping off the edge of the board voids the Fruit Samurai run

### DIFF
--- a/lib/fruitSamuraiSim.js
+++ b/lib/fruitSamuraiSim.js
@@ -98,6 +98,37 @@ export const SLICE_FORGIVENESS = 6
 // fruit fall onto it. Squared, because distances are never square-rooted here.
 export const MIN_SLICE_DIST2 = 36 // 6 world units
 
+// How far outside the world a recorded blade sample may sit.
+//
+// Swiping off the edge of the board is completely normal play — you follow through past a
+// fruit, or start the stroke from beyond the frame — and the pointer is captured on
+// pointerdown, so the browser keeps reporting positions long after the finger has left the
+// canvas. Those raw positions are unbounded: drag to the far side of a desktop monitor and
+// they run into the thousands.
+//
+// Every recorded sample is therefore CLAMPED into this box, by the client as it records and by
+// the server as it validates. Two reasons it is a clamp and not a wider bound:
+//
+//  * The bound cannot simply be removed. The segment/circle test squares a cross product, so
+//    coordinates in the tens of thousands would push that intermediate past 2^53 and the
+//    "exact integer arithmetic" guarantee this whole file rests on would quietly stop holding.
+//  * Clamping is what the player already sees. The canvas clips at its edge, so the blade is
+//    drawn stopping there regardless; pinning the sample to the same place makes the hitbox
+//    agree with the visual instead of tracking an invisible finger.
+//
+// The margin is wide enough to reach anything cuttable: fruit stay slicable until they fall
+// MISS_MARGIN past the bottom edge, and this comfortably covers that band.
+export const COORD_MARGIN = 64
+
+/** Clamp a recorded blade sample into the legal box. Shared so both sides clamp identically. */
+export function clampSampleX (x) {
+  return x < -COORD_MARGIN ? -COORD_MARGIN : (x > WORLD_W + COORD_MARGIN ? WORLD_W + COORD_MARGIN : x)
+}
+
+export function clampSampleY (y) {
+  return y < -COORD_MARGIN ? -COORD_MARGIN : (y > WORLD_H + COORD_MARGIN ? WORLD_H + COORD_MARGIN : y)
+}
+
 // A blade segment spanning more than this many ticks does not cut.
 //
 // This is the fix for a real exploit, not a tidiness rule. Press the finger down, background

--- a/pages/newsite/fruitsamurai.vue
+++ b/pages/newsite/fruitsamurai.vue
@@ -125,7 +125,8 @@
             <p class="final-line" v-if="finalSlices">
               {{ finalSlices.toLocaleString() }} cut · {{ Math.floor(finalTicks / 60) }}s survived
             </p>
-            <p v-if="wasRanked" class="points-line">
+            <p v-if="submitFailed" class="points-line points-line--failed">Run could not be recorded</p>
+            <p v-else-if="wasRanked" class="points-line">
               <span v-if="pointsError">Your score is recorded — points could not be awarded just now.</span>
               <span v-else-if="pointsAwarded > 0">+{{ pointsAwarded }} points</span>
               <span v-else>No points left in today's pool</span>
@@ -181,6 +182,8 @@ import {
   FRUIT_TYPES,
   createState,
   createSegmentFeeder,
+  clampSampleX,
+  clampSampleY,
   hashSeed,
   step
 } from '~/lib/fruitSamuraiSim.js'
@@ -218,6 +221,10 @@ const finalSlices = ref(0)
 const pointsAwarded = ref(0)
 const pointsError = ref(false)
 const wasRanked = ref(false)
+// Distinct from `wasRanked === false`. A rejected submission used to fall through to the
+// practice branch and tell the player "Practice run — not scored", which was simply untrue:
+// the run was ranked, the attempt was spent, and the score was lost.
+const submitFailed = ref(false)
 
 const jackLine = ref('')
 
@@ -351,9 +358,13 @@ function toWorld (ev) {
   // slightly away from where the player actually swiped.
   const rect = canvas.getBoundingClientRect()
   if (rect.width < 1 || rect.height < 1) return null
+  // Clamped into the legal box before it can ever reach the log. The pointer is captured on
+  // pointerdown, so following a swipe off the edge of the board — which is completely ordinary
+  // play — keeps delivering positions well outside the world, and an unclamped sample there
+  // used to fail validation and cost the player the entire run.
   return {
-    x: Math.round((ev.clientX - rect.left) * WORLD_W / rect.width),
-    y: Math.round((ev.clientY - rect.top) * WORLD_H / rect.height)
+    x: clampSampleX(Math.round((ev.clientX - rect.left) * WORLD_W / rect.width)),
+    y: clampSampleY(Math.round((ev.clientY - rect.top) * WORLD_H / rect.height))
   }
 }
 
@@ -846,6 +857,7 @@ async function startGame () {
     rankedPlaysLeft.value = r.playsLeft
     piggyMultiplier.value = cfg.piggyMultiplier
 
+    submitFailed.value = false
     strokes = []
     openStroke = null
     activePointerId = null
@@ -904,7 +916,7 @@ async function finishRun () {
     await fetchStatus()
   } catch (err) {
     submitError.value = err?.data?.statusMessage || 'Could not submit your run. Score not recorded.'
-    wasRanked.value = false
+    submitFailed.value = true
   }
 
   uiState.value = 'gameover'
@@ -1191,6 +1203,7 @@ onBeforeUnmount(() => {
 }
 .final-line { font-size: 0.85rem; opacity: 0.72; margin-bottom: 8px; }
 .points-line { font-size: 0.92rem; margin-bottom: 14px; font-weight: 600; }
+.points-line--failed { color: #ff9d8f; }
 .err-text { color: #ff9d8f; font-size: 0.85rem; margin-top: 10px; }
 
 .btn-start {

--- a/server/utils/fruitSamuraiEngine.js
+++ b/server/utils/fruitSamuraiEngine.js
@@ -36,9 +36,10 @@
 // roughly 3x rather than leaving it unbounded. It is a rail, not a scoring rule — an honest
 // run cannot reach it, because MAX_TICKS ends the run first at normal pacing.
 import {
-  WORLD_W,
-  WORLD_H,
   TICK_HZ,
+  COORD_MARGIN,
+  clampSampleX,
+  clampSampleY,
   normalizeConfig,
   hashSeed,
   simulate
@@ -58,10 +59,10 @@ export const MAX_STROKES = 3000
 // ceiling for a run that ever lifts a finger, and it bounds the request body.
 export const MAX_SAMPLES = 12000
 
-// Coordinates may legitimately land slightly outside the world — a swipe that starts or ends
-// past the edge is normal play. Anything beyond this margin is rejected rather than clamped:
-// clamping would bend a forged log into a valid one and quietly disagree with the client.
-export const COORD_MARGIN = 64
+// COORD_MARGIN and the clamp helpers now live in lib/fruitSamuraiSim.js, because the client
+// has to apply exactly the same bound as it records. Re-exported so existing importers of this
+// module keep working.
+export { COORD_MARGIN }
 
 // A run claiming N ticks must have taken at least this fraction of N/60 seconds of real time.
 // 0.75 leaves headroom for clock skew, a slow /start round trip, and rAF throttling.
@@ -133,12 +134,21 @@ export function sanitizeStrokes(raw) {
       if (dt < lastDt) throw new Error(`strokes[${i}].p dt must not decrease`)
       if (dt < 0) throw new Error(`strokes[${i}].p dt must not be negative`)
       if (t + dt > MAX_TICKS) throw new Error(`strokes[${i}] runs past the tick limit`)
-      if (x < -COORD_MARGIN || x > WORLD_W + COORD_MARGIN) throw new Error(`strokes[${i}].p x out of range`)
-      if (y < -COORD_MARGIN || y > WORLD_H + COORD_MARGIN) throw new Error(`strokes[${i}].p y out of range`)
       lastDt = dt
       cleanP[j] = dt
-      cleanP[j + 1] = x
-      cleanP[j + 2] = y
+      // Clamped, not rejected.
+      //
+      // This used to throw, and that was a bug with real teeth: following a swipe off the edge
+      // of the board is ordinary play, the captured pointer keeps reporting positions far
+      // outside the world, and one such sample failed the whole submission. The player lost an
+      // entire run — and, because the play is recorded at /start, a ranked attempt with it.
+      //
+      // The client now clamps as it records, so for a current client this is a no-op. For a
+      // client still running the old bundle it reconstructs the sample that a fixed client
+      // would have sent, which is a far better answer than destroying the run. Rejection is
+      // reserved for things no client should ever produce: non-integers, NaN, Infinity.
+      cleanP[j + 1] = clampSampleX(x)
+      cleanP[j + 2] = clampSampleY(y)
     }
 
     prevStrokeEnd = t + lastDt

--- a/tests/fruitSamuraiEngine.test.js
+++ b/tests/fruitSamuraiEngine.test.js
@@ -2,6 +2,8 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  clampSampleX,
+  clampSampleY,
   createState,
   createSegmentFeeder,
   normalizeConfig,
@@ -16,6 +18,7 @@ import {
   K_FRUIT,
   MAX_SAMPLE_GAP_TICKS,
   MIN_SLICE_DIST2,
+  COORD_MARGIN,
   MAX_LIVE_FRUIT
 } from '../lib/fruitSamuraiSim.js'
 
@@ -26,7 +29,6 @@ import {
   MAX_TICKS,
   MAX_STROKES,
   MAX_SAMPLES,
-  COORD_MARGIN,
   MAX_SESSION_SECONDS
 } from '../server/utils/fruitSamuraiEngine.js'
 
@@ -277,6 +279,47 @@ test('sanitizeStrokes accepts a well-formed log and returns fresh objects', () =
   assert.deepEqual(out[0].p, [0, 10, 10, 2, 60, 60])
 })
 
+// This is the regression that shipped: swiping off the edge of the board is ordinary play, the
+// captured pointer keeps reporting far outside the world, and the sanitizer used to throw —
+// costing the player the whole run and the ranked attempt that went with it.
+test('a swipe that leaves the board is clamped, not rejected', () => {
+  const wild = [{ t: 5, p: [0, -4000, 400, 2, 9999, -8000, 4, 240, 380] }]
+  const out = sanitizeStrokes(wild)
+  assert.equal(out[0].p[1], -COORD_MARGIN)
+  assert.equal(out[0].p[2], 400)
+  assert.equal(out[0].p[4], WORLD_W + COORD_MARGIN)
+  assert.equal(out[0].p[5], -COORD_MARGIN)
+  assert.equal(out[0].p[7], 240, 'in-range samples are untouched')
+  assert.equal(out[0].p[8], 380)
+})
+
+test('a full run containing off-board samples still submits', () => {
+  const { st, strokes } = playInteractively('offboard', 12)
+  // Push every stroke well outside the world, the way a followed-through swipe does.
+  for (const s of strokes) {
+    for (let j = 1; j < s.p.length; j += 3) {
+      if (j % 2 === 1) { s.p[j] -= 3000; s.p[j + 1] += 5000 }
+    }
+  }
+  const result = replayFruitSamuraiGame({
+    runSeed: 'offboard',
+    cfg: CFG,
+    strokes,
+    elapsedMs: Math.ceil((st.tick / 60) * 1000)
+  })
+  assert.ok(Number.isInteger(result.score), 'the run is scored rather than thrown out')
+})
+
+test('the client and the server clamp samples identically', () => {
+  // The client clamps as it records and the server clamps as it validates. If those two ever
+  // disagreed, the player would watch one score and be told another.
+  for (const v of [-99999, -65, -64, -1, 0, 240, WORLD_W, WORLD_W + 64, WORLD_W + 65, 99999]) {
+    const viaSanitizer = sanitizeStrokes([{ t: 1, p: [0, v, 10, 1, 10, v] }])[0].p
+    assert.equal(viaSanitizer[1], clampSampleX(v))
+    assert.equal(viaSanitizer[5], clampSampleY(v))
+  }
+})
+
 test('sanitizeStrokes rejects malformed input', () => {
   const cases = {
     'not an array': 'nope',
@@ -293,8 +336,6 @@ test('sanitizeStrokes rejects malformed input', () => {
     'NaN coordinate': [{ t: 1, p: [0, NaN, 1, 1, 2, 2] }],
     'Infinity coordinate': [{ t: 1, p: [0, Infinity, 1, 1, 2, 2] }],
     'non-integer coordinate': [{ t: 1, p: [0, 1.5, 1, 1, 2, 2] }],
-    'coordinate far off world': [{ t: 1, p: [0, WORLD_W + COORD_MARGIN + 1, 1, 1, 2, 2] }],
-    'negative coordinate past margin': [{ t: 1, p: [0, -COORD_MARGIN - 1, 1, 1, 2, 2] }],
     'runs past the tick cap': [{ t: MAX_TICKS - 1, p: [0, 1, 1, 50, 2, 2] }],
     'overlapping strokes': [{ t: 1, p: [0, 1, 1, 5, 2, 2] }, { t: 3, p: [0, 1, 1, 1, 2, 2] }],
     'strokes out of order': [{ t: 10, p: [0, 1, 1, 1, 2, 2] }, { t: 2, p: [0, 1, 1, 1, 2, 2] }]


### PR DESCRIPTION
Follow-up to #878, reported from live play: swiping outside the play field immediately invalidates the run with `Invalid stroke log: strokes[N].p x out of range`, and because the play is recorded at `/start`, the ranked attempt is spent too. A 25,183-point run was lost this way.

## Cause

Following a swipe past the edge of the board is ordinary play. The pointer is captured on `pointerdown`, so the browser keeps reporting positions long after the finger has left the canvas — on a desktop drag those run into the thousands. The client recorded them raw, and `sanitizeStrokes` hard-rejected any sample beyond the world margin, so one follow-through failed the entire submission.

I wrote that rejection deliberately, reasoning that clamping "would bend a forged log into a valid one". That was the wrong call: it treated a completely normal gesture as an attack, and the cost of being wrong fell entirely on the player.

## Fix

**The client clamps every sample as it records**, so the log is valid by construction. The bound cannot simply be widened away — the segment/circle test squares a cross product, and coordinates in the tens of thousands would push that intermediate past 2^53 and quietly break the exact-integer guarantee the whole simulation rests on. Clamping is also what the player already sees, since the canvas clips at its edge: it makes the hitbox agree with the drawn blade instead of tracking an invisible finger.

**The server clamps rather than rejects.** For a current client that is a no-op, since both sides now share one bound and one clamp helper from `lib/fruitSamuraiSim.js`. For anyone still running the previously deployed bundle it reconstructs the sample a fixed client would have sent, which is a far better answer than destroying the run. Rejection is reserved for what no client should ever produce: non-integers, `NaN`, `Infinity`.

**The game-over screen stopped lying.** After a failed submission it fell through to the practice branch and said "Practice run — not scored" (visible in the report). The run was ranked and the attempt was spent, so that was untrue; it now reports that the run could not be recorded.

## On the lost ranked attempt

Ranked attempts are still **not** refunded when a submission is rejected, and I'd recommend keeping it that way: refunding hands players a reroll — play, see the run going badly, submit garbage, get the attempt back. With this fix, legitimate play can no longer produce a rejected log in the first place.

## Verification

Against a real Postgres 16 + Redis on the production build, driven in Chromium:

- 40 swipes starting 300px left of the board and ending 300px right of it — previously fatal — now play through and submit: **+50 points, no error**, score and ticks written to `FruitSamuraiScore`, `GamePointLog` credited.
- A raw `/end` payload carrying `x: -5000` and `9000` now passes the sanitizer entirely and is judged on its merits by the wall-clock gate, instead of dying on `x out of range`.
- 3 new regression tests: off-board samples are clamped rather than rejected, a full run containing them still scores, and the client's clamp and the server's clamp agree at every boundary value — the two must never disagree or the player would watch one score and be told another.

28 engine tests pass. `tests/monsterBattleEngine.test.js` has one pre-existing failure on `dev`, unrelated and untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJV1EBnLQv6XsvJz27YAGC)_