### PR TITLE
Make the site honour browser zoom and stop shrinking on 768p laptops

### DIFF
--- a/components/newsite/EconomyCtoonHistoryModal.vue
+++ b/components/newsite/EconomyCtoonHistoryModal.vue
@@ -2,27 +2,34 @@
   <!-- Custom overlay (not the shared Modal.vue) with a z-index above it, since
        this can be opened from inside EconomyTopValuableModal and must render
        on top of it rather than behind/under it. -->
-  <div class="hist-overlay" @click.self="$emit('close')">
-    <div class="hist-card">
-      <div class="hist-header">
-        <img v-if="info?.assetPath" class="hist-thumb" :src="info.assetPath" :alt="info?.name" />
-        <div class="hist-heading">
-          <h3 class="hist-name">{{ info?.name || 'Loading…' }}</h3>
-          <p v-if="info?.releaseDate" class="hist-sub">Released {{ formatDate(info.releaseDate) }}</p>
+  <!-- Teleported to body: .site-container carries a `transform`, which makes it the
+       containing block for `position: fixed` descendants and then clips them with
+       `overflow: hidden`. Without this the overlay is pinned to the chrome's box
+       rather than the viewport, so on a page scrolled down it renders offset and
+       partly unreachable. Same approach as AuctionModal / CtoonInfoCard / Trade. -->
+  <Teleport to="body">
+    <div class="hist-overlay" @click.self="$emit('close')">
+      <div class="hist-card">
+        <div class="hist-header">
+          <img v-if="info?.assetPath" class="hist-thumb" :src="info.assetPath" :alt="info?.name" />
+          <div class="hist-heading">
+            <h3 class="hist-name">{{ info?.name || 'Loading…' }}</h3>
+            <p v-if="info?.releaseDate" class="hist-sub">Released {{ formatDate(info.releaseDate) }}</p>
+          </div>
+          <button type="button" class="hist-close" @click="$emit('close')" aria-label="Close">✕</button>
         </div>
-        <button type="button" class="hist-close" @click="$emit('close')" aria-label="Close">✕</button>
-      </div>
 
-      <p v-if="pending" class="hist-empty">Loading price history…</p>
-      <p v-else-if="!hasAnyData" class="hist-empty">Not enough auction or trade activity yet to chart a price history for this cToon.</p>
-      <template v-else>
-        <div class="chart-container">
-          <canvas ref="canvasEl"></canvas>
-        </div>
-        <p class="hist-note">Tap a legend item to toggle a series. Gaps mean too few transactions that period to show a reliable average.</p>
-      </template>
+        <p v-if="pending" class="hist-empty">Loading price history…</p>
+        <p v-else-if="!hasAnyData" class="hist-empty">Not enough auction or trade activity yet to chart a price history for this cToon.</p>
+        <template v-else>
+          <div class="chart-container">
+            <canvas ref="canvasEl"></canvas>
+          </div>
+          <p class="hist-note">Tap a legend item to toggle a series. Gaps mean too few transactions that period to show a reliable average.</p>
+        </template>
+      </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script setup>

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -917,7 +917,14 @@ function getCoords(e) {
 function toCanvasCoords(cx, cy) {
   const r = canvasRect()
   if (!r) return { x: 0, y: 0 }
-  const s = scale.value || 1
+  // Derived from the canvas's own on-screen rectangle rather than from `scale`,
+  // because a pointer event's clientX/clientY are in visual pixels while `scale`
+  // is only this component's own layout scale. The newsite shell wraps the page
+  // in its own `transform: scale()`, so the two differ whenever the shell is
+  // scaled down, and dividing by the wrong one drops every toon short of where
+  // it was actually released — by 1/shellScale, growing with distance from the
+  // transform origin. Same reasoning as pages/newsite/fruitsamurai.vue.
+  const s = r.width > 0 ? r.width / CANVAS_W : (scale.value || 1)
   return { x: (cx - r.left) / s, y: (cy - r.top) / s }
 }
 

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -1,6 +1,18 @@
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@300..700&display=swap');
 
+html.newsite-active {
+  /* Always reserve the vertical scrollbar gutter. The layout scale is derived
+     from documentElement.clientWidth, which shrinks when a classic scrollbar
+     appears — and since the chrome's height is a multiple of that scale, a
+     narrow band of window sizes exists where the scrollbar's arrival shrinks
+     the page just enough to make the scrollbar unnecessary, which brings it
+     back, at frame rate. Reserving the gutter unconditionally breaks that loop,
+     and stops the page jumping sideways when navigating between a short page
+     and a long one. */
+  overflow-y: scroll;
+}
+
 html.newsite-active,
 html.newsite-active body {
   background: var(--bg-color);
@@ -25,7 +37,12 @@ html.newsite-active body {
   --font-family:                     'Nunito', sans-serif;
 
   --site-container-bg:               transparent;
-  --site-container-height:           862px;
+  /* topbar 105 + sidebar 682 + footer 60, plus the two 10px row gaps between
+     them. This was 862px, five short, so `overflow: hidden` clipped the bottom
+     edge of the footer. Barely visible while everything was scaled to 70%;
+     plainly visible now that the chrome renders at 1:1. Mirrored by SITE_HEIGHT
+     in utils/siteScale.js. */
+  --site-container-height:           867px;
   --site-container-width:            1040px;
   --site-container-radius:           0px;
   --site-container-border-thickness: 0px;
@@ -278,6 +295,8 @@ html.newsite-active body {
 </template>
 
 <script setup>
+import { computeSiteScale, scaleMarginBottom, MOBILE_QUERY } from '~/utils/siteScale'
+
 const route = useRoute()
 const { isOpen: ctoonModalIsOpen } = useCtoonModal()
 const {
@@ -329,7 +348,7 @@ const mainContentBorder = computed(() => route.meta.mainContentBorder === false 
 
 
 // Pages that opt into `fluidLayout` (currently the admin console) escape the
-// fixed 1040x862 retro chrome entirely. That chrome is a `transform: scale()`
+// fixed-size retro chrome entirely. That chrome is a `transform: scale()`
 // container, and a transform — even `scale(1)` — makes the element the
 // containing block for `position: fixed` descendants, so every `fixed inset-0`
 // modal inside it resolves against the 1040px box and is then clipped by
@@ -351,45 +370,77 @@ const gridRows = computed(() => {
     : 'var(--topbar-height) 1fr'
 })
 
-const SITE_WIDTH = 1040
-const SITE_HEIGHT = 862
-const SITE_PADDING = 20
-const MOBILE_BREAKPOINT = 768
-const MAIN_CONTENT_WIDTH = 800
-const MAIN_CONTENT_HEIGHT = 669
+// Opt back into the old shrink-to-fit-the-height behaviour. The chrome is taller
+// than a 768p laptop's viewport, so fitting height means never rendering at full
+// size there — but a handful of pages genuinely cannot tolerate a scrolling
+// page and are better off small. Two verified reasons, not hypotheticals:
+// pages/newsite/blackjack.vue measures document overflow and shrinks its table
+// to absorb it (a deliberately-overflowing page would collapse the table to its
+// 300px floor), and pages/newsite/flappypowerpuff.vue pins `body` on every game
+// start to defeat pull-to-refresh, which would strand the bottom of a scrolling
+// playfield off-screen. Timed canvas games also just play badly when the
+// playfield can scroll out from under the player.
+const fitHeight = computed(() => route.meta.fitHeight === true)
+
 const scale = ref(1)
 const isMobile = ref(false)
 
-// Captured once on mount (assumed to be at 100% zoom). devicePixelRatio is the
-// only cross-browser API that reliably reflects browser zoom; outerWidth includes
-// browser chrome in Firefox, making outerWidth/innerWidth an inaccurate zoom proxy there.
-let baseDPR = null
+// `isMobile` comes straight from the same media query the CSS uses, rather than
+// from a measured width, so the layout's JS and its own `@media (max-width:
+// 768px)` blocks cannot disagree about which mode they are in. That mismatch is
+// exactly what composables/useIsNarrow.js was written to work around back when
+// this was computed from a zoom-adjusted width.
+let mql = null
 
+// Measured in CSS pixels, with no devicePixelRatio anywhere: see the long note
+// in utils/siteScale.js for why trying to detect and cancel out browser zoom is
+// what broke reloads for zoomed-in players. clientWidth excludes a classic
+// vertical scrollbar; innerWidth (which includes it) is the SSR-safe fallback.
+const measure = () => {
+  const el = document.documentElement
+  const width = el?.clientWidth || window.innerWidth
+  scale.value = fitHeight.value
+    ? computeSiteScale(width, el?.clientHeight || window.innerHeight)
+    : computeSiteScale(width)
+}
+
+// Re-measures inline rather than going through the rAF-coalesced path: Vue
+// flushes on the microtask queue, which runs before the next animation frame,
+// so deferring here would paint one frame of the new mode at the old mode's
+// scale — a visible pop when a phone rotates across the breakpoint.
+const applyMobile = e => {
+  isMobile.value = e.matches
+  measure()
+}
+
+// Coalesced into a frame. Not for frequency — browsers already cap `resize` at
+// one per frame — but for ordering: it defers the ref write, and so Vue's DOM
+// patch, past the other resize listeners in the same dispatch. Several pages
+// (MyCzone, CzoneEdit) read geometry in their own resize handlers, and without
+// this they read it immediately after this layout rewrites `transform` on the
+// whole chrome subtree, forcing a synchronous reflow.
+let frame = null
 const computeLayout = () => {
-  if (baseDPR === null) baseDPR = window.devicePixelRatio
-  const zoomFactor = window.devicePixelRatio / baseDPR
-  const effectiveWidth = Math.round(window.innerWidth * zoomFactor)
-  const effectiveHeight = Math.round(window.innerHeight * zoomFactor)
-
-  // <=, not <: every `@media (max-width: 768px)` in the app matches *at* 768.
-  // With `<` the layout stayed in desktop mode at exactly 768px — 1032px of
-  // grid tracks inside a 768px container, with the right edge of main-content
-  // clipped off-screen by `body { overflow-x: hidden }` and no scrollbar —
-  // while the components inside were already using their mobile rules.
-  isMobile.value = effectiveWidth <= MOBILE_BREAKPOINT
-  if (!isMobile.value) {
-    const scaleX = (effectiveWidth - SITE_PADDING) / SITE_WIDTH
-    const scaleY = (effectiveHeight - SITE_PADDING) / SITE_HEIGHT
-    scale.value = Math.min(scaleX, scaleY, 1)
-  }
+  if (frame !== null) return
+  frame = requestAnimationFrame(() => {
+    frame = null
+    measure()
+  })
 }
 
 onMounted(() => {
-  computeLayout()
+  mql = window.matchMedia(MOBILE_QUERY)
+  // Read on mount, not during setup: the server always renders the desktop
+  // branch, so applying a `mobile` value any earlier would be a hydration
+  // mismatch on every narrow load.
+  applyMobile(mql)
+  mql.addEventListener('change', applyMobile)
   window.addEventListener('resize', computeLayout)
 })
 
 onUnmounted(() => {
+  if (frame !== null) cancelAnimationFrame(frame)
+  mql?.removeEventListener('change', applyMobile)
   window.removeEventListener('resize', computeLayout)
 })
 
@@ -411,10 +462,18 @@ const scaleStyle = computed(() => {
       height: 'auto',
     }
   }
+  // The transform stays even at scale(1). It is free — a static 2D scale is not
+  // layer-promoted — and dropping it conditionally would make the container a
+  // containing block for `position: fixed` descendants at some window widths
+  // but not others. Several places already depend on the current, consistent
+  // behaviour (pages/newsite/edrps.vue teleports its overlay to body for
+  // exactly this reason), and a containing block that flips on viewport width
+  // produces bugs that only reproduce at specific window sizes. `fluidLayout`
+  // above is the explicit, per-route way to opt out.
   return {
     transform: `scale(${scale.value})`,
     transformOrigin: 'top center',
-    marginBottom: `${(scale.value - 1) * SITE_HEIGHT}px`
+    marginBottom: `${scaleMarginBottom(scale.value)}px`
   }
 })
 </script>

--- a/pages/newsite/asteroid.vue
+++ b/pages/newsite/asteroid.vue
@@ -263,7 +263,9 @@
 </template>
 
 <script setup>
-definePageMeta({ ssr: false })
+// fitHeight keeps the whole playfield on screen: a timed game that can scroll
+// out from under the player is worse than one rendered a little smaller.
+definePageMeta({ ssr: false, fitHeight: true })
 
 // Zoom is disabled for this page only. nuxt.config.js sets the app-wide viewport, and
 // overriding it there would kill pinch-zoom on every page of the site — an accessibility

--- a/pages/newsite/blackjack.vue
+++ b/pages/newsite/blackjack.vue
@@ -388,6 +388,10 @@ definePageMeta({
   // some other game pages pass to <NuxtLayout> are ignored, since the layout declares none.
   showSidebar: false,
   showFooter: false,
+  // Required, not cosmetic: measure() below shrinks the table by however much the
+  // document overflows. On a page that is allowed to scroll, that correction never
+  // converges and drives the table straight to its 300px floor.
+  fitHeight: true,
   ssr: false,
   title: 'ReOrbit Blackjack',
   description: 'Play heads-up blackjack against Johnny Bravo in the Cartoon ReOrbit casino. Practice for free or wager points.'

--- a/pages/newsite/edrps.vue
+++ b/pages/newsite/edrps.vue
@@ -222,6 +222,9 @@ definePageMeta({
   // these to <NuxtLayout> instead would silently do nothing.
   showSidebar: false,
   showFooter: false,
+  // This page disables pinch-zoom, so a page tall enough to scroll would leave a
+  // short-viewport player no way to reach the bottom of the match.
+  fitHeight: true,
   ssr: false,
   title: 'Ed, Edd n Eddy Rock Paper Scissors',
   description: 'Face off in the cul-de-sac. Pick Ed, Edd or Eddy and play rock paper scissors head to head for points on Cartoon ReOrbit.'

--- a/pages/newsite/flappypowerpuff.vue
+++ b/pages/newsite/flappypowerpuff.vue
@@ -147,6 +147,10 @@ definePageMeta({
   // fastest way to make a tap-timed game feel broken on a phone.
   showSidebar: false,
   showFooter: false,
+  // Required, not cosmetic: startGame pins `body` to defeat pull-to-refresh, which
+  // freezes page scrolling for the whole run. If the page were tall enough to scroll,
+  // the bottom of the playfield would be stranded off-screen until the run ended.
+  fitHeight: true,
   ssr: false,
   title: 'Flappy Powerpuff!',
   description: 'Fly through the Townsville skyline as Blossom, Bubbles or Buttercup in Flappy Powerpuff, a Cartoon ReOrbit arcade game.'

--- a/pages/newsite/fruitsamurai.vue
+++ b/pages/newsite/fruitsamurai.vue
@@ -187,7 +187,8 @@ import {
 
 // ssr: false to match the other canvas game — the whole page is a render loop against a
 // canvas sized from the real viewport, so there is nothing worth rendering on the server.
-definePageMeta({ middleware: 'newsite', ssr: false })
+// fitHeight keeps the whole playfield on screen; see the flag's note in the layout.
+definePageMeta({ middleware: 'newsite', ssr: false, fitHeight: true })
 
 const MS_PER_TICK = 1000 / TICK_HZ
 

--- a/pages/newsite/gtoons/play.vue
+++ b/pages/newsite/gtoons/play.vue
@@ -116,8 +116,14 @@
             @close="infoCard = null"
           />
 
-          <!-- Game-over modal -->
-          <transition name="fade">
+          <!-- Game-over modal. Teleported to body: .site-container carries a
+               `transform`, making it the containing block for `position: fixed`
+               descendants, which are then clipped by its `overflow: hidden`. Without
+               this the overlay is pinned to the chrome's box rather than the viewport
+               and renders offset once the page is scrolled. Teleport wraps the
+               transition because Transition needs a single resolvable element child. -->
+          <Teleport to="body">
+            <transition name="fade">
             <div
               v-if="summary"
               class="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
@@ -159,7 +165,8 @@
                 </NuxtLink>
               </div>
             </div>
-          </transition>
+            </transition>
+          </Teleport>
         </div>
       </div>
 </template>

--- a/pages/newsite/lottery.vue
+++ b/pages/newsite/lottery.vue
@@ -49,36 +49,45 @@
       </div>
 
       <!-- Result modal -->
-      <transition name="fade">
-        <div v-if="showModal" class="modal-overlay" @click.self="closeModal">
-          <div class="modal-box">
-            <h2 class="modal-title">{{ modalTitle }}</h2>
-            <div class="modal-body">
-              <div v-if="modalCtoon" class="modal-ctoon">
-                <CtoonAsset
-                  :src="modalCtoon.assetPath"
-                  :alt="modalCtoon.name"
-                  :name="modalCtoon.name"
-                  :ctoon-id="modalCtoon.id"
-                  image-class="modal-ctoon-image"
-                />
-                <p class="modal-ctoon-name">{{ modalCtoon.name }}</p>
-              </div>
-              <div v-else-if="modalVerificationCode" class="modal-verification">
-                <p>{{ modalMessage }}</p>
-                <div class="verification-box">
-                  <p><strong>Code:</strong> {{ modalVerificationCode }}</p>
-                  <p class="break-all"><strong>Hash:</strong> <span class="verification-hash">{{ modalVerificationHash }}</span></p>
+      <!-- Teleported to body: .site-container carries a `transform`, which makes it the
+           containing block for `position: fixed` descendants and then clips them with
+           `overflow: hidden`. Without this the overlay is pinned to the chrome's box
+           rather than the viewport, so on a page scrolled down it renders offset and
+           partly unreachable. Same approach as AuctionModal / CtoonInfoCard / Trade.
+           Teleport wraps the transition, not the other way round: Transition needs a
+           single resolvable element child, which a Teleport is not. -->
+      <Teleport to="body">
+        <transition name="fade">
+          <div v-if="showModal" class="modal-overlay" @click.self="closeModal">
+            <div class="modal-box">
+              <h2 class="modal-title">{{ modalTitle }}</h2>
+              <div class="modal-body">
+                <div v-if="modalCtoon" class="modal-ctoon">
+                  <CtoonAsset
+                    :src="modalCtoon.assetPath"
+                    :alt="modalCtoon.name"
+                    :name="modalCtoon.name"
+                    :ctoon-id="modalCtoon.id"
+                    image-class="modal-ctoon-image"
+                  />
+                  <p class="modal-ctoon-name">{{ modalCtoon.name }}</p>
                 </div>
+                <div v-else-if="modalVerificationCode" class="modal-verification">
+                  <p>{{ modalMessage }}</p>
+                  <div class="verification-box">
+                    <p><strong>Code:</strong> {{ modalVerificationCode }}</p>
+                    <p class="break-all"><strong>Hash:</strong> <span class="verification-hash">{{ modalVerificationHash }}</span></p>
+                  </div>
+                </div>
+                <p v-else class="modal-message">{{ modalMessage }}</p>
               </div>
-              <p v-else class="modal-message">{{ modalMessage }}</p>
-            </div>
-            <div class="modal-actions">
-              <button class="btn-modal-close" @click="closeModal">Close</button>
+              <div class="modal-actions">
+                <button class="btn-modal-close" @click="closeModal">Close</button>
+              </div>
             </div>
           </div>
-        </div>
-      </transition>
+        </transition>
+      </Teleport>
 </template>
 
 <script setup>

--- a/pages/newsite/marbles.vue
+++ b/pages/newsite/marbles.vue
@@ -77,7 +77,8 @@ import { io as ioClient } from 'socket.io-client'
 import * as THREE from 'three'
 import { useRuntimeConfig } from '#imports'
 
-definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true })
+// fitHeight keeps the whole board on screen; see the flag's note in the layout.
+definePageMeta({ layout: false, middleware: 'newsite', showAdbar: true, showNav: true, fitHeight: true })
 
 // This page opts out of the newsite layout, so it sets its own SEO tags.
 useSeoMeta({

--- a/pages/newsite/newwinball.vue
+++ b/pages/newsite/newwinball.vue
@@ -54,6 +54,8 @@ definePageMeta({
   middleware: 'newsite',
   showAdbar: true,
   showNav: true,
+  // fitHeight keeps the whole playfield on screen; see the flag's note in the layout.
+  fitHeight: true,
   title: 'Winball',
   description: 'Play Winball, the pinball-style game on Cartoon ReOrbit, for a chance to win points and exclusive cToons.'
 })

--- a/pages/newsite/reorbitmatch.vue
+++ b/pages/newsite/reorbitmatch.vue
@@ -162,7 +162,8 @@
 </template>
 
 <script setup>
-definePageMeta({ ssr: false })
+// fitHeight keeps the whole board on screen; see the flag's note in the layout.
+definePageMeta({ ssr: false, fitHeight: true })
 
 // ─── Game constants ────────────────────────────────────────────────────────────
 const TILE_GAP = 3

--- a/pages/newsite/settings.vue
+++ b/pages/newsite/settings.vue
@@ -43,62 +43,76 @@
       </div>
 
       <!-- Avatar modal -->
-      <div v-if="showAvatarModal" class="modal-overlay" @click.self="closeAvatarModal">
-        <div class="modal-box">
-          <h2 class="modal-title">Change Avatar</h2>
-          <p class="modal-desc">Choose a new avatar and click save.</p>
+      <!-- Teleported to body: .site-container carries a `transform`, which makes it the
+           containing block for `position: fixed` descendants and then clips them with
+           `overflow: hidden`. Without this the overlay is pinned to the chrome's box
+           rather than the viewport, so on a page scrolled down it renders offset and
+           partly unreachable. Same approach as AuctionModal / CtoonInfoCard / Trade. -->
+      <Teleport to="body">
+        <div v-if="showAvatarModal" class="modal-overlay" @click.self="closeAvatarModal">
+          <div class="modal-box">
+            <h2 class="modal-title">Change Avatar</h2>
+            <p class="modal-desc">Choose a new avatar and click save.</p>
 
-          <div class="avatar-grid">
-            <label v-for="img in avatars" :key="img" class="avatar-option">
-              <img
-                :src="`/avatars/${img}`"
-                :class="['avatar-img', avatarDraft === img ? 'avatar-selected' : '']"
-              />
-              <input v-model="avatarDraft" type="radio" class="sr-only" :value="img" />
-            </label>
-          </div>
+            <div class="avatar-grid">
+              <label v-for="img in avatars" :key="img" class="avatar-option">
+                <img
+                  :src="`/avatars/${img}`"
+                  :class="['avatar-img', avatarDraft === img ? 'avatar-selected' : '']"
+                />
+                <input v-model="avatarDraft" type="radio" class="sr-only" :value="img" />
+              </label>
+            </div>
 
-          <p v-if="avatarError" class="modal-error">{{ avatarError }}</p>
+            <p v-if="avatarError" class="modal-error">{{ avatarError }}</p>
 
-          <div class="modal-actions">
-            <button class="btn-cancel" @click="closeAvatarModal">Cancel</button>
-            <button class="btn-save-blue" :disabled="savingAvatar" @click="saveAvatar">
-              {{ savingAvatar ? 'Saving...' : 'Save' }}
-            </button>
+            <div class="modal-actions">
+              <button class="btn-cancel" @click="closeAvatarModal">Cancel</button>
+              <button class="btn-save-blue" :disabled="savingAvatar" @click="saveAvatar">
+                {{ savingAvatar ? 'Saving...' : 'Save' }}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      </Teleport>
 
       <!-- Username modal -->
-      <div v-if="showUsernameModal" class="modal-overlay" @click.self="closeUsernameModal">
-        <div class="modal-box">
-          <h2 class="modal-title">Change Username</h2>
-          <p class="modal-desc">Pick from the Cartoon Orbit username builder.</p>
+      <!-- Teleported to body: .site-container carries a `transform`, which makes it the
+           containing block for `position: fixed` descendants and then clips them with
+           `overflow: hidden`. Without this the overlay is pinned to the chrome's box
+           rather than the viewport, so on a page scrolled down it renders offset and
+           partly unreachable. Same approach as AuctionModal / CtoonInfoCard / Trade. -->
+      <Teleport to="body">
+        <div v-if="showUsernameModal" class="modal-overlay" @click.self="closeUsernameModal">
+          <div class="modal-box">
+            <h2 class="modal-title">Change Username</h2>
+            <p class="modal-desc">Pick from the Cartoon Orbit username builder.</p>
 
-          <div class="username-selects">
-            <select v-model="part1" class="username-select">
-              <option v-for="w in wordLists[0]" :key="`s-1-${w}`" :value="w">{{ w }}</option>
-            </select>
-            <select v-model="part2" class="username-select">
-              <option v-for="w in wordLists[1]" :key="`s-2-${w}`" :value="w">{{ w }}</option>
-            </select>
-            <select v-model="part3" class="username-select">
-              <option v-for="w in wordLists[2]" :key="`s-3-${w}`" :value="w">{{ w }}</option>
-            </select>
-          </div>
+            <div class="username-selects">
+              <select v-model="part1" class="username-select">
+                <option v-for="w in wordLists[0]" :key="`s-1-${w}`" :value="w">{{ w }}</option>
+              </select>
+              <select v-model="part2" class="username-select">
+                <option v-for="w in wordLists[1]" :key="`s-2-${w}`" :value="w">{{ w }}</option>
+              </select>
+              <select v-model="part3" class="username-select">
+                <option v-for="w in wordLists[2]" :key="`s-3-${w}`" :value="w">{{ w }}</option>
+              </select>
+            </div>
 
-          <button @click="randomize" class="btn-randomize">🔄 Randomize</button>
+            <button @click="randomize" class="btn-randomize">🔄 Randomize</button>
 
-          <p v-if="usernameError" class="modal-error">{{ usernameError }}</p>
+            <p v-if="usernameError" class="modal-error">{{ usernameError }}</p>
 
-          <div class="modal-actions">
-            <button class="btn-cancel" @click="closeUsernameModal">Cancel</button>
-            <button class="btn-save-purple" :disabled="savingUsername" @click="saveUsername">
-              {{ savingUsername ? 'Saving...' : 'Save' }}
-            </button>
+            <div class="modal-actions">
+              <button class="btn-cancel" @click="closeUsernameModal">Cancel</button>
+              <button class="btn-save-purple" :disabled="savingUsername" @click="saveUsername">
+                {{ savingUsername ? 'Saving...' : 'Save' }}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      </Teleport>
 </template>
 
 <script setup>

--- a/pages/newsite/spinthewheel.vue
+++ b/pages/newsite/spinthewheel.vue
@@ -78,6 +78,8 @@ definePageMeta({
   middleware: 'newsite',
   showAdbar: true,
   showNav: true,
+  // fitHeight keeps the whole playfield on screen; see the flag's note in the layout.
+  fitHeight: true,
   title: 'Spin the Wheel',
   description: 'Spin the wheel on Cartoon ReOrbit for a chance to win points and prizes.'
 })

--- a/pages/newsite/tower.vue
+++ b/pages/newsite/tower.vue
@@ -158,7 +158,8 @@
 </template>
 
 <script setup>
-definePageMeta({ ssr: false })
+// fitHeight keeps the whole tower on screen; see the flag's note in the layout.
+definePageMeta({ ssr: false, fitHeight: true })
 
 // ─── Shared world/physics constants — MUST stay in sync with server/utils/towerStackEngine.js ──
 const BASE_WIDTH = 100

--- a/pages/newsite/winball.vue
+++ b/pages/newsite/winball.vue
@@ -31,6 +31,8 @@ definePageMeta({
   middleware: 'newsite',
   showAdbar: true,
   showNav: true,
+  // fitHeight keeps the whole playfield on screen; see the flag's note in the layout.
+  fitHeight: true,
   title: 'Winball',
   description: 'Play Winball, the pinball-style game on Cartoon ReOrbit, for a chance to win points and exclusive cToons.'
 })

--- a/tests/siteScale.test.js
+++ b/tests/siteScale.test.js
@@ -1,0 +1,131 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const read = p => readFileSync(join(root, p), 'utf8')
+
+// utils/siteScale.js is plain ESM with no Nuxt auto-imports, so it imports
+// directly — same source-contract style as adminSections / shortCardVarContract.
+const {
+  computeSiteScale, scaleMarginBottom,
+  SITE_WIDTH, SITE_HEIGHT, SITE_PADDING, MOBILE_QUERY, MIN_SITE_SCALE
+} = await import(join(root, 'utils/siteScale.js'))
+
+test('renders at full size whenever the window is wide enough', () => {
+  for (const w of [1060, 1366, 1440, 1920, 2560]) {
+    assert.equal(computeSiteScale(w), 1, `${w}px should not be scaled down`)
+  }
+})
+
+test('never scales up past 1', () => {
+  assert.equal(computeSiteScale(5000), 1)
+})
+
+test('scales down proportionally on windows narrower than the chrome', () => {
+  // 1040 + 20 padding is the exact break-even point.
+  assert.equal(computeSiteScale(1060), 1)
+  assert.ok(computeSiteScale(1000) < 1)
+  assert.equal(computeSiteScale(1000), 980 / 1040)
+})
+
+test('is monotonic in width', () => {
+  let prev = 0
+  for (let w = 300; w <= 1600; w += 10) {
+    const s = computeSiteScale(w)
+    assert.ok(s >= prev, `scale decreased from ${prev} to ${s} at ${w}px`)
+    prev = s
+  }
+})
+
+// The regression this file exists for. On the reporter's 1366x768 display the
+// old height-aware rule produced ~0.70 no matter what, and browser zoom could
+// not raise it because the result depended on a devicePixelRatio baseline
+// captured once at mount.
+test('the reporter\'s 1366-wide display gets a full-size site', () => {
+  assert.equal(computeSiteScale(1366), 1)
+})
+
+test('viewport height is ignored unless a route opts in', () => {
+  // A 1366x640 laptop: the 867px-tall chrome cannot fit, and that must not
+  // shrink the site. This is the exact case from the bug report.
+  assert.equal(computeSiteScale(1366), 1)
+  assert.equal(computeSiteScale(1366, undefined), 1)
+  assert.equal(computeSiteScale(1366, null), 1)
+})
+
+test('fitHeight routes still shrink to fit the shorter axis', () => {
+  const s = computeSiteScale(1366, 640)
+  assert.ok(s < 1, 'a 640px viewport cannot show an 867px chrome at full size')
+  assert.equal(s, (640 - SITE_PADDING) / SITE_HEIGHT)
+  // Width still wins when it is the tighter constraint.
+  assert.equal(computeSiteScale(800, 2000), (800 - SITE_PADDING) / SITE_WIDTH)
+})
+
+test('a broken height measurement cannot poison a good width measurement', () => {
+  for (const h of [NaN, Infinity, -Infinity]) {
+    assert.equal(computeSiteScale(1366, h), 1, `height ${h} must be ignored`)
+  }
+})
+
+test('a degenerate or hostile measurement can never invert or collapse the layout', () => {
+  for (const w of [0, -1, -99999, 1, 19, 20, NaN, Infinity, -Infinity, undefined]) {
+    const s = computeSiteScale(w)
+    assert.ok(Number.isFinite(s), `scale for ${w} must be finite, got ${s}`)
+    assert.ok(s > 0, `scale for ${w} must be positive, got ${s}`)
+    assert.ok(s <= 1, `scale for ${w} must not exceed 1, got ${s}`)
+    assert.ok(s >= MIN_SITE_SCALE, `scale for ${w} must respect the floor, got ${s}`)
+  }
+})
+
+test('margin compensation cancels the layout box the transform leaves behind', () => {
+  assert.equal(scaleMarginBottom(1), 0)
+  assert.equal(scaleMarginBottom(0.5), -SITE_HEIGHT / 2)
+  assert.ok(scaleMarginBottom(computeSiteScale(900)) < 0)
+})
+
+// Contract tests against the layout itself: these are the invariants that broke.
+const layout = read('layouts/newsite-template.vue')
+// Comments in this file discuss devicePixelRatio and the old constants at
+// length, so the code-contract assertions below run against code only.
+const layoutCode = layout
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/(^|[^:])\/\/.*$/gm, '$1')
+
+test('the layout no longer reads devicePixelRatio', () => {
+  assert.ok(
+    !/devicePixelRatio/.test(layoutCode),
+    'devicePixelRatio is a zoom-dependent value that cannot be baselined at mount; ' +
+    'reintroducing it brings back the shrink-on-reload bug'
+  )
+})
+
+test('the layout derives its sizing from utils/siteScale.js rather than redeclaring it', () => {
+  assert.ok(/computeSiteScale/.test(layoutCode), 'layout should call the shared helper')
+  for (const literal of ['1040', '862']) {
+    assert.ok(
+      !new RegExp(`=\\s*${literal}\\b`).test(layoutCode),
+      `layout redeclares ${literal}; it must come from utils/siteScale.js`
+    )
+  }
+})
+
+test('the mobile breakpoint matches the media queries the layout ships with', () => {
+  const declared = MOBILE_QUERY.match(/max-width:\s*(\d+)px/)[1]
+  assert.equal(declared, '768')
+  assert.ok(
+    layout.includes('@media (max-width: 768px)'),
+    'MOBILE_QUERY must stay in step with the layout\'s own CSS'
+  )
+})
+
+test('the design constants match the CSS custom properties they mirror', () => {
+  assert.ok(layout.includes(`--site-container-width:            ${SITE_WIDTH}px`) ||
+            new RegExp(`--site-container-width:\\s*${SITE_WIDTH}px`).test(layout),
+            `--site-container-width must be ${SITE_WIDTH}px`)
+  assert.ok(new RegExp(`--site-container-height:\\s*${SITE_HEIGHT}px`).test(layout),
+            `--site-container-height must be ${SITE_HEIGHT}px`)
+  assert.equal(SITE_PADDING, 20)
+})

--- a/utils/siteScale.js
+++ b/utils/siteScale.js
@@ -1,0 +1,76 @@
+// Sizing rule for the fixed-size "retro" newsite chrome.
+//
+// The chrome is authored at a fixed SITE_WIDTH x SITE_HEIGHT and shrunk with
+// `transform: scale()` when the window is too narrow for it. Kept here as pure
+// functions so the rule is testable without a browser (see tests/siteScale.test.js)
+// and so the numbers can't drift between the JS and the CSS.
+//
+// WIDTH ONLY, DELIBERATELY. An earlier version also divided by the viewport
+// height, which made the chrome shrink to ~70% on any laptop shorter than about
+// 1050px — the 862px design height simply doesn't fit a 768px screen. Two
+// consequences, both bad:
+//
+//   1. The site was permanently small on the most common laptop resolution.
+//   2. Browser zoom could not fix it. Fitting to the viewport is inherently
+//      zoom-proof: zooming shrinks the CSS viewport by exactly the factor the
+//      scale grows, so the *physical* size never changes. The old code tried to
+//      work around that by normalising against a `devicePixelRatio` captured
+//      once on mount and assumed to be 100% zoom — an assumption that is simply
+//      false for anyone whose browser persists a zoom level per origin. Their
+//      page loaded already-zoomed, the captured baseline was wrong, and the
+//      site shrank on every reload and shrank again if zoom was reset.
+//
+// Scaling on width alone means the chrome renders at its intended size whenever
+// the window is wide enough and the page scrolls vertically when it isn't.
+// Browser zoom then behaves the way it does on any normal site, with no
+// devicePixelRatio reads and nothing to keep in sync across reloads.
+// Pages that genuinely cannot afford a scrolling page — timed canvas games, and
+// blackjack, whose table measures itself against the document's overflow — opt
+// back into height-aware fitting with `definePageMeta({ fitHeight: true })`.
+// They keep the old shrink-to-fit behaviour (minus the zoom bug) so the whole
+// playfield stays on screen.
+export const SITE_WIDTH = 1040
+
+// The sum of the grid tracks: topbar 105 + sidebar 682 + footer 60, plus two
+// 10px row gaps. The container was declared 862px for a long time, which quietly
+// clipped the bottom 5px of the footer against `overflow: hidden`. Keep this in
+// step with --site-container-height.
+export const SITE_HEIGHT = 867
+
+// Breathing room so the chrome never sits flush against a window edge, and so a
+// classic (non-overlay) vertical scrollbar can't push it into a horizontal one.
+export const SITE_PADDING = 20
+
+// Matches the `@media (max-width: 768px)` blocks in layouts/newsite-template.vue
+// and across the newsite components, so the layout's JS and its own CSS can
+// never disagree about which mode they are in. Note this is intentionally NOT
+// the 767.98px used by composables/useIsNarrow.js, which is pinned to Tailwind's
+// `md:` breakpoint instead; see the comment there.
+export const MOBILE_QUERY = '(max-width: 768px)'
+
+// Purely defensive. Any width at or above the mobile breakpoint yields at least
+// (768 - 20) / 1040 = 0.719, and below that breakpoint no transform is applied
+// at all, so this floor is unreachable in practice. It exists so a degenerate
+// or zero measurement can never produce a zero, negative, or NaN scale, which
+// would collapse or mirror the entire layout.
+export const MIN_SITE_SCALE = 0.25
+
+// `availableHeight` is only passed by routes that set `fitHeight: true`; leave
+// it undefined for the normal width-only rule.
+export function computeSiteScale (availableWidth, availableHeight) {
+  let raw = (availableWidth - SITE_PADDING) / SITE_WIDTH
+  if (availableHeight !== undefined && availableHeight !== null) {
+    const byHeight = (availableHeight - SITE_PADDING) / SITE_HEIGHT
+    // A non-finite height must not poison a perfectly good width measurement.
+    if (Number.isFinite(byHeight)) raw = Math.min(raw, byHeight)
+  }
+  if (!Number.isFinite(raw)) return 1
+  return Math.min(1, Math.max(MIN_SITE_SCALE, raw))
+}
+
+// The scaled chrome still reserves its full unscaled height in layout, because
+// `transform` doesn't affect layout boxes. Pull the following content up by the
+// difference so a scaled-down site doesn't trail a block of dead space.
+export function scaleMarginBottom (scale) {
+  return (scale - 1) * SITE_HEIGHT
+}


### PR DESCRIPTION
Fixes a player report from Waterfox at 1366x768: browser zoom improved the page, but changing pages or refreshing reverted it, and resetting zoom to 100% then left the site *smaller than it started*.

## Root cause

`layouts/newsite-template.vue` scaled the fixed-size chrome to fit the window, measuring that window by multiplying `innerWidth`/`innerHeight` by `devicePixelRatio / baseDPR` — where `baseDPR` was captured once on mount and **assumed to be 100% zoom**.

That assumption is false for anyone whose browser persists a zoom level per origin. The page loads already-zoomed, the baseline is wrong by exactly the zoom factor, and the site shrinks on every reload and shrinks again if zoom is reset.

Reproduced all four steps of the report in Chromium before changing anything, driving the real CSS and the real sizing math:

| Step | Before | After |
|---|---|---|
| Load @100% | 748px | **1040px** |
| Zoom → 160% | 1197px | 1334px |
| Reload @160% | **734px** — snaps back | **1334px** — holds |
| Reset → 100% | **458px** — worse than start | **1040px** — exactly the start |

## Why this isn't only a bugfix

The second half of the report — "the default zoom level on my display is quite small" — could not be fixed by repairing the DPR math. **Fitting to the viewport is inherently zoom-proof**: zooming shrinks the CSS viewport by exactly the factor the scale grows, so the physical size never changes. The height term was also why the site sat at ~70% permanently, since the chrome is taller than a 768p viewport.

So the sizing rule now scales on **width alone**, measured in CSS pixels, with no `devicePixelRatio` anywhere. The chrome renders at its intended size whenever the window is wide enough and the page scrolls vertically when it isn't. Browser zoom then behaves as it does on any normal site, with no state to keep in sync across reloads.

Large screens are unaffected — 1920x1080 already scaled to 1 and still has zero page scroll.

## `fitHeight` opt-out

Some pages genuinely cannot tolerate a scrolling page, so they opt back into height fitting with `definePageMeta({ fitHeight: true })`. Two verified reasons, not hypotheticals:

- **blackjack** shrinks its table by however much the document overflows. On a deliberately-overflowing page that correction never converges and drives the table to its 300px floor, hiding the spectators.
- **Flappy Powerpuff** pins `body` on every game start to defeat pull-to-refresh, freezing page scroll for the whole run — which would strand the bottom of the playfield off-screen.

The timed canvas games take it too, since a playfield that can scroll out from under the player is worse than one rendered slightly smaller.

## Fallout also fixed

All of these were latent, and only became reachable (or visible) once the page could scroll and the chrome rendered at 1:1:

- **`isMobile` reads the same media query the CSS uses**, so the layout and its own `@media (max-width: 768px)` blocks can no longer disagree about which mode they're in.
- **Reserve the scrollbar gutter.** The scale derives from `clientWidth`, which shrinks when a scrollbar appears — and a narrow band of window sizes existed where that shrink removed the need for the scrollbar, at frame rate.
- **Teleport five `position: fixed` overlays to body** (lottery, settings ×2, economy history, gToons game-over). The chrome's transform makes it the containing block for fixed descendants and then clips them; this was invisible only because the page never scrolled. Matches the existing convention used by AuctionModal / CtoonInfoCard / Trade.
- **The grid is 867px tall, not the 862px declared**, so `overflow: hidden` clipped the footer's bottom edge. Harmless at 70%, plainly visible at 1:1.
- **cZone drag-drop** divided pointer deltas by its own scale while measuring a rect that already included the shell's transform, dropping toons short by `1/shellScale`. Now derived from the canvas's on-screen rect, matching the pattern already documented in `fruitsamurai.vue`.

## Testing

- New `utils/siteScale.js` holds the sizing rule as pure functions, covered by 14 tests in `tests/siteScale.test.js` — including monotonicity, degenerate/hostile viewport values, the `fitHeight` path, and a guard that the layout never reads `devicePixelRatio` again.
- All 17 changed SFCs compile via `@vue/compiler-sfc`.
- Full suite: 294/295. The one failure is `monsterBattleEngine.test.js`, which **fails identically on a clean tree** — pre-existing and unrelated to this change.

## Known gaps, deliberately left

- Between 769–1060px wide the site still scales below 1, so text shrinks there and browser zoom can't fully recover it.
- `composables/useIsNarrow.js` turns out to have zero call sites, while five components still hand-roll `innerWidth <= 768`.

Both are follow-ups, not regressions from this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZoH1rcHiztCqwkN9bYLVe)_