### PR TITLE
Give text on light surfaces a readable default colour

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -41,4 +41,69 @@
     color: #111827;
     background-color: #ffffff;
   }
+
+  /*
+   * Readable text on light surfaces, everywhere.
+   *
+   * Same root cause as the form-control rule above: nothing sets a colour, so
+   * text inherits #ffffff from the newsite layout. A `bg-white` card or a
+   * `bg-gray-50` panel then renders white-on-white. This bit the admin console
+   * hardest — the legacy tools were written as light full-page views and used
+   * to render under layouts/admin.vue, which has no white base colour — but it
+   * also affects shared surfaces that appear on ordinary pages, such as the
+   * bulk-edit and second-edition modals.
+   *
+   * Pairing the background with a foreground is the fix: if an element declares
+   * a light background, its text defaults to dark. There is no case where white
+   * text on `bg-white` was intended, so this cannot take away a deliberate
+   * choice.
+   *
+   * In @layer base for the same reason as above: Tailwind's layer order means a
+   * `text-white` utility or a component's scoped CSS still wins, so anything
+   * that genuinely wants light text on these backgrounds keeps it.
+   */
+  /*
+   * Attribute selectors, not `.bg-white`. Writing these as class selectors makes
+   * Tailwind treat them as utility definitions and variant-expand them, which
+   * emitted extra `.hover\:bg-gray-100:hover{color:…}` rules into the utilities
+   * layer at (0,2,0) — enough to beat a `text-white` utility and flip an
+   * element's text on hover. `[class~="…"]` matches the same single class,
+   * stays at (0,1,0), and is invisible to Tailwind's variant machinery, so the
+   * rule does exactly what it says and nothing else.
+   */
+  [class~="bg-white"],
+  [class~="bg-gray-50"], [class~="bg-gray-100"], [class~="bg-gray-200"],
+  [class~="bg-slate-50"], [class~="bg-slate-100"], [class~="bg-slate-200"],
+  [class~="bg-zinc-50"], [class~="bg-zinc-100"], [class~="bg-zinc-200"],
+  [class~="bg-neutral-50"], [class~="bg-neutral-100"], [class~="bg-neutral-200"],
+  [class~="bg-stone-50"], [class~="bg-stone-100"], [class~="bg-stone-200"] {
+    color: #111827; /* gray-900 */
+  }
+
+  /*
+   * The same pairing for tinted light surfaces — the 50/100 shades used for
+   * alert, info and highlight boxes. These are near-white (bg-yellow-50 is
+   * #fefce8), so inherited white text is just as invisible on them as on
+   * bg-white. Stops at 100: darker shades start being used as solid accents
+   * where a light foreground can be a deliberate choice.
+   */
+  [class~="bg-red-50"], [class~="bg-red-100"],
+  [class~="bg-orange-50"], [class~="bg-orange-100"],
+  [class~="bg-amber-50"], [class~="bg-amber-100"],
+  [class~="bg-yellow-50"], [class~="bg-yellow-100"],
+  [class~="bg-lime-50"], [class~="bg-lime-100"],
+  [class~="bg-green-50"], [class~="bg-green-100"],
+  [class~="bg-emerald-50"], [class~="bg-emerald-100"],
+  [class~="bg-teal-50"], [class~="bg-teal-100"],
+  [class~="bg-cyan-50"], [class~="bg-cyan-100"],
+  [class~="bg-sky-50"], [class~="bg-sky-100"],
+  [class~="bg-blue-50"], [class~="bg-blue-100"],
+  [class~="bg-indigo-50"], [class~="bg-indigo-100"],
+  [class~="bg-violet-50"], [class~="bg-violet-100"],
+  [class~="bg-purple-50"], [class~="bg-purple-100"],
+  [class~="bg-fuchsia-50"], [class~="bg-fuchsia-100"],
+  [class~="bg-pink-50"], [class~="bg-pink-100"],
+  [class~="bg-rose-50"], [class~="bg-rose-100"] {
+    color: #111827; /* gray-900 */
+  }
 }

--- a/pages/newsite/admin/[...path].vue
+++ b/pages/newsite/admin/[...path].vue
@@ -189,6 +189,13 @@ html.newsite-admin-page body {
   overflow-y: auto;
   overscroll-behavior: contain;
   background: #f9fafb;
+  /* The panel is light, but the newsite layout sets `color: #ffffff` on body,
+     so anything in a section that does not name its own colour inherits white
+     and disappears. The light-background utilities are handled globally in
+     assets/css/tailwind.css; this covers content that sits straight on the
+     panel with no background class of its own. Inherited, so it reaches into
+     every section component. */
+  color: #111827;
 }
 
 .newsite-admin-loading {

--- a/tests/lightSurfaceContrast.test.js
+++ b/tests/lightSurfaceContrast.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execSync } from 'node:child_process'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const read = p => readFileSync(join(root, p), 'utf8')
+
+const ENTRY = 'assets/css/tailwind.css'
+const ADMIN_PAGE = 'pages/newsite/admin/[...path].vue'
+
+// The newsite layout sets `color: #ffffff` on html/body, so any text that does
+// not name its own colour inherits white. On a light surface — a `bg-white`
+// card, a `bg-gray-50` panel, the admin console's own background — that renders
+// white on white. These lock in the two rules that pair light surfaces with a
+// readable foreground.
+
+test('light background utilities get a dark default text colour', () => {
+  const css = read(ENTRY)
+  const base = css.slice(css.indexOf('@layer base'))
+  const rule = base.match(/\[class~="bg-white"\][\s\S]*?\{[^}]*\}/)
+  assert.ok(rule, 'no light-surface colour rule in @layer base')
+  assert.match(rule[0], /color:\s*#[0-9a-f]{6}/i, 'must set an explicit colour')
+  assert.doesNotMatch(rule[0], /color:\s*(inherit|#fff(fff)?|white)\b/i, 'must not be white or inherit')
+
+  for (const bg of ['bg-white', 'bg-gray-50', 'bg-gray-100', 'bg-slate-50', 'bg-neutral-100', 'bg-stone-200']) {
+    assert.ok(rule[0].includes(`[class~="${bg}"]`), `rule does not cover ${bg}`)
+  }
+})
+
+test('tinted light surfaces are covered too', () => {
+  // Alert/info boxes use the 50 and 100 shades, which are near-white
+  // (bg-yellow-50 is #fefce8) and just as unreadable with inherited white text.
+  const css = read(ENTRY)
+  const base = css.slice(css.indexOf('@layer base'))
+  for (const bg of ['bg-yellow-50', 'bg-blue-50', 'bg-red-100', 'bg-green-100', 'bg-rose-50', 'bg-emerald-100']) {
+    assert.ok(base.includes(`[class~="${bg}"]`), `rule does not cover ${bg}`)
+  }
+})
+
+test('the light-surface rule uses attribute selectors, not class selectors', () => {
+  // Written as `.bg-white`, Tailwind treats these as utility definitions and
+  // variant-expands them, emitting `.hover\:bg-gray-100:hover{color:…}` into
+  // the utilities layer at (0,2,0) — enough to beat a `text-white` utility and
+  // flip an element's text colour on hover. `[class~="…"]` matches the same
+  // single class, stays at (0,1,0), and Tailwind's variant machinery ignores it.
+  const css = read(ENTRY)
+  const base = css.slice(css.indexOf('@layer base'))
+  const selectors = base.match(/^\s*\.bg-(?:white|gray|slate|zinc|neutral|stone)[\w-]*\s*[,{]/gm) || []
+  assert.deepEqual(selectors, [], 'use [class~="bg-…"] instead of .bg-… to avoid Tailwind variant expansion')
+})
+
+test('the light-surface rule lives in @layer base so utilities still win', () => {
+  const css = read(ENTRY)
+  const i = css.indexOf('@layer base')
+  const j = css.indexOf('[class~="bg-white"]')
+  assert.ok(i > -1 && j > i, 'the rule must be inside @layer base, not at top level')
+})
+
+test('the admin console panel sets an explicit text colour', () => {
+  // The panel background is CSS, not a utility class, so content sitting
+  // straight on it is not covered by the light-surface rule above.
+  const src = read(ADMIN_PAGE)
+  // Two rules carry this selector: a global one for scroll behaviour and the
+  // scoped one that paints the panel. Only the painted one needs a colour.
+  const block = (src.match(/\.newsite-admin-body\s*\{[^}]*\}/g) || [])
+    .find(b => /background:/.test(b))
+  assert.ok(block, '.newsite-admin-body rule with a background not found')
+  // Strip comments first — the explanatory comment quotes `color: #ffffff` as
+  // prose, and matching against it would test the wrong thing.
+  const decls = block.replace(/\/\*[\s\S]*?\*\//g, '')
+  assert.match(decls, /color:\s*#[0-9a-f]{6}/i, 'the console panel must name a text colour')
+  assert.doesNotMatch(decls, /color:\s*(inherit|#fff(fff)?|white)\b/i)
+})
+
+// The rule is only safe because no element wants white text on a light surface.
+// If someone writes that combination, the element is unreadable either way and
+// this catches it at the point it is introduced.
+test('nothing asks for white text on a static light background', () => {
+  const files = execSync("find pages components layouts -name '*.vue'", { cwd: root })
+    .toString().trim().split('\n')
+
+  // Only flag when both land in the same quoted class literal, so the two
+  // branches of a ternary (`cond ? 'bg-green-600 text-white' : 'bg-white'`)
+  // are not counted — those never apply at the same time.
+  const LIGHT = /\bbg-(?:white|gray-(?:50|100|200)|slate-(?:50|100|200)|zinc-(?:50|100|200)|neutral-(?:50|100|200)|stone-(?:50|100|200))\b(?!\/)/
+
+  const offenders = []
+  for (const f of files) {
+    const src = readFileSync(join(root, f), 'utf8')
+    const singles = src.match(/'[^'\n]*'/g) || []
+    const doubles = (src.match(/"[^"\n]*"/g) || []).filter(d => !d.includes("'"))
+    for (const lit of [...singles, ...doubles]) {
+      if (!/\btext-white\b/.test(lit)) continue
+      if (!LIGHT.test(lit)) continue
+      offenders.push(`${f}: ${lit.slice(0, 110)}`)
+    }
+  }
+  assert.deepEqual(offenders, [], 'white text on a light background is unreadable regardless of this rule')
+})


### PR DESCRIPTION
Follow-up to the form-field fix (#895). Same root cause, but it affects ordinary display text, not just enterable fields. Reported for **Manage cToons**, where the "All cToons" heading and the table around it render white on a white card.

## Cause

`layouts/newsite-template.vue` sets `color: #ffffff` on `html` and `body`, so any text that doesn't name its own colour inherits white. On a light surface that's invisible.

The legacy admin tools were written as light full-page views and used to render under `layouts/admin.vue`, which has no white base colour — moving them into the console at `/newsite/admin` is what exposed this. `AdminLegacyCtoons.vue:6` is the reported case exactly: `<h1 class="text-2xl font-semibold">All cToons</h1>` inside a `bg-white` card, with no colour of its own.

Measured scope: **484** light-background elements inside the console and **65** elsewhere name no text colour, plus **107** on tinted alert/info backgrounds.

## Fix — two rules, both in `@layer base`

**1. Light surfaces pair background with foreground.** If an element declares `bg-white`, a gray/slate/zinc/neutral/stone 50–200, or a colour 50/100 tint, its text defaults to `#111827`. There is no case where white on `bg-white` was intended, so this can't take away a real choice. It stops at the 100 shade for tints because darker shades start being used as solid accents where a light foreground can be deliberate.

**2. The admin console panel sets its own colour.** Its background is CSS rather than a utility class, so content sitting straight on it isn't covered by rule 1. `color` inherits, so one declaration reaches every section component.

Both live in `@layer base`, so Tailwind's layer order means `text-white` and component scoped CSS still win.

## One thing worth reviewing

The selectors are written as `[class~="bg-white"]`, **not** `.bg-white`.

Written as class selectors, Tailwind treats them as utility definitions and variant-expands them. The build emitted these into the **utilities** layer:

```css
.hover\:bg-gray-100:hover{color:#111827}
.odd\:bg-white:nth-child(odd){color:#111827}
```

At specificity (0,2,0), in a later layer, those beat a `text-white` utility (0,1,0) — so an element with `text-white hover:bg-gray-50` would have flipped its text colour on hover. Nothing in the codebase currently combines those (I checked; the apparent hits are mutually exclusive ternary branches), but it's an unintended side effect that would bite later.

The attribute form matches the same single class, stays at (0,1,0) in the base layer, and Tailwind's variant machinery ignores it. Verified in the built CSS that the rule now lands after preflight, before the utilities layer, and that the variant rules are gone.

## Verification

- `npm run build` passes. Checked the compiled output rather than assuming: the rule sits at base-layer position, after preflight's `color:inherit`, before `.container` (start of utilities), with `.text-white` later still winning. Confirmed coverage of `bg-white`, `bg-gray-50`, `bg-yellow-50`, `bg-blue-100`, `bg-rose-50`, `bg-emerald-100`.
- `npm test`: **303/304**. The single failure (`monsterBattleEngine`, "attack-vs-attack KO prevents counterattack") is pre-existing on `dev` and unrelated.
- New `tests/lightSurfaceContrast.test.js` (6 tests): the rule exists in `@layer base` with a non-white colour, covers plain and tinted light surfaces, uses attribute selectors rather than class selectors, the console panel names a colour, and nothing in the codebase asks for white text on a light background.

**Not verified in a browser.** Worth a look at Manage cToons, one alert box (a `bg-yellow-50` warning), and one dark-surface page to confirm the newsite chrome still renders white text as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYvaLzwcKab3nczqgjk9oe

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYvaLzwcKab3nczqgjk9oe)_