### PR TITLE
Restrict auto-listing auctions to rarities with a real price floor

### DIFF
--- a/components/newsite/AdminVpnQueue.vue
+++ b/components/newsite/AdminVpnQueue.vue
@@ -183,7 +183,8 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  color: #fff;
+  color: #111827;
+  background: #f9fafb;
   font-family: var(--font-family, 'Nunito', sans-serif);
   overflow-y: auto;
   height: 100%;
@@ -202,10 +203,11 @@ onUnmounted(() => {
   font-size: 1.25rem;
   font-weight: 700;
   margin: 0;
+  color: #111827;
 }
 .monitor-sub {
   font-size: 0.75rem;
-  opacity: 0.65;
+  color: #6b7280;
   margin: 2px 0 0;
 }
 .header-actions {
@@ -219,28 +221,28 @@ onUnmounted(() => {
   align-items: center;
   gap: 6px;
   font-size: 0.8rem;
-  opacity: 0.8;
+  color: #4b5563;
   cursor: pointer;
 }
 .btn-refresh {
   padding: 5px 14px;
   font-size: 0.8rem;
   font-family: inherit;
-  background: var(--OrbitLightBlue, #3399CC);
+  background: #2563eb;
   color: #fff;
   border: none;
   border-radius: 6px;
   cursor: pointer;
   font-weight: 600;
 }
-.btn-refresh:hover { opacity: 0.85; }
+.btn-refresh:hover { background: #1d4ed8; }
 .btn-refresh:disabled { opacity: 0.45; cursor: not-allowed; }
 
 /* Error banner */
 .error-banner {
-  background: rgba(220, 38, 38, 0.2);
-  border: 1px solid rgba(220, 38, 38, 0.5);
-  color: #fca5a5;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
   border-radius: 8px;
   padding: 10px 14px;
   font-size: 0.85rem;
@@ -258,12 +260,14 @@ onUnmounted(() => {
   font-size: 0.85rem;
 }
 .status-running {
-  background: rgba(51, 153, 204, 0.2);
-  border: 1px solid rgba(51, 153, 204, 0.5);
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #1e3a8a;
 }
 .status-idle {
-  background: rgba(102, 204, 0, 0.15);
-  border: 1px solid rgba(102, 204, 0, 0.4);
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #14532d;
 }
 .status-left {
   display: flex;
@@ -272,13 +276,13 @@ onUnmounted(() => {
 }
 .status-label { font-weight: 700; }
 .status-eta { opacity: 0.7; }
-.status-time { font-size: 0.75rem; opacity: 0.55; margin-left: auto; }
+.status-time { font-size: 0.75rem; opacity: 0.6; margin-left: auto; }
 
 /* Spinner */
-.spin-icon { width: 18px; height: 18px; animation: spin 1s linear infinite; color: var(--OrbitLightBlue); }
+.spin-icon { width: 18px; height: 18px; animation: spin 1s linear infinite; color: #2563eb; }
 .spin-track { opacity: 0.25; }
 .spin-fill  { opacity: 0.85; }
-.check-icon { width: 18px; height: 18px; color: var(--OrbitGreen, #66CC00); }
+.check-icon { width: 18px; height: 18px; color: #16a34a; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
 /* Stats */
@@ -289,21 +293,22 @@ onUnmounted(() => {
 }
 @media (max-width: 640px) { .stats-grid { grid-template-columns: repeat(2, 1fr); } }
 .stat-card {
-  background: rgba(0, 0, 0, 0.25);
-  border: 1px solid rgba(255,255,255,0.1);
+  background: #fff;
+  border: 1px solid #e5e7eb;
   border-radius: 8px;
   padding: 10px 12px;
 }
-.stat-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.6; margin-bottom: 4px; }
-.stat-value { font-size: 1.5rem; font-weight: 800; }
-.stat-red   { color: #f87171; }
-.stat-sub   { font-size: 0.7rem; opacity: 0.45; margin-top: 2px; }
+.stat-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280; margin-bottom: 4px; }
+.stat-value { font-size: 1.5rem; font-weight: 800; color: #111827; }
+.stat-red   { color: #dc2626; }
+.stat-sub   { font-size: 0.7rem; color: #9ca3af; margin-top: 2px; }
 
 /* Session note */
 .session-note {
   font-size: 0.78rem;
-  opacity: 0.65;
-  background: rgba(0,0,0,0.15);
+  color: #4b5563;
+  background: #fff;
+  border: 1px solid #e5e7eb;
   border-radius: 6px;
   padding: 7px 12px;
 }
@@ -319,8 +324,8 @@ onUnmounted(() => {
 @media (max-width: 700px) { .panels { grid-template-columns: 1fr; } }
 
 .panel {
-  background: rgba(0,0,0,0.25);
-  border: 1px solid rgba(255,255,255,0.1);
+  background: #fff;
+  border: 1px solid #e5e7eb;
   border-radius: 8px;
   display: flex;
   flex-direction: column;
@@ -335,11 +340,11 @@ onUnmounted(() => {
   justify-content: space-between;
   gap: 8px;
   padding: 10px 12px;
-  border-bottom: 1px solid rgba(255,255,255,0.08);
+  border-bottom: 1px solid #e5e7eb;
   flex-shrink: 0;
 }
-.panel-title { font-size: 0.9rem; font-weight: 700; }
-.panel-sub   { font-size: 0.7rem; opacity: 0.5; margin-top: 1px; }
+.panel-title { font-size: 0.9rem; font-weight: 700; color: #111827; }
+.panel-sub   { font-size: 0.7rem; color: #9ca3af; margin-top: 1px; }
 
 .error-badge {
   font-size: 0.7rem;
@@ -348,8 +353,8 @@ onUnmounted(() => {
   border-radius: 999px;
   flex-shrink: 0;
 }
-.badge-red   { background: rgba(220,38,38,0.25); color: #fca5a5; border: 1px solid rgba(220,38,38,0.4); }
-.badge-green { background: rgba(102,204,0,0.2);  color: #86efac; border: 1px solid rgba(102,204,0,0.35); }
+.badge-red   { background: #fee2e2; color: #b91c1c; border: 1px solid #fecaca; }
+.badge-green { background: #dcfce7; color: #15803d; border: 1px solid #bbf7d0; }
 
 .panel-scroll {
   overflow-y: auto;
@@ -360,18 +365,18 @@ onUnmounted(() => {
   padding: 24px;
   text-align: center;
   font-size: 0.8rem;
-  opacity: 0.4;
+  color: #9ca3af;
 }
 
 /* Error rows */
 .error-row {
   padding: 8px 12px;
-  border-bottom: 1px solid rgba(255,255,255,0.05);
+  border-bottom: 1px solid #f3f4f6;
   font-size: 0.75rem;
 }
-.error-time { opacity: 0.5; margin-bottom: 2px; }
-.error-msg  { color: #fca5a5; font-family: monospace; word-break: break-all; }
-.error-meta { opacity: 0.4; font-family: monospace; margin-top: 2px; font-size: 0.7rem; }
+.error-time { color: #9ca3af; margin-bottom: 2px; }
+.error-msg  { color: #b91c1c; font-family: monospace; word-break: break-all; }
+.error-meta { color: #9ca3af; font-family: monospace; margin-top: 2px; font-size: 0.7rem; }
 
 /* Activity rows */
 .activity-row {
@@ -379,7 +384,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 8px;
   padding: 7px 12px;
-  border-bottom: 1px solid rgba(255,255,255,0.05);
+  border-bottom: 1px solid #f3f4f6;
   font-size: 0.78rem;
   flex-wrap: wrap;
 }
@@ -390,13 +395,13 @@ onUnmounted(() => {
   border-radius: 999px;
   flex-shrink: 0;
 }
-.pill-vpn   { background: rgba(220,38,38,0.25); color: #fca5a5; border: 1px solid rgba(220,38,38,0.4); }
-.pill-clean { background: rgba(102,204,0,0.2);  color: #86efac; border: 1px solid rgba(102,204,0,0.35); }
+.pill-vpn   { background: #fee2e2; color: #b91c1c; border: 1px solid #fecaca; }
+.pill-clean { background: #dcfce7; color: #15803d; border: 1px solid #bbf7d0; }
 
-.activity-user   { font-weight: 700; flex-shrink: 0; }
-.activity-ip     { font-family: monospace; font-size: 0.7rem; opacity: 0.5; flex-shrink: 0; }
-.activity-type   { font-size: 0.7rem; color: #fbbf24; flex-shrink: 0; }
-.activity-isp    { font-size: 0.7rem; opacity: 0.55; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 140px; }
-.activity-country { font-size: 0.7rem; opacity: 0.45; flex-shrink: 0; }
-.activity-time   { font-size: 0.7rem; opacity: 0.4; margin-left: auto; flex-shrink: 0; }
+.activity-user   { font-weight: 700; color: #111827; flex-shrink: 0; }
+.activity-ip     { font-family: monospace; font-size: 0.7rem; color: #9ca3af; flex-shrink: 0; }
+.activity-type   { font-size: 0.7rem; color: #b45309; flex-shrink: 0; }
+.activity-isp    { font-size: 0.7rem; color: #6b7280; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 140px; }
+.activity-country { font-size: 0.7rem; color: #9ca3af; flex-shrink: 0; }
+.activity-time   { font-size: 0.7rem; color: #9ca3af; margin-left: auto; flex-shrink: 0; }
 </style>

--- a/components/newsite/admin/legacy/AdminLegacyAchievements.vue
+++ b/components/newsite/admin/legacy/AdminLegacyAchievements.vue
@@ -1,132 +1,133 @@
 <template>
-  <div class="max-w-5xl mx-auto p-4 mt-12">
-    <div class="mt-12 mb-6 flex flex-col gap-3 items-start lg:flex-row lg:items-center lg:justify-between">
-      <h1 class="text-3xl font-bold">Admin: Achievements</h1>
-      <div class="flex flex-col items-start gap-3 lg:flex-row lg:items-center">
-        <button class="px-3 py-2 bg-blue-600 text-white rounded" @click="openCreate">Create Achievement</button>
-        <button class="px-3 py-2 border rounded" @click="queueAll" :disabled="queuing">
+  <div class="admin-legacy-achievements bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+    <div class="flex flex-col gap-2 items-start mb-3 lg:flex-row lg:items-center lg:justify-between lg:gap-2">
+      <h1 class="text-base font-semibold">Admin: Achievements</h1>
+      <div class="flex flex-col items-start gap-2 lg:flex-row lg:items-center">
+        <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700" @click="openCreate">Create Achievement</button>
+        <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="queueAll" :disabled="queuing">
           {{ queuing ? 'Queuing…' : 'Queue Achievements Now' }}
         </button>
-        <button class="px-3 py-2 border rounded" @click="openSettings">Settings</button>
+        <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="openSettings">Settings</button>
       </div>
     </div>
 
     <!-- Modal -->
-    <div v-if="showForm" class="fixed inset-0 z-50 flex items-center justify-center">
+    <div v-if="showForm" class="fixed inset-0 z-50 flex items-center justify-center p-2">
       <div class="absolute inset-0 bg-black/50" @click="closeForm"></div>
-      <div class="relative bg-white rounded shadow max-w-4xl w-full mx-4 max-h-[90vh] flex flex-col overflow-hidden">
-        <div class="px-4 pt-4 pb-2">
-          <h2 class="text-xl font-semibold">{{ editId ? 'Edit Achievement' : 'Create Achievement' }}</h2>
+      <div class="relative bg-white w-full max-w-4xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="px-4 py-3 border-b flex-shrink-0">
+          <h2 class="text-sm font-semibold">{{ editId ? 'Edit Achievement' : 'Create Achievement' }}</h2>
         </div>
         <form @submit.prevent="save" class="flex flex-col flex-1 min-h-0">
-          <div class="px-4 pb-4 overflow-y-auto">
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label class="block text-sm font-medium">Title</label>
-                <input v-model="form.title" class="w-full border rounded px-2 py-1" required />
+          <div class="px-4 py-3 overflow-y-auto flex-1 space-y-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Title</label>
+                <input v-model="form.title" class="border rounded-md px-2 py-1.5 text-sm" required />
               </div>
-              <div>
-                <label class="block text-sm font-medium">Slug (optional)</label>
-                <input v-model="form.slug" class="w-full border rounded px-2 py-1" placeholder="auto from title" :disabled="!!editId" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Slug (optional)</label>
+                <input v-model="form.slug" class="border rounded-md px-2 py-1.5 text-sm" placeholder="auto from title" :disabled="!!editId" />
               </div>
-            <div class="md:col-span-2">
-              <label class="block text-sm font-medium">Description</label>
-              <textarea v-model="form.description" class="w-full border rounded px-2 py-1" rows="2" />
+            <div class="md:col-span-2 flex flex-col gap-1">
+              <label class="text-xs font-medium">Description</label>
+              <textarea v-model="form.description" class="border rounded-md px-2 py-1.5 text-sm" rows="2" />
             </div>
-              <div>
-                <label class="block text-sm font-medium">Image (png/jpg/gif)</label>
-                <input ref="imageInput" type="file" accept="image/png,image/jpeg,image/gif" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Image (png/jpg/gif)</label>
+                <input ref="imageInput" type="file" accept="image/png,image/jpeg,image/gif" class="text-xs" />
               </div>
               <div class="flex items-center gap-2">
                 <input type="checkbox" v-model="form.isActive" id="isActive" />
-                <label for="isActive">Active</label>
+                <label for="isActive" class="text-xs">Active</label>
               </div>
               <div v-if="editId" class="flex items-center gap-2">
                 <input type="checkbox" v-model="form.notifyDiscord" id="notifyDiscord" />
-                <label for="notifyDiscord">Announce in Discord</label>
+                <label for="notifyDiscord" class="text-xs">Announce in Discord</label>
               </div>
-              <div class="md:col-span-2">
-                <label class="block text-sm font-medium">Discord Role Name (optional)</label>
-                <input v-model="form.discordRoleName" class="w-full border rounded px-2 py-1" placeholder="Role name to grant on achievement" />
+              <div class="md:col-span-2 flex flex-col gap-1">
+                <label class="text-xs font-medium">Discord Role Name (optional)</label>
+                <input v-model="form.discordRoleName" class="border rounded-md px-2 py-1.5 text-sm" placeholder="Role name to grant on achievement" />
               </div>
             </div>
 
-            <h3 class="text-lg font-semibold mt-6">Criteria</h3>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div>
-                <label class="block text-sm">Total Points ≥</label>
-                <input v-model.number="form.criteria.pointsGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
+            <h3 class="text-xs font-semibold">Criteria</h3>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Total Points ≥</label>
+                <input v-model.number="form.criteria.pointsGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block text-sm">Total cToons ≥</label>
-                <input v-model.number="form.criteria.totalCtoonsGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Total cToons ≥</label>
+                <input v-model.number="form.criteria.totalCtoonsGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block text-sm">Unique cToons ≥</label>
-                <input v-model.number="form.criteria.uniqueCtoonsGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Unique cToons ≥</label>
+                <input v-model.number="form.criteria.uniqueCtoonsGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block text-sm">Auctions Won ≥</label>
-                <input v-model.number="form.criteria.auctionsWonGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Auctions Won ≥</label>
+                <input v-model.number="form.criteria.auctionsWonGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block text-sm">Auctions Created (Completed) ≥</label>
-                <input v-model.number="form.criteria.auctionsCreatedGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Auctions Created (Completed) ≥</label>
+                <input v-model.number="form.criteria.auctionsCreatedGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block text-sm">Accepted Trades ≥</label>
-                <input v-model.number="form.criteria.tradesAcceptedGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Accepted Trades ≥</label>
+                <input v-model.number="form.criteria.tradesAcceptedGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block text-sm">Accepted cToon Suggestions ≥</label>
-                <input v-model.number="form.criteria.ctoonSuggestionsAcceptedGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Accepted cToon Suggestions ≥</label>
+                <input v-model.number="form.criteria.ctoonSuggestionsAcceptedGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block text-sm">Cumulative Active Days ≥</label>
-                <input v-model.number="form.criteria.cumulativeActiveDaysGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
-                <p class="text-xs text-gray-500 mt-1">Counts days with any site activity, not just logins.</p>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Cumulative Active Days ≥</label>
+                <input v-model.number="form.criteria.cumulativeActiveDaysGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[10px] text-gray-500 mt-1">Counts days with any site activity, not just logins.</p>
               </div>
-              <div>
-                <label class="block text-sm">TKO Wins ≥</label>
-                <input v-model.number="form.criteria.tkoWinsGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
-                <p class="text-xs text-gray-500 mt-1">Counted round wins in the TKO game.</p>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">TKO Wins ≥</label>
+                <input v-model.number="form.criteria.tkoWinsGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[10px] text-gray-500 mt-1">Counted round wins in the TKO game.</p>
               </div>
-              <div>
-                <label class="block text-sm">Wordle Crown Wins ≥</label>
-                <input v-model.number="form.criteria.wordleWinsGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
-                <p class="text-xs text-gray-500 mt-1">Total times the user earned the 👑 (best score of the day).</p>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Wordle Crown Wins ≥</label>
+                <input v-model.number="form.criteria.wordleWinsGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[10px] text-gray-500 mt-1">Total times the user earned the 👑 (best score of the day).</p>
               </div>
-              <div>
-                <label class="block text-sm">Wordle Crown Streak ≥</label>
-                <input v-model.number="form.criteria.wordleCurrentStreakGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
-                <p class="text-xs text-gray-500 mt-1">Current consecutive-day streak of earning the 👑.</p>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Wordle Crown Streak ≥</label>
+                <input v-model.number="form.criteria.wordleCurrentStreakGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[10px] text-gray-500 mt-1">Current consecutive-day streak of earning the 👑.</p>
               </div>
-              <div>
-                <label class="block text-sm">Flappy Powerpuff Best Score ≥</label>
-                <input v-model.number="form.criteria.flappyBestScoreGte" type="number" min="0" class="w-full border rounded px-2 py-1" />
-                <p class="text-xs text-gray-500 mt-1">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Flappy Powerpuff Best Score ≥</label>
+                <input v-model.number="form.criteria.flappyBestScoreGte" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[10px] text-gray-500 mt-1">
                   Highest number of buildings passed in a ranked run. Achievement rewards bypass the
                   daily points cap, so keep thresholds at levels a real player reaches and avoid
                   attaching high-value cToons here.
                 </p>
               </div>
-              <div class="md:col-span-3">
-                <label class="block text-sm">User created before</label>
-                <input v-model="form.criteria.userCreatedBefore" type="date" class="w-full border rounded px-2 py-1 max-w-xs" />
-                <p class="text-xs text-gray-500 mt-1">Users with an account created strictly earlier than this date qualify.</p>
+              <div class="md:col-span-3 flex flex-col gap-1">
+                <label class="text-xs font-medium">User created before</label>
+                <input v-model="form.criteria.userCreatedBefore" type="date" class="border rounded-md px-2 py-1.5 text-sm max-w-xs" />
+                <p class="text-[10px] text-gray-500 mt-1">Users with an account created strictly earlier than this date qualify.</p>
               </div>
             </div>
           <div class="mt-3">
-            <label class="block text-sm">Set completion (AND):</label>
-            <div class="flex gap-2 items-center mb-2">
+            <label class="block text-xs font-medium">Set completion (AND):</label>
+            <div class="flex gap-2 items-center mb-2 mt-1">
               <datalist id="ach-sets-list">
                 <option v-for="opt in filteredSetOptions(setInput)" :key="opt" :value="opt" />
               </datalist>
-              <input v-model="setInput" list="ach-sets-list" class="border rounded px-2 py-1 flex-1" placeholder="Type 3+ characters to search" />
-              <button type="button" class="px-3 py-1 border rounded" @click="addSet">Add</button>
+              <input v-model="setInput" list="ach-sets-list" class="border rounded-md px-2 py-1.5 text-sm flex-1" placeholder="Type 3+ characters to search" />
+              <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="addSet">Add</button>
             </div>
             <div class="flex flex-wrap gap-2">
-              <span v-for="s in form.criteria.setsRequired" :key="s" class="px-2 py-1 bg-gray-100 rounded">
+              <span v-for="s in form.criteria.setsRequired" :key="s" class="px-2 py-1 text-xs bg-gray-100 rounded">
                 {{ s }}
                 <button type="button" class="ml-1 text-red-600" @click="removeSet(s)">×</button>
               </span>
@@ -134,11 +135,11 @@
           </div>
 
           <div class="mt-3">
-            <label class="block text-sm">cToons Required (must own all):</label>
-            <div class="relative">
+            <label class="block text-xs font-medium">cToons Required (must own all):</label>
+            <div class="relative mt-1">
               <input
                 v-model="ctoonsRequiredInput"
-                class="w-full border rounded px-2 py-1"
+                class="border rounded-md px-2 py-1.5 text-sm w-full"
                 placeholder="Type 3+ characters to search"
                 autocomplete="off"
                 @focus="showCtoonsRequiredDropdown = true"
@@ -146,17 +147,17 @@
               />
               <div
                 v-if="showCtoonsRequiredDropdown && filteredCtoonsRequired.length"
-                class="absolute z-10 bg-white border rounded shadow-lg w-full max-h-52 overflow-y-auto"
+                class="absolute z-10 bg-white border rounded-md shadow-lg w-full max-h-52 overflow-y-auto"
               >
                 <button
                   v-for="c in filteredCtoonsRequired"
                   :key="c.id"
                   type="button"
-                  class="flex items-center gap-2 w-full px-2 py-1 hover:bg-gray-100 text-left"
+                  class="flex items-center gap-2 w-full px-2 py-1.5 hover:bg-gray-100 text-left"
                   @mousedown.prevent="addRequiredCtoon(c)"
                 >
                   <img :src="c.assetPath" class="w-8 h-8 object-contain flex-shrink-0" alt="" />
-                  <span class="text-sm truncate">{{ c.name }}</span>
+                  <span class="text-xs truncate">{{ c.name }}</span>
                 </button>
               </div>
             </div>
@@ -164,23 +165,23 @@
               <div
                 v-for="(r, i) in form.criteria.ctoonsRequired"
                 :key="r.ctoonId"
-                class="flex items-center gap-1 px-2 py-1 bg-gray-100 rounded"
+                class="flex items-center gap-1 px-2 py-1 text-xs bg-gray-100 rounded"
               >
                 <img v-if="r.assetPath" :src="r.assetPath" class="w-6 h-6 object-contain flex-shrink-0" alt="" />
-                <span class="text-sm">{{ r.name }}</span>
+                <span class="text-xs">{{ r.name }}</span>
                 <button type="button" class="ml-1 text-red-600" @click="form.criteria.ctoonsRequired.splice(i, 1)">×</button>
               </div>
             </div>
           </div>
 
-            <h3 class="text-lg font-semibold mt-6">Rewards</h3>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div>
-                <label class="block text-sm">Points</label>
-                <input v-model.number="form.rewards.points" type="number" min="0" class="w-full border rounded px-2 py-1" />
+            <h3 class="text-xs font-semibold mt-4">Rewards</h3>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Points</label>
+                <input v-model.number="form.rewards.points" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-            <div class="md:col-span-2">
-              <label class="block text-sm">Add cToon reward</label>
+            <div class="md:col-span-2 flex flex-col gap-1">
+              <label class="text-xs font-medium">Add cToon reward</label>
               <div class="flex gap-2 items-center">
                 <datalist id="ach-ctoon-list">
                   <option v-for="c in filteredCtoons(ctoonSelection.name)" :key="c.id" :value="c.name" />
@@ -188,13 +189,13 @@
                 <input
                   v-model="ctoonSelection.name"
                   list="ach-ctoon-list"
-                  class="border rounded px-2 py-1 w-full"
+                  class="border rounded-md px-2 py-1.5 text-sm w-full"
                   placeholder="Type 3+ characters to search"
                 />
-                <input v-model.number="ctoonSelection.qty" type="number" min="1" class="w-24 border rounded px-2 py-1" />
-                <button type="button" class="px-3 py-1 border rounded" @click="addCtoon">Add</button>
+                <input v-model.number="ctoonSelection.qty" type="number" min="1" class="w-24 border rounded-md px-2 py-1.5 text-sm" />
+                <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="addCtoon">Add</button>
               </div>
-              <div class="text-sm mt-1" v-if="form.rewards.ctoons.length">
+              <div class="text-xs mt-1" v-if="form.rewards.ctoons.length">
                 <div v-for="(r, i) in form.rewards.ctoons" :key="r.ctoonId" class="flex items-center gap-2">
                   <span>{{ nameForCtoon(r.ctoonId) }} × {{ r.quantity }}</span>
                   <button type="button" class="text-red-600" @click="form.rewards.ctoons.splice(i,1)">Remove</button>
@@ -204,8 +205,8 @@
             </div>
 
           <div class="mt-3">
-            <label class="block text-sm">Backgrounds</label>
-            <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 max-h-48 overflow-auto border p-2 rounded">
+            <label class="block text-xs font-medium">Backgrounds</label>
+            <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 max-h-48 overflow-auto border p-2 rounded-md mt-1">
               <button
                 v-for="b in backgrounds"
                 :key="b.id"
@@ -225,77 +226,77 @@
             </div>
           </div>
 
-          <h3 class="text-lg font-semibold mt-6">Claimable Reward (optional)</h3>
+          <h3 class="text-xs font-semibold mt-4">Claimable Reward (optional)</h3>
           <div class="flex items-center gap-2">
             <input type="checkbox" v-model="form.isClaimable" id="isClaimable" />
-            <label for="isClaimable">User picks 1 of up to 4 reward options instead of auto-granting the Rewards above</label>
+            <label for="isClaimable" class="text-xs">User picks 1 of up to 4 reward options instead of auto-granting the Rewards above</label>
           </div>
-          <div v-if="form.isClaimable" class="mt-2 space-y-3">
-            <div v-for="(opt, i) in form.claimOptions" :key="i" class="border rounded p-2 grid grid-cols-1 md:grid-cols-4 gap-2 items-end">
-              <div>
-                <label class="block text-xs">Label</label>
-                <input v-model="opt.label" class="w-full border rounded px-2 py-1" placeholder="Option name" />
+          <div v-if="form.isClaimable" class="mt-2 space-y-2">
+            <div v-for="(opt, i) in form.claimOptions" :key="i" class="border rounded-md p-2 grid grid-cols-1 md:grid-cols-4 gap-2 items-end">
+              <div class="flex flex-col gap-1">
+                <label class="text-[10px] font-medium">Label</label>
+                <input v-model="opt.label" class="border rounded-md px-2 py-1.5 text-sm" placeholder="Option name" />
               </div>
-              <div>
-                <label class="block text-xs">Points</label>
-                <input v-model.number="opt.points" type="number" min="0" class="w-full border rounded px-2 py-1" />
+              <div class="flex flex-col gap-1">
+                <label class="text-[10px] font-medium">Points</label>
+                <input v-model.number="opt.points" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block text-xs">cToon</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-[10px] font-medium">cToon</label>
                 <datalist :id="`claim-ctoon-list-${i}`">
                   <option v-for="c in filteredCtoons(opt.ctoonName)" :key="c.id" :value="c.name" />
                 </datalist>
                 <input
                   v-model="opt.ctoonName"
                   :list="`claim-ctoon-list-${i}`"
-                  class="w-full border rounded px-2 py-1"
+                  class="border rounded-md px-2 py-1.5 text-sm"
                   placeholder="Type 3+ chars"
                   @change="setClaimOptionCtoon(opt, opt.ctoonName)"
                 />
               </div>
               <div class="flex items-end gap-2">
-                <div class="flex-1">
-                  <label class="block text-xs">Qty</label>
-                  <input v-model.number="opt.quantity" type="number" min="1" class="w-full border rounded px-2 py-1" />
+                <div class="flex-1 flex flex-col gap-1">
+                  <label class="text-[10px] font-medium">Qty</label>
+                  <input v-model.number="opt.quantity" type="number" min="1" class="border rounded-md px-2 py-1.5 text-sm" />
                 </div>
-                <button type="button" class="text-red-600 px-2 py-1" @click="removeClaimOption(i)">Remove</button>
+                <button type="button" class="text-red-600 px-2 py-1 text-xs" @click="removeClaimOption(i)">Remove</button>
               </div>
             </div>
-            <button v-if="form.claimOptions.length < 4" type="button" class="px-3 py-1 border rounded" @click="addClaimOption">
+            <button v-if="form.claimOptions.length < 4" type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="addClaimOption">
               Add option ({{ form.claimOptions.length }}/4)
             </button>
           </div>
           </div>
-          <div class="px-4 py-3 border-t flex gap-3 justify-end">
-            <button type="button" class="px-4 py-2 border rounded" @click="closeForm">Cancel</button>
-            <button class="px-4 py-2 bg-blue-600 text-white rounded" type="submit">{{ editId ? 'Save Changes' : 'Create Achievement' }}</button>
+          <div class="px-4 py-3 border-t flex gap-2 justify-end flex-shrink-0">
+            <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeForm">Cancel</button>
+            <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700" type="submit">{{ editId ? 'Save Changes' : 'Create Achievement' }}</button>
           </div>
         </form>
       </div>
     </div>
 
     <!-- Settings Modal -->
-    <div v-if="showSettings" class="fixed inset-0 z-50 flex items-center justify-center">
+    <div v-if="showSettings" class="fixed inset-0 z-50 flex items-center justify-center p-2">
       <div class="absolute inset-0 bg-black/50" @click="closeSettings"></div>
-      <div class="relative bg-white rounded shadow max-w-lg w-full mx-4 flex flex-col overflow-hidden">
-        <div class="px-4 pt-4 pb-2">
-          <h2 class="text-xl font-semibold">Achievement Settings</h2>
+      <div class="relative bg-white w-full max-w-lg rounded-lg shadow-lg flex flex-col">
+        <div class="px-4 py-3 border-b flex-shrink-0">
+          <h2 class="text-sm font-semibold">Achievement Settings</h2>
         </div>
-        <div class="px-4 pb-4">
-          <label class="block text-sm font-medium">Discord Channel ID (Announcements)</label>
+        <div class="px-4 py-3">
+          <label class="block text-xs font-medium">Discord Channel ID (Announcements)</label>
           <input
             v-model="settingsForm.achievementDiscordChannelId"
-            class="w-full border rounded px-2 py-1"
+            class="border rounded-md px-2 py-1.5 text-sm w-full mt-1"
             placeholder="123456789012345678"
             :disabled="settingsLoading || settingsSaving"
           />
-          <p class="text-xs text-gray-500 mt-1">
+          <p class="text-[10px] text-gray-500 mt-1">
             Leave blank to use the DISCORD_ANNOUNCEMENTS_CHANNEL environment variable.
           </p>
         </div>
-        <div class="px-4 py-3 border-t flex gap-3 justify-end">
-          <button type="button" class="px-4 py-2 border rounded" @click="closeSettings">Cancel</button>
-          <button class="px-4 py-2 bg-blue-600 text-white rounded" type="button" @click="saveSettings" :disabled="settingsSaving">
+        <div class="px-4 py-3 border-t flex gap-2 justify-end flex-shrink-0">
+          <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeSettings">Cancel</button>
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700" type="button" @click="saveSettings" :disabled="settingsSaving">
             {{ settingsSaving ? 'Saving…' : 'Save Settings' }}
           </button>
         </div>
@@ -303,19 +304,20 @@
     </div>
 
     <div>
-      <h2 class="text-xl font-semibold mb-3">Existing Achievements</h2>
-      <div v-if="pending">Loading…</div>
-      <div v-else class="divide-y border rounded">
-        <div v-for="a in achievements" :key="a.id" class="p-3 flex items-center gap-4">
+      <h2 class="text-xs font-semibold mb-2">Existing Achievements</h2>
+      <div v-if="pending" class="text-gray-500 py-6 text-center">Loading…</div>
+      <div v-else class="divide-y border rounded-md">
+        <div v-for="a in achievements" :key="a.id" class="p-2 flex items-center gap-3">
           <img v-if="a.imagePath" :src="a.imagePath" class="w-12 h-12 object-cover rounded" alt="" />
-          <div class="flex-1">
-            <div class="font-medium">{{ a.title }}</div>
-            <div class="text-xs text-gray-500">Slug: {{ a.slug }} • Active: {{ a.isActive ? 'yes' : 'no' }}</div>
+          <div class="flex-1 min-w-0">
+            <div class="font-medium text-xs">{{ a.title }}</div>
+            <div class="text-[10px] text-gray-500">Slug: {{ a.slug }} • Active: {{ a.isActive ? 'yes' : 'no' }}</div>
           </div>
-          <button class="px-3 py-1 border rounded" @click="startEdit(a)">Edit</button>
-          <button class="px-3 py-1 border rounded text-red-600" @click="remove(a)">Delete</button>
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="startEdit(a)">Edit</button>
+          <button class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="remove(a)">Delete</button>
         </div>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyAdminChanges.vue
+++ b/components/newsite/admin/legacy/AdminLegacyAdminChanges.vue
@@ -1,127 +1,129 @@
 <template>
 
-  <div class="bg-gray-100 p-6 ">
-    <h1 class="text-3xl font-bold mb-6">Admin: Admin Changes</h1>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+      <h1 class="text-base font-semibold mb-3">Admin: Admin Changes</h1>
 
-    <div class="bg-white rounded-lg shadow-md p-4 md:p-6 max-w-6xl mx-auto">
-      <!-- Filters -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 gap-3 md:gap-4 mb-4 md:mb-6">
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Admin</label>
-          <select v-model="filters.userId" class="input">
-            <option value="">All admins</option>
-            <option v-for="u in adminUsers" :key="u.id" :value="u.id">{{ u.username || u.discordTag || u.id }}</option>
-          </select>
+      <div class="bg-white rounded border p-3">
+        <!-- Filters -->
+        <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-end mb-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Admin</label>
+            <select v-model="filters.userId" class="text-xs border rounded-md px-1.5 py-1">
+              <option value="">All admins</option>
+              <option v-for="u in adminUsers" :key="u.id" :value="u.id">{{ u.username || u.discordTag || u.id }}</option>
+            </select>
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Target user</label>
+            <input
+              v-model.trim="filters.targetUsername"
+              type="text"
+              placeholder="Username affected"
+              class="text-xs border rounded-md px-1.5 py-1"
+              @keydown.enter="applyFilters"
+            />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Start date</label>
+            <input type="date" v-model="filters.startDate" class="text-xs border rounded-md px-1.5 py-1" />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">End date</label>
+            <input type="date" v-model="filters.endDate" class="text-xs border rounded-md px-1.5 py-1" />
+          </div>
+          <div class="flex items-center gap-2">
+            <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700" @click="applyFilters">Apply</button>
+            <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="clearFilters">Clear</button>
+          </div>
         </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Target user</label>
-          <input
-            v-model.trim="filters.targetUsername"
-            type="text"
-            placeholder="Username affected"
-            class="input"
-            @keydown.enter="applyFilters"
-          />
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Start date</label>
-          <input type="date" v-model="filters.startDate" class="input" />
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">End date</label>
-          <input type="date" v-model="filters.endDate" class="input" />
-        </div>
-        <div class="flex items-end gap-2">
-          <button class="btn-primary w-full" @click="applyFilters">Apply</button>
-          <button class="btn-secondary" @click="clearFilters">Clear</button>
-        </div>
-      </div>
 
-      <div v-if="loading" class="text-center text-gray-500 py-6">Loading…</div>
+        <div v-if="loading" class="text-center text-gray-500 py-6">Loading…</div>
 
-      <template v-else>
-        <!-- Desktop table -->
-        <div class="hidden md:block overflow-x-auto">
-          <table class="min-w-full text-sm">
-            <thead>
-              <tr class="text-left text-gray-600 border-b">
-                <th class="px-3 py-2">When (CDT)</th>
-                <th class="px-3 py-2">Admin</th>
-                <th class="px-3 py-2">Target</th>
-                <th class="px-3 py-2">Area</th>
-                <th class="px-3 py-2">Key</th>
-                <th class="px-3 py-2">Previous</th>
-                <th class="px-3 py-2">New</th>
-              </tr>
-            </thead>
-            <tbody>
-              <template v-for="row in rows" :key="row.id">
-                <tr class="border-b align-top">
-                  <td class="px-3 py-2 whitespace-nowrap">{{ row.createdAtCdt }}</td>
-                  <td class="px-3 py-2 break-words">{{ labelUser(row.user) }}</td>
-                  <td class="px-3 py-2 break-words">{{ row.targetUsername || '—' }}</td>
-                  <td class="px-3 py-2 break-words">{{ row.area }}</td>
-                  <td class="px-3 py-2 break-words">{{ row.key }}</td>
-                  <td class="px-3 py-2 text-gray-700 break-words">
-                    <pre v-if="!row.seizure" class="whitespace-pre-wrap">{{ row.prevValue ?? '—' }}</pre>
-                    <span v-else class="text-xs text-gray-400">—</span>
-                  </td>
-                  <td class="px-3 py-2 text-gray-900 break-words min-w-0">
-                    <template v-if="row.seizure">
-                      <div>{{ seizureSummary(row.seizure) }}</div>
-                      <button class="mt-1 text-indigo-600 text-xs underline" @click="toggleExpand(row.id)">
-                        {{ expandedIds.has(row.id) ? 'Hide details' : 'Show details' }}
-                      </button>
-                    </template>
-                    <pre v-else class="whitespace-pre-wrap">{{ row.newValue ?? '—' }}</pre>
-                  </td>
+        <template v-else>
+          <!-- Desktop table -->
+          <div class="hidden md:block overflow-x-auto">
+            <table class="min-w-full text-xs">
+              <thead>
+                <tr>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">When (CDT)</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Admin</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Target</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Area</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Key</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Previous</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">New</th>
                 </tr>
-                <tr v-if="row.seizure && expandedIds.has(row.id)" class="border-b bg-indigo-50/40">
-                  <td colspan="7" class="px-3 py-3">
-                    <SeizureDetail :seizure="row.seizure" />
-                  </td>
+              </thead>
+              <tbody class="divide-y">
+                <template v-for="row in rows" :key="row.id">
+                  <tr class="align-top">
+                    <td class="px-2 py-1.5 whitespace-nowrap">{{ row.createdAtCdt }}</td>
+                    <td class="px-2 py-1.5 break-words">{{ labelUser(row.user) }}</td>
+                    <td class="px-2 py-1.5 break-words">{{ row.targetUsername || '—' }}</td>
+                    <td class="px-2 py-1.5 break-words">{{ row.area }}</td>
+                    <td class="px-2 py-1.5 break-words">{{ row.key }}</td>
+                    <td class="px-2 py-1.5 text-gray-700 break-words">
+                      <pre v-if="!row.seizure" class="whitespace-pre-wrap">{{ row.prevValue ?? '—' }}</pre>
+                      <span v-else class="text-[10px] text-gray-400">—</span>
+                    </td>
+                    <td class="px-2 py-1.5 text-gray-900 break-words min-w-0">
+                      <template v-if="row.seizure">
+                        <div>{{ seizureSummary(row.seizure) }}</div>
+                        <button class="mt-1 text-blue-600 text-[11px] underline" @click="toggleExpand(row.id)">
+                          {{ expandedIds.has(row.id) ? 'Hide details' : 'Show details' }}
+                        </button>
+                      </template>
+                      <pre v-else class="whitespace-pre-wrap">{{ row.newValue ?? '—' }}</pre>
+                    </td>
+                  </tr>
+                  <tr v-if="row.seizure && expandedIds.has(row.id)" class="bg-blue-50/40">
+                    <td colspan="7" class="px-2 py-2">
+                      <SeizureDetail :seizure="row.seizure" />
+                    </td>
+                  </tr>
+                </template>
+                <tr v-if="!rows.length">
+                  <td colspan="7" class="px-2 py-6 text-center text-gray-500">No changes found.</td>
                 </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Mobile cards -->
+          <div class="md:hidden grid grid-cols-1 gap-2">
+            <div v-for="row in rows" :key="row.id" class="bg-white border rounded-lg shadow p-2">
+              <div class="text-[10px] text-gray-500">{{ row.createdAtCdt }}</div>
+              <div class="text-xs font-medium break-words">{{ labelUser(row.user) }}</div>
+              <div class="text-[11px] text-gray-700 break-words">{{ row.area }} · {{ row.key }}</div>
+              <div v-if="row.targetUsername" class="text-[10px] text-gray-500 break-words">Target: {{ row.targetUsername }}</div>
+
+              <template v-if="row.seizure">
+                <div class="mt-1 text-[11px] break-words">{{ seizureSummary(row.seizure) }}</div>
+                <button class="mt-1 text-blue-600 text-[11px] underline" @click="toggleExpand(row.id)">
+                  {{ expandedIds.has(row.id) ? 'Hide details' : 'Show details' }}
+                </button>
+                <div v-if="expandedIds.has(row.id)" class="mt-1 pt-1 border-t">
+                  <SeizureDetail :seizure="row.seizure" />
+                </div>
               </template>
-              <tr v-if="!rows.length">
-                <td colspan="7" class="px-3 py-6 text-center text-gray-500">No changes found.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
 
-        <!-- Mobile cards -->
-        <div class="md:hidden space-y-3">
-          <div v-for="row in rows" :key="row.id" class="rounded-lg border border-gray-200 bg-gray-50 p-3">
-            <div class="text-xs text-gray-500">{{ row.createdAtCdt }}</div>
-            <div class="font-medium break-words">{{ labelUser(row.user) }}</div>
-            <div class="text-sm text-gray-700 break-words">{{ row.area }} · {{ row.key }}</div>
-            <div v-if="row.targetUsername" class="text-xs text-gray-500 break-words">Target: {{ row.targetUsername }}</div>
-
-            <template v-if="row.seizure">
-              <div class="mt-2 text-sm break-words">{{ seizureSummary(row.seizure) }}</div>
-              <button class="mt-1 text-indigo-600 text-xs underline" @click="toggleExpand(row.id)">
-                {{ expandedIds.has(row.id) ? 'Hide details' : 'Show details' }}
-              </button>
-              <div v-if="expandedIds.has(row.id)" class="mt-2 pt-2 border-t border-gray-200">
-                <SeizureDetail :seizure="row.seizure" />
-              </div>
-            </template>
-
-            <div v-else class="mt-2 grid grid-cols-1 gap-2">
-              <div>
-                <div class="text-xs text-gray-500">Previous</div>
-                <div class="text-sm break-words"><pre class="whitespace-pre-wrap">{{ row.prevValue ?? '—' }}</pre></div>
-              </div>
-              <div>
-                <div class="text-xs text-gray-500">New</div>
-                <div class="text-sm break-words"><pre class="whitespace-pre-wrap">{{ row.newValue ?? '—' }}</pre></div>
+              <div v-else class="mt-1 grid grid-cols-1 gap-1">
+                <div>
+                  <div class="text-[10px] text-gray-500">Previous</div>
+                  <div class="text-[11px] break-words"><pre class="whitespace-pre-wrap">{{ row.prevValue ?? '—' }}</pre></div>
+                </div>
+                <div>
+                  <div class="text-[10px] text-gray-500">New</div>
+                  <div class="text-[11px] break-words"><pre class="whitespace-pre-wrap">{{ row.newValue ?? '—' }}</pre></div>
+                </div>
               </div>
             </div>
+            <div v-if="!rows.length" class="text-center text-gray-500 py-4">No changes found.</div>
           </div>
-          <div v-if="!rows.length" class="text-center text-gray-500 py-4">No changes found.</div>
-        </div>
-      </template>
+        </template>
 
+      </div>
     </div>
   </div>
 </template>
@@ -260,10 +262,3 @@ onMounted(async () => {
 })
 </script>
 
-<style scoped>
-.input { width: 100%; border: 1px solid #D1D5DB; border-radius: .375rem; padding: .5rem; outline: none }
-.input:focus { border-color: #6366F1; box-shadow: 0 0 0 1px #6366F1 }
-.btn-primary{ background-color:#6366F1; color:#fff; padding:.5rem 1.25rem; border-radius:.375rem }
-.btn-primary:disabled{ opacity:.5 }
-.btn-secondary{ background-color:#E5E7EB; color:#374151; padding:.5rem 1rem; border-radius:.375rem }
-</style>

--- a/components/newsite/admin/legacy/AdminLegacyAds.vue
+++ b/components/newsite/admin/legacy/AdminLegacyAds.vue
@@ -1,46 +1,47 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
-    <div class="max-w-5xl mx-auto bg-white rounded-lg shadow p-6">
-      <div class="flex items-center justify-between mb-4">
-        <h1 class="text-2xl font-semibold">Ad Images</h1>
+    <div class="bg-white rounded border p-3">
+      <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+        <h1 class="text-base font-semibold">Ad Images</h1>
         <button
-          class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
           @click="openUpload"
         >
           Upload
         </button>
       </div>
 
-      <div v-if="error" class="text-red-600 mb-4">{{ error.message }}</div>
-      <div v-if="pending" class="text-gray-500">Loading…</div>
+      <div v-if="error" class="text-red-600 mb-3">{{ error.message }}</div>
+      <div v-if="pending" class="text-gray-500 py-6 text-center">Loading…</div>
 
-      <div v-if="images?.length" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div v-if="images?.length" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
         <div
           v-for="img in images"
           :key="img.id"
-          class="border rounded-lg overflow-hidden flex flex-col"
+          class="bg-white border rounded-lg shadow overflow-hidden flex flex-col"
         >
           <div class="aspect-video bg-gray-100 flex items-center justify-center">
             <img :src="img.imagePath" alt="" class="max-h-full max-w-full object-contain" />
           </div>
-          <div class="p-3 text-sm flex-1">
-            <p class="break-words"><strong>Path:</strong> {{ img.imagePath }}</p>
-            <p class="text-gray-500 mt-1">
+          <div class="p-2 text-[11px] flex-1">
+            <p class="break-words"><span class="text-gray-500">Path:</span> {{ img.imagePath }}</p>
+            <p class="text-gray-500 mt-0.5">
               {{ new Date(img.createdAt).toLocaleString() }}
             </p>
-            <p v-if="img.label" class="mt-1"><strong>Label:</strong> {{ img.label }}</p>
-            <p v-if="img.url" class="mt-1 break-words">
-              <strong>URL:</strong>
+            <p v-if="img.label" class="mt-0.5"><span class="text-gray-500">Label:</span> {{ img.label }}</p>
+            <p v-if="img.url" class="mt-0.5 break-words">
+              <span class="text-gray-500">URL:</span>
               <a :href="img.url" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
                 {{ img.url }}
               </a>
             </p>
-            <p v-else class="mt-1 text-gray-500"><strong>URL:</strong> /newsite/home (default)</p>
+            <p v-else class="mt-0.5 text-gray-500"><span class="text-gray-500">URL:</span> /newsite/home (default)</p>
           </div>
-          <div class="p-3 pt-0 flex justify-end gap-2">
+          <div class="p-2 pt-0 flex justify-end gap-2">
             <button
-              class="text-red-700 hover:text-red-900"
+              class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50"
               @click="del(img.id)"
             >
               Delete
@@ -48,47 +49,48 @@
           </div>
         </div>
       </div>
-      <div v-else class="text-gray-500">No images.</div>
+      <div v-else class="text-gray-500 py-6 text-center">No images.</div>
+    </div>
     </div>
 
     <!-- Upload Modal -->
-    <div v-if="showUpload" class="fixed inset-0 z-50 flex items-center justify-center">
+    <div v-if="showUpload" class="fixed inset-0 z-50 flex items-center justify-center p-2">
       <div class="absolute inset-0 bg-black/50" @click="closeUpload"></div>
-      <div class="relative bg-white rounded-lg shadow-lg w-full max-w-lg max-h-[90vh] flex flex-col">
-        <div class="p-4 border-b flex items-center justify-between">
-          <h2 class="text-lg font-semibold">Upload Ad Image</h2>
-          <button class="text-gray-600 hover:text-gray-800" @click="closeUpload">Close</button>
+      <div class="relative bg-white w-full max-w-lg rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+          <h2 class="text-sm font-semibold">Upload Ad Image</h2>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeUpload">Close</button>
         </div>
 
-        <div class="p-4 overflow-y-auto">
-          <div class="space-y-4">
-            <div>
-              <label class="block mb-1 font-medium">Select Image</label>
-              <input ref="fileInput" type="file" accept="image/*" class="w-full" />
-              <p class="text-xs text-gray-500 mt-1">PNG, JPG, GIF, WEBP, or SVG</p>
+        <div class="overflow-y-auto flex-1 px-4 py-3">
+          <div class="space-y-3">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Select Image</label>
+              <input ref="fileInput" type="file" accept="image/*" class="text-xs" />
+              <p class="text-[10px] text-gray-500">PNG, JPG, GIF, WEBP, or SVG</p>
             </div>
-            <div>
-              <label class="block mb-1 font-medium">Label (optional)</label>
-              <input v-model="label" type="text" class="w-full border rounded px-3 py-2" />
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Label (optional)</label>
+              <input v-model="label" type="text" class="border rounded-md px-2 py-1.5 text-sm" />
             </div>
-            <div>
-              <label class="block mb-1 font-medium">URL (optional)</label>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">URL (optional)</label>
               <input
                 v-model="linkUrl"
                 type="url"
                 placeholder="https://example.com"
-                class="w-full border rounded px-3 py-2"
+                class="border rounded-md px-2 py-1.5 text-sm"
               />
-              <p class="text-xs text-gray-500 mt-1">Leave blank to link to /newsite/home</p>
+              <p class="text-[10px] text-gray-500">Leave blank to link to /newsite/home</p>
             </div>
-            <div v-if="uploadError" class="text-red-600 text-sm">{{ uploadError }}</div>
+            <div v-if="uploadError" class="text-red-600 text-[11px]">{{ uploadError }}</div>
           </div>
         </div>
 
-        <div class="p-4 border-t flex justify-end gap-2">
-          <button class="px-4 py-2 rounded border" @click="closeUpload">Close</button>
+        <div class="flex items-center justify-end gap-2 px-4 py-3 border-t flex-shrink-0">
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeUpload">Close</button>
           <button
-            class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
             :disabled="uploading"
             @click="upload"
           >

--- a/components/newsite/admin/legacy/AdminLegacyAnnouncements.vue
+++ b/components/newsite/admin/legacy/AdminLegacyAnnouncements.vue
@@ -1,71 +1,71 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-5xl mx-auto bg-white rounded-lg shadow p-6">
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
-        <h1 class="text-2xl font-semibold">Manage Announcements</h1>
+    <div class="px-2 py-2 bg-white rounded-lg shadow p-3">
+      <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+        <h1 class="text-base font-semibold">Manage Announcements</h1>
         <button
-          class="w-full sm:w-auto bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
           @click="openCreate"
         >
           Add Announcement
         </button>
       </div>
 
-      <div v-if="error" class="text-red-600 mb-4">
+      <div v-if="error" class="text-red-600 mb-3">
         {{ error.message || 'Failed to load announcements' }}
       </div>
-      <div v-if="pending" class="text-gray-500">Loading...</div>
+      <div v-if="pending" class="text-gray-500 py-6 text-center">Loading...</div>
 
       <div v-if="announcements?.length">
-        <div class="space-y-4 sm:hidden">
-          <div v-for="row in announcements" :key="row.id" class="border rounded-lg p-4 bg-white">
-            <div class="text-sm text-gray-500">Go Live (CST)</div>
-            <div class="font-medium text-gray-900">{{ formatCentral(row.scheduledAt) }}</div>
-            <div class="mt-3 text-sm text-gray-500">Preview</div>
-            <div class="text-gray-900">{{ previewMessage(row.message) }}</div>
-            <div class="text-xs text-gray-500 mt-2 flex flex-wrap gap-2">
+        <div class="space-y-2 sm:hidden">
+          <div v-for="row in announcements" :key="row.id" class="bg-white border rounded-lg shadow p-2">
+            <div class="text-[10px] text-gray-500">Go Live (CST)</div>
+            <div class="font-medium text-xs text-gray-900">{{ formatCentral(row.scheduledAt) }}</div>
+            <div class="mt-2 text-[10px] text-gray-500">Preview</div>
+            <div class="text-xs text-gray-900">{{ previewMessage(row.message) }}</div>
+            <div class="text-[10px] text-gray-500 mt-1.5 flex flex-wrap gap-2">
               <span v-if="row.pingOption">Ping: {{ row.pingOption }}</span>
               <span v-if="imageCount(row)">Images: {{ imageCount(row) }}</span>
             </div>
-            <div v-if="row.sendError" class="text-xs text-red-600 mt-2">
+            <div v-if="row.sendError" class="text-[10px] text-red-600 mt-1.5">
               Last error: {{ row.sendError }}
             </div>
-            <div class="mt-3 flex gap-3">
-              <button class="text-blue-600 hover:text-blue-800" @click="openEdit(row)">Edit</button>
-              <button class="text-red-600 hover:text-red-800" @click="remove(row)">Delete</button>
+            <div class="mt-2 flex gap-2">
+              <button class="flex-1 px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50" @click="openEdit(row)">Edit</button>
+              <button class="flex-1 px-2 py-1 text-[11px] border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="remove(row)">Delete</button>
             </div>
           </div>
         </div>
 
         <div class="hidden sm:block overflow-x-auto">
-          <table class="w-full text-sm">
+          <table class="w-full text-xs">
           <thead>
-            <tr class="text-left border-b">
-              <th class="py-2 pr-4">Preview</th>
-              <th class="py-2 pr-4 whitespace-nowrap">Go Live (CST)</th>
-              <th class="py-2 pr-4">Actions</th>
+            <tr>
+              <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Preview</th>
+              <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100 whitespace-nowrap">Go Live (CST)</th>
+              <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Actions</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="row in announcements" :key="row.id" class="border-b last:border-b-0">
-              <td class="py-3 pr-4 align-top">
+              <td class="px-2 py-1.5 align-top">
                 <div class="text-gray-900">
                   {{ previewMessage(row.message) }}
                 </div>
-                <div class="text-xs text-gray-500 mt-1 flex flex-wrap gap-2">
+                <div class="text-[10px] text-gray-500 mt-1 flex flex-wrap gap-2">
                   <span v-if="row.pingOption">Ping: {{ row.pingOption }}</span>
                   <span v-if="imageCount(row)">Images: {{ imageCount(row) }}</span>
                 </div>
-                <div v-if="row.sendError" class="text-xs text-red-600 mt-2">
+                <div v-if="row.sendError" class="text-[10px] text-red-600 mt-1.5">
                   Last error: {{ row.sendError }}
                 </div>
               </td>
-              <td class="py-3 pr-4 align-top whitespace-nowrap">
+              <td class="px-2 py-1.5 align-top whitespace-nowrap">
                 {{ formatCentral(row.scheduledAt) }}
               </td>
-              <td class="py-3 pr-4 align-top whitespace-nowrap">
-                <button class="text-blue-600 hover:text-blue-800 mr-3" @click="openEdit(row)">Edit</button>
+              <td class="px-2 py-1.5 align-top whitespace-nowrap">
+                <button class="text-blue-600 hover:text-blue-800 mr-2" @click="openEdit(row)">Edit</button>
                 <button class="text-red-600 hover:text-red-800" @click="remove(row)">Delete</button>
               </td>
             </tr>
@@ -73,111 +73,111 @@
           </table>
         </div>
       </div>
-      <div v-else-if="!pending" class="text-gray-500">No upcoming announcements.</div>
+      <div v-else-if="!pending" class="text-gray-500 py-6 text-center">No upcoming announcements.</div>
     </div>
 
     <!-- Add/Edit Modal -->
-    <div v-if="showModal" class="fixed inset-0 z-50 flex items-center justify-center">
+    <div v-if="showModal" class="fixed inset-0 z-50 flex items-center justify-center p-2">
       <div class="absolute inset-0 bg-black/50" @click="closeModal"></div>
-      <div class="relative bg-white rounded-lg shadow-lg w-full max-w-xl max-h-[90vh] flex flex-col">
-        <div class="p-4 border-b flex items-center justify-between flex-shrink-0">
-          <h2 class="text-lg font-semibold">{{ modalTitle }}</h2>
-          <button class="text-gray-600 hover:text-gray-800" @click="closeModal">Close</button>
+      <div class="relative bg-white w-full max-w-xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+          <h3 class="text-sm font-semibold">{{ modalTitle }}</h3>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeModal">✕</button>
         </div>
 
-        <div class="p-4 overflow-y-auto flex-1">
-          <div class="space-y-4">
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <label class="block mb-1 font-medium">Date (CST)</label>
-                <input v-model="form.date" type="date" class="w-full border rounded px-3 py-2" />
+        <div class="overflow-y-auto flex-1 px-4 py-3">
+          <div class="space-y-3">
+            <div class="grid sm:grid-cols-2 gap-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Date (CST)</label>
+                <input v-model="form.date" type="date" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
-              <div>
-                <label class="block mb-1 font-medium">Time (CST)</label>
-                <input v-model="form.time" type="time" class="w-full border rounded px-3 py-2" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Time (CST)</label>
+                <input v-model="form.time" type="time" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
             </div>
 
-            <div>
-              <label class="block mb-1 font-medium">Ping Option</label>
-              <select v-model="form.pingOption" class="w-full border rounded px-3 py-2">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Ping Option</label>
+              <select v-model="form.pingOption" class="border rounded-md px-2 py-1.5 text-sm">
                 <option value="">None</option>
                 <option value="@everyone">@everyone</option>
                 <option value="@here">@here</option>
               </select>
             </div>
 
-            <div>
-              <label class="block mb-1 font-medium">Message</label>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Message</label>
               <textarea
                 ref="messageInput"
                 v-model="form.message"
                 maxlength="1000"
                 rows="5"
-                class="w-full border rounded px-3 py-2"
+                class="border rounded-md px-2 py-1.5 text-sm"
                 @input="onMessageInput"
                 @click="onMessageInput"
                 @keydown="onMessageKeydown"
               ></textarea>
-              <div class="text-xs text-gray-500 mt-1">
+              <div class="text-[10px] text-gray-500">
                 {{ messageCount }}/1000 characters
               </div>
-              <div v-if="showMentionSuggestions" class="mt-2 border rounded bg-white shadow-sm max-h-48 overflow-y-auto">
-                <div v-if="mentionLoading" class="px-3 py-2 text-xs text-gray-500">Searching...</div>
+              <div v-if="showMentionSuggestions" class="mt-1 border rounded-md bg-white shadow-sm max-h-48 overflow-y-auto">
+                <div v-if="mentionLoading" class="px-2 py-1.5 text-[10px] text-gray-500">Searching...</div>
                 <button
                   v-for="user in mentionSuggestions"
                   :key="user.id || user.username"
-                  class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed disabled:hover:bg-white"
+                  class="w-full text-left px-2 py-1.5 text-xs hover:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed disabled:hover:bg-white"
                   :disabled="!user.discordId"
                   @mousedown.prevent="applyMention(user)"
                 >
                   <span>@{{ user.username }}</span>
-                  <span v-if="!user.discordId" class="ml-2 text-xs text-gray-400">(no Discord ID)</span>
+                  <span v-if="!user.discordId" class="ml-2 text-[10px] text-gray-400">(no Discord ID)</span>
                 </button>
-                <div v-if="!mentionLoading && !mentionSuggestions.length" class="px-3 py-2 text-xs text-gray-500">
+                <div v-if="!mentionLoading && !mentionSuggestions.length" class="px-2 py-1.5 text-[10px] text-gray-500">
                   No matching users with Discord IDs
                 </div>
               </div>
             </div>
 
-            <div>
-              <label class="block mb-1 font-medium">Images (optional, up to 3)</label>
-              <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Images (optional, up to 3)</label>
+              <div class="grid sm:grid-cols-3 gap-2">
                 <div>
-                  <label class="block text-xs text-gray-600 mb-1">Image 1</label>
-                  <input ref="fileInput1" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'image1')" />
-                  <div v-if="form.imagePath" class="text-xs text-gray-500 mt-2">
+                  <label class="block text-[10px] text-gray-600 mb-1">Image 1</label>
+                  <input ref="fileInput1" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" class="text-xs" @change="onFileChange($event, 'image1')" />
+                  <div v-if="form.imagePath" class="text-[10px] text-gray-500 mt-1.5">
                     Current: {{ form.imagePath }}
                   </div>
-                  <div v-if="imageFile1" class="text-xs text-gray-500 mt-1">Selected: {{ imageFile1.name }}</div>
+                  <div v-if="imageFile1" class="text-[10px] text-gray-500 mt-1">Selected: {{ imageFile1.name }}</div>
                 </div>
                 <div>
-                  <label class="block text-xs text-gray-600 mb-1">Image 2</label>
-                  <input ref="fileInput2" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'image2')" />
-                  <div v-if="form.imagePath2" class="text-xs text-gray-500 mt-2">
+                  <label class="block text-[10px] text-gray-600 mb-1">Image 2</label>
+                  <input ref="fileInput2" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" class="text-xs" @change="onFileChange($event, 'image2')" />
+                  <div v-if="form.imagePath2" class="text-[10px] text-gray-500 mt-1.5">
                     Current: {{ form.imagePath2 }}
                   </div>
-                  <div v-if="imageFile2" class="text-xs text-gray-500 mt-1">Selected: {{ imageFile2.name }}</div>
+                  <div v-if="imageFile2" class="text-[10px] text-gray-500 mt-1">Selected: {{ imageFile2.name }}</div>
                 </div>
                 <div>
-                  <label class="block text-xs text-gray-600 mb-1">Image 3</label>
-                  <input ref="fileInput3" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'image3')" />
-                  <div v-if="form.imagePath3" class="text-xs text-gray-500 mt-2">
+                  <label class="block text-[10px] text-gray-600 mb-1">Image 3</label>
+                  <input ref="fileInput3" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" class="text-xs" @change="onFileChange($event, 'image3')" />
+                  <div v-if="form.imagePath3" class="text-[10px] text-gray-500 mt-1.5">
                     Current: {{ form.imagePath3 }}
                   </div>
-                  <div v-if="imageFile3" class="text-xs text-gray-500 mt-1">Selected: {{ imageFile3.name }}</div>
+                  <div v-if="imageFile3" class="text-[10px] text-gray-500 mt-1">Selected: {{ imageFile3.name }}</div>
                 </div>
               </div>
             </div>
 
-            <div v-if="formError" class="text-red-600 text-sm">{{ formError }}</div>
+            <div v-if="formError" class="text-red-600 text-xs">{{ formError }}</div>
           </div>
         </div>
 
-        <div class="p-4 border-t flex justify-end gap-2 flex-shrink-0">
-          <button class="px-4 py-2 rounded border" @click="closeModal">Cancel</button>
+        <div class="flex items-center justify-end gap-2 px-4 py-3 border-t flex-shrink-0">
+          <button class="px-3 py-1 text-sm border rounded-md" @click="closeModal">Cancel</button>
           <button
-            class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+            class="px-3 py-1 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
             :disabled="saving"
             @click="saveAnnouncement"
           >

--- a/components/newsite/admin/legacy/AdminLegacyAuctions.vue
+++ b/components/newsite/admin/legacy/AdminLegacyAuctions.vue
@@ -1,27 +1,27 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-5xl mx-auto mt-6">
-      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
-        <h1 class="text-2xl font-semibold">Manage Auctions (AuctionOnly)</h1>
+    <div class="px-2 py-2">
+      <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+        <h1 class="text-base font-semibold">Manage Auctions (AuctionOnly)</h1>
         <div class="flex flex-wrap items-center gap-2">
           <button
             type="button"
-            class="px-3 py-2 text-sm rounded border border-gray-400 text-gray-700 hover:bg-gray-100"
+            class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
             @click="openHistory"
           >
             History
           </button>
           <button
             type="button"
-            class="px-3 py-2 text-sm rounded border border-gray-400 text-gray-700 hover:bg-gray-100"
+            class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
             @click="openErrorLog"
           >
             Error Log
           </button>
           <NuxtLink
             to="/newsite/admin/auctions/new"
-            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
           >
             Add Auction
           </NuxtLink>
@@ -31,51 +31,52 @@
       <div v-if="upcomingAuctions.length" class="flex justify-end mb-2">
         <button
           type="button"
-          class="px-3 py-1.5 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50"
+          class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50"
           @click="activeModal = 'removeAll'"
         >
           Remove All ({{ upcomingAuctions.length }})
         </button>
       </div>
 
-      <div v-if="upcomingAuctions.length" class="bg-white rounded-lg shadow divide-y">
+      <div v-if="upcomingAuctions.length" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
         <div
           v-for="a in upcomingAuctions"
           :key="a.id"
-          class="p-4 flex items-center gap-4"
+          class="bg-white border rounded-lg shadow p-2 flex flex-col gap-2"
         >
-          <img
-            :src="a.ctoon.assetPath"
-            class="w-14 h-14 rounded object-cover border"
-            alt="cToon"
-          />
-          <div class="min-w-0 flex-1">
-            <div class="font-medium truncate">{{ a.ctoon.name }}</div>
-            <div class="text-xs text-gray-500 truncate">
-              {{ a.ctoon.rarity }}
-              <span v-if="a.mintNumber !== null && a.mintNumber !== undefined"> • Mint #{{ a.mintNumber }}</span>
-            </div>
-            <div class="text-sm text-gray-600 mt-1">
-              <span class="font-medium">Starts:</span> {{ fmtCST(a.startsAt) }}
-              <span class="mx-2">•</span>
-              <span class="font-medium">Ends:</span> {{ fmtCST(a.endsAt) }}
+          <div class="flex items-start gap-2">
+            <img
+              :src="a.ctoon.assetPath"
+              class="w-12 h-12 rounded object-cover border flex-shrink-0"
+              alt="cToon"
+            />
+            <div class="min-w-0 flex-1">
+              <div class="font-medium text-xs truncate">{{ a.ctoon.name }}</div>
+              <div class="text-[10px] text-gray-500 truncate">
+                {{ a.ctoon.rarity }}
+                <span v-if="a.mintNumber !== null && a.mintNumber !== undefined"> • Mint #{{ a.mintNumber }}</span>
+              </div>
             </div>
           </div>
-          <div class="text-right">
-            <div class="text-lg font-semibold">
+          <div class="text-[10px] text-gray-600 space-y-0.5">
+            <div><span class="text-gray-500">Starts:</span> {{ fmtCST(a.startsAt) }}</div>
+            <div><span class="text-gray-500">Ends:</span> {{ fmtCST(a.endsAt) }}</div>
+          </div>
+          <div class="flex items-center justify-between gap-2 mt-auto pt-1">
+            <div class="text-sm font-semibold">
               {{ formatPts(a.pricePoints) }}
             </div>
-            <div class="mt-2 flex items-center justify-end gap-2">
+            <div class="flex items-center gap-1.5">
               <button
                 type="button"
-                class="px-3 py-1 text-sm rounded border border-blue-600 text-blue-700 hover:bg-blue-50"
+                class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                 @click="openEdit(a)"
               >
                 Edit
               </button>
               <button
                 type="button"
-                class="px-3 py-1 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50"
+                class="px-2 py-1 text-[11px] border rounded-md text-red-700 border-red-200 hover:bg-red-50"
                 @click="deleteAuction(a)"
               >
                 Delete
@@ -85,48 +86,48 @@
         </div>
       </div>
 
-      <p v-else class="text-gray-500 mt-6">No upcoming auctions.</p>
-      <p v-if="error" class="text-red-600 mt-4">{{ error }}</p>
+      <p v-else class="text-gray-500 py-6 text-center">No upcoming auctions.</p>
+      <p v-if="error" class="text-red-600 mt-2 text-xs">{{ error }}</p>
     </div>
 
     <!-- Edit modal -->
-    <div v-if="activeModal === 'edit'" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
-      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-lg max-h-[85vh] overflow-y-auto p-4 sm:p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-xl font-semibold">Edit Auction</h2>
-          <button class="text-gray-500 hover:text-gray-700 p-2 -m-2" @click="closeModal">X</button>
+    <div v-if="activeModal === 'edit'" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+      <div class="relative bg-white w-full max-w-lg rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+          <h2 class="text-sm font-semibold">Edit Auction</h2>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeModal">✕</button>
         </div>
 
-        <form @submit.prevent="saveEdit" class="space-y-4">
-          <div>
-            <label class="block font-medium mb-1">Price (points)</label>
-            <input v-model.number="editPrice" type="number" min="0" class="w-full border rounded p-2" />
+        <form @submit.prevent="saveEdit" class="overflow-y-auto flex-1 px-4 py-3 space-y-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Price (points)</label>
+            <input v-model.number="editPrice" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
           </div>
 
-          <div>
-            <label class="block font-medium mb-1">Go-live (CST/CDT)</label>
-            <div class="grid grid-cols-2 gap-3">
-              <input v-model="editStartDate" type="date" class="w-full border rounded p-2" required />
-              <select v-model="editStartHour" class="w-full border rounded p-2" required>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Go-live (CST/CDT)</label>
+            <div class="grid grid-cols-2 gap-2">
+              <input v-model="editStartDate" type="date" class="border rounded-md px-2 py-1.5 text-sm" required />
+              <select v-model="editStartHour" class="border rounded-md px-2 py-1.5 text-sm" required>
                 <option disabled value="">Select hour</option>
                 <option v-for="h in hourOptions" :key="h" :value="h">{{ h }}</option>
               </select>
             </div>
           </div>
 
-          <div>
-            <label class="block font-medium mb-1">Duration</label>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Duration</label>
             <div class="flex items-center gap-3">
               <input v-model.number="editDurationDays" type="range" min="1" max="5" class="w-full" />
-              <span class="w-10 text-center">{{ editDurationDays }}d</span>
+              <span class="w-10 text-center text-xs">{{ editDurationDays }}d</span>
             </div>
           </div>
 
           <div class="flex items-center gap-2">
             <input id="editIsFeatured" v-model="editIsFeatured" type="checkbox" class="h-4 w-4 border-gray-300 rounded" />
-            <label for="editIsFeatured" class="text-sm font-medium text-gray-700">Is Featured</label>
+            <label for="editIsFeatured" class="text-xs font-medium text-gray-700">Is Featured</label>
           </div>
-          <p class="text-xs text-gray-500">
+          <p class="text-[10px] text-gray-500">
             Marks the auction as featured on the auctions page. Users cannot bid if they
             currently own 2+ of this cToon or have received 2+ in the last 30 days.
           </p>
@@ -135,36 +136,36 @@
             <button
               type="submit"
               :disabled="editSaving"
-              class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
             >
               Save Changes
             </button>
-            <button type="button" class="px-4 py-2 rounded border" @click="closeModal">Cancel</button>
-            <span v-if="editError" class="text-red-600 text-sm">{{ editError }}</span>
+            <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeModal">Cancel</button>
+            <span v-if="editError" class="text-red-600 text-[11px]">{{ editError }}</span>
           </div>
         </form>
       </div>
     </div>
 
     <!-- Remove All confirmation modal -->
-    <div v-if="activeModal === 'removeAll'" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
-      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-md max-h-[85vh] overflow-y-auto p-4 sm:p-6">
-        <h2 class="text-xl font-semibold mb-3">Remove All Upcoming Auctions?</h2>
-        <p class="text-sm text-gray-600">
+    <div v-if="activeModal === 'removeAll'" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+      <div class="relative bg-white w-full max-w-md rounded-lg shadow-lg p-5">
+        <h2 class="text-sm font-semibold mb-2">Remove All Upcoming Auctions?</h2>
+        <p class="text-xs text-gray-600">
           This permanently deletes all {{ upcomingAuctions.length }} upcoming AuctionOnly
           listing(s) shown on this page (none of them have gone live yet). This cannot be undone.
         </p>
-        <p v-if="removeAllError" class="text-red-600 text-sm mt-3 whitespace-pre-wrap break-words">{{ removeAllError }}</p>
-        <div class="pt-4 mt-2 border-t flex flex-wrap items-center gap-2">
+        <p v-if="removeAllError" class="text-red-600 text-[11px] mt-2 whitespace-pre-wrap break-words">{{ removeAllError }}</p>
+        <div class="pt-3 mt-2 border-t flex flex-wrap items-center gap-2">
           <button
             type="button"
-            class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 disabled:opacity-50 min-h-[40px]"
+            class="px-3 py-1 text-xs rounded-md text-white bg-red-600 hover:bg-red-700 disabled:bg-red-300"
             :disabled="removeAllBusy"
             @click="removeAllUpcoming"
           >
             {{ removeAllBusy ? 'Removing…' : 'Yes, Remove All' }}
           </button>
-          <button type="button" class="px-4 py-2 rounded border min-h-[40px]" :disabled="removeAllBusy" @click="closeModal">
+          <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" :disabled="removeAllBusy" @click="closeModal">
             Cancel
           </button>
         </div>
@@ -172,161 +173,165 @@
     </div>
 
     <!-- Error Log modal -->
-    <div v-if="activeModal === 'errorLog'" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
-      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-2xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
-        <div class="flex items-center justify-between mb-4 gap-2">
-          <h2 class="text-xl font-semibold">Error Log</h2>
+    <div v-if="activeModal === 'errorLog'" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+      <div class="relative bg-white w-full max-w-2xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0 gap-2">
+          <h2 class="text-sm font-semibold">Error Log</h2>
           <div class="flex items-center gap-2">
             <button
               v-if="errorLog.length"
               type="button"
-              class="px-3 py-1.5 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50"
+              class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50"
               @click="clearErrorLog"
             >
               Clear Log
             </button>
-            <button class="text-gray-500 hover:text-gray-700 p-2 -m-2" @click="closeModal">X</button>
+            <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeModal">✕</button>
           </div>
         </div>
 
-        <div v-if="errorLogLoading" class="text-gray-500 py-6 text-center">Loading…</div>
-        <template v-else>
-          <div v-if="errorLog.length" class="bg-gray-50 rounded-lg border divide-y">
-            <div v-for="e in errorLog" :key="e.id" class="p-3 sm:p-4">
-              <div class="flex flex-wrap items-center gap-2 text-sm">
-                <span
-                  class="px-2 py-0.5 rounded text-xs font-medium"
-                  :class="errorContextBadgeClass(e.context)"
-                >
-                  {{ errorContextLabel(e.context) }}
-                </span>
-                <span class="text-gray-500">{{ fmtCST(e.createdAt) }}</span>
-                <span v-if="e.auctionOnlyId" class="text-gray-400 truncate max-w-full">• {{ e.auctionOnlyId }}</span>
+        <div class="overflow-y-auto flex-1 px-4 py-3">
+          <div v-if="errorLogLoading" class="text-gray-500 py-6 text-center">Loading…</div>
+          <template v-else>
+            <div v-if="errorLog.length" class="bg-gray-50 rounded-lg border divide-y">
+              <div v-for="e in errorLog" :key="e.id" class="p-2">
+                <div class="flex flex-wrap items-center gap-2 text-xs">
+                  <span
+                    class="px-1.5 py-0 rounded text-[10px] font-medium"
+                    :class="errorContextBadgeClass(e.context)"
+                  >
+                    {{ errorContextLabel(e.context) }}
+                  </span>
+                  <span class="text-gray-500">{{ fmtCST(e.createdAt) }}</span>
+                  <span v-if="e.auctionOnlyId" class="text-gray-400 truncate max-w-full">• {{ e.auctionOnlyId }}</span>
+                </div>
+                <pre class="text-[11px] text-red-700 mt-1.5 whitespace-pre-wrap break-words">{{ e.message }}</pre>
               </div>
-              <pre class="text-xs text-red-700 mt-2 whitespace-pre-wrap break-words">{{ e.message }}</pre>
             </div>
-          </div>
-          <p v-else class="text-gray-500">No errors logged.</p>
-        </template>
-        <p v-if="errorLogError" class="text-red-600 mt-2 text-sm">{{ errorLogError }}</p>
+            <p v-else class="text-gray-500 py-6 text-center">No errors logged.</p>
+          </template>
+          <p v-if="errorLogError" class="text-red-600 mt-2 text-xs">{{ errorLogError }}</p>
+        </div>
       </div>
     </div>
 
     <!-- History modal -->
-    <div v-if="activeModal === 'history'" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
-      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-3xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
-        <div class="flex items-center justify-between mb-4 gap-2">
-          <h2 class="text-xl font-semibold">History (last 7 days)</h2>
-          <button class="text-gray-500 hover:text-gray-700 p-2 -m-2" @click="closeModal">X</button>
+    <div v-if="activeModal === 'history'" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+      <div class="relative bg-white w-full max-w-3xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0 gap-2">
+          <h2 class="text-sm font-semibold">History (last 7 days)</h2>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeModal">✕</button>
         </div>
 
-        <div v-if="historyLoading" class="text-gray-500 py-6 text-center">Loading…</div>
-        <template v-else>
-          <div v-if="history.length" class="bg-gray-50 rounded-lg border divide-y">
-            <div v-for="h in history" :key="h.id" class="p-3 sm:p-4">
-              <div class="flex flex-col gap-3">
-                <div class="flex items-start gap-3 min-w-0 flex-wrap">
-                  <img
-                    v-if="h.ctoon?.assetPath"
-                    :src="h.ctoon.assetPath"
-                    class="w-12 h-12 rounded object-cover border shrink-0"
-                    alt="cToon"
-                  />
-                  <div class="min-w-0 flex-1 basis-40">
-                    <div class="font-medium truncate">{{ h.ctoon?.name || 'Unknown cToon' }}</div>
-                    <div class="text-xs text-gray-500 break-words">
-                      <span v-if="h.mintNumber !== null && h.mintNumber !== undefined">Mint #{{ h.mintNumber }} • </span>
-                      <span v-if="h.ownerUsername">{{ h.ownerUsername }} • </span>
-                      {{ fmtCST(h.startsAt) }}
+        <div class="overflow-y-auto flex-1 px-4 py-3">
+          <div v-if="historyLoading" class="text-gray-500 py-6 text-center">Loading…</div>
+          <template v-else>
+            <div v-if="history.length" class="bg-gray-50 rounded-lg border divide-y">
+              <div v-for="h in history" :key="h.id" class="p-2">
+                <div class="flex flex-col gap-2">
+                  <div class="flex items-start gap-2 min-w-0 flex-wrap">
+                    <img
+                      v-if="h.ctoon?.assetPath"
+                      :src="h.ctoon.assetPath"
+                      class="w-10 h-10 rounded object-cover border shrink-0"
+                      alt="cToon"
+                    />
+                    <div class="min-w-0 flex-1 basis-40">
+                      <div class="font-medium text-xs truncate">{{ h.ctoon?.name || 'Unknown cToon' }}</div>
+                      <div class="text-[10px] text-gray-500 break-words">
+                        <span v-if="h.mintNumber !== null && h.mintNumber !== undefined">Mint #{{ h.mintNumber }} • </span>
+                        <span v-if="h.ownerUsername">{{ h.ownerUsername }} • </span>
+                        {{ fmtCST(h.startsAt) }}
+                      </div>
                     </div>
+                    <span
+                      class="px-1.5 py-0 rounded text-[10px] font-medium border-l-4 shrink-0 whitespace-nowrap"
+                      :class="historyStatusBadgeClass(h.status)"
+                    >
+                      {{ historyStatusLabel(h.status) }}
+                    </span>
                   </div>
-                  <span
-                    class="px-2 py-1 rounded text-xs font-medium border-l-4 shrink-0 whitespace-nowrap"
-                    :class="historyStatusBadgeClass(h.status)"
-                  >
-                    {{ historyStatusLabel(h.status) }}
-                  </span>
+
+                  <div class="flex flex-wrap items-center gap-1.5">
+                    <button
+                      v-if="h.status === 'stuck' && confirmingStartId !== h.id"
+                      type="button"
+                      class="px-2 py-1 text-[11px] border rounded-md text-green-700 border-green-200 hover:bg-green-50"
+                      :disabled="startingId === h.id"
+                      @click="confirmingStartId = h.id"
+                    >
+                      Start Now
+                    </button>
+
+                    <template v-else-if="confirmingStartId === h.id">
+                      <button
+                        type="button"
+                        class="px-2 py-1 text-[11px] rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+                        :disabled="startingId === h.id"
+                        @click="startHistoryItem(h)"
+                      >
+                        {{ startingId === h.id ? 'Starting…' : 'Confirm Start' }}
+                      </button>
+                      <button
+                        type="button"
+                        class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
+                        :disabled="startingId === h.id"
+                        @click="confirmingStartId = null"
+                      >
+                        Cancel
+                      </button>
+                    </template>
+
+                    <button
+                      v-if="h.removable && confirmingId !== h.id"
+                      type="button"
+                      class="px-2 py-1 text-[11px] border rounded-md text-red-700 border-red-200 hover:bg-red-50"
+                      :disabled="removingId === h.id"
+                      @click="confirmingId = h.id"
+                    >
+                      Remove
+                    </button>
+
+                    <template v-else-if="confirmingId === h.id">
+                      <button
+                        type="button"
+                        class="px-2 py-1 text-[11px] rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+                        :disabled="removingId === h.id"
+                        @click="removeHistoryItem(h)"
+                      >
+                        {{ removingId === h.id ? 'Removing…' : 'Confirm Remove' }}
+                      </button>
+                      <button
+                        type="button"
+                        class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
+                        :disabled="removingId === h.id"
+                        @click="confirmingId = null"
+                      >
+                        Cancel
+                      </button>
+                    </template>
+
+                    <span
+                      v-if="h.status !== 'stuck' && !h.removable && confirmingId !== h.id"
+                      class="text-[10px] text-gray-400 italic"
+                    >
+                      Not removable
+                    </span>
+                  </div>
                 </div>
 
-                <div class="flex flex-wrap items-center gap-2">
-                  <button
-                    v-if="h.status === 'stuck' && confirmingStartId !== h.id"
-                    type="button"
-                    class="px-3 py-1.5 text-sm rounded border border-green-600 text-green-700 hover:bg-green-50 min-h-[40px]"
-                    :disabled="startingId === h.id"
-                    @click="confirmingStartId = h.id"
-                  >
-                    Start Now
-                  </button>
-
-                  <template v-else-if="confirmingStartId === h.id">
-                    <button
-                      type="button"
-                      class="px-3 py-1.5 text-sm rounded bg-green-600 text-white hover:bg-green-700 min-h-[40px] disabled:opacity-50"
-                      :disabled="startingId === h.id"
-                      @click="startHistoryItem(h)"
-                    >
-                      {{ startingId === h.id ? 'Starting…' : 'Confirm Start' }}
-                    </button>
-                    <button
-                      type="button"
-                      class="px-3 py-1.5 text-sm rounded border min-h-[40px]"
-                      :disabled="startingId === h.id"
-                      @click="confirmingStartId = null"
-                    >
-                      Cancel
-                    </button>
-                  </template>
-
-                  <button
-                    v-if="h.removable && confirmingId !== h.id"
-                    type="button"
-                    class="px-3 py-1.5 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50 min-h-[40px]"
-                    :disabled="removingId === h.id"
-                    @click="confirmingId = h.id"
-                  >
-                    Remove
-                  </button>
-
-                  <template v-else-if="confirmingId === h.id">
-                    <button
-                      type="button"
-                      class="px-3 py-1.5 text-sm rounded bg-red-600 text-white hover:bg-red-700 min-h-[40px] disabled:opacity-50"
-                      :disabled="removingId === h.id"
-                      @click="removeHistoryItem(h)"
-                    >
-                      {{ removingId === h.id ? 'Removing…' : 'Confirm Remove' }}
-                    </button>
-                    <button
-                      type="button"
-                      class="px-3 py-1.5 text-sm rounded border min-h-[40px]"
-                      :disabled="removingId === h.id"
-                      @click="confirmingId = null"
-                    >
-                      Cancel
-                    </button>
-                  </template>
-
-                  <span
-                    v-if="h.status !== 'stuck' && !h.removable && confirmingId !== h.id"
-                    class="text-xs text-gray-400 italic"
-                  >
-                    Not removable
-                  </span>
-                </div>
+                <p v-if="h.blockedReason && confirmingId !== h.id" class="text-[10px] text-gray-500 mt-1.5">
+                  {{ h.blockedReason }}
+                </p>
+                <p v-if="historyErrors[h.id]" class="text-[11px] text-red-700 mt-1.5 whitespace-pre-wrap break-words">
+                  {{ historyErrors[h.id] }}
+                </p>
               </div>
-
-              <p v-if="h.blockedReason && confirmingId !== h.id" class="text-xs text-gray-500 mt-2">
-                {{ h.blockedReason }}
-              </p>
-              <p v-if="historyErrors[h.id]" class="text-xs text-red-700 mt-2 whitespace-pre-wrap break-words">
-                {{ historyErrors[h.id] }}
-              </p>
             </div>
-          </div>
-          <p v-else class="text-gray-500">No auctions were scheduled to go live in the last 7 days.</p>
-        </template>
-        <p v-if="historyError" class="text-red-600 mt-2 text-sm">{{ historyError }}</p>
+            <p v-else class="text-gray-500 py-6 text-center">No auctions were scheduled to go live in the last 7 days.</p>
+          </template>
+          <p v-if="historyError" class="text-red-600 mt-2 text-xs">{{ historyError }}</p>
+        </div>
       </div>
     </div>
   </div>

--- a/components/newsite/admin/legacy/AdminLegacyAuctionsNew.vue
+++ b/components/newsite/admin/legacy/AdminLegacyAuctionsNew.vue
@@ -1,40 +1,40 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-2xl mx-auto bg-white rounded-lg shadow p-6 mt-6">
-      <h1 class="text-2xl font-semibold mb-4">Add Auction (AuctionOnly)</h1>
+    <div class="px-2 py-2 max-w-2xl mx-auto">
+      <h1 class="text-base font-semibold mb-3">Add Auction (AuctionOnly)</h1>
 
-      <form @submit.prevent="submitForm" class="space-y-6 relative">
+      <form @submit.prevent="submitForm" class="bg-white rounded border p-3 space-y-3 relative">
         <!-- cToon selector -->
-        <div>
-          <label class="block font-medium mb-1">Select cToon from CartoonReOrbitOfficial</label>
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Select cToon from CartoonReOrbitOfficial</label>
           <div class="relative">
             <input
               v-model="search"
               @input="onSearchInput"
               type="text"
-              class="w-full border rounded p-2"
+              class="w-full border rounded-md px-2 py-1.5 text-sm"
               placeholder="Type 3+ characters"
               autocomplete="off"
             />
             <div
               v-if="showDropdown && results.length"
-              class="absolute z-10 mt-1 w-full bg-white border rounded shadow max-h-72 overflow-auto"
+              class="absolute z-10 mt-1 w-full bg-white border rounded-md shadow max-h-72 overflow-auto"
             >
               <button
                 v-for="opt in results"
                 :key="opt.userCtoonId"
                 type="button"
-                class="w-full text-left px-2 py-2 hover:bg-gray-50 flex items-center gap-3"
+                class="w-full text-left px-2 py-1.5 hover:bg-gray-50 flex items-center gap-2"
                 @click="selectOption(opt)"
               >
-                <img :src="opt.assetPath" alt="preview" class="w-10 h-10 rounded object-cover border" />
+                <img :src="opt.assetPath" alt="preview" class="w-8 h-8 rounded object-cover border flex-shrink-0" />
                 <div class="min-w-0">
-                  <div class="font-medium truncate flex items-center gap-2">
+                  <div class="font-medium text-xs truncate flex items-center gap-1.5">
                     <span class="truncate">{{ opt.name }}</span>
                     <span v-if="opt.isSecondEdition" class="se-badge">2nd Ed.</span>
                   </div>
-                <div class="text-xs text-gray-500">
+                <div class="text-[10px] text-gray-500">
                   {{ opt.rarity }}
                   <span v-if="opt.mintNumber !== null && opt.mintNumber !== undefined"> • Mint #{{ opt.mintNumber }}</span>
                 </div>
@@ -43,75 +43,75 @@
           </div>
         </div>
 
-          <div v-if="selected" class="mt-3 flex items-center gap-3">
-            <img :src="selected.assetPath" class="w-14 h-14 rounded object-cover border" />
+          <div v-if="selected" class="mt-2 flex items-center gap-2">
+            <img :src="selected.assetPath" class="w-10 h-10 rounded object-cover border flex-shrink-0" />
             <div>
-              <div class="font-medium flex items-center gap-2">
+              <div class="font-medium text-xs flex items-center gap-1.5">
                 <span>{{ selected.name }}</span>
                 <span v-if="selected.isSecondEdition" class="se-badge">2nd Ed.</span>
               </div>
-              <div class="text-sm text-gray-500">
+              <div class="text-[10px] text-gray-500">
                 {{ selected.rarity }}
                 <span v-if="selected.mintNumber !== null && selected.mintNumber !== undefined"> • Mint #{{ selected.mintNumber }}</span>
               </div>
             </div>
-            <button type="button" class="ml-auto text-blue-600 hover:underline text-sm" @click="clearSelected">Change</button>
+            <button type="button" class="ml-auto text-blue-600 hover:underline text-xs" @click="clearSelected">Change</button>
           </div>
         </div>
 
         <!-- Price auto-fill -->
-        <div>
-          <label class="block font-medium mb-1">Price (points)</label>
-          <input v-model.number="price" type="number" min="0" class="w-full border rounded p-2" />
-          <p class="text-xs text-gray-500 mt-1">Auto-filled from rarity. You can override.</p>
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Price (points)</label>
+          <input v-model.number="price" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+          <p class="text-[10px] text-gray-500">Auto-filled from rarity. You can override.</p>
         </div>
 
         <!-- Start date/hour in CST -->
-        <div>
-          <label class="block font-medium mb-1">Go-live (CST/CDT)</label>
-          <div class="grid grid-cols-2 gap-3">
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Go-live (CST/CDT)</label>
+          <div class="grid grid-cols-2 gap-2">
             <div>
-              <input v-model="startDate" type="date" class="w-full border rounded p-2" required />
+              <input v-model="startDate" type="date" class="w-full border rounded-md px-2 py-1.5 text-sm" required />
             </div>
             <div>
-              <select v-model="startHour" class="w-full border rounded p-2" required>
+              <select v-model="startHour" class="w-full border rounded-md px-2 py-1.5 text-sm" required>
                 <option disabled value="">Select hour</option>
                 <option v-for="h in hourOptions" :key="h" :value="h">{{ h }}</option>
               </select>
-              <p class="text-xs text-gray-500">Hour only.</p>
+              <p class="text-[10px] text-gray-500">Hour only.</p>
             </div>
           </div>
         </div>
 
         <!-- Duration slider -->
-        <div>
-          <label class="block font-medium mb-1">Duration</label>
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Duration</label>
           <div class="flex items-center gap-3">
             <input v-model.number="durationDays" type="range" min="1" max="5" class="w-full" />
-            <span class="w-10 text-center">{{ durationDays }}d</span>
+            <span class="w-10 text-center text-xs">{{ durationDays }}d</span>
           </div>
         </div>
 
         <!-- Create multiple auctions -->
-        <div>
-          <label class="block font-medium mb-1">Create X Auctions</label>
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Create X Auctions</label>
           <input
             v-model.number="createCount"
             type="number"
             min="1"
-            class="w-full border rounded p-2"
+            class="border rounded-md px-2 py-1.5 text-sm"
             @input="clampCreateCount"
           />
-          <p class="text-xs text-gray-500 mt-1">
+          <p class="text-[10px] text-gray-500">
             Official account owns {{ maxOwned }} available. Requesting more will prompt to mint the
             remainder on save (supply permitting).
           </p>
         </div>
 
-        <div v-if="createCount > 1">
-          <label class="block font-medium mb-1">Release Every Y Hours</label>
-          <input v-model.number="releaseEveryHours" type="number" min="1" class="w-full border rounded p-2" />
-          <p class="text-xs text-gray-500 mt-1">Hours between each Auction Only created.</p>
+        <div v-if="createCount > 1" class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Release Every Y Hours</label>
+          <input v-model.number="releaseEveryHours" type="number" min="1" class="border rounded-md px-2 py-1.5 text-sm" />
+          <p class="text-[10px] text-gray-500">Hours between each Auction Only created.</p>
         </div>
 
         <!-- Is Featured checkbox -->
@@ -122,86 +122,88 @@
             type="checkbox"
             class="h-4 w-4 border-gray-300 rounded"
           />
-          <label for="isFeatured" class="text-sm font-medium text-gray-700">
+          <label for="isFeatured" class="text-xs font-medium text-gray-700">
             Is Featured
           </label>
         </div>
-        <p class="text-xs text-gray-500">
+        <p class="text-[10px] text-gray-500">
           Marks the auction as featured on the auctions page. Users cannot bid if they
           currently own 2+ of this cToon or have received 2+ in the last 30 days.
         </p>
 
-        <div class="pt-4 border-t">
+        <div class="pt-3 border-t flex items-center flex-wrap gap-2">
           <button
             type="submit"
             :disabled="saving"
-            class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
           >
             Save Auction
           </button>
-          <span v-if="error" class="ml-3 text-red-600">{{ error }}</span>
-          <span v-if="saving" class="ml-3 text-gray-500">Saving…</span>
+          <span v-if="error" class="text-red-600 text-xs">{{ error }}</span>
+          <span v-if="saving" class="text-gray-500 text-xs">Saving…</span>
         </div>
       </form>
     </div>
 
     <!-- Shortfall decision modal -->
-    <div v-if="decision" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
-      <div class="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-xl font-semibold">Not enough owned copies</h2>
-          <button class="text-gray-500 hover:text-gray-700" @click="cancelDecision">X</button>
+    <div v-if="decision" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+      <div class="relative bg-white w-full max-w-lg rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+          <h2 class="text-sm font-semibold">Not enough owned copies</h2>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="cancelDecision">✕</button>
         </div>
 
-        <div class="text-sm text-gray-700 space-y-2">
-          <p>
-            You asked to create <strong>{{ decision.requested }}</strong> auction<span v-if="decision.requested !== 1">s</span>,
-            but the official account only has <strong>{{ decision.available }}</strong> available cop<span v-if="decision.available === 1">y</span><span v-else>ies</span>
-            of this cToon.
-          </p>
-          <p class="text-gray-600">
-            Supply cap:
-            <strong>{{ decision.unlimited ? 'Unlimited' : decision.quantity }}</strong>
-            <span v-if="!decision.unlimited"> ({{ decision.totalMinted }} minted, {{ decision.remaining }} left to mint)</span>
-          </p>
-          <p v-if="decision.mintable > 0" class="text-gray-600">
-            “Mint Remaining Needed” would mint <strong>{{ decision.mintable }}</strong> new cop<span v-if="decision.mintable === 1">y</span><span v-else>ies</span>
-            to the official account, then create <strong>{{ decision.willCreateWithMint }}</strong> auction<span v-if="decision.willCreateWithMint !== 1">s</span> total.
-          </p>
-          <p v-if="decision.mintable < (decision.requested - decision.available)" class="text-amber-700">
-            ⚠️ The supply cap limits minting, so this creates fewer than the {{ decision.requested }} you requested.
-          </p>
-          <p v-if="decision.mintable === 0" class="text-amber-700">
-            ⚠️ The supply cap is reached — no new copies can be minted.
-          </p>
-        </div>
+        <div class="overflow-y-auto flex-1 px-4 py-3">
+          <div class="text-xs text-gray-700 space-y-2">
+            <p>
+              You asked to create <strong>{{ decision.requested }}</strong> auction<span v-if="decision.requested !== 1">s</span>,
+              but the official account only has <strong>{{ decision.available }}</strong> available cop<span v-if="decision.available === 1">y</span><span v-else>ies</span>
+              of this cToon.
+            </p>
+            <p class="text-gray-600">
+              Supply cap:
+              <strong>{{ decision.unlimited ? 'Unlimited' : decision.quantity }}</strong>
+              <span v-if="!decision.unlimited"> ({{ decision.totalMinted }} minted, {{ decision.remaining }} left to mint)</span>
+            </p>
+            <p v-if="decision.mintable > 0" class="text-gray-600">
+              “Mint Remaining Needed” would mint <strong>{{ decision.mintable }}</strong> new cop<span v-if="decision.mintable === 1">y</span><span v-else>ies</span>
+              to the official account, then create <strong>{{ decision.willCreateWithMint }}</strong> auction<span v-if="decision.willCreateWithMint !== 1">s</span> total.
+            </p>
+            <p v-if="decision.mintable < (decision.requested - decision.available)" class="text-amber-700">
+              ⚠️ The supply cap limits minting, so this creates fewer than the {{ decision.requested }} you requested.
+            </p>
+            <p v-if="decision.mintable === 0" class="text-amber-700">
+              ⚠️ The supply cap is reached — no new copies can be minted.
+            </p>
+          </div>
 
-        <div class="mt-5 flex flex-col gap-2">
-          <button
-            type="button"
-            :disabled="saving || decision.mintable < 1"
-            class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50"
-            @click="confirmDecision('mint')"
-          >
-            Mint Remaining Needed &amp; Create {{ decision.willCreateWithMint }} Auction<span v-if="decision.willCreateWithMint !== 1">s</span>
-          </button>
-          <button
-            type="button"
-            :disabled="saving || decision.available < 1"
-            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
-            @click="confirmDecision('availableOnly')"
-          >
-            Only Create Auctions For Available Mints ({{ decision.available }})
-          </button>
-          <button
-            type="button"
-            :disabled="saving"
-            class="px-4 py-2 rounded border hover:bg-gray-50 disabled:opacity-50"
-            @click="cancelDecision"
-          >
-            Cancel Request Completely
-          </button>
-          <span v-if="error" class="text-red-600 text-sm">{{ error }}</span>
+          <div class="mt-4 flex flex-col gap-2">
+            <button
+              type="button"
+              :disabled="saving || decision.mintable < 1"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+              @click="confirmDecision('mint')"
+            >
+              Mint Remaining Needed &amp; Create {{ decision.willCreateWithMint }} Auction<span v-if="decision.willCreateWithMint !== 1">s</span>
+            </button>
+            <button
+              type="button"
+              :disabled="saving || decision.available < 1"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+              @click="confirmDecision('availableOnly')"
+            >
+              Only Create Auctions For Available Mints ({{ decision.available }})
+            </button>
+            <button
+              type="button"
+              :disabled="saving"
+              class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50 disabled:opacity-50"
+              @click="cancelDecision"
+            >
+              Cancel Request Completely
+            </button>
+            <span v-if="error" class="text-red-600 text-[11px]">{{ error }}</span>
+          </div>
         </div>
       </div>
     </div>

--- a/components/newsite/admin/legacy/AdminLegacyBackgrounds.vue
+++ b/components/newsite/admin/legacy/AdminLegacyBackgrounds.vue
@@ -1,65 +1,66 @@
 <template>
-  <div class="p-6 space-y-8 max-w-6xl mx-auto">
+  <div class="bg-gray-50 text-xs">
+   <div class="px-2 py-2 space-y-3">
     <!-- Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-      <h1 class="text-2xl font-semibold tracking-tight">Backgrounds</h1>
+    <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+      <h1 class="text-base font-semibold">Backgrounds</h1>
     </div>
 
     <!-- Upload card -->
-    <section class="bg-white rounded-xl border border-gray-200 shadow p-6 space-y-4">
-      <h2 class="text-lg font-semibold">Add a Background</h2>
-      <form @submit.prevent="submit" class="grid md:grid-cols-2 gap-6 items-start">
-        <div class="space-y-3">
+    <section class="bg-white rounded-lg border shadow p-3 space-y-3">
+      <h2 class="text-xs font-semibold">Add a Background</h2>
+      <form @submit.prevent="submit" class="grid sm:grid-cols-2 gap-3 items-start">
+        <div class="space-y-2">
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium">Label (optional)</label>
+            <label class="text-xs font-medium">Label (optional)</label>
             <input v-model="label" type="text" placeholder="e.g. Night City"
-              class="rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" />
+              class="border rounded-md px-2 py-1.5 text-sm focus:ring-2 focus:ring-blue-600 focus:border-blue-600" />
           </div>
 
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium">Visibility</label>
+            <label class="text-xs font-medium">Visibility</label>
             <select v-model="visibility"
-              class="rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600">
+              class="border rounded-md px-2 py-1.5 text-sm focus:ring-2 focus:ring-blue-600 focus:border-blue-600">
               <option value="public">Public</option>
               <option value="code-only">Code only</option>
             </select>
-            <p class="text-xs text-gray-500">"Code only" hides it from normal UI; still available to your code.</p>
+            <p class="text-[10px] text-gray-500">"Code only" hides it from normal UI; still available to your code.</p>
           </div>
 
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium">Image (PNG, GIF, or JPEG)</label>
+            <label class="text-xs font-medium">Image (PNG, GIF, or JPEG)</label>
             <input ref="fileInput" type="file" accept="image/png,image/gif,image/jpeg" @change="onFile"
-              class="block w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-600 file:text-white hover:file:bg-blue-700" />
-            <p class="text-xs text-gray-500">Exactly <strong>510×344</strong> or <strong>512×346</strong> or <strong>800×600</strong> px.</p>
+              class="block w-full text-xs text-gray-700 file:mr-2 file:py-1 file:px-2 file:rounded-md file:border-0 file:text-xs file:font-semibold file:bg-blue-600 file:text-white hover:file:bg-blue-700" />
+            <p class="text-[10px] text-gray-500">Exactly <strong>510×344</strong> or <strong>512×346</strong> or <strong>800×600</strong> px.</p>
           </div>
 
           <button type="submit" :disabled="!imageFile || uploading" :title="!imageFile ? 'Choose an image' : ''"
-            class="inline-flex items-center gap-2 rounded-md px-5 py-2.5 font-semibold text-white disabled:bg-gray-400 disabled:cursor-not-allowed bg-blue-700 hover:bg-blue-800 focus-visible:outline-2 focus-visible:outline-blue-700">
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed">
             {{ uploading ? 'Uploading…' : 'Upload' }}
           </button>
         </div>
 
         <!-- Preview -->
         <div class="flex items-center justify-center">
-          <img v-if="imagePreview" :src="imagePreview" alt="Preview" class="max-w-full rounded-md border border-gray-300" />
-          <div v-else class="text-sm text-gray-500">No image selected.</div>
+          <img v-if="imagePreview" :src="imagePreview" alt="Preview" class="max-w-full rounded-md border" />
+          <div v-else class="text-xs text-gray-500">No image selected.</div>
         </div>
       </form>
     </section>
 
     <!-- List -->
     <section>
-      <div v-if="pending" class="py-10 text-gray-500 text-center">Loading…</div>
-      <div v-else-if="error" class="py-10 text-red-600 text-center">{{ error.message || 'Failed to fetch backgrounds' }}</div>
+      <div v-if="pending" class="text-gray-500 py-6 text-center">Loading…</div>
+      <div v-else-if="error" class="text-red-600 py-6 text-center">{{ error.message || 'Failed to fetch backgrounds' }}</div>
       <template v-else>
-        <div v-if="updateError" class="mb-4 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+        <div v-if="updateError" class="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
           {{ updateError }}
         </div>
 
-        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
-          <div v-for="bg in backgrounds" :key="bg.id" class="bg-white rounded-xl border border-gray-200 shadow overflow-hidden">
-            <img :src="bg.imagePath" :alt="bg.label || 'Background'" class="w-full h-44 object-cover" />
-            <div class="p-4 space-y-2 text-sm">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+          <div v-for="bg in backgrounds" :key="bg.id" class="bg-white border rounded-lg shadow overflow-hidden">
+            <img :src="bg.imagePath" :alt="bg.label || 'Background'" class="w-full h-32 object-cover" />
+            <div class="p-2 space-y-1.5 text-xs">
               <div class="font-medium truncate">{{ bg.label || '—' }}</div>
               <div class="text-gray-600">{{ bg.width }}×{{ bg.height }} • {{ shortMime(bg.mimeType) }}</div>
               <div class="flex items-center gap-2">
@@ -69,7 +70,7 @@
                   :disabled="!!saving[bg.id]"
                   :title="bg.visibility === 'PUBLIC' ? 'Click to make Code Only' : 'Click to make Public'"
                   :class="[
-                    'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold transition-colors min-h-[28px]',
+                    'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold transition-colors min-h-[22px]',
                     bg.visibility === 'PUBLIC'
                       ? 'bg-green-100 text-green-800 hover:bg-green-200'
                       : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
@@ -80,15 +81,15 @@
                   {{ fromEnum(bg.visibility) }}
                 </button>
               </div>
-              <div class="text-gray-500">Added: {{ formatDate(bg.createdAt) }}</div>
+              <div class="text-[10px] text-gray-500">Added: {{ formatDate(bg.createdAt) }}</div>
             </div>
-            <div class="px-4 pb-4 flex gap-2">
+            <div class="px-2 pb-2 flex gap-1.5">
               <button @click="openEdit(bg)"
-                class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                class="flex-1 px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50">
                 Edit
               </button>
               <button @click="openDelete(bg)"
-                class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500">
+                class="flex-1 px-2 py-1 text-[11px] border rounded-md text-red-700 border-red-200 hover:bg-red-50">
                 Delete
               </button>
             </div>
@@ -96,30 +97,31 @@
         </div>
       </template>
     </section>
+   </div>
   </div>
 
   <!-- ── Edit Modal ──────────────────────────────────────────────────── -->
-  <div v-if="editModal.show" class="fixed inset-0 z-50 flex items-center justify-center">
+  <div v-if="editModal.show" class="fixed inset-0 z-50 flex items-center justify-center p-2">
     <div class="absolute inset-0 bg-black/50" @click="closeEdit" />
-    <div class="relative bg-white rounded-lg shadow-lg w-full max-w-xl max-h-[90vh] flex flex-col">
-      <div class="p-4 border-b flex items-center justify-between flex-shrink-0">
-        <h2 class="text-lg font-semibold">Edit Background</h2>
-        <button class="text-gray-500 hover:text-gray-700 text-xl leading-none" @click="closeEdit">&times;</button>
+    <div class="relative bg-white w-full max-w-xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+      <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+        <h3 class="text-sm font-semibold">Edit Background</h3>
+        <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeEdit">&times;</button>
       </div>
 
-      <div class="p-4 overflow-y-auto flex-1 space-y-4">
+      <div class="overflow-y-auto flex-1 px-4 py-3 space-y-3">
         <!-- Label -->
         <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium">Label</label>
+          <label class="text-xs font-medium">Label</label>
           <input v-model="editModal.label" type="text" placeholder="e.g. Night City"
-            class="rounded-md border border-gray-400 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-600 focus:border-blue-600" />
+            class="border rounded-md px-2 py-1.5 text-sm focus:ring-2 focus:ring-blue-600 focus:border-blue-600" />
         </div>
 
         <!-- Visibility -->
         <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium">Visibility</label>
+          <label class="text-xs font-medium">Visibility</label>
           <select v-model="editModal.visibility"
-            class="rounded-md border border-gray-400 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-600 focus:border-blue-600">
+            class="border rounded-md px-2 py-1.5 text-sm focus:ring-2 focus:ring-blue-600 focus:border-blue-600">
             <option value="PUBLIC">Public</option>
             <option value="CODE_ONLY">Code only</option>
           </select>
@@ -127,36 +129,36 @@
 
         <!-- Replace image -->
         <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium">Replace Image (optional)</label>
-          <div class="text-xs text-gray-500 mb-1">
+          <label class="text-xs font-medium">Replace Image (optional)</label>
+          <div class="text-[10px] text-gray-500 mb-1">
             Current: {{ editModal.bg?.width }}×{{ editModal.bg?.height }} px
           </div>
           <input ref="editFileInput" type="file" accept="image/png,image/gif,image/jpeg"
             @change="onEditFile"
-            class="block w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200" />
-          <p class="text-xs text-gray-500">Exactly <strong>510×344</strong>, <strong>512×346</strong>, or <strong>800×600</strong> px. All cZones using this background will be updated to the new image.</p>
+            class="block w-full text-xs text-gray-700 file:mr-2 file:py-1 file:px-2 file:rounded-md file:border-0 file:text-xs file:font-semibold file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200" />
+          <p class="text-[10px] text-gray-500">Exactly <strong>510×344</strong>, <strong>512×346</strong>, or <strong>800×600</strong> px. All cZones using this background will be updated to the new image.</p>
         </div>
 
         <!-- Dimension mismatch warning -->
-        <div v-if="editModal.dimensionWarning" class="rounded-md bg-yellow-50 border border-yellow-300 px-3 py-2 text-sm text-yellow-800">
+        <div v-if="editModal.dimensionWarning" class="rounded-md bg-yellow-50 border border-yellow-300 px-3 py-2 text-xs text-yellow-800">
           {{ editModal.dimensionWarning }}
         </div>
 
         <!-- New image preview -->
         <div v-if="editModal.imagePreview" class="flex flex-col gap-1">
-          <div class="text-xs text-gray-500 font-medium">New image preview:</div>
-          <img :src="editModal.imagePreview" alt="New image preview" class="max-w-full rounded-md border border-gray-300 max-h-48 object-contain" />
+          <div class="text-[10px] text-gray-500 font-medium">New image preview:</div>
+          <img :src="editModal.imagePreview" alt="New image preview" class="max-w-full rounded-md border max-h-48 object-contain" />
         </div>
 
-        <div v-if="editModal.error" class="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+        <div v-if="editModal.error" class="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
           {{ editModal.error }}
         </div>
       </div>
 
-      <div class="p-4 border-t flex justify-end gap-2 flex-shrink-0">
-        <button class="px-4 py-2 rounded border border-gray-300 text-sm font-medium" @click="closeEdit">Cancel</button>
+      <div class="flex items-center justify-end gap-2 px-4 py-3 border-t flex-shrink-0">
+        <button class="px-3 py-1 text-sm border rounded-md" @click="closeEdit">Cancel</button>
         <button
-          class="px-4 py-2 rounded bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="px-3 py-1 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 disabled:cursor-not-allowed"
           :disabled="editModal.saving"
           @click="saveEdit">
           <span v-if="!editModal.saving">Save</span>
@@ -167,54 +169,54 @@
   </div>
 
   <!-- ── Delete Confirmation Modal ───────────────────────────────────── -->
-  <div v-if="deleteModal.show" class="fixed inset-0 z-50 flex items-center justify-center">
+  <div v-if="deleteModal.show" class="fixed inset-0 z-50 flex items-center justify-center p-2">
     <div class="absolute inset-0 bg-black/50" @click="closeDelete" />
-    <div class="relative bg-white rounded-lg shadow-lg w-full max-w-md flex flex-col">
-      <div class="p-4 border-b flex items-center justify-between flex-shrink-0">
-        <h2 class="text-lg font-semibold text-red-700">Delete Background</h2>
-        <button class="text-gray-500 hover:text-gray-700 text-xl leading-none" @click="closeDelete">&times;</button>
+    <div class="relative bg-white w-full max-w-md rounded-lg shadow-lg flex flex-col">
+      <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+        <h3 class="text-sm font-semibold text-red-700">Delete Background</h3>
+        <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeDelete">&times;</button>
       </div>
 
-      <div class="p-4 space-y-4">
-        <p class="text-sm text-gray-700">
+      <div class="px-4 py-3 space-y-3">
+        <p class="text-xs text-gray-700">
           You are about to permanently delete
           <strong>{{ deleteModal.bg?.label || 'this background' }}</strong>.
           This cannot be undone.
         </p>
 
         <!-- Loading usage -->
-        <div v-if="deleteModal.loading" class="text-sm text-gray-500 flex items-center gap-2">
+        <div v-if="deleteModal.loading" class="text-xs text-gray-500 flex items-center gap-2">
           <span class="inline-block w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
           Checking usage…
         </div>
 
         <!-- Usage summary -->
-        <div v-else-if="deleteModal.usage" class="rounded-md border border-gray-200 divide-y text-sm">
-          <div class="px-3 py-2 flex justify-between">
+        <div v-else-if="deleteModal.usage" class="rounded-md border divide-y text-xs">
+          <div class="px-2 py-1.5 flex justify-between">
             <span class="text-gray-600">Player owners (will lose it)</span>
             <span :class="deleteModal.usage.userCount > 0 ? 'font-semibold text-red-700' : 'text-gray-500'">
               {{ deleteModal.usage.userCount }}
             </span>
           </div>
-          <div class="px-3 py-2 flex justify-between">
+          <div class="px-2 py-1.5 flex justify-between">
             <span class="text-gray-600">cZones using this background</span>
             <span :class="deleteModal.usage.czoneCount > 0 ? 'font-semibold text-amber-700' : 'text-gray-500'">
               {{ deleteModal.usage.czoneCount }}
             </span>
           </div>
-          <div class="px-3 py-2 flex justify-between">
+          <div class="px-2 py-1.5 flex justify-between">
             <span class="text-gray-600">Claim code reward slots (will be removed)</span>
             <span :class="deleteModal.usage.rewardBackgroundCount > 0 ? 'font-semibold text-amber-700' : 'text-gray-500'">
               {{ deleteModal.usage.rewardBackgroundCount }}
             </span>
           </div>
-          <div class="px-3 py-2 flex justify-between">
+          <div class="px-2 py-1.5 flex justify-between">
             <span class="text-gray-600">Achievement reward slots (will be removed)</span>
             <span :class="deleteModal.usage.achievementRewardCount > 0 ? 'font-semibold text-amber-700' : 'text-gray-500'">
               {{ deleteModal.usage.achievementRewardCount }}
             </span>
           </div>
-          <div class="px-3 py-2 flex justify-between">
+          <div class="px-2 py-1.5 flex justify-between">
             <span class="text-gray-600">cZone search conditions (will be cleared)</span>
             <span :class="deleteModal.usage.searchPrizeCount > 0 ? 'font-semibold text-red-700' : 'text-gray-500'">
               {{ deleteModal.usage.searchPrizeCount }}
@@ -224,19 +226,19 @@
 
         <!-- Active search condition warning -->
         <div v-if="deleteModal.usage?.searchPrizeCount > 0"
-          class="rounded-md bg-red-50 border border-red-300 px-3 py-2 text-sm text-red-800">
+          class="rounded-md bg-red-50 border border-red-300 px-3 py-2 text-xs text-red-800">
           This background is a condition on {{ deleteModal.usage.searchPrizeCount }} active search prize{{ deleteModal.usage.searchPrizeCount === 1 ? '' : 's' }}. Deleting it will permanently disable those conditions — players won't be able to satisfy them.
         </div>
 
-        <div v-if="deleteModal.error" class="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+        <div v-if="deleteModal.error" class="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
           {{ deleteModal.error }}
         </div>
       </div>
 
-      <div class="p-4 border-t flex justify-end gap-2 flex-shrink-0">
-        <button class="px-4 py-2 rounded border border-gray-300 text-sm font-medium" @click="closeDelete">Cancel</button>
+      <div class="flex items-center justify-end gap-2 px-4 py-3 border-t flex-shrink-0">
+        <button class="px-3 py-1 text-sm border rounded-md" @click="closeDelete">Cancel</button>
         <button
-          class="px-4 py-2 rounded bg-red-600 text-white text-sm font-medium hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="px-3 py-1 text-sm rounded-md text-white bg-red-600 hover:bg-red-700 disabled:bg-red-300 disabled:cursor-not-allowed"
           :disabled="deleteModal.loading || deleteModal.deleting"
           @click="confirmDelete">
           <span v-if="deleteModal.deleting">Deleting…</span>

--- a/components/newsite/admin/legacy/AdminLegacyCheatingTool.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCheatingTool.vue
@@ -1,23 +1,23 @@
 <template>
-  <div class="p-6 space-y-6 ">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-4xl mx-auto" style="margin-top: 50px;">
-      <h1 class="text-2xl font-bold mb-1">Cheating Tool</h1>
-      <p class="text-sm text-gray-500 mb-6">
+    <div class="px-2 py-2 max-w-4xl mx-auto">
+      <h1 class="text-base font-semibold mb-1">Cheating Tool</h1>
+      <p class="text-[11px] text-gray-500 mb-3">
         Analyzes trade rooms, trade offers, and auctions between a suspected cheater and connected accounts.
         Reports point value received and cToons still held, then lets you move them to CartoonReOrbitOfficial.
       </p>
 
       <!-- Input form -->
-      <form @submit.prevent="runReport" class="space-y-4 bg-white border rounded p-4 mb-6">
+      <form @submit.prevent="runReport" class="bg-white rounded border p-3 space-y-3 mb-3">
 
         <!-- Target -->
-        <div class="relative">
-          <label class="block text-sm font-medium mb-1">Suspected cheater (target username)</label>
+        <div class="relative flex flex-col gap-1">
+          <label class="text-xs font-medium">Suspected cheater (target username)</label>
           <input
             ref="targetInputEl"
             v-model.trim="target"
-            class="w-full border rounded px-3 py-2"
+            class="border rounded-md px-2 py-1.5 text-sm"
             placeholder="e.g. ZenVikingGuru"
             required
             autocomplete="off"
@@ -26,32 +26,32 @@
           />
           <div
             v-if="targetFocused && targetSuggestions.length"
-            class="absolute z-20 mt-1 w-full bg-white border rounded shadow-lg"
+            class="absolute z-20 top-full mt-1 w-full bg-white border rounded-md shadow-lg"
           >
             <button
               v-for="u in targetSuggestions"
               :key="u.id"
               type="button"
-              class="w-full text-left px-3 py-2 hover:bg-gray-50 border-b last:border-b-0"
+              class="w-full text-left px-2 py-1.5 hover:bg-gray-50 border-b last:border-b-0"
               @mousedown.prevent="selectTarget(u.username)"
             >
               <div class="flex items-center justify-between">
-                <span class="font-medium">{{ u.username }}</span>
-                <span class="text-xs text-gray-500">{{ u.points?.toLocaleString() }} pts · {{ u.totalCtoons }} cToons</span>
+                <span class="font-medium text-xs">{{ u.username }}</span>
+                <span class="text-[10px] text-gray-500">{{ u.points?.toLocaleString() }} pts · {{ u.totalCtoons }} cToons</span>
               </div>
-              <div class="text-xs text-gray-400">{{ u.discordTag }}</div>
+              <div class="text-[10px] text-gray-400">{{ u.discordTag }}</div>
             </button>
           </div>
         </div>
 
         <!-- Suspects -->
-        <div>
-          <label class="block text-sm font-medium mb-1">Connected accounts (suspects)</label>
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Connected accounts (suspects)</label>
           <div class="flex gap-2 relative">
             <div class="relative flex-1">
               <input
                 v-model.trim="suspectInput"
-                class="w-full border rounded px-3 py-2"
+                class="w-full border rounded-md px-2 py-1.5 text-sm"
                 placeholder="Type a username and press Add or Enter"
                 autocomplete="off"
                 @keydown.enter.prevent="addSuspect"
@@ -60,31 +60,31 @@
               />
               <div
                 v-if="suspectFocused && suspectSuggestions.length"
-                class="absolute z-20 mt-1 w-full bg-white border rounded shadow-lg"
+                class="absolute z-20 top-full mt-1 w-full bg-white border rounded-md shadow-lg"
               >
                 <button
                   v-for="u in suspectSuggestions"
                   :key="u.id"
                   type="button"
-                  class="w-full text-left px-3 py-2 hover:bg-gray-50 border-b last:border-b-0"
+                  class="w-full text-left px-2 py-1.5 hover:bg-gray-50 border-b last:border-b-0"
                   @mousedown.prevent="addSuspectFromSuggestion(u.username)"
                 >
                   <div class="flex items-center justify-between">
-                    <span class="font-medium">{{ u.username }}</span>
-                    <span class="text-xs text-gray-500">{{ u.points?.toLocaleString() }} pts · {{ u.totalCtoons }} cToons</span>
+                    <span class="font-medium text-xs">{{ u.username }}</span>
+                    <span class="text-[10px] text-gray-500">{{ u.points?.toLocaleString() }} pts · {{ u.totalCtoons }} cToons</span>
                   </div>
-                  <div class="text-xs text-gray-400">{{ u.discordTag }}</div>
+                  <div class="text-[10px] text-gray-400">{{ u.discordTag }}</div>
                 </button>
               </div>
             </div>
-            <button type="button" class="px-4 py-2 border rounded bg-gray-50 hover:bg-gray-100" @click="addSuspect">Add</button>
+            <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="addSuspect">Add</button>
           </div>
 
-          <div class="mt-2 flex flex-wrap gap-2">
+          <div class="mt-1 flex flex-wrap gap-1.5">
             <span
               v-for="(s, i) in suspects"
               :key="s"
-              class="inline-flex items-center gap-1.5 bg-orange-100 text-orange-800 px-2 py-1 rounded text-sm"
+              class="inline-flex items-center gap-1.5 bg-orange-100 text-orange-800 px-2 py-0.5 rounded text-[11px]"
             >
               {{ s }}
               <button type="button" class="text-orange-500 hover:text-orange-700 font-bold leading-none" @click="removeSuspect(i)">×</button>
@@ -92,63 +92,63 @@
           </div>
         </div>
 
-        <div class="flex items-center gap-3">
+        <div class="flex items-center gap-2 pt-1">
           <button
             :disabled="loading || !target || suspects.length === 0"
-            class="px-5 py-2 bg-indigo-600 text-white rounded font-medium disabled:opacity-50 hover:bg-indigo-700"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
           >
             {{ loading ? 'Analysing…' : 'Run Analysis' }}
           </button>
-          <span v-if="error" class="text-red-600 text-sm">{{ error }}</span>
+          <span v-if="error" class="text-red-600 text-xs">{{ error }}</span>
         </div>
       </form>
 
       <!-- Report -->
-      <div v-if="report" class="space-y-5">
+      <div v-if="report" class="space-y-3">
 
         <!-- Section 1: cToons traded to target -->
-        <div class="bg-white border rounded p-4">
-          <h2 class="font-semibold text-base mb-3">
+        <div class="bg-white rounded border p-3">
+          <h2 class="text-xs font-semibold mb-2">
             Section 1 — cToons Traded to {{ report.target }} (TradeRoom + TradeOffer)
           </h2>
-          <div v-if="report.ctoonRows.length === 0" class="text-sm text-gray-500">(none found)</div>
-          <div v-else class="overflow-auto">
-            <table class="min-w-full text-sm">
-              <thead class="bg-gray-50">
+          <div v-if="report.ctoonRows.length === 0" class="text-xs text-gray-500">(none found)</div>
+          <div v-else class="overflow-x-auto">
+            <table class="min-w-full text-xs">
+              <thead>
                 <tr>
-                  <th class="px-3 py-2 text-left font-medium">cToon</th>
-                  <th class="px-3 py-2 text-left font-medium">Rarity</th>
-                  <th class="px-3 py-2 text-right font-medium">Traded</th>
-                  <th class="px-3 py-2 text-right font-medium">Still Owned</th>
-                  <th class="px-3 py-2 text-right font-medium">No Longer Owned</th>
-                  <th class="px-3 py-2 text-right font-medium">Unit Value</th>
-                  <th class="px-3 py-2 text-right font-medium">Point Value Lost</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">cToon</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Rarity</th>
+                  <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100">Traded</th>
+                  <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100">Still Owned</th>
+                  <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100">No Longer Owned</th>
+                  <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100">Unit Value</th>
+                  <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100">Point Value Lost</th>
                 </tr>
               </thead>
               <tbody>
                 <tr v-for="row in report.ctoonRows" :key="row.ctoonId" class="border-t hover:bg-gray-50">
-                  <td class="px-3 py-2 font-medium">{{ row.name }}</td>
-                  <td class="px-3 py-2">
-                    <span :class="rarityClass(row.rarity)" class="px-1.5 py-0.5 rounded text-xs font-medium">{{ row.rarity }}</span>
+                  <td class="px-2 py-1.5 font-medium">{{ row.name }}</td>
+                  <td class="px-2 py-1.5">
+                    <span :class="rarityClass(row.rarity)" class="px-1.5 py-0 rounded text-[10px] font-medium">{{ row.rarity }}</span>
                   </td>
-                  <td class="px-3 py-2 text-right">{{ row.total }}</td>
-                  <td class="px-3 py-2 text-right text-green-700">{{ row.ownedCount }}</td>
-                  <td class="px-3 py-2 text-right text-red-600">{{ row.notOwnedCount }}</td>
-                  <td class="px-3 py-2 text-right">
+                  <td class="px-2 py-1.5 text-right">{{ row.total }}</td>
+                  <td class="px-2 py-1.5 text-right text-green-700">{{ row.ownedCount }}</td>
+                  <td class="px-2 py-1.5 text-right text-red-600">{{ row.notOwnedCount }}</td>
+                  <td class="px-2 py-1.5 text-right">
                     {{ row.unitPrice.toLocaleString() }} pts
-                    <div class="text-xs text-gray-400">
+                    <div class="text-[10px] text-gray-400">
                       {{ row.avgPx > row.rarityPx
                         ? `avg auction (${row.avgPx.toLocaleString()} from ${row.auctionCount})`
                         : `cMart (${row.rarityPx.toLocaleString()})` }}
                     </div>
                   </td>
-                  <td class="px-3 py-2 text-right font-semibold">{{ row.lostValue.toLocaleString() }} pts</td>
+                  <td class="px-2 py-1.5 text-right font-semibold">{{ row.lostValue.toLocaleString() }} pts</td>
                 </tr>
               </tbody>
               <tfoot class="border-t-2 border-gray-300 bg-gray-50">
                 <tr>
-                  <td colspan="6" class="px-3 py-2 font-semibold text-right">Subtotal (not-owned cToon value)</td>
-                  <td class="px-3 py-2 text-right font-bold">{{ report.totalCtoonPointValue.toLocaleString() }} pts</td>
+                  <td colspan="6" class="px-2 py-1.5 font-semibold text-right">Subtotal (not-owned cToon value)</td>
+                  <td class="px-2 py-1.5 text-right font-bold">{{ report.totalCtoonPointValue.toLocaleString() }} pts</td>
                 </tr>
               </tfoot>
             </table>
@@ -156,55 +156,55 @@
         </div>
 
         <!-- Section 2: TradeOffer points -->
-        <div class="bg-white border rounded p-4">
-          <h2 class="font-semibold text-base mb-3">Section 2 — Points Received via TradeOffer</h2>
-          <div v-if="report.tradeOfferBreakdown.length === 0" class="text-sm text-gray-500">(none found)</div>
+        <div class="bg-white rounded border p-3">
+          <h2 class="text-xs font-semibold mb-2">Section 2 — Points Received via TradeOffer</h2>
+          <div v-if="report.tradeOfferBreakdown.length === 0" class="text-xs text-gray-500">(none found)</div>
           <div v-else class="space-y-1">
             <div
               v-for="(row, i) in report.tradeOfferBreakdown"
               :key="i"
-              class="flex items-center justify-between text-sm border-b py-1.5"
+              class="flex items-center justify-between text-xs border-b py-1"
             >
               <span class="font-medium">{{ row.suspectName }}</span>
               <span class="text-gray-700">{{ row.pointsOffered.toLocaleString() }} pts offered</span>
             </div>
           </div>
-          <div class="mt-2 pt-2 border-t flex justify-between font-semibold text-sm">
+          <div class="mt-1.5 pt-1.5 border-t flex justify-between font-semibold text-xs">
             <span>Subtotal</span>
             <span>{{ report.tradeOfferPointsToTarget.toLocaleString() }} pts</span>
           </div>
         </div>
 
         <!-- Section 3: Auction points -->
-        <div class="bg-white border rounded p-4">
-          <h2 class="font-semibold text-base mb-3">Section 3 — Auction Proceeds (target sold to suspects)</h2>
-          <div v-if="report.auctionBreakdown.length === 0" class="text-sm text-gray-500">(none found)</div>
+        <div class="bg-white rounded border p-3">
+          <h2 class="text-xs font-semibold mb-2">Section 3 — Auction Proceeds (target sold to suspects)</h2>
+          <div v-if="report.auctionBreakdown.length === 0" class="text-xs text-gray-500">(none found)</div>
           <div v-else class="space-y-1">
             <div
               v-for="(row, i) in report.auctionBreakdown"
               :key="i"
-              class="flex items-center justify-between text-sm border-b py-1.5"
+              class="flex items-center justify-between text-xs border-b py-1"
             >
               <span>
                 <span class="font-medium">{{ row.itemName }}</span>
-                <span class="text-gray-400 text-xs ml-2">won by {{ row.winnerName }}</span>
+                <span class="text-gray-400 text-[10px] ml-2">won by {{ row.winnerName }}</span>
               </span>
               <span class="text-gray-700">{{ row.highestBid.toLocaleString() }} pts</span>
             </div>
           </div>
-          <div class="mt-2 pt-2 border-t flex justify-between font-semibold text-sm">
+          <div class="mt-1.5 pt-1.5 border-t flex justify-between font-semibold text-xs">
             <span>Subtotal</span>
             <span>{{ report.auctionPointsToTarget.toLocaleString() }} pts</span>
           </div>
         </div>
 
         <!-- Section 4: Pending (informational) -->
-        <div class="bg-white border rounded p-4">
-          <h2 class="font-semibold text-base mb-1">
+        <div class="bg-white rounded border p-3">
+          <h2 class="text-xs font-semibold mb-1">
             Section 4 — Pending Trades
-            <span class="font-normal text-gray-500 text-sm">(informational — not included in totals)</span>
+            <span class="font-normal text-gray-500 text-[11px]">(informational — not included in totals)</span>
           </h2>
-          <div class="mt-2 text-sm space-y-1">
+          <div class="mt-1.5 text-xs space-y-1">
             <div v-if="report.pendingRoomsDisplay.length === 0 && report.pendingOffersDisplay.length === 0" class="text-gray-500">No pending trades.</div>
             <div v-if="report.pendingRoomsDisplay.length">
               <p class="font-medium mb-1">Pending TradeRoom sessions</p>
@@ -212,7 +212,7 @@
                 {{ row.name }}: {{ row.count }} room(s)
               </div>
             </div>
-            <div v-if="report.pendingOffersDisplay.length" class="mt-2">
+            <div v-if="report.pendingOffersDisplay.length" class="mt-1.5">
               <p class="font-medium mb-1">Pending TradeOffers</p>
               <div v-for="(row, i) in report.pendingOffersDisplay" :key="i" class="ml-3 text-gray-700">
                 {{ row.suspectName }} ({{ row.role }}) — {{ row.pointsOffered.toLocaleString() }} pts offered
@@ -222,9 +222,9 @@
         </div>
 
         <!-- Summary -->
-        <div class="bg-indigo-50 border border-indigo-200 rounded p-4">
-          <h2 class="font-bold text-base mb-3 text-indigo-900">Summary</h2>
-          <div class="grid sm:grid-cols-2 gap-3 text-sm">
+        <div class="bg-indigo-50 border border-indigo-200 rounded p-3">
+          <h2 class="text-xs font-semibold mb-2 text-indigo-900">Summary</h2>
+          <div class="grid sm:grid-cols-2 gap-2 text-xs">
             <div class="flex justify-between border-b border-indigo-100 py-1">
               <span class="text-gray-700">cToon trade value (not-owned)</span>
               <span class="font-semibold">{{ report.totalCtoonPointValue.toLocaleString() }} pts</span>
@@ -242,17 +242,17 @@
               <span class="font-semibold">{{ report.ctoonStillOwnedCount }}</span>
             </div>
           </div>
-          <div class="mt-3 pt-3 border-t border-indigo-300 flex items-center justify-between">
+          <div class="mt-2 pt-2 border-t border-indigo-300 flex items-center justify-between flex-wrap gap-2">
             <div>
-              <div class="text-indigo-900 font-bold text-lg">
+              <div class="text-indigo-900 font-bold text-sm">
                 Total to remove from {{ report.target }}: {{ report.totalPointsToRemove.toLocaleString() }} pts
               </div>
-              <div class="text-sm text-indigo-700">
+              <div class="text-xs text-indigo-700">
                 + transfer {{ report.ctoonStillOwnedCount }} cToon(s) to CartoonReOrbitOfficial
               </div>
             </div>
             <button
-              class="px-5 py-2.5 bg-red-600 text-white rounded font-semibold hover:bg-red-700 disabled:opacity-50"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
               :disabled="report.totalPointsToRemove === 0 && report.ctoonStillOwnedCount === 0"
               @click="openConfirm"
             >
@@ -265,20 +265,20 @@
     </div>
 
     <!-- Confirmation / Progress / Results modal -->
-    <div v-if="showConfirm" class="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-      <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-auto">
-        <div class="p-5">
+    <div v-if="showConfirm" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+      <div class="relative bg-white w-full max-w-2xl rounded-lg shadow-lg flex flex-col max-h-[92vh] overflow-y-auto">
+        <div class="p-4">
 
           <!-- ── Phase: review (before applying) ── -->
           <template v-if="modalPhase === 'review'">
-            <h3 class="text-lg font-bold mb-1">Confirm — Move Points &amp; cToons</h3>
-            <p class="text-sm text-gray-600 mb-4">
+            <h3 class="text-sm font-semibold mb-1">Confirm — Move Points &amp; cToons</h3>
+            <p class="text-xs text-gray-600 mb-3">
               This will deduct points from <strong>{{ report?.target }}</strong> and add them to
               <strong>CartoonReOrbitOfficial</strong>, then transfer the cToons listed below.
               This action cannot be undone.
             </p>
 
-            <div class="space-y-2 text-sm mb-4">
+            <div class="space-y-1.5 text-xs mb-3">
               <div class="flex justify-between py-1 border-b">
                 <span>Points to deduct from <strong>{{ report?.target }}</strong></span>
                 <span class="font-semibold text-red-700">{{ report?.totalPointsToRemove?.toLocaleString() }} pts</span>
@@ -289,13 +289,13 @@
               </div>
             </div>
 
-            <div v-if="report?.ctoonStillOwned?.length" class="mb-4">
-              <h4 class="font-semibold text-sm mb-2">cToons to transfer ({{ report.ctoonStillOwned.length }})</h4>
-              <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-60 overflow-auto">
+            <div v-if="report?.ctoonStillOwned?.length" class="mb-3">
+              <h4 class="text-xs font-semibold mb-2">cToons to transfer ({{ report.ctoonStillOwned.length }})</h4>
+              <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-60 overflow-y-auto">
                 <div
                   v-for="uc in report.ctoonStillOwned"
                   :key="uc.id"
-                  class="border rounded p-2 text-xs bg-gray-50"
+                  class="border rounded-md p-2 text-[11px] bg-gray-50"
                 >
                   <div class="aspect-square bg-white border rounded mb-1.5 flex items-center justify-center overflow-hidden">
                     <img
@@ -304,7 +304,7 @@
                       :alt="uc.ctoon?.name || 'cToon'"
                       class="object-contain w-full h-full"
                     />
-                    <div v-else class="text-gray-300 text-xs">No image</div>
+                    <div v-else class="text-gray-300 text-[10px]">No image</div>
                   </div>
                   <div class="font-medium truncate">{{ uc.ctoon?.name || 'cToon' }}</div>
                   <div class="text-gray-500">{{ uc.ctoon?.rarity || '—' }}</div>
@@ -312,12 +312,12 @@
                 </div>
               </div>
             </div>
-            <div v-else class="text-sm text-gray-500 mb-4">No cToons to transfer (target no longer holds any).</div>
+            <div v-else class="text-xs text-gray-500 mb-3">No cToons to transfer (target no longer holds any).</div>
 
             <div class="flex justify-end gap-2">
-              <button class="px-4 py-2 border rounded hover:bg-gray-50" @click="closeConfirm">Cancel</button>
+              <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeConfirm">Cancel</button>
               <button
-                class="px-4 py-2 bg-red-600 text-white rounded font-semibold hover:bg-red-700"
+                class="px-3 py-1.5 text-xs font-semibold rounded-md bg-red-600 text-white hover:bg-red-700"
                 @click="applyChanges"
               >
                 Confirm &amp; Apply
@@ -327,26 +327,26 @@
 
           <!-- ── Phase: processing (SSE progress bar) ── -->
           <template v-if="modalPhase === 'processing'">
-            <h3 class="text-lg font-bold mb-4">Applying Changes…</h3>
+            <h3 class="text-sm font-semibold mb-3">Applying Changes…</h3>
 
             <!-- Overall progress bar -->
-            <div class="mb-4">
-              <div class="flex justify-between text-sm font-medium mb-1">
+            <div class="mb-3">
+              <div class="flex justify-between text-xs font-medium mb-1">
                 <span>Progress</span>
                 <span>{{ progressDone }} / {{ progressTotal }} steps</span>
               </div>
-              <div class="w-full bg-gray-200 rounded-full h-5 overflow-hidden">
+              <div class="w-full bg-gray-200 rounded-full h-4 overflow-hidden">
                 <div
-                  class="h-5 rounded-full transition-all duration-300"
+                  class="h-4 rounded-full transition-all duration-300"
                   :class="progressHasError ? 'bg-yellow-400' : 'bg-indigo-600'"
                   :style="{ width: progressPercent + '%' }"
                 />
               </div>
-              <div class="text-xs text-gray-500 mt-1 text-right">{{ progressPercent }}% complete</div>
+              <div class="text-[10px] text-gray-500 mt-1 text-right">{{ progressPercent }}% complete</div>
             </div>
 
             <!-- Live step feed -->
-            <div class="border rounded bg-gray-50 max-h-52 overflow-auto p-2 space-y-1 text-sm font-mono">
+            <div class="border rounded-md bg-gray-50 max-h-52 overflow-y-auto p-2 space-y-1 text-xs font-mono">
               <div
                 v-for="(step, i) in progressSteps"
                 :key="i"
@@ -359,46 +359,46 @@
               <div v-if="progressSteps.length === 0" class="text-gray-400 italic">Starting…</div>
             </div>
 
-            <p class="text-xs text-gray-500 mt-3 text-center">Please wait — do not close this window.</p>
+            <p class="text-[10px] text-gray-500 mt-2 text-center">Please wait — do not close this window.</p>
           </template>
 
           <!-- ── Phase: done (results) ── -->
           <template v-if="modalPhase === 'done'">
-            <h3 class="text-lg font-bold mb-3">Result</h3>
+            <h3 class="text-sm font-semibold mb-2">Result</h3>
 
             <!-- Fatal transport error -->
-            <div v-if="applyFatalError" class="p-3 rounded bg-red-50 border border-red-200 text-red-700 text-sm mb-3">
+            <div v-if="applyFatalError" class="p-2 rounded-md bg-red-50 border border-red-200 text-red-700 text-xs mb-2">
               {{ applyFatalError }}
             </div>
 
             <!-- Summary card -->
-            <div v-if="applyResult" class="p-3 rounded mb-3" :class="applyResult.hasErrors ? 'bg-yellow-50 border border-yellow-200' : 'bg-green-50 border border-green-200'">
-              <p class="font-semibold mb-2" :class="applyResult.hasErrors ? 'text-yellow-800' : 'text-green-800'">
+            <div v-if="applyResult" class="p-2 rounded-md mb-2" :class="applyResult.hasErrors ? 'bg-yellow-50 border border-yellow-200' : 'bg-green-50 border border-green-200'">
+              <p class="text-xs font-semibold mb-1.5" :class="applyResult.hasErrors ? 'text-yellow-800' : 'text-green-800'">
                 {{ applyResult.hasErrors ? 'Completed with issues' : 'Completed successfully' }}
               </p>
-              <div class="grid sm:grid-cols-2 gap-x-4 text-sm" :class="applyResult.hasErrors ? 'text-yellow-900' : 'text-green-900'">
+              <div class="grid sm:grid-cols-2 gap-x-4 text-xs" :class="applyResult.hasErrors ? 'text-yellow-900' : 'text-green-900'">
                 <div>Points removed: <strong>{{ applyResult.pointsRemoved?.toLocaleString() }}</strong></div>
                 <div>cToons transferred: <strong>{{ applyResult.ctoonsTransferred }}</strong> / {{ applyResult.totalAttempted }}</div>
               </div>
             </div>
 
             <!-- Error table -->
-            <div v-if="applyResult?.errors?.length" class="mb-3">
-              <h4 class="font-semibold text-sm mb-1">Errors</h4>
-              <div class="overflow-auto border rounded">
+            <div v-if="applyResult?.errors?.length" class="mb-2">
+              <h4 class="text-xs font-semibold mb-1">Errors</h4>
+              <div class="overflow-x-auto border rounded-md">
                 <table class="min-w-full text-xs">
                   <thead class="bg-gray-100">
                     <tr>
-                      <th class="px-2 py-1 text-left">Phase</th>
-                      <th class="px-2 py-1 text-left">UserCtoon ID</th>
-                      <th class="px-2 py-1 text-left">Message</th>
+                      <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Phase</th>
+                      <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">UserCtoon ID</th>
+                      <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Message</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr v-for="(e, i) in applyResult.errors" :key="i" class="border-t">
-                      <td class="px-2 py-1">{{ e.phase }}</td>
-                      <td class="px-2 py-1 font-mono">{{ e.userCtoonId ?? '—' }}</td>
-                      <td class="px-2 py-1">{{ e.message }}</td>
+                      <td class="px-2 py-1.5">{{ e.phase }}</td>
+                      <td class="px-2 py-1.5 font-mono">{{ e.userCtoonId ?? '—' }}</td>
+                      <td class="px-2 py-1.5">{{ e.message }}</td>
                     </tr>
                   </tbody>
                 </table>
@@ -406,7 +406,7 @@
             </div>
 
             <div class="flex justify-end">
-              <button class="px-4 py-2 border rounded hover:bg-gray-50" @click="closeConfirm">Close</button>
+              <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeConfirm">Close</button>
             </div>
           </template>
 

--- a/components/newsite/admin/legacy/AdminLegacyCheckCheating.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCheckCheating.vue
@@ -1,17 +1,17 @@
 <template>
-  <div class="p-6 space-y-6 ">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-3xl mx-auto" style="margin-top: 50px;">
-      <h1 class="text-2xl font-bold mb-4">Check Cheating</h1>
+    <div class="px-2 py-2 max-w-3xl mx-auto">
+      <h1 class="text-base font-semibold mb-3">Check Cheating</h1>
 
-      <form @submit.prevent="runCheck" class="space-y-4 bg-white border rounded p-4">
+      <form @submit.prevent="runCheck" class="bg-white rounded border p-3 space-y-3">
         <!-- Target -->
-        <div class="relative">
-          <label class="block text-sm font-medium mb-1">Target username</label>
+        <div class="relative flex flex-col gap-1">
+          <label class="text-xs font-medium">Target username</label>
           <input
             ref="targetInputEl"
             v-model.trim="target"
-            class="w-full border rounded px-3 py-2"
+            class="border rounded-md px-2 py-1.5 text-sm"
             placeholder="e.g. LegendaryWarriorGuru"
             required
             @focus="targetFocused = true"
@@ -20,32 +20,32 @@
           <!-- Target suggestions -->
           <div
             v-if="targetFocused && targetSuggestions.length"
-            class="absolute z-10 mt-1 w-full bg-white border rounded shadow"
+            class="absolute z-10 top-full mt-1 w-full bg-white border rounded-md shadow"
           >
             <button
               v-for="u in targetSuggestions"
               :key="u.id"
               type="button"
-              class="w-full text-left px-3 py-2 hover:bg-gray-50"
+              class="w-full text-left px-2 py-1.5 hover:bg-gray-50"
               @click="selectTarget(u.username)"
             >
               <div class="flex items-center justify-between">
-                <span class="font-medium">{{ u.username }}</span>
-                <span class="text-xs text-gray-500">{{ u.points }} pts • {{ u.totalCtoons }} cToons</span>
+                <span class="font-medium text-xs">{{ u.username }}</span>
+                <span class="text-[10px] text-gray-500">{{ u.points }} pts • {{ u.totalCtoons }} cToons</span>
               </div>
-              <div class="text-xs text-gray-500">{{ u.discordTag }}</div>
+              <div class="text-[10px] text-gray-500">{{ u.discordTag }}</div>
             </button>
           </div>
         </div>
 
         <!-- Sources -->
-        <div class="relative">
-          <label class="block text-sm font-medium mb-1">Source usernames</label>
+        <div class="relative flex flex-col gap-1">
+          <label class="text-xs font-medium">Source usernames</label>
           <div class="flex gap-2">
             <div class="relative flex-1">
               <input
                 v-model.trim="sourceInput"
-                class="w-full border rounded px-3 py-2"
+                class="w-full border rounded-md px-2 py-1.5 text-sm"
                 placeholder="Type a username and press Add"
                 @keydown.enter.prevent="addSource"
                 @focus="sourceFocused = true"
@@ -54,45 +54,45 @@
               <!-- Source suggestions -->
               <div
                 v-if="sourceFocused && sourceSuggestions.length"
-                class="absolute z-10 mt-1 w-full bg-white border rounded shadow"
+                class="absolute z-10 top-full mt-1 w-full bg-white border rounded-md shadow"
               >
                 <button
                   v-for="u in sourceSuggestions"
                   :key="u.id"
                   type="button"
-                  class="w-full text-left px-3 py-2 hover:bg-gray-50"
+                  class="w-full text-left px-2 py-1.5 hover:bg-gray-50"
                   @click="addSourceFromSuggestion(u.username)"
                 >
                   <div class="flex items-center justify-between">
-                    <span class="font-medium">{{ u.username }}</span>
-                    <span class="text-xs text-gray-500">{{ u.points }} pts • {{ u.totalCtoons }} cToons</span>
+                    <span class="font-medium text-xs">{{ u.username }}</span>
+                    <span class="text-[10px] text-gray-500">{{ u.points }} pts • {{ u.totalCtoons }} cToons</span>
                   </div>
-                  <div class="text-xs text-gray-500">{{ u.discordTag }}</div>
+                  <div class="text-[10px] text-gray-500">{{ u.discordTag }}</div>
                 </button>
               </div>
             </div>
-            <button type="button" class="px-3 py-2 border rounded" @click="addSource">Add</button>
+            <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="addSource">Add</button>
           </div>
-          <div class="mt-2 flex flex-wrap gap-2">
-            <span v-for="(s,i) in sources" :key="s" class="inline-flex items-center gap-2 bg-gray-100 px-2 py-1 rounded">
+          <div class="mt-1 flex flex-wrap gap-1.5">
+            <span v-for="(s,i) in sources" :key="s" class="inline-flex items-center gap-1.5 bg-gray-100 px-2 py-0.5 rounded text-[11px]">
               <span>{{ s }}</span>
               <button type="button" class="text-gray-600" @click="removeSource(i)">×</button>
             </span>
           </div>
         </div>
 
-        <div class="flex items-center gap-3">
-          <button :disabled="loading || !target || sources.length===0" class="px-4 py-2 bg-indigo-600 text-white rounded disabled:opacity-50">
+        <div class="flex items-center gap-2 pt-1">
+          <button :disabled="loading || !target || sources.length===0" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50">
             {{ loading ? 'Checking…' : 'Run check' }}
           </button>
-          <span v-if="error" class="text-red-600 text-sm">{{ error }}</span>
+          <span v-if="error" class="text-red-600 text-xs">{{ error }}</span>
         </div>
       </form>
 
-      <div v-if="result" class="grid md:grid-cols-2 gap-4">
-        <div class="p-4 border rounded bg-white">
-          <h2 class="font-semibold mb-2">Summary</h2>
-          <ul class="space-y-1 text-sm">
+      <div v-if="result" class="grid md:grid-cols-2 gap-2 mt-3">
+        <div class="bg-white rounded border p-3">
+          <h2 class="text-xs font-semibold mb-2">Summary</h2>
+          <ul class="space-y-1 text-xs">
             <li><strong>Target:</strong> {{ result.target }}</li>
             <li><strong>Sources:</strong> {{ result.sources.join(', ') }}</li>
             <li><strong>Seed items:</strong> {{ result.seedCount }}</li>
@@ -102,7 +102,7 @@
           </ul>
 
           <button
-            class="mt-4 px-4 py-2 bg-red-600 text-white rounded disabled:opacity-50"
+            class="mt-3 px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50 disabled:opacity-50"
             :disabled="!result || enforcing"
             @click="openPreview()"
           >
@@ -111,58 +111,62 @@
         </div>
 
         <!-- Review + Confirm Modal -->
-        <div v-if="showPreview" class="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div class="bg-white rounded-lg shadow-xl w-full max-w-4xl p-5 max-h-[90vh] overflow-auto">
+        <div v-if="showPreview" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+          <div class="relative bg-white w-full max-w-4xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
             <!-- BEFORE processing: review -->
             <template v-if="!hasOutcome">
-              <h3 class="text-lg font-semibold">Review Removal</h3>
-
-              <div class="mt-3">
-                <p class="text-sm"><strong>Deactivate accounts:</strong>
-                  <span v-if="result?.preview?.deactivationUsernames?.length">
-                    {{ result.preview.deactivationUsernames.join(', ') }}
-                  </span>
-                  <span v-else>—</span>
-                </p>
-                <p class="text-sm mt-1">
-                  <strong>Points to remove from {{ result?.target }}:</strong>
-                  {{ result?.preview?.pointsToRemove ?? 0 }}
-                </p>
+              <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+                <h3 class="text-sm font-semibold">Review Removal</h3>
               </div>
 
-              <div class="mt-4">
-                <h4 class="font-medium">cToons to transfer and auction</h4>
-                <p class="text-xs text-gray-500 mb-2">Includes target’s relevant items and all source-owned items.</p>
+              <div class="overflow-y-auto flex-1 px-4 py-3">
+                <div>
+                  <p class="text-xs"><strong>Deactivate accounts:</strong>
+                    <span v-if="result?.preview?.deactivationUsernames?.length">
+                      {{ result.preview.deactivationUsernames.join(', ') }}
+                    </span>
+                    <span v-else>—</span>
+                  </p>
+                  <p class="text-xs mt-1">
+                    <strong>Points to remove from {{ result?.target }}:</strong>
+                    {{ result?.preview?.pointsToRemove ?? 0 }}
+                  </p>
+                </div>
 
-                <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                  <div
-                    v-for="it in allPreviewItems"
-                    :key="it.id"
-                    class="border rounded p-2 bg-gray-50"
-                  >
-                    <div class="aspect-square bg-white border rounded mb-2 flex items-center justify-center overflow-hidden">
-                      <img
-                        v-if="it.ctoon?.assetPath"
-                        :src="imgUrl(it.ctoon.assetPath)"
-                        :alt="it.ctoon?.name || 'cToon'"
-                        class="object-contain w-full h-full"
-                      />
-                      <div v-else class="text-xs text-gray-400">No image</div>
+                <div class="mt-3">
+                  <h4 class="text-xs font-semibold">cToons to transfer and auction</h4>
+                  <p class="text-[10px] text-gray-500 mb-2">Includes target’s relevant items and all source-owned items.</p>
+
+                  <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-2">
+                    <div
+                      v-for="it in allPreviewItems"
+                      :key="it.id"
+                      class="border rounded-md p-2 bg-gray-50"
+                    >
+                      <div class="aspect-square bg-white border rounded mb-2 flex items-center justify-center overflow-hidden">
+                        <img
+                          v-if="it.ctoon?.assetPath"
+                          :src="imgUrl(it.ctoon.assetPath)"
+                          :alt="it.ctoon?.name || 'cToon'"
+                          class="object-contain w-full h-full"
+                        />
+                        <div v-else class="text-[10px] text-gray-400">No image</div>
+                      </div>
+                      <div class="text-xs font-medium truncate">{{ it.ctoon?.name || 'cToon' }}</div>
+                      <div class="text-[10px] text-gray-600">Rarity: {{ it.ctoon?.rarity || '—' }}</div>
+                      <div class="text-[10px]">Owner: <span class="font-mono">{{ it.user?.username || '—' }}</span></div>
+                      <div class="text-[10px]">Mint #: <span class="font-mono">{{ it.mintNumber ?? '—' }}</span></div>
                     </div>
-                    <div class="text-sm font-medium truncate">{{ it.ctoon?.name || 'cToon' }}</div>
-                    <div class="text-xs text-gray-600">Rarity: {{ it.ctoon?.rarity || '—' }}</div>
-                    <div class="text-xs">Owner: <span class="font-mono">{{ it.user?.username || '—' }}</span></div>
-                    <div class="text-xs">Mint #: <span class="font-mono">{{ it.mintNumber ?? '—' }}</span></div>
                   </div>
                 </div>
+
+                <div v-if="enforceError" class="text-red-600 text-[11px] mt-3">{{ enforceError }}</div>
               </div>
 
-              <div v-if="enforceError" class="text-red-600 text-sm mt-3">{{ enforceError }}</div>
-
-              <div class="mt-5 flex justify-end gap-2">
-                <button class="px-4 py-2 border rounded" @click="closePreview" :disabled="enforcing">Cancel</button>
+              <div class="flex items-center justify-end gap-2 px-4 py-3 border-t flex-shrink-0">
+                <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closePreview" :disabled="enforcing">Cancel</button>
                 <button
-                  class="px-4 py-2 bg-red-600 text-white rounded disabled:opacity-50"
+                  class="px-3 py-1 text-xs rounded-md text-white bg-red-600 hover:bg-red-700 disabled:bg-red-300"
                   :disabled="enforcing"
                   @click="enforce()"
                 >
@@ -173,86 +177,90 @@
 
             <!-- AFTER processing: results (success or with errors) -->
             <template v-else>
-              <h3 class="text-lg font-semibold">Removal Results</h3>
-
-              <!-- Transport-level error -->
-              <div v-if="enforceError" class="mt-3 p-3 border rounded bg-red-50 text-red-700">
-                {{ enforceError }}
+              <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+                <h3 class="text-sm font-semibold">Removal Results</h3>
               </div>
 
-              <!-- Summary -->
-              <div v-else class="mt-3 p-3 border rounded bg-green-50 text-green-800">
-                <p class="font-medium mb-1">
-                  {{ hasAnyErrors ? 'Completed with issues' : 'Completed successfully' }}
-                </p>
-                <div class="grid sm:grid-cols-2 gap-x-6 text-sm">
-                  <div>Transferred (target seeds): <strong>{{ enforceResult?.transferredCount ?? 0 }}</strong></div>
-                  <div>Auctions (target seeds): <strong>{{ enforceResult?.auctionsCreated ?? 0 }}</strong></div>
-                  <div>Transferred (sources): <strong>{{ enforceResult?.sourceTransferredCount ?? 0 }}</strong></div>
-                  <div>Auctions (sources): <strong>{{ enforceResult?.sourceAuctionsCreated ?? 0 }}</strong></div>
-                  <div>Points removed: <strong>{{ enforceResult?.pointsRemoved ?? 0 }}</strong></div>
-                  <div>Sources deactivated: <strong>{{ enforceResult?.deactivatedSources ?? 0 }}</strong></div>
+              <div class="overflow-y-auto flex-1 px-4 py-3">
+                <!-- Transport-level error -->
+                <div v-if="enforceError" class="p-2 border rounded-md bg-red-50 text-red-700 text-xs">
+                  {{ enforceError }}
                 </div>
-              </div>
 
-              <!-- Detailed errors -->
-              <div v-if="hasAnyErrors" class="mt-4 space-y-4">
-                <div v-if="(enforceResult?.errors?.target?.length || 0) > 0">
-                  <h4 class="font-medium">Issues while processing target items</h4>
-                  <div class="overflow-auto border rounded">
-                    <table class="min-w-full text-sm">
-                      <thead class="bg-gray-100">
-                        <tr>
-                          <th class="px-2 py-1 text-left">UserCtoonId</th>
-                          <th class="px-2 py-1 text-left">Phase</th>
-                          <th class="px-2 py-1 text-left">Message</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr v-for="(e,i) in enforceResult.errors.target" :key="'t'+i" class="border-t">
-                          <td class="px-2 py-1 font-mono">{{ e.userCtoonId || '—' }}</td>
-                          <td class="px-2 py-1">{{ e.phase }}</td>
-                          <td class="px-2 py-1">{{ e.message }}</td>
-                        </tr>
-                      </tbody>
-                    </table>
+                <!-- Summary -->
+                <div v-else class="p-2 border rounded-md bg-green-50 text-green-800">
+                  <p class="text-xs font-medium mb-1">
+                    {{ hasAnyErrors ? 'Completed with issues' : 'Completed successfully' }}
+                  </p>
+                  <div class="grid sm:grid-cols-2 gap-x-4 text-xs">
+                    <div>Transferred (target seeds): <strong>{{ enforceResult?.transferredCount ?? 0 }}</strong></div>
+                    <div>Auctions (target seeds): <strong>{{ enforceResult?.auctionsCreated ?? 0 }}</strong></div>
+                    <div>Transferred (sources): <strong>{{ enforceResult?.sourceTransferredCount ?? 0 }}</strong></div>
+                    <div>Auctions (sources): <strong>{{ enforceResult?.sourceAuctionsCreated ?? 0 }}</strong></div>
+                    <div>Points removed: <strong>{{ enforceResult?.pointsRemoved ?? 0 }}</strong></div>
+                    <div>Sources deactivated: <strong>{{ enforceResult?.deactivatedSources ?? 0 }}</strong></div>
                   </div>
                 </div>
 
-                <div v-if="(enforceResult?.errors?.sources?.length || 0) > 0">
-                  <h4 class="font-medium">Issues while processing source items</h4>
-                  <div class="overflow-auto border rounded">
-                    <table class="min-w-full text-sm">
-                      <thead class="bg-gray-100">
-                        <tr>
-                          <th class="px-2 py-1 text-left">UserCtoonId</th>
-                          <th class="px-2 py-1 text-left">Phase</th>
-                          <th class="px-2 py-1 text-left">Message</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr v-for="(e,i) in enforceResult.errors.sources" :key="'s'+i" class="border-t">
-                          <td class="px-2 py-1 font-mono">{{ e.userCtoonId || '—' }}</td>
-                          <td class="px-2 py-1">{{ e.phase }}</td>
-                          <td class="px-2 py-1">{{ e.message }}</td>
-                        </tr>
-                      </tbody>
-                    </table>
+                <!-- Detailed errors -->
+                <div v-if="hasAnyErrors" class="mt-3 space-y-3">
+                  <div v-if="(enforceResult?.errors?.target?.length || 0) > 0">
+                    <h4 class="text-xs font-semibold">Issues while processing target items</h4>
+                    <div class="overflow-x-auto border rounded-md">
+                      <table class="min-w-full text-xs">
+                        <thead class="bg-gray-100">
+                          <tr>
+                            <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">UserCtoonId</th>
+                            <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Phase</th>
+                            <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Message</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr v-for="(e,i) in enforceResult.errors.target" :key="'t'+i" class="border-t">
+                            <td class="px-2 py-1.5 font-mono">{{ e.userCtoonId || '—' }}</td>
+                            <td class="px-2 py-1.5">{{ e.phase }}</td>
+                            <td class="px-2 py-1.5">{{ e.message }}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div v-if="(enforceResult?.errors?.sources?.length || 0) > 0">
+                    <h4 class="text-xs font-semibold">Issues while processing source items</h4>
+                    <div class="overflow-x-auto border rounded-md">
+                      <table class="min-w-full text-xs">
+                        <thead class="bg-gray-100">
+                          <tr>
+                            <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">UserCtoonId</th>
+                            <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Phase</th>
+                            <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Message</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr v-for="(e,i) in enforceResult.errors.sources" :key="'s'+i" class="border-t">
+                            <td class="px-2 py-1.5 font-mono">{{ e.userCtoonId || '—' }}</td>
+                            <td class="px-2 py-1.5">{{ e.phase }}</td>
+                            <td class="px-2 py-1.5">{{ e.message }}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
                   </div>
                 </div>
               </div>
 
-              <div class="mt-5 flex justify-end">
-                <button class="px-4 py-2 border rounded" @click="closePreview" :disabled="enforcing">Close</button>
+              <div class="flex items-center justify-end px-4 py-3 border-t flex-shrink-0">
+                <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closePreview" :disabled="enforcing">Close</button>
               </div>
             </template>
           </div>
         </div>
 
-        <div class="p-4 border rounded bg-white">
-          <h2 class="font-semibold mb-2">By source</h2>
-          <div v-if="result.bySource && Object.keys(result.bySource).length" class="space-y-2 text-sm">
-            <div v-for="(row, name) in result.bySource" :key="name" class="flex flex-col justify-between bg-gray-50 p-2 rounded">
+        <div class="bg-white rounded border p-3">
+          <h2 class="text-xs font-semibold mb-2">By source</h2>
+          <div v-if="result.bySource && Object.keys(result.bySource).length" class="space-y-2 text-xs">
+            <div v-for="(row, name) in result.bySource" :key="name" class="flex flex-col justify-between bg-gray-50 p-2 rounded-md">
               <div class="font-medium">{{ name }}</div>
               <span>{{ row.seedCount }} cToons
                 <br><br>{{ row.currentOwnedCount }} of those cToons are currently owned by {{ result.target }}
@@ -260,44 +268,44 @@
                 <br><br>Trade Value: {{ row.tradeValue }} points in trade value received</span>
             </div>
           </div>
-          <div v-else class="text-sm text-gray-500">No breakdown.</div>
+          <div v-else class="text-xs text-gray-500">No breakdown.</div>
         </div>
 
-        <div class="md:col-span-2 p-4 border rounded bg-white">
-          <h2 class="font-semibold mb-2">Debug</h2>
-          <pre class="text-xs overflow-auto">{{ result }}</pre>
+        <div class="md:col-span-2 bg-white rounded border p-3">
+          <h2 class="text-xs font-semibold mb-2">Debug</h2>
+          <pre class="text-[10px] overflow-auto">{{ result }}</pre>
         </div>
       </div>
     </div>
 
     <!-- Legacy modal kept (unused if using preview) -->
-    <div v-if="showModal" class="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg shadow-xl w-full max-w-xl p-5">
-        <h3 class="text-lg font-semibold mb-2">Confirm Enforcement</h3>
-        <p class="text-sm text-gray-700">
+    <div v-if="showModal" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+      <div class="relative bg-white w-full max-w-xl rounded-lg shadow-lg p-4">
+        <h3 class="text-sm font-semibold mb-2">Confirm Enforcement</h3>
+        <p class="text-xs text-gray-700">
           Target <strong>{{ result?.target }}</strong>. Sources: <strong>{{ result?.sources?.join(', ') }}</strong>.
         </p>
-        <p class="text-sm text-gray-700 mt-2">
+        <p class="text-xs text-gray-700 mt-2">
           This will transfer the target’s relevant cToons to <strong>CartoonReOrbitOfficial</strong>,
           create 3-day auctions at rarity floor, and remove previously gained auction points.
         </p>
-        <ul class="text-sm mt-3 space-y-1">
+        <ul class="text-xs mt-2 space-y-1">
           <li>Seed items: <strong>{{ result?.seedCount }}</strong></li>
           <li>Currently owned by target: <strong>{{ result?.currentOwnedCount }}</strong></li>
           <li>Points to remove (max): <strong>{{ result?.auctionPoints }}</strong></li>
         </ul>
 
-        <div v-if="enforceError" class="text-red-600 text-sm mt-3">{{ enforceError }}</div>
-        <div v-if="enforceResult" class="text-sm mt-3">
-          <div class="p-2 rounded bg-green-50 border">
+        <div v-if="enforceError" class="text-red-600 text-[11px] mt-2">{{ enforceError }}</div>
+        <div v-if="enforceResult" class="text-xs mt-2">
+          <div class="p-2 rounded-md bg-green-50 border">
             Done. Transferred: {{ enforceResult.transferredCount }}. Auctions created: {{ enforceResult.auctionsCreated }}. Points removed: {{ enforceResult.pointsRemoved }}.
           </div>
         </div>
 
-        <div class="mt-5 flex justify-end gap-2">
-          <button class="px-4 py-2 border rounded" @click="closeEnforce" :disabled="enforcing">Cancel</button>
+        <div class="mt-4 flex justify-end gap-2">
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeEnforce" :disabled="enforcing">Cancel</button>
           <button
-            class="px-4 py-2 bg-red-600 text-white rounded disabled:opacity-50"
+            class="px-3 py-1 text-xs rounded-md text-white bg-red-600 hover:bg-red-700 disabled:bg-red-300"
             :disabled="enforcing"
             @click="enforce()"
           >

--- a/components/newsite/admin/legacy/AdminLegacyClashTournaments.vue
+++ b/components/newsite/admin/legacy/AdminLegacyClashTournaments.vue
@@ -1,28 +1,29 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="admin-legacy-clash-tournaments bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
-    <div class="max-w-6xl mx-auto mt-6 space-y-6">
-      <div class="bg-white rounded-lg shadow p-5">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <h1 class="text-2xl font-semibold">Manage gToons Clash Tournaments</h1>
+    <div class="max-w-6xl mx-auto space-y-3">
+      <div class="bg-white rounded border shadow p-3">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <h1 class="text-base font-semibold">Manage gToons Clash Tournaments</h1>
           <div class="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              class="px-3 py-2 rounded border text-sm hover:bg-gray-50"
+              class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
               @click="loadTournaments"
             >
               Refresh
             </button>
             <button
               type="button"
-              class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
               @click="openCreateModal"
             >
               Create Tournament
             </button>
             <button
               type="button"
-              class="bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-amber-600 text-white hover:bg-amber-700"
               @click="openResolveModal"
             >
               Resolve Match
@@ -31,43 +32,43 @@
         </div>
       </div>
 
-      <div class="bg-white rounded-lg shadow">
-        <div class="px-5 py-3 border-b flex items-center justify-between">
-          <h2 class="text-lg font-semibold">Existing Tournaments</h2>
-          <span class="text-xs text-gray-500">Total: {{ tournaments.length }}</span>
+      <div class="bg-white rounded border shadow">
+        <div class="px-3 py-2 border-b flex items-center justify-between">
+          <h2 class="text-xs font-semibold">Existing Tournaments</h2>
+          <span class="text-[10px] text-gray-500">Total: {{ tournaments.length }}</span>
         </div>
 
-        <div v-if="loading" class="p-5 text-gray-500">Loading tournaments...</div>
-        <div v-else-if="!tournaments.length" class="p-5 text-gray-500">No tournaments yet.</div>
+        <div v-if="loading" class="p-3 text-gray-500">Loading tournaments...</div>
+        <div v-else-if="!tournaments.length" class="p-3 text-gray-500">No tournaments yet.</div>
         <div v-else class="divide-y">
-          <div v-for="t in tournaments" :key="t.id" class="p-5 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div v-for="t in tournaments" :key="t.id" class="p-3 flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
             <div>
               <div class="flex items-center gap-2">
-                <span class="font-semibold text-lg">{{ t.name }}</span>
-                <span class="text-xs px-2 py-1 rounded-full" :class="statusClass(t.status)">{{ statusLabel(t.status) }}</span>
+                <span class="font-semibold text-xs">{{ t.name }}</span>
+                <span class="px-1.5 py-0 rounded text-[10px] font-medium border" :class="statusClass(t.status)">{{ statusLabel(t.status) }}</span>
               </div>
-              <div class="text-sm text-gray-600 mt-1">Opt-in (CST): {{ formatDate(t.optInStartAt) }} → {{ formatDate(t.optInEndAt) }}</div>
-              <div class="text-sm text-gray-600 mt-1">Opt-ins: <span class="font-semibold">{{ t.optInCount }}</span></div>
-              <div v-if="t.format" class="text-sm text-gray-600 mt-1">Format: {{ formatLabel(t.format) }}</div>
+              <div class="text-[11px] text-gray-600 mt-1">Opt-in (CST): {{ formatDate(t.optInStartAt) }} → {{ formatDate(t.optInEndAt) }}</div>
+              <div class="text-[11px] text-gray-600 mt-1">Opt-ins: <span class="font-semibold">{{ t.optInCount }}</span></div>
+              <div v-if="t.format" class="text-[11px] text-gray-600 mt-1">Format: {{ formatLabel(t.format) }}</div>
             </div>
 
             <div class="flex flex-wrap gap-2">
               <NuxtLink
                 :to="`/games/clash/tournaments/${t.id}`"
-                class="px-3 py-2 rounded border text-sm hover:bg-gray-50"
+                class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
               >
                 View
               </NuxtLink>
               <button
                 type="button"
-                class="px-3 py-2 rounded border text-sm hover:bg-gray-50"
+                class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
                 @click="openEditModal(t)"
               >
                 Edit
               </button>
               <button
                 type="button"
-                class="px-3 py-2 rounded border text-sm hover:bg-gray-50"
+                class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
                 @click="recompute(t.id)"
                 :disabled="actionLoading"
               >
@@ -75,7 +76,7 @@
               </button>
               <button
                 type="button"
-                class="px-3 py-2 rounded border border-red-500 text-red-600 text-sm hover:bg-red-50"
+                class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50"
                 @click="cancelTournament(t.id)"
                 :disabled="actionLoading"
                 v-if="t.status !== 'CANCELLED'"
@@ -88,39 +89,40 @@
       </div>
 
     </div>
+    </div>
   </div>
 
-  <div v-if="showCreateModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="closeCreateModal"></div>
-    <div class="relative w-full max-w-lg bg-white rounded-lg shadow-lg flex flex-col max-h-[90vh]">
-      <div class="px-6 py-4 border-b flex items-center justify-between">
-        <h2 class="text-lg font-semibold">Create Tournament</h2>
-        <button class="text-gray-500 hover:text-gray-700" @click="closeCreateModal">✕</button>
+  <div v-if="showCreateModal" class="fixed inset-0 z-50 flex items-center justify-center p-2">
+    <div class="absolute inset-0 bg-black/50" @click="closeCreateModal"></div>
+    <div class="relative bg-white w-full max-w-lg rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+      <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+        <h2 class="text-sm font-semibold">Create Tournament</h2>
+        <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeCreateModal">✕</button>
       </div>
 
-      <div class="px-6 py-4 overflow-y-auto">
-        <form @submit.prevent="createTournament" class="grid grid-cols-1 gap-4">
-          <div>
-            <label class="block text-sm font-medium mb-1">Name</label>
-            <input v-model="form.name" type="text" class="w-full border rounded p-2" required />
+      <div class="overflow-y-auto flex-1 px-4 py-3">
+        <form @submit.prevent="createTournament" class="grid grid-cols-1 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Name</label>
+            <input v-model="form.name" type="text" class="border rounded-md px-2 py-1.5 text-sm" required />
           </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Opt-in start</label>
-            <input v-model="form.optInStartAt" type="datetime-local" class="w-full border rounded p-2" required />
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Opt-in start</label>
+            <input v-model="form.optInStartAt" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" required />
           </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Opt-in end</label>
-            <input v-model="form.optInEndAt" type="datetime-local" class="w-full border rounded p-2" required />
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Opt-in end</label>
+            <input v-model="form.optInEndAt" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" required />
           </div>
-          <span v-if="saveError" class="text-red-600 text-sm">{{ saveError }}</span>
+          <span v-if="saveError" class="text-red-600 text-xs">{{ saveError }}</span>
         </form>
       </div>
 
-      <div class="px-6 py-4 border-t flex items-center justify-end gap-2">
-        <button type="button" class="px-4 py-2 rounded border" @click="closeCreateModal">Cancel</button>
+      <div class="px-4 py-3 border-t flex-shrink-0 flex items-center justify-end gap-2">
+        <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeCreateModal">Cancel</button>
         <button
           type="button"
-          class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
           :disabled="saving"
           @click="createTournament"
         >
@@ -130,37 +132,37 @@
     </div>
   </div>
 
-  <div v-if="showEditModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="closeEditModal"></div>
-    <div class="relative w-full max-w-lg bg-white rounded-lg shadow-lg flex flex-col max-h-[90vh]">
-      <div class="px-6 py-4 border-b flex items-center justify-between">
-        <h2 class="text-lg font-semibold">Edit Tournament</h2>
-        <button class="text-gray-500 hover:text-gray-700" @click="closeEditModal">✕</button>
+  <div v-if="showEditModal" class="fixed inset-0 z-50 flex items-center justify-center p-2">
+    <div class="absolute inset-0 bg-black/50" @click="closeEditModal"></div>
+    <div class="relative bg-white w-full max-w-lg rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+      <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+        <h2 class="text-sm font-semibold">Edit Tournament</h2>
+        <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeEditModal">✕</button>
       </div>
 
-      <div class="px-6 py-4 overflow-y-auto">
-        <form @submit.prevent="saveEdit" class="grid grid-cols-1 gap-4">
-          <div>
-            <label class="block text-sm font-medium mb-1">Name</label>
-            <input v-model="editForm.name" type="text" class="w-full border rounded p-2" required />
+      <div class="overflow-y-auto flex-1 px-4 py-3">
+        <form @submit.prevent="saveEdit" class="grid grid-cols-1 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Name</label>
+            <input v-model="editForm.name" type="text" class="border rounded-md px-2 py-1.5 text-sm" required />
           </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Opt-in start</label>
-            <input v-model="editForm.optInStartAt" type="datetime-local" class="w-full border rounded p-2" required />
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Opt-in start</label>
+            <input v-model="editForm.optInStartAt" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" required />
           </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Opt-in end</label>
-            <input v-model="editForm.optInEndAt" type="datetime-local" class="w-full border rounded p-2" required />
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Opt-in end</label>
+            <input v-model="editForm.optInEndAt" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" required />
           </div>
-          <span v-if="editError" class="text-red-600 text-sm">{{ editError }}</span>
+          <span v-if="editError" class="text-red-600 text-xs">{{ editError }}</span>
         </form>
       </div>
 
-      <div class="px-6 py-4 border-t flex items-center justify-end gap-2">
-        <button type="button" class="px-4 py-2 rounded border" @click="closeEditModal">Cancel</button>
+      <div class="px-4 py-3 border-t flex-shrink-0 flex items-center justify-end gap-2">
+        <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeEditModal">Cancel</button>
         <button
           type="button"
-          class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
           :disabled="editSaving"
           @click="saveEdit"
         >
@@ -170,20 +172,20 @@
     </div>
   </div>
 
-  <div v-if="showResolveModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="closeResolveModal"></div>
-    <div class="relative w-full max-w-lg bg-white rounded-lg shadow-lg flex flex-col max-h-[90vh]">
-      <div class="px-6 py-4 border-b flex items-center justify-between">
-        <h2 class="text-lg font-semibold">Resolve Match (Admin Select)</h2>
-        <button class="text-gray-500 hover:text-gray-700" @click="closeResolveModal">✕</button>
+  <div v-if="showResolveModal" class="fixed inset-0 z-50 flex items-center justify-center p-2">
+    <div class="absolute inset-0 bg-black/50" @click="closeResolveModal"></div>
+    <div class="relative bg-white w-full max-w-lg rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+      <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+        <h2 class="text-sm font-semibold">Resolve Match (Admin Select)</h2>
+        <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeResolveModal">✕</button>
       </div>
 
-      <div class="px-6 py-4 overflow-y-auto">
-        <form @submit.prevent="resolveMatch" class="grid grid-cols-1 gap-4">
-          <div>
-            <label class="block text-sm font-medium mb-1">Select Tournament</label>
+      <div class="overflow-y-auto flex-1 px-4 py-3">
+        <form @submit.prevent="resolveMatch" class="grid grid-cols-1 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Select Tournament</label>
             <select
-              class="w-full border rounded p-2"
+              class="border rounded-md px-2 py-1.5 text-sm"
               :value="selectedTournamentId"
               @change="selectResolveTournament($event.target.value)"
             >
@@ -191,10 +193,10 @@
               <option v-for="t in tournaments" :key="t.id" :value="t.id">{{ t.name }} ({{ t.id }})</option>
             </select>
           </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Select Match</label>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Select Match</label>
             <select
-              class="w-full border rounded p-2"
+              class="border rounded-md px-2 py-1.5 text-sm"
               :value="selectedMatchId"
               @change="selectResolveMatch($event.target.value)"
               :disabled="!resolveMatches.length"
@@ -205,10 +207,10 @@
               </option>
             </select>
           </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Select User To Make Winner</label>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Select User To Make Winner</label>
             <select
-              class="w-full border rounded p-2"
+              class="border rounded-md px-2 py-1.5 text-sm"
               :value="selectedWinnerId"
               @change="selectResolveWinner($event.target.value)"
               :disabled="!selectedMatch"
@@ -225,19 +227,19 @@
               </option>
             </select>
           </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Notes (optional)</label>
-            <input v-model="resolveForm.notes" type="text" class="w-full border rounded p-2" />
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Notes (optional)</label>
+            <input v-model="resolveForm.notes" type="text" class="border rounded-md px-2 py-1.5 text-sm" />
           </div>
-          <span v-if="resolveError" class="text-red-600 text-sm">{{ resolveError }}</span>
+          <span v-if="resolveError" class="text-red-600 text-xs">{{ resolveError }}</span>
         </form>
       </div>
 
-      <div class="px-6 py-4 border-t flex items-center justify-end gap-2">
-        <button type="button" class="px-4 py-2 rounded border" @click="closeResolveModal">Cancel</button>
+      <div class="px-4 py-3 border-t flex-shrink-0 flex items-center justify-end gap-2">
+        <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeResolveModal">Cancel</button>
         <button
           type="button"
-          class="bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700 disabled:opacity-50"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-amber-600 text-white hover:bg-amber-700 disabled:opacity-50"
           :disabled="actionLoading"
           @click="resolveMatch"
         >

--- a/components/newsite/admin/legacy/AdminLegacyCodes.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCodes.vue
@@ -1,248 +1,250 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
-    <div class="max-w-4xl mx-auto bg-white rounded-lg shadow p-6">
-      <div class="flex justify-between items-center mb-4">
-        <h1 class="text-2xl font-semibold">Claim Codes Admin</h1>
-        <NuxtLink
-          to="/newsite/admin/codes/new"
-          class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-        >
-          Create New Code
-        </NuxtLink>
-      </div>
-
-      <!-- Tabs -->
-      <div class="mb-6 border-b">
-        <nav class="flex -mb-px">
-          <button
-            @click="activeTab = 'created'"
-            :class="activeTab === 'created'
-              ? 'border-b-2 border-blue-600 text-blue-600'
-              : 'text-gray-600 hover:text-gray-800'"
-            class="px-4 py-2 mr-4"
+      <div class="bg-white rounded border p-3">
+        <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+          <h1 class="text-base font-semibold">Claim Codes Admin</h1>
+          <NuxtLink
+            to="/newsite/admin/codes/new"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
           >
-            Created Codes
-          </button>
-          <button
-            @click="activeTab = 'claimed'"
-            :class="activeTab === 'claimed'
-              ? 'border-b-2 border-blue-600 text-blue-600'
-              : 'text-gray-600 hover:text-gray-800'"
-            class="px-4 py-2"
-          >
-            Claimed Codes
-          </button>
-        </nav>
-      </div>
-
-      <!-- Created Codes Tab -->
-      <div v-if="activeTab === 'created'">
-        <div class="mb-4 flex flex-wrap items-end gap-4">
-          <div class="flex-1">
-            <label for="createdFilter" class="block text-sm font-medium text-gray-700 mb-1">Filter by code or cToon</label>
-            <input
-              id="createdFilter"
-              v-model="createdQuery"
-              type="text"
-              placeholder="Type a code or cToon name..."
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-            />
-          </div>
-          <div class="w-full sm:w-60">
-            <label for="createdSort" class="block text-sm font-medium text-gray-700 mb-1">Sort by</label>
-            <select
-              id="createdSort"
-              v-model="createdSort"
-              class="w-full border border-gray-300 rounded px-3 py-2 bg-white focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-            >
-              <option value="created">Created date</option>
-              <option value="expires">Expiration date</option>
-            </select>
-          </div>
+            Create New Code
+          </NuxtLink>
         </div>
-        <div v-if="createdError" class="text-red-600 mb-4">{{ createdError.message }}</div>
-        <div v-else-if="createdLoading" class="text-gray-500">Loading…</div>
-        <div v-else>
-          <!-- Desktop Table -->
-          <div class="hidden lg:block">
-            <table
-              v-if="codes.length"
-              class="w-full table-auto border-collapse"
+
+        <!-- Tabs -->
+        <div class="mb-3 border-b">
+          <nav class="flex -mb-px">
+            <button
+              @click="activeTab = 'created'"
+              :class="activeTab === 'created'
+                ? 'border-b-2 border-blue-600 text-blue-600'
+                : 'text-gray-600 hover:text-gray-800'"
+              class="px-3 py-1.5 text-xs mr-2"
             >
-              <thead>
-                <tr class="bg-gray-100">
-                  <th class="px-4 py-2 text-left">Code</th>
-                  <th class="px-4 py-2 text-left">Available At (CST)</th>
-                  <th class="px-4 py-2 text-left">Expires At</th>
-                  <th class="px-4 py-2 text-right"># cToons</th>
-                  <th class="px-4 py-2 text-right"># of Backgrounds</th>
-                  <th class="px-4 py-2 text-right">Points</th>
-                  <th class="px-4 py-2 text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="c in codes" :key="c.code" class="border-b hover:bg-gray-50">
-                  <td class="px-4 py-2 max-w-[15ch] truncate" :title="c.code">{{ c.code }}</td>
-                  <td class="px-4 py-2">
-                    <span v-if="c.startsAt">
-                      {{ formatCST(c.startsAt) }}
-                    </span>
-                    <span v-else class="text-gray-500">Immediately</span>
-                  </td>
-                  <td class="px-4 py-2">
+              Created Codes
+            </button>
+            <button
+              @click="activeTab = 'claimed'"
+              :class="activeTab === 'claimed'
+                ? 'border-b-2 border-blue-600 text-blue-600'
+                : 'text-gray-600 hover:text-gray-800'"
+              class="px-3 py-1.5 text-xs"
+            >
+              Claimed Codes
+            </button>
+          </nav>
+        </div>
+
+        <!-- Created Codes Tab -->
+        <div v-if="activeTab === 'created'">
+          <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-end mb-2">
+            <div class="flex-1 flex flex-col gap-1">
+              <label for="createdFilter" class="text-xs font-medium">Filter by code or cToon</label>
+              <input
+                id="createdFilter"
+                v-model="createdQuery"
+                type="text"
+                placeholder="Type a code or cToon name..."
+                class="text-xs border rounded-md px-1.5 py-1"
+              />
+            </div>
+            <div class="w-full sm:w-60 flex flex-col gap-1">
+              <label for="createdSort" class="text-xs font-medium">Sort by</label>
+              <select
+                id="createdSort"
+                v-model="createdSort"
+                class="text-xs border rounded-md px-1.5 py-1 bg-white"
+              >
+                <option value="created">Created date</option>
+                <option value="expires">Expiration date</option>
+              </select>
+            </div>
+          </div>
+          <div v-if="createdError" class="text-red-600 mb-2 text-[11px]">{{ createdError.message }}</div>
+          <div v-else-if="createdLoading" class="text-gray-500 py-6 text-center">Loading…</div>
+          <div v-else>
+            <!-- Desktop Table -->
+            <div class="hidden lg:block overflow-x-auto">
+              <table
+                v-if="codes.length"
+                class="w-full text-xs"
+              >
+                <thead>
+                  <tr>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Code</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Available At (CST)</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Expires At</th>
+                    <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100"># cToons</th>
+                    <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100"># of Backgrounds</th>
+                    <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100">Points</th>
+                    <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y">
+                  <tr v-for="c in codes" :key="c.code" class="hover:bg-gray-50">
+                    <td class="px-2 py-1.5 max-w-[15ch] truncate" :title="c.code">{{ c.code }}</td>
+                    <td class="px-2 py-1.5">
+                      <span v-if="c.startsAt">
+                        {{ formatCST(c.startsAt) }}
+                      </span>
+                      <span v-else class="text-gray-500">Immediately</span>
+                    </td>
+                    <td class="px-2 py-1.5">
+                      <span v-if="c.expiresAt">
+                        {{ new Date(c.expiresAt).toLocaleDateString() }}
+                      </span>
+                      <span v-else class="text-gray-500">Never</span>
+                    </td>
+                    <td class="px-2 py-1.5 text-right">{{ countCtoons(c) }}</td>
+                    <td class="px-2 py-1.5 text-right">{{ countBackgrounds(c) }}</td>
+                    <td class="px-2 py-1.5 text-right">{{ countPoints(c) }}</td>
+                    <td class="px-2 py-1.5 text-right">
+                      <NuxtLink
+                        :to="`/newsite/admin/codes/edit?code=${encodeURIComponent(c.code)}`"
+                        class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
+                      >
+                        Edit
+                      </NuxtLink>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div v-if="!codes.length" class="text-gray-500 py-6 text-center">
+                No codes found.
+              </div>
+            </div>
+
+            <!-- Mobile Cards -->
+            <div class="block lg:hidden grid grid-cols-1 gap-2">
+              <div
+                v-for="c in codes"
+                :key="c.code"
+                class="bg-white border rounded-lg shadow p-2 flex flex-col gap-1"
+              >
+                <div class="text-[11px] space-y-0.5">
+                  <p><strong>Code:</strong> {{ c.code }}</p>
+                  <p>
+                    <strong>Available At:</strong>
+                    <span v-if="c.startsAt">{{ formatCST(c.startsAt) }}</span>
+                    <span v-else>Immediately</span>
+                  </p>
+                  <p>
+                    <strong>Expires:</strong>
                     <span v-if="c.expiresAt">
                       {{ new Date(c.expiresAt).toLocaleDateString() }}
                     </span>
-                    <span v-else class="text-gray-500">Never</span>
-                  </td>
-                  <td class="px-4 py-2 text-right">{{ countCtoons(c) }}</td>
-                  <td class="px-4 py-2 text-right">{{ countBackgrounds(c) }}</td>
-                  <td class="px-4 py-2 text-right">{{ countPoints(c) }}</td>
-                  <td class="px-4 py-2 text-right">
-                    <NuxtLink
-                      :to="`/newsite/admin/codes/edit?code=${encodeURIComponent(c.code)}`"
-                      class="text-blue-600 hover:underline"
-                    >
-                      Edit
-                    </NuxtLink>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <div v-if="!codes.length" class="text-gray-500">
-              No codes found.
-            </div>
-          </div>
-
-          <!-- Mobile Cards -->
-          <div class="block lg:hidden space-y-4">
-            <div
-              v-for="c in codes"
-              :key="c.code"
-              class="bg-gray-100 rounded-lg p-4 flex flex-col"
-            >
-              <div class="space-y-2">
-                <p><strong>Code:</strong> {{ c.code }}</p>
-                <p>
-                  <strong>Available At:</strong>
-                  <span v-if="c.startsAt">{{ formatCST(c.startsAt) }}</span>
-                  <span v-else>Immediately</span>
-                </p>
-                <p>
-                  <strong>Expires:</strong>
-                  <span v-if="c.expiresAt">
-                    {{ new Date(c.expiresAt).toLocaleDateString() }}
-                  </span>
-                  <span v-else>Never</span>
-                </p>
-                <p><strong># cToons:</strong> {{ countCtoons(c) }}</p>
-                <p><strong># Backgrounds:</strong> {{ countBackgrounds(c) }}</p>
-                <p><strong>Points:</strong> {{ countPoints(c) }}</p>
+                    <span v-else>Never</span>
+                  </p>
+                  <p><strong># cToons:</strong> {{ countCtoons(c) }}</p>
+                  <p><strong># Backgrounds:</strong> {{ countBackgrounds(c) }}</p>
+                  <p><strong>Points:</strong> {{ countPoints(c) }}</p>
+                </div>
+                <NuxtLink
+                  :to="`/newsite/admin/codes/edit?code=${encodeURIComponent(c.code)}`"
+                  class="self-end px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
+                >
+                  Edit
+                </NuxtLink>
               </div>
-              <NuxtLink
-                :to="`/newsite/admin/codes/edit?code=${encodeURIComponent(c.code)}`"
-                class="mt-4 self-end text-blue-600 hover:underline"
+              <div v-if="!codes.length" class="text-gray-500 py-6 text-center">
+                No codes found.
+              </div>
+            </div>
+          </div>
+
+          <!-- Created Pagination -->
+          <div v-if="!createdLoading && codes.length" class="mt-3 flex items-center justify-between">
+            <div class="text-[11px] text-gray-600">
+              Page {{ createdPage }} of {{ createdTotalPages }} - Showing {{ createdShowingRange }}
+            </div>
+            <div class="space-x-1">
+              <button class="px-2 py-0.5 text-[11px] border rounded-md" :disabled="createdPage <= 1" @click="prevCreatedPage">Prev</button>
+              <button class="px-2 py-0.5 text-[11px] border rounded-md" :disabled="createdPage >= createdTotalPages" @click="nextCreatedPage">Next</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Claimed Codes Tab -->
+        <div v-if="activeTab === 'claimed'">
+          <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-end mb-2">
+            <div class="flex-1 flex flex-col gap-1">
+              <label for="claimedFilter" class="text-xs font-medium">Filter by username, code, or cToon</label>
+              <input
+                id="claimedFilter"
+                v-model="claimedQuery"
+                list="claimedUserSuggestions"
+                type="text"
+                @focus="fetchClaimedUserSuggestions"
+                placeholder="Type a username, code, or cToon name..."
+                class="text-xs border rounded-md px-1.5 py-1"
+              />
+              <datalist id="claimedUserSuggestions">
+                <option v-for="u in claimedUserSuggestions" :key="u" :value="u" />
+              </datalist>
+            </div>
+          </div>
+
+          <div v-if="claimedError" class="text-red-600 mb-2 text-[11px]">{{ claimedError.message }}</div>
+          <div v-else-if="claimedLoading" class="text-gray-500 py-6 text-center">Loading…</div>
+          <div v-else>
+            <!-- Desktop Table -->
+            <div class="hidden lg:block overflow-x-auto">
+              <table
+                v-if="claimed.length"
+                class="w-full text-xs"
               >
-                Edit
-              </NuxtLink>
+                <thead>
+                  <tr>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Code</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">User</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Claimed At</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y">
+                  <tr v-for="row in claimed" :key="row.id" class="hover:bg-gray-50">
+                    <td class="px-2 py-1.5 break-words">{{ row.code }}</td>
+                    <td class="px-2 py-1.5">{{ row.user.username }}</td>
+                    <td class="px-2 py-1.5">
+                      {{ new Date(row.claimedAt).toLocaleString() }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div v-if="!claimed.length" class="text-gray-500 py-6 text-center">
+                No claims found.
+              </div>
             </div>
-            <div v-if="!codes.length" class="text-gray-500">
-              No codes found.
-            </div>
-          </div>
-        </div>
 
-        <!-- Created Pagination -->
-        <div v-if="!createdLoading && codes.length" class="mt-6 flex items-center justify-between">
-          <div class="text-sm text-gray-600">
-            Page {{ createdPage }} of {{ createdTotalPages }} - Showing {{ createdShowingRange }}
-          </div>
-          <div class="space-x-2">
-            <button class="px-3 py-1 border rounded" :disabled="createdPage <= 1" @click="prevCreatedPage">Prev</button>
-            <button class="px-3 py-1 border rounded" :disabled="createdPage >= createdTotalPages" @click="nextCreatedPage">Next</button>
-          </div>
-        </div>
-      </div>
-
-      <!-- Claimed Codes Tab -->
-      <div v-if="activeTab === 'claimed'">
-        <div class="mb-4 flex flex-wrap items-end gap-4">
-          <div class="flex-1">
-            <label for="claimedFilter" class="block text-sm font-medium text-gray-700 mb-1">Filter by username, code, or cToon</label>
-            <input
-              id="claimedFilter"
-              v-model="claimedQuery"
-              list="claimedUserSuggestions"
-              type="text"
-              @focus="fetchClaimedUserSuggestions"
-              placeholder="Type a username, code, or cToon name..."
-              class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-            />
-            <datalist id="claimedUserSuggestions">
-              <option v-for="u in claimedUserSuggestions" :key="u" :value="u" />
-            </datalist>
-          </div>
-        </div>
-
-        <div v-if="claimedError" class="text-red-600 mb-4">{{ claimedError.message }}</div>
-        <div v-else-if="claimedLoading" class="text-gray-500">Loading…</div>
-        <div v-else>
-          <!-- Desktop Table -->
-          <div class="hidden lg:block">
-            <table
-              v-if="claimed.length"
-              class="w-full table-auto border-collapse"
-            >
-              <thead>
-                <tr class="bg-gray-100">
-                  <th class="px-4 py-2 text-left">Code</th>
-                  <th class="px-4 py-2 text-left">User</th>
-                  <th class="px-4 py-2 text-left">Claimed At</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="row in claimed" :key="row.id" class="border-b hover:bg-gray-50">
-                  <td class="px-4 py-2 break-words">{{ row.code }}</td>
-                  <td class="px-4 py-2">{{ row.user.username }}</td>
-                  <td class="px-4 py-2">
-                    {{ new Date(row.claimedAt).toLocaleString() }}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <div v-if="!claimed.length" class="text-gray-500">
-              No claims found.
+            <!-- Mobile Cards -->
+            <div class="block lg:hidden grid grid-cols-1 gap-2">
+              <div
+                v-for="row in claimed"
+                :key="row.id"
+                class="bg-white border rounded-lg shadow p-2 flex flex-col gap-0.5 text-[11px]"
+              >
+                <p><strong>Code:</strong> {{ row.code }}</p>
+                <p><strong>User:</strong> {{ row.user.username }}</p>
+                <p><strong>Claimed At:</strong>
+                  {{ new Date(row.claimedAt).toLocaleString() }}
+                </p>
+              </div>
+              <div v-if="!claimed.length" class="text-gray-500 py-6 text-center">
+                No claims found.
+              </div>
             </div>
           </div>
 
-          <!-- Mobile Cards -->
-          <div class="block lg:hidden space-y-4">
-            <div
-              v-for="row in claimed"
-              :key="row.id"
-              class="bg-gray-100 rounded-lg p-4 flex flex-col"
-            >
-              <p><strong>Code:</strong> {{ row.code }}</p>
-              <p><strong>User:</strong> {{ row.user.username }}</p>
-              <p><strong>Claimed At:</strong>
-                {{ new Date(row.claimedAt).toLocaleString() }}
-              </p>
+          <!-- Claimed Pagination -->
+          <div v-if="!claimedLoading && claimed.length" class="mt-3 flex items-center justify-between">
+            <div class="text-[11px] text-gray-600">
+              Page {{ claimedPage }} of {{ claimedTotalPages }} - Showing {{ claimedShowingRange }}
             </div>
-            <div v-if="!claimed.length" class="text-gray-500">
-              No claims found.
+            <div class="space-x-1">
+              <button class="px-2 py-0.5 text-[11px] border rounded-md" :disabled="claimedPage <= 1" @click="prevClaimedPage">Prev</button>
+              <button class="px-2 py-0.5 text-[11px] border rounded-md" :disabled="claimedPage >= claimedTotalPages" @click="nextClaimedPage">Next</button>
             </div>
-          </div>
-        </div>
-
-        <!-- Claimed Pagination -->
-        <div v-if="!claimedLoading && claimed.length" class="mt-6 flex items-center justify-between">
-          <div class="text-sm text-gray-600">
-            Page {{ claimedPage }} of {{ claimedTotalPages }} - Showing {{ claimedShowingRange }}
-          </div>
-          <div class="space-x-2">
-            <button class="px-3 py-1 border rounded" :disabled="claimedPage <= 1" @click="prevClaimedPage">Prev</button>
-            <button class="px-3 py-1 border rounded" :disabled="claimedPage >= claimedTotalPages" @click="nextClaimedPage">Next</button>
           </div>
         </div>
       </div>

--- a/components/newsite/admin/legacy/AdminLegacyCodesEdit.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCodesEdit.vue
@@ -1,300 +1,302 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2 max-w-2xl mx-auto">
 
-    <div class="max-w-2xl mx-auto bg-white rounded-lg shadow p-6 mt-6">
-      <h1 class="text-2xl font-semibold mb-4">Edit Claim Code</h1>
+      <div class="bg-white rounded border p-3">
+        <h1 class="text-base font-semibold mb-3">Edit Claim Code</h1>
 
-      <div v-if="pending" class="text-gray-500">Loading…</div>
-      <div v-else-if="fetchError" class="text-red-600">{{ fetchError.message }}</div>
-      <div v-else>
-        <form @submit.prevent="submitForm" class="space-y-4">
-          <!-- Code (read-only) -->
-          <div>
-            <label class="block font-medium mb-1">Code</label>
-            <input
-              v-model="code"
-              type="text"
-              disabled
-              class="w-full bg-gray-100 border rounded p-2"
-            />
-          </div>
+        <div v-if="pending" class="text-gray-500 py-6 text-center">Loading…</div>
+        <div v-else-if="fetchError" class="text-red-600 text-[11px]">{{ fetchError.message }}</div>
+        <div v-else>
+          <form @submit.prevent="submitForm" class="space-y-3">
+            <!-- Code (read-only) -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Code</label>
+              <input
+                v-model="code"
+                type="text"
+                disabled
+                class="bg-gray-100 border rounded-md px-2 py-1.5 text-sm"
+              />
+            </div>
 
-          <!-- Max Claims -->
-          <div>
-            <label class="block font-medium mb-1">Max Claims</label>
-            <input
-              v-model.number="maxClaims"
-              type="number"
-              min="1"
-              required
-              class="w-full border rounded p-2"
-            />
-          </div>
+            <!-- Max Claims -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Max Claims</label>
+              <input
+                v-model.number="maxClaims"
+                type="number"
+                min="1"
+                required
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
+            </div>
 
-          <!-- Available At -->
-          <div>
-            <label class="block font-medium mb-1">Available At (CST)</label>
-            <input
-              v-model="startsAt"
-              type="datetime-local"
-              class="w-full border rounded p-2"
-            />
-            <p class="text-sm text-gray-500">Leave blank or set to any date/time (including past) — users can only redeem on or after this time.</p>
-          </div>
+            <!-- Available At -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Available At (CST)</label>
+              <input
+                v-model="startsAt"
+                type="datetime-local"
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
+              <p class="text-[10px] text-gray-500">Leave blank or set to any date/time (including past) — users can only redeem on or after this time.</p>
+            </div>
 
-          <!-- Expires At -->
-          <div>
-            <label class="block font-medium mb-1">Expires At (CST)</label>
-            <input
-              v-model="expiresAt"
-              type="datetime-local"
-              class="w-full border rounded p-2"
-            />
-            <p class="text-sm text-gray-500">Leave blank for no expiration</p>
-          </div>
+            <!-- Expires At -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Expires At (CST)</label>
+              <input
+                v-model="expiresAt"
+                type="datetime-local"
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
+              <p class="text-[10px] text-gray-500">Leave blank for no expiration</p>
+            </div>
 
-          <!-- Points Reward -->
-          <div>
-            <label class="block font-medium mb-1">Points Reward</label>
-            <input
-              v-model.number="points"
-              type="number"
-              min="0"
-              class="w-full border rounded p-2"
-            />
-          </div>
+            <!-- Points Reward -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Points Reward</label>
+              <input
+                v-model.number="points"
+                type="number"
+                min="0"
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
+            </div>
 
-          <!-- Pooled cToon Rewards -->
-          <div class="space-y-2">
-            <label class="inline-flex items-center gap-2">
-              <input type="checkbox" v-model="pooledEnabled" />
-              <span class="font-medium">Use pooled cToon rewards</span>
-            </label>
+            <!-- Pooled cToon Rewards -->
+            <div class="space-y-1">
+              <label class="inline-flex items-center gap-2">
+                <input type="checkbox" v-model="pooledEnabled" />
+                <span class="text-xs font-medium">Use pooled cToon rewards</span>
+              </label>
 
-            <div v-if="pooledEnabled" class="rounded border p-3 space-y-3">
-              <div>
-                <label class="block font-medium mb-1">Number to give out (unique)</label>
-                <input v-model.number="poolUniqueCount" type="number" min="1" class="w-32 border rounded p-2" />
-              </div>
-
-              <div>
-                <label class="block font-medium mb-1">Pool cToons</label>
-                <div v-for="(row, idx) in poolItems" :key="'pool-'+idx" class="flex items-center gap-2 mb-2">
-                  <datalist :id="`pool-ctoons-${idx}`">
-                    <option v-for="ct in filteredCtoons(row.ctoonName)" :key="ct.id" :value="ct.name" />
-                  </datalist>
-
-                  <input v-model="row.ctoonName" :list="`pool-ctoons-${idx}`" class="flex-1 border rounded p-2" placeholder="Type 3+ characters" />
-
-                  <!-- NEW: preview -->
-                  <img
-                    v-if="findCtoon(row.ctoonName)?.assetPath"
-                    :src="findCtoon(row.ctoonName).assetPath"
-                    class="w-8 h-8 object-cover rounded"
-                    alt="cToon preview"
-                  />
-
-                  <input v-model.number="row.weight" type="number" min="1" class="w-20 border rounded p-2" title="Weight" />
-                  <button type="button" @click="removePoolItem(idx)" class="text-red-600 hover:underline">Remove</button>
+              <div v-if="pooledEnabled" class="bg-white rounded border p-2 space-y-2">
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Number to give out (unique)</label>
+                  <input v-model.number="poolUniqueCount" type="number" min="1" class="w-28 border rounded-md px-2 py-1 text-sm" />
                 </div>
-                <button type="button" @click="addPoolItem" class="text-blue-600 hover:underline text-sm">+ Add pool cToon</button>
-                <p class="text-sm text-gray-500">Users receive <strong>unique</strong> picks from this pool.</p>
+
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Pool cToons</label>
+                  <div v-for="(row, idx) in poolItems" :key="'pool-'+idx" class="flex items-center gap-2">
+                    <datalist :id="`pool-ctoons-${idx}`">
+                      <option v-for="ct in filteredCtoons(row.ctoonName)" :key="ct.id" :value="ct.name" />
+                    </datalist>
+
+                    <input v-model="row.ctoonName" :list="`pool-ctoons-${idx}`" class="flex-1 border rounded-md px-2 py-1.5 text-sm" placeholder="Type 3+ characters" />
+
+                    <!-- NEW: preview -->
+                    <img
+                      v-if="findCtoon(row.ctoonName)?.assetPath"
+                      :src="findCtoon(row.ctoonName).assetPath"
+                      class="w-7 h-7 object-cover rounded border"
+                      alt="cToon preview"
+                    />
+
+                    <input v-model.number="row.weight" type="number" min="1" class="w-16 border rounded px-1 py-0.5 text-xs" title="Weight" />
+                    <button type="button" @click="removePoolItem(idx)" class="text-red-700 hover:underline text-[11px]">Remove</button>
+                  </div>
+                  <button type="button" @click="addPoolItem" class="text-blue-600 hover:underline text-xs text-left">+ Add pool cToon</button>
+                  <p class="text-[10px] text-gray-500">Users receive <strong>unique</strong> picks from this pool.</p>
+                </div>
               </div>
             </div>
-          </div>
 
-          <!-- cToon Rewards -->
-          <div>
-            <label class="block font-medium mb-1">cToon Rewards</label>
-            <p class="text-sm text-gray-500 mb-2">
-              Optionally set an End Bonus Date/Time (CST) per cToon below — if set, that cToon is only
-              given out when redeemed between the code's Available At time and that cToon's End Bonus
-              Date/Time. Leave blank to give it out normally whenever the code is redeemed.
-            </p>
+            <!-- cToon Rewards -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">cToon Rewards</label>
+              <p class="text-[10px] text-gray-500">
+                Optionally set an End Bonus Date/Time (CST) per cToon below — if set, that cToon is only
+                given out when redeemed between the code's Available At time and that cToon's End Bonus
+                Date/Time. Leave blank to give it out normally whenever the code is redeemed.
+              </p>
 
-            <div
-              v-for="(rc, idx) in ctoonRewards"
-              :key="idx"
-              class="border rounded p-3 mb-2 grid grid-cols-2 sm:grid-cols-[1fr_auto_5rem_auto] gap-2 sm:items-center"
-            >
-              <!-- per-row datalist, filtered by current input -->
-              <datalist :id="`reward-ctoon-list-${idx}`">
-                <option
-                  v-for="ct in filteredCtoons(rc.ctoonName)"
-                  :key="ct.id"
-                  :value="ct.name"
+              <div
+                v-for="(rc, idx) in ctoonRewards"
+                :key="idx"
+                class="border rounded-md p-2 grid grid-cols-2 sm:grid-cols-[1fr_auto_5rem_auto] gap-2 sm:items-center"
+              >
+                <!-- per-row datalist, filtered by current input -->
+                <datalist :id="`reward-ctoon-list-${idx}`">
+                  <option
+                    v-for="ct in filteredCtoons(rc.ctoonName)"
+                    :key="ct.id"
+                    :value="ct.name"
+                  />
+                </datalist>
+
+                <div class="col-span-2 sm:col-span-1">
+                  <label class="text-[10px] text-gray-500 sm:hidden">cToon</label>
+                  <input
+                    v-model="rc.ctoonName"
+                    :list="`reward-ctoon-list-${idx}`"
+                    type="text"
+                    required
+                    class="w-full border rounded-md px-2 py-1.5 text-sm"
+                    placeholder="Type 3+ characters to search"
+                  />
+                </div>
+
+                <img
+                  v-if="findCtoon(rc.ctoonName)?.assetPath"
+                  :src="findCtoon(rc.ctoonName).assetPath"
+                  class="w-7 h-7 object-cover rounded border justify-self-center"
+                  alt="cToon preview"
                 />
-              </datalist>
 
-              <div class="col-span-2 sm:col-span-1">
-                <label class="text-xs text-gray-500 sm:hidden">cToon</label>
+                <div>
+                  <label class="text-[10px] text-gray-500 sm:hidden">Qty</label>
+                  <input
+                    v-model.number="rc.quantity"
+                    type="number"
+                    min="1"
+                    class="w-full sm:w-16 border rounded px-1 py-1 text-sm"
+                    placeholder="Qty"
+                  />
+                </div>
+
+                <button
+                  type="button"
+                  @click="removeCtoonReward(idx)"
+                  class="text-red-700 hover:underline text-[11px] justify-self-end sm:justify-self-auto"
+                >
+                  Remove
+                </button>
+
+                <div class="col-span-2 flex flex-col gap-1">
+                  <label class="text-[10px] text-gray-500">End Bonus Date/Time (CST) &middot; optional</label>
+                  <input
+                    v-model="rc.endBonusAt"
+                    type="datetime-local"
+                    class="w-full border rounded-md px-2 py-1.5 text-sm"
+                  />
+                </div>
+              </div>
+
+              <button
+                type="button"
+                @click="addCtoonReward"
+                class="text-blue-600 hover:underline text-xs text-left"
+              >
+                + Add another cToon
+              </button>
+            </div>
+
+            <!-- Prerequisite cToons -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Prerequisite cToons</label>
+
+              <div
+                v-for="(pc, idx) in prereqCtoons"
+                :key="idx"
+                class="flex items-center gap-2"
+              >
+                <!-- per-row datalist, filtered by current input -->
+                <datalist :id="`prereq-ctoon-list-${idx}`">
+                  <option
+                    v-for="ct in filteredCtoons(pc.ctoonName)"
+                    :key="ct.id"
+                    :value="ct.name"
+                  />
+                </datalist>
+
                 <input
-                  v-model="rc.ctoonName"
-                  :list="`reward-ctoon-list-${idx}`"
+                  v-model="pc.ctoonName"
+                  :list="`prereq-ctoon-list-${idx}`"
                   type="text"
-                  required
-                  class="w-full border rounded p-2 text-base"
+                  class="flex-1 border rounded-md px-2 py-1.5 text-sm"
                   placeholder="Type 3+ characters to search"
                 />
-              </div>
 
-              <img
-                v-if="findCtoon(rc.ctoonName)?.assetPath"
-                :src="findCtoon(rc.ctoonName).assetPath"
-                class="w-8 h-8 object-cover rounded justify-self-center"
-                alt="cToon preview"
-              />
-
-              <div>
-                <label class="text-xs text-gray-500 sm:hidden">Qty</label>
-                <input
-                  v-model.number="rc.quantity"
-                  type="number"
-                  min="1"
-                  class="w-full sm:w-20 border rounded p-2 text-base"
-                  placeholder="Qty"
+                <img
+                  v-if="findCtoon(pc.ctoonName)?.assetPath"
+                  :src="findCtoon(pc.ctoonName).assetPath"
+                  class="w-7 h-7 object-cover rounded border"
+                  alt="cToon preview"
                 />
+                <button
+                  type="button"
+                  @click="removePrereqCtoon(idx)"
+                  class="text-red-700 hover:underline text-[11px]"
+                >
+                  Remove
+                </button>
               </div>
 
               <button
                 type="button"
-                @click="removeCtoonReward(idx)"
-                class="text-red-600 hover:underline justify-self-end sm:justify-self-auto p-2 -m-2"
+                @click="addPrereqCtoon"
+                class="text-blue-600 hover:underline text-xs text-left"
               >
-                Remove
+                + Add prerequisite cToon
               </button>
+              <p class="text-[10px] text-gray-500">Leave empty for no prerequisites.</p>
 
-              <div class="col-span-2">
-                <label class="text-xs text-gray-500">End Bonus Date/Time (CST) &middot; optional</label>
-                <input
-                  v-model="rc.endBonusAt"
-                  type="datetime-local"
-                  class="w-full border rounded p-2 text-base"
-                />
+              <div class="mt-1 space-y-1">
+                <label class="inline-flex items-center gap-2">
+                  <input type="checkbox" v-model="prereqPoolEnabled" />
+                  <span class="text-xs font-medium">Only require owning some cToons from this pool</span>
+                </label>
+                <div v-if="prereqPoolEnabled" class="flex items-center gap-2">
+                  <span class="text-xs">Must own at least</span>
+                  <input
+                    v-model.number="prereqMinOwned"
+                    type="number"
+                    min="1"
+                    class="w-20 border rounded-md px-2 py-1 text-sm"
+                  />
+                  <span class="text-xs">of the selected cToons</span>
+                </div>
+                <p v-if="prereqPoolEnabled" class="text-[10px] text-gray-500">
+                  Unchecked, users must own ALL prerequisite cToons. Checked, owning any {{ prereqMinOwned || 'X' }} from the pool is enough.
+                </p>
+                <div v-if="prereqPoolEnabled" class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Add Set</label>
+                  <datalist id="prereq-set-list">
+                    <option v-for="s in filteredSets(setSearch)" :key="s" :value="s" />
+                  </datalist>
+                  <input
+                    v-model="setSearch"
+                    list="prereq-set-list"
+                    type="text"
+                    class="border rounded-md px-2 py-1.5 text-sm"
+                    placeholder="Type 3+ characters to search sets"
+                    @change="onSetSelected"
+                  />
+                  <p class="text-[10px] text-gray-500">Selecting a set adds all of its cToons to the prerequisite list above.</p>
+                </div>
               </div>
             </div>
 
-            <button
-              type="button"
-              @click="addCtoonReward"
-              class="text-blue-600 hover:underline text-sm"
-            >
-              + Add another cToon
-            </button>
-          </div>
-
-          <!-- Prerequisite cToons -->
-          <div>
-            <label class="block font-medium mb-1">Prerequisite cToons</label>
-
-            <div
-              v-for="(pc, idx) in prereqCtoons"
-              :key="idx"
-              class="flex items-center space-x-2 mb-2"
-            >
-              <!-- per-row datalist, filtered by current input -->
-              <datalist :id="`prereq-ctoon-list-${idx}`">
-                <option
-                  v-for="ct in filteredCtoons(pc.ctoonName)"
-                  :key="ct.id"
-                  :value="ct.name"
-                />
+            <!-- Background Rewards -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Background Rewards (CODE_ONLY)</label>
+              <datalist id="bg-list">
+                <option v-for="b in bgOptions" :key="b.id" :value="b.label || b.id" />
               </datalist>
+              <div v-for="(rb, idx) in bgRewards" :key="idx" class="flex items-center gap-2">
+                <input v-model="rb.bgLabel" list="bg-list" class="flex-1 border rounded-md px-2 py-1.5 text-sm" placeholder="Type or select background label" />
+                <img v-if="findBg(rb.bgLabel)?.imagePath" :src="findBg(rb.bgLabel).imagePath" class="w-10 h-7 object-cover rounded border" />
+                <button type="button" @click="removeBgReward(idx)" class="text-red-700 hover:underline text-[11px]">Remove</button>
+              </div>
+              <button type="button" @click="addBgReward" class="text-blue-600 hover:underline text-xs text-left">+ Add background</button>
+            </div>
 
-              <input
-                v-model="pc.ctoonName"
-                :list="`prereq-ctoon-list-${idx}`"
-                type="text"
-                class="flex-1 border rounded p-2"
-                placeholder="Type 3+ characters to search"
-              />
-
-              <img
-                v-if="findCtoon(pc.ctoonName)?.assetPath"
-                :src="findCtoon(pc.ctoonName).assetPath"
-                class="w-8 h-8 object-cover rounded"
-                alt="cToon preview"
-              />
+            <!-- Submit & Errors -->
+            <div class="pt-3 border-t flex items-center justify-between flex-wrap gap-2">
               <button
-                type="button"
-                @click="removePrereqCtoon(idx)"
-                class="text-red-600 hover:underline"
+                type="submit"
+                class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700"
               >
-                Remove
+                Save Changes
               </button>
+              <p v-if="error" class="text-[11px] text-red-600">{{ error }}</p>
+              <p v-if="!error && warning" class="text-[11px] text-amber-600">{{ warning }}</p>
             </div>
-
-            <button
-              type="button"
-              @click="addPrereqCtoon"
-              class="text-blue-600 hover:underline text-sm"
-            >
-              + Add prerequisite cToon
-            </button>
-            <p class="text-sm text-gray-500">Leave empty for no prerequisites.</p>
-
-            <div class="mt-3 space-y-2">
-              <label class="inline-flex items-center gap-2">
-                <input type="checkbox" v-model="prereqPoolEnabled" />
-                <span class="font-medium">Only require owning some cToons from this pool</span>
-              </label>
-              <div v-if="prereqPoolEnabled" class="flex items-center gap-2">
-                <span class="text-sm">Must own at least</span>
-                <input
-                  v-model.number="prereqMinOwned"
-                  type="number"
-                  min="1"
-                  class="w-24 border rounded p-2"
-                />
-                <span class="text-sm">of the selected cToons</span>
-              </div>
-              <p v-if="prereqPoolEnabled" class="text-sm text-gray-500">
-                Unchecked, users must own ALL prerequisite cToons. Checked, owning any {{ prereqMinOwned || 'X' }} from the pool is enough.
-              </p>
-              <div v-if="prereqPoolEnabled">
-                <label class="block font-medium mb-1">Add Set</label>
-                <datalist id="prereq-set-list">
-                  <option v-for="s in filteredSets(setSearch)" :key="s" :value="s" />
-                </datalist>
-                <input
-                  v-model="setSearch"
-                  list="prereq-set-list"
-                  type="text"
-                  class="w-full border rounded p-2"
-                  placeholder="Type 3+ characters to search sets"
-                  @change="onSetSelected"
-                />
-                <p class="text-sm text-gray-500">Selecting a set adds all of its cToons to the prerequisite list above.</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Background Rewards -->
-          <div>
-            <label class="block font-medium mb-1">Background Rewards (CODE_ONLY)</label>
-            <datalist id="bg-list">
-              <option v-for="b in bgOptions" :key="b.id" :value="b.label || b.id" />
-            </datalist>
-            <div v-for="(rb, idx) in bgRewards" :key="idx" class="flex items-center gap-2 mb-2">
-              <input v-model="rb.bgLabel" list="bg-list" class="flex-1 border rounded p-2" placeholder="Type or select background label" />
-              <img v-if="findBg(rb.bgLabel)?.imagePath" :src="findBg(rb.bgLabel).imagePath" class="w-12 h-8 object-cover rounded border" />
-              <button type="button" @click="removeBgReward(idx)" class="text-red-600 hover:underline">Remove</button>
-            </div>
-            <button type="button" @click="addBgReward" class="text-blue-600 hover:underline text-sm">+ Add background</button>
-          </div>
-
-          <!-- Submit & Errors -->
-          <div class="pt-4 border-t flex items-center justify-between">
-            <button
-              type="submit"
-              class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-            >
-              Save Changes
-            </button>
-            <p v-if="error" class="text-red-600">{{ error }}</p>
-            <p v-if="!error && warning" class="text-amber-600">{{ warning }}</p>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
   </div>

--- a/components/newsite/admin/legacy/AdminLegacyCodesNew.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCodesNew.vue
@@ -1,304 +1,306 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2 max-w-2xl mx-auto">
 
-    <div class="max-w-2xl mx-auto bg-white rounded-lg shadow p-6 mt-6">
-      <h1 class="text-2xl font-semibold mb-4">Create New Claim Code</h1>
-      <form @submit.prevent="submitForm" class="space-y-4">
-        <!-- Code -->
-        <div>
-          <label class="block font-medium mb-1">Code</label>
-          <input
-            v-model="code"
-            type="text"
-            required
-            class="w-full border rounded p-2"
-            placeholder="e.g. SPRING2025"
-          />
-        </div>
-
-        <!-- Max Claims -->
-        <div>
-          <label class="block font-medium mb-1">Max Claims</label>
-          <input
-            v-model.number="maxClaims"
-            type="number"
-            min="1"
-            required
-            class="w-full border rounded p-2"
-          />
-        </div>
-
-        <!-- Available At -->
-        <div>
-          <label class="block font-medium mb-1">Available At (CST)</label>
-          <input
-            v-model="startsAt"
-            type="datetime-local"
-            class="w-full border rounded p-2"
-          />
-          <p class="text-sm text-gray-500">
-            Leave blank or set to any date/time (including past) — users can only redeem on or after this time. Defaults to now (CST).
-          </p>
-        </div>
-
-        <!-- Expires At -->
-        <div>
-          <label class="block font-medium mb-1">Expires At (CST)</label>
-          <input
-            v-model="expiresAt"
-            type="datetime-local"
-            class="w-full border rounded p-2"
-          />
-          <p class="text-sm text-gray-500">
-            Leave blank for no expiration
-          </p>
-        </div>
-
-        <!-- Prerequisite cToons -->
-        <div>
-          <label class="block font-medium mb-1">Prerequisite cToons</label>
-
-          <div
-            v-for="(pc, idx) in prereqCtoons"
-            :key="idx"
-            class="flex items-center space-x-2 mb-2"
-          >
-            <datalist :id="`prereq-ctoon-list-${idx}`">
-              <option
-                v-for="ct in filteredCtoons(pc.ctoonName)"
-                :key="ct.id"
-                :value="ctoonLabel(ct)"
-              />
-            </datalist>
-
+      <div class="bg-white rounded border p-3">
+        <h1 class="text-base font-semibold mb-3">Create New Claim Code</h1>
+        <form @submit.prevent="submitForm" class="space-y-3">
+          <!-- Code -->
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Code</label>
             <input
-              v-model="pc.ctoonName"
-              :list="`prereq-ctoon-list-${idx}`"
+              v-model="code"
               type="text"
-              class="flex-1 border rounded p-2"
-              placeholder="Type 3+ characters to search"
+              required
+              class="border rounded-md px-2 py-1.5 text-sm"
+              placeholder="e.g. SPRING2025"
             />
-
-            <img
-              v-if="findCtoonByInput(pc.ctoonName)?.assetPath"
-              :src="findCtoonByInput(pc.ctoonName).assetPath"
-              class="w-8 h-8 object-cover rounded"
-              alt="cToon preview"
-            />
-            <button
-              type="button"
-              @click="removePrereqCtoon(idx)"
-              class="text-red-600 hover:underline"
-            >
-              Remove
-            </button>
           </div>
 
-          <button
-            type="button"
-            @click="addPrereqCtoon"
-            class="text-blue-600 hover:underline text-sm"
-          >
-            + Add prerequisite cToon
-          </button>
-          <p class="text-sm text-gray-500">Leave empty for no prerequisites.</p>
+          <!-- Max Claims -->
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Max Claims</label>
+            <input
+              v-model.number="maxClaims"
+              type="number"
+              min="1"
+              required
+              class="border rounded-md px-2 py-1.5 text-sm"
+            />
+          </div>
 
-          <div class="mt-3 space-y-2">
-            <label class="inline-flex items-center gap-2">
-              <input type="checkbox" v-model="prereqPoolEnabled" />
-              <span class="font-medium">Only require owning some cToons from this pool</span>
-            </label>
-            <div v-if="prereqPoolEnabled" class="flex items-center gap-2">
-              <span class="text-sm">Must own at least</span>
-              <input
-                v-model.number="prereqMinOwned"
-                type="number"
-                min="1"
-                class="w-24 border rounded p-2"
-              />
-              <span class="text-sm">of the selected cToons</span>
-            </div>
-            <p v-if="prereqPoolEnabled" class="text-sm text-gray-500">
-              Unchecked, users must own ALL prerequisite cToons. Checked, owning any {{ prereqMinOwned || 'X' }} from the pool is enough.
+          <!-- Available At -->
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Available At (CST)</label>
+            <input
+              v-model="startsAt"
+              type="datetime-local"
+              class="border rounded-md px-2 py-1.5 text-sm"
+            />
+            <p class="text-[10px] text-gray-500">
+              Leave blank or set to any date/time (including past) — users can only redeem on or after this time. Defaults to now (CST).
             </p>
-            <div v-if="prereqPoolEnabled">
-              <label class="block font-medium mb-1">Add Set</label>
-              <datalist id="prereq-set-list">
-                <option v-for="s in filteredSets(setSearch)" :key="s" :value="s" />
-              </datalist>
-              <input
-                v-model="setSearch"
-                list="prereq-set-list"
-                type="text"
-                class="w-full border rounded p-2"
-                placeholder="Type 3+ characters to search sets"
-                @change="onSetSelected"
-              />
-              <p class="text-sm text-gray-500">Selecting a set adds all of its cToons to the prerequisite list above.</p>
-            </div>
           </div>
-        </div>
 
-        <!-- Points Reward -->
-        <div>
-          <label class="block font-medium mb-1">Points Reward</label>
-          <input
-            v-model.number="points"
-            type="number"
-            min="0"
-            class="w-full border rounded p-2 bg-gray-100"
-          />
-        </div>
+          <!-- Expires At -->
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Expires At (CST)</label>
+            <input
+              v-model="expiresAt"
+              type="datetime-local"
+              class="border rounded-md px-2 py-1.5 text-sm"
+            />
+            <p class="text-[10px] text-gray-500">
+              Leave blank for no expiration
+            </p>
+          </div>
 
-        <!-- Pooled cToon Rewards -->
-        <div class="space-y-2">
-          <label class="inline-flex items-center gap-2">
-            <input type="checkbox" v-model="pooledEnabled" />
-            <span class="font-medium">Use pooled cToon rewards</span>
-          </label>
+          <!-- Prerequisite cToons -->
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Prerequisite cToons</label>
 
-          <div v-if="pooledEnabled" class="rounded border p-3 space-y-3">
-            <div>
-              <label class="block font-medium mb-1">Number to give out (unique)</label>
-              <input v-model.number="poolUniqueCount" type="number" min="1" class="w-32 border rounded p-2" />
-            </div>
-
-            <div>
-              <label class="block font-medium mb-1">Pool cToons</label>
-              <div v-for="(row, idx) in poolItems" :key="'pool-'+idx" class="flex items-center gap-2 mb-2">
-                <datalist :id="`pool-ctoons-${idx}`">
-                  <option v-for="ct in filteredCtoons(row.ctoonName)" :key="ct.id" :value="ctoonLabel(ct)" />
-                </datalist>
-
-                <input v-model="row.ctoonName" :list="`pool-ctoons-${idx}`" class="flex-1 border rounded p-2" placeholder="Type 3+ characters" />
-
-                <!-- NEW: preview -->
-                <img
-                  v-if="findCtoonByInput(row.ctoonName)?.assetPath"
-                  :src="findCtoonByInput(row.ctoonName).assetPath"
-                  class="w-8 h-8 object-cover rounded"
-                  alt="cToon preview"
+            <div
+              v-for="(pc, idx) in prereqCtoons"
+              :key="idx"
+              class="flex items-center gap-2"
+            >
+              <datalist :id="`prereq-ctoon-list-${idx}`">
+                <option
+                  v-for="ct in filteredCtoons(pc.ctoonName)"
+                  :key="ct.id"
+                  :value="ctoonLabel(ct)"
                 />
+              </datalist>
 
-                <input v-model.number="row.weight" type="number" min="1" class="w-20 border rounded p-2" title="Weight" />
-                <button type="button" @click="removePoolItem(idx)" class="text-red-600 hover:underline">Remove</button>
-              </div>
-              <button type="button" @click="addPoolItem" class="text-blue-600 hover:underline text-sm">+ Add pool cToon</button>
-              <p class="text-sm text-gray-500">Users receive <strong>unique</strong> picks from this pool.</p>
-            </div>
-          </div>
-        </div>
-
-        <!-- cToon Rewards -->
-        <div>
-          <label class="block font-medium mb-1">cToon Rewards</label>
-          <p class="text-sm text-gray-500 mb-2">
-            Optionally set an End Bonus Date/Time (CST) per cToon below — if set, that cToon is only
-            given out when redeemed between the code's Available At time and that cToon's End Bonus
-            Date/Time. Leave blank to give it out normally whenever the code is redeemed.
-          </p>
-
-          <div
-            v-for="(rc, idx) in ctoonRewards"
-            :key="idx"
-            class="border rounded p-3 mb-2 grid grid-cols-2 sm:grid-cols-[1fr_auto_5rem_auto] gap-2 sm:items-center"
-          >
-            <!-- per-row datalist fed by filtered options -->
-            <datalist :id="`ctoon-list-${idx}`">
-              <option
-                v-for="ct in filteredCtoons(rc.ctoonName)"
-                :key="ct.id"
-                :value="ctoonLabel(ct)"
-              />
-            </datalist>
-
-            <div class="col-span-2 sm:col-span-1">
-              <label class="text-xs text-gray-500 sm:hidden">cToon</label>
               <input
-                :value="rc.ctoonName"
-                @input="e => {
-                  const val = e.target.value;
-                  rc.ctoonName = val;
-                  onCtoonInput(val);
-                }"
-                :list="`ctoon-list-${idx}`"
+                v-model="pc.ctoonName"
+                :list="`prereq-ctoon-list-${idx}`"
                 type="text"
-                required
-                class="w-full border rounded p-2 text-base"
+                class="flex-1 border rounded-md px-2 py-1.5 text-sm"
                 placeholder="Type 3+ characters to search"
               />
-            </div>
 
-            <img
-              v-if="findCtoonByInput(rc.ctoonName)"
-              :src="findCtoonByInput(rc.ctoonName).assetPath"
-              class="w-8 h-8 object-cover rounded justify-self-center"
-              alt="cToon preview"
-            />
-
-            <div>
-              <label class="text-xs text-gray-500 sm:hidden">Qty</label>
-              <input
-                v-model.number="rc.quantity"
-                type="number"
-                min="1"
-                class="w-full sm:w-20 border rounded p-2 text-base"
-                placeholder="Qty"
+              <img
+                v-if="findCtoonByInput(pc.ctoonName)?.assetPath"
+                :src="findCtoonByInput(pc.ctoonName).assetPath"
+                class="w-7 h-7 object-cover rounded border"
+                alt="cToon preview"
               />
+              <button
+                type="button"
+                @click="removePrereqCtoon(idx)"
+                class="text-red-700 hover:underline text-[11px]"
+              >
+                Remove
+              </button>
             </div>
 
             <button
               type="button"
-              @click="removeCtoonReward(idx)"
-              class="text-red-600 hover:underline justify-self-end sm:justify-self-auto p-2 -m-2"
+              @click="addPrereqCtoon"
+              class="text-blue-600 hover:underline text-xs text-left"
             >
-              Remove
+              + Add prerequisite cToon
             </button>
+            <p class="text-[10px] text-gray-500">Leave empty for no prerequisites.</p>
 
-            <div class="col-span-2">
-              <label class="text-xs text-gray-500">End Bonus Date/Time (CST) &middot; optional</label>
-              <input
-                v-model="rc.endBonusAt"
-                type="datetime-local"
-                class="w-full border rounded p-2 text-base"
-              />
+            <div class="mt-1 space-y-1">
+              <label class="inline-flex items-center gap-2">
+                <input type="checkbox" v-model="prereqPoolEnabled" />
+                <span class="text-xs font-medium">Only require owning some cToons from this pool</span>
+              </label>
+              <div v-if="prereqPoolEnabled" class="flex items-center gap-2">
+                <span class="text-xs">Must own at least</span>
+                <input
+                  v-model.number="prereqMinOwned"
+                  type="number"
+                  min="1"
+                  class="w-20 border rounded-md px-2 py-1 text-sm"
+                />
+                <span class="text-xs">of the selected cToons</span>
+              </div>
+              <p v-if="prereqPoolEnabled" class="text-[10px] text-gray-500">
+                Unchecked, users must own ALL prerequisite cToons. Checked, owning any {{ prereqMinOwned || 'X' }} from the pool is enough.
+              </p>
+              <div v-if="prereqPoolEnabled" class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Add Set</label>
+                <datalist id="prereq-set-list">
+                  <option v-for="s in filteredSets(setSearch)" :key="s" :value="s" />
+                </datalist>
+                <input
+                  v-model="setSearch"
+                  list="prereq-set-list"
+                  type="text"
+                  class="border rounded-md px-2 py-1.5 text-sm"
+                  placeholder="Type 3+ characters to search sets"
+                  @change="onSetSelected"
+                />
+                <p class="text-[10px] text-gray-500">Selecting a set adds all of its cToons to the prerequisite list above.</p>
+              </div>
             </div>
           </div>
 
-          <button
-            type="button"
-            @click="addCtoonReward"
-            class="text-blue-600 hover:underline text-sm"
-          >
-            + Add another cToon
-          </button>
-        </div>
-
-        <div>
-          <label class="block font-medium mb-1">Background Rewards (CODE_ONLY)</label>
-          <datalist id="bg-list">
-            <option v-for="b in bgOptions" :key="b.id" :value="b.label || b.id" />
-          </datalist>
-          <div v-for="(rb, idx) in bgRewards" :key="idx" class="flex items-center gap-2 mb-2">
-            <input v-model="rb.bgLabel" list="bg-list" class="flex-1 border rounded p-2" placeholder="Type or select background label" />
-            <img v-if="findBg(rb.bgLabel)?.imagePath" :src="findBg(rb.bgLabel).imagePath" class="w-12 h-8 object-cover rounded border" />
-            <button type="button" @click="removeBgReward(idx)" class="text-red-600 hover:underline">Remove</button>
+          <!-- Points Reward -->
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Points Reward</label>
+            <input
+              v-model.number="points"
+              type="number"
+              min="0"
+              class="border rounded-md px-2 py-1.5 text-sm bg-gray-100"
+            />
           </div>
-          <button type="button" @click="addBgReward" class="text-blue-600 hover:underline text-sm">+ Add background</button>
-        </div>
 
-        <!-- Submit & Errors -->
-        <div class="pt-4 border-t">
-          <button
-            type="submit"
-            class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-          >
-            Save Code
-          </button>
-          <p v-if="error" class="mt-2 text-red-600">{{ error }}</p>
-          <p v-if="!error && warning" class="mt-2 text-amber-600">{{ warning }}</p>
-        </div>
-      </form>
+          <!-- Pooled cToon Rewards -->
+          <div class="space-y-1">
+            <label class="inline-flex items-center gap-2">
+              <input type="checkbox" v-model="pooledEnabled" />
+              <span class="text-xs font-medium">Use pooled cToon rewards</span>
+            </label>
+
+            <div v-if="pooledEnabled" class="bg-white rounded border p-2 space-y-2">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Number to give out (unique)</label>
+                <input v-model.number="poolUniqueCount" type="number" min="1" class="w-28 border rounded-md px-2 py-1 text-sm" />
+              </div>
+
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Pool cToons</label>
+                <div v-for="(row, idx) in poolItems" :key="'pool-'+idx" class="flex items-center gap-2">
+                  <datalist :id="`pool-ctoons-${idx}`">
+                    <option v-for="ct in filteredCtoons(row.ctoonName)" :key="ct.id" :value="ctoonLabel(ct)" />
+                  </datalist>
+
+                  <input v-model="row.ctoonName" :list="`pool-ctoons-${idx}`" class="flex-1 border rounded-md px-2 py-1.5 text-sm" placeholder="Type 3+ characters" />
+
+                  <!-- NEW: preview -->
+                  <img
+                    v-if="findCtoonByInput(row.ctoonName)?.assetPath"
+                    :src="findCtoonByInput(row.ctoonName).assetPath"
+                    class="w-7 h-7 object-cover rounded border"
+                    alt="cToon preview"
+                  />
+
+                  <input v-model.number="row.weight" type="number" min="1" class="w-16 border rounded px-1 py-0.5 text-xs" title="Weight" />
+                  <button type="button" @click="removePoolItem(idx)" class="text-red-700 hover:underline text-[11px]">Remove</button>
+                </div>
+                <button type="button" @click="addPoolItem" class="text-blue-600 hover:underline text-xs text-left">+ Add pool cToon</button>
+                <p class="text-[10px] text-gray-500">Users receive <strong>unique</strong> picks from this pool.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- cToon Rewards -->
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">cToon Rewards</label>
+            <p class="text-[10px] text-gray-500">
+              Optionally set an End Bonus Date/Time (CST) per cToon below — if set, that cToon is only
+              given out when redeemed between the code's Available At time and that cToon's End Bonus
+              Date/Time. Leave blank to give it out normally whenever the code is redeemed.
+            </p>
+
+            <div
+              v-for="(rc, idx) in ctoonRewards"
+              :key="idx"
+              class="border rounded-md p-2 grid grid-cols-2 sm:grid-cols-[1fr_auto_5rem_auto] gap-2 sm:items-center"
+            >
+              <!-- per-row datalist fed by filtered options -->
+              <datalist :id="`ctoon-list-${idx}`">
+                <option
+                  v-for="ct in filteredCtoons(rc.ctoonName)"
+                  :key="ct.id"
+                  :value="ctoonLabel(ct)"
+                />
+              </datalist>
+
+              <div class="col-span-2 sm:col-span-1">
+                <label class="text-[10px] text-gray-500 sm:hidden">cToon</label>
+                <input
+                  :value="rc.ctoonName"
+                  @input="e => {
+                    const val = e.target.value;
+                    rc.ctoonName = val;
+                    onCtoonInput(val);
+                  }"
+                  :list="`ctoon-list-${idx}`"
+                  type="text"
+                  required
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
+                  placeholder="Type 3+ characters to search"
+                />
+              </div>
+
+              <img
+                v-if="findCtoonByInput(rc.ctoonName)"
+                :src="findCtoonByInput(rc.ctoonName).assetPath"
+                class="w-7 h-7 object-cover rounded border justify-self-center"
+                alt="cToon preview"
+              />
+
+              <div>
+                <label class="text-[10px] text-gray-500 sm:hidden">Qty</label>
+                <input
+                  v-model.number="rc.quantity"
+                  type="number"
+                  min="1"
+                  class="w-full sm:w-16 border rounded px-1 py-1 text-sm"
+                  placeholder="Qty"
+                />
+              </div>
+
+              <button
+                type="button"
+                @click="removeCtoonReward(idx)"
+                class="text-red-700 hover:underline text-[11px] justify-self-end sm:justify-self-auto"
+              >
+                Remove
+              </button>
+
+              <div class="col-span-2 flex flex-col gap-1">
+                <label class="text-[10px] text-gray-500">End Bonus Date/Time (CST) &middot; optional</label>
+                <input
+                  v-model="rc.endBonusAt"
+                  type="datetime-local"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
+                />
+              </div>
+            </div>
+
+            <button
+              type="button"
+              @click="addCtoonReward"
+              class="text-blue-600 hover:underline text-xs text-left"
+            >
+              + Add another cToon
+            </button>
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Background Rewards (CODE_ONLY)</label>
+            <datalist id="bg-list">
+              <option v-for="b in bgOptions" :key="b.id" :value="b.label || b.id" />
+            </datalist>
+            <div v-for="(rb, idx) in bgRewards" :key="idx" class="flex items-center gap-2">
+              <input v-model="rb.bgLabel" list="bg-list" class="flex-1 border rounded-md px-2 py-1.5 text-sm" placeholder="Type or select background label" />
+              <img v-if="findBg(rb.bgLabel)?.imagePath" :src="findBg(rb.bgLabel).imagePath" class="w-10 h-7 object-cover rounded border" />
+              <button type="button" @click="removeBgReward(idx)" class="text-red-700 hover:underline text-[11px]">Remove</button>
+            </div>
+            <button type="button" @click="addBgReward" class="text-blue-600 hover:underline text-xs text-left">+ Add background</button>
+          </div>
+
+          <!-- Submit & Errors -->
+          <div class="pt-3 border-t">
+            <button
+              type="submit"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700"
+            >
+              Save Code
+            </button>
+            <p v-if="error" class="mt-2 text-[11px] text-red-600">{{ error }}</p>
+            <p v-if="!error && warning" class="mt-2 text-[11px] text-amber-600">{{ warning }}</p>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyCtoonSuggestions.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCtoonSuggestions.vue
@@ -1,21 +1,22 @@
 <template>
-  <div class="bg-gray-50 p-6">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-6xl mx-auto bg-white rounded-lg shadow p-6 ">
-      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between mb-6">
+    <div class="px-2 py-2">
+    <div class="bg-white rounded-lg shadow p-3">
+      <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-3">
         <div>
-          <h1 class="text-2xl font-semibold">cToon Suggestions</h1>
-          <p class="text-sm text-gray-500">{{ headerDescription }}</p>
-          <div class="mt-3 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+          <h1 class="text-base font-semibold">cToon Suggestions</h1>
+          <p class="text-xs text-gray-500">{{ headerDescription }}</p>
+          <div class="mt-2 inline-flex rounded-md border border-gray-200 bg-gray-50 p-0.5">
             <button
-              class="px-3 py-1.5 text-sm rounded-md transition"
+              class="px-2 py-1 text-xs rounded-md transition"
               :class="activeTab === 'IN_REVIEW' ? 'bg-white shadow text-gray-900' : 'text-gray-600 hover:text-gray-900'"
               @click="setTab('IN_REVIEW')"
             >
               In Review
             </button>
             <button
-              class="px-3 py-1.5 text-sm rounded-md transition"
+              class="px-2 py-1 text-xs rounded-md transition"
               :class="activeTab === 'HISTORY' ? 'bg-white shadow text-gray-900' : 'text-gray-600 hover:text-gray-900'"
               @click="setTab('HISTORY')"
             >
@@ -24,7 +25,7 @@
           </div>
         </div>
         <button
-          class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
           :disabled="loading"
           @click="fetchSuggestions"
         >
@@ -32,17 +33,17 @@
         </button>
       </div>
 
-      <div v-if="loading" class="text-gray-500">Loading suggestions...</div>
-      <div v-else-if="error" class="text-red-600">{{ error }}</div>
-      <div v-else-if="!suggestions.length" class="text-gray-500">
+      <div v-if="loading" class="text-gray-500 py-6 text-center">Loading suggestions...</div>
+      <div v-else-if="error" class="text-red-600 py-6 text-center">{{ error }}</div>
+      <div v-else-if="!suggestions.length" class="text-gray-500 py-6 text-center">
         {{ activeTab === 'HISTORY' ? 'No accepted or rejected suggestions yet.' : 'No suggestions currently in review.' }}
       </div>
 
       <div v-else>
         <!-- Mobile cards -->
-        <div class="space-y-3 md:hidden">
-          <div v-for="s in suggestions" :key="s.id" class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-            <div class="flex items-start gap-3">
+        <div class="space-y-2 md:hidden">
+          <div v-for="s in suggestions" :key="s.id" class="bg-white border rounded-lg shadow p-2">
+            <div class="flex items-start gap-2">
               <input
                 v-if="activeTab === 'IN_REVIEW'"
                 type="checkbox"
@@ -57,21 +58,21 @@
                 class="w-14 h-14 object-contain rounded bg-gray-100 p-1"
               />
               <div class="flex-1">
-                <div class="font-semibold text-gray-900">{{ s.ctoon?.name || 'Unknown cToon' }}</div>
-                <div class="text-xs text-gray-500">{{ s.ctoon?.series || 'No series' }} · {{ s.ctoon?.set || 'No set' }}</div>
-                <div class="mt-2 text-sm text-gray-700">
+                <div class="font-semibold text-xs text-gray-900">{{ s.ctoon?.name || 'Unknown cToon' }}</div>
+                <div class="text-[10px] text-gray-500">{{ s.ctoon?.series || 'No series' }} · {{ s.ctoon?.set || 'No set' }}</div>
+                <div class="mt-1 text-xs text-gray-700">
                   Suggested by <span class="font-medium">{{ s.user?.username || 'Unknown' }}</span>
                 </div>
-                <div class="text-xs text-gray-500">{{ s.user?.discordTag || 'No tag' }}</div>
-                <div class="mt-2 text-xs text-gray-500">Submitted {{ formatDateTime(s.createdAt) }}</div>
-                <div v-if="activeTab === 'HISTORY'" class="mt-1 text-xs text-gray-600">
+                <div class="text-[10px] text-gray-500">{{ s.user?.discordTag || 'No tag' }}</div>
+                <div class="mt-1 text-[10px] text-gray-500">Submitted {{ formatDateTime(s.createdAt) }}</div>
+                <div v-if="activeTab === 'HISTORY'" class="mt-0.5 text-[10px] text-gray-600">
                   Status: <span class="font-semibold">{{ formatStatus(s.status) }}</span>
                 </div>
               </div>
             </div>
-            <div class="mt-4 flex justify-end">
+            <div class="mt-2 flex justify-end">
               <button
-                class="text-blue-600 hover:text-blue-800 font-medium"
+                class="text-xs text-blue-600 hover:text-blue-800 font-medium"
                 @click="openReview(s)"
               >
                 {{ activeTab === 'HISTORY' ? 'View' : 'Review' }}
@@ -82,10 +83,10 @@
 
         <!-- Desktop table -->
         <div class="hidden md:block overflow-x-auto">
-          <table class="min-w-full table-auto border-collapse">
+          <table class="min-w-full table-auto border-collapse text-xs">
             <thead>
-              <tr class="bg-gray-100">
-                <th v-if="activeTab === 'IN_REVIEW'" class="px-4 py-2 w-10">
+              <tr>
+                <th v-if="activeTab === 'IN_REVIEW'" class="px-2 py-1.5 w-10 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">
                   <input
                     ref="selectAllCheckboxRef"
                     type="checkbox"
@@ -94,16 +95,16 @@
                     @change="toggleAll"
                   />
                 </th>
-                <th class="px-4 py-2 text-left">cToon</th>
-                <th class="px-4 py-2 text-left">Suggested By</th>
-                <th class="px-4 py-2 text-left">Submitted</th>
-                <th v-if="activeTab === 'HISTORY'" class="px-4 py-2 text-left">Status</th>
-                <th class="px-4 py-2 text-right">Action</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">cToon</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Suggested By</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Submitted</th>
+                <th v-if="activeTab === 'HISTORY'" class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Status</th>
+                <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600 bg-gray-100">Action</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="s in suggestions" :key="s.id" class="border-b">
-                <td v-if="activeTab === 'IN_REVIEW'" class="px-4 py-2 w-10">
+                <td v-if="activeTab === 'IN_REVIEW'" class="px-2 py-1.5 w-10">
                   <input
                     type="checkbox"
                     class="h-4 w-4 rounded border-gray-300 text-blue-600 cursor-pointer"
@@ -111,29 +112,29 @@
                     @change="toggleSelection(s.id)"
                   />
                 </td>
-                <td class="px-4 py-2">
-                  <div class="flex items-center gap-3">
+                <td class="px-2 py-1.5">
+                  <div class="flex items-center gap-2">
                     <img
                       v-if="s.ctoon?.assetPath"
                       :src="s.ctoon.assetPath"
                       :alt="s.ctoon?.name || 'cToon'"
-                      class="w-12 h-12 object-contain rounded bg-gray-100 p-1"
+                      class="w-10 h-10 object-contain rounded bg-gray-100 p-1"
                     />
                     <div>
                       <div class="font-medium">{{ s.ctoon?.name || 'Unknown cToon' }}</div>
-                      <div class="text-xs text-gray-500">{{ s.ctoon?.series || 'No series' }} · {{ s.ctoon?.set || 'No set' }}</div>
+                      <div class="text-[10px] text-gray-500">{{ s.ctoon?.series || 'No series' }} · {{ s.ctoon?.set || 'No set' }}</div>
                     </div>
                   </div>
                 </td>
-                <td class="px-4 py-2">
+                <td class="px-2 py-1.5">
                   <div class="font-medium">{{ s.user?.username || 'Unknown' }}</div>
-                  <div class="text-xs text-gray-500">{{ s.user?.discordTag || 'No tag' }}</div>
+                  <div class="text-[10px] text-gray-500">{{ s.user?.discordTag || 'No tag' }}</div>
                 </td>
-                <td class="px-4 py-2 text-sm text-gray-600">{{ formatDateTime(s.createdAt) }}</td>
-                <td v-if="activeTab === 'HISTORY'" class="px-4 py-2 text-sm text-gray-600">
+                <td class="px-2 py-1.5 text-gray-600">{{ formatDateTime(s.createdAt) }}</td>
+                <td v-if="activeTab === 'HISTORY'" class="px-2 py-1.5 text-gray-600">
                   {{ formatStatus(s.status) }}
                 </td>
-                <td class="px-4 py-2 text-right">
+                <td class="px-2 py-1.5 text-right">
                   <button
                     class="text-blue-600 hover:text-blue-800 font-medium"
                     @click="openReview(s)"
@@ -146,18 +147,18 @@
           </table>
         </div>
 
-        <div v-if="total > 0" class="mt-4 flex flex-col gap-2 text-sm text-gray-600 md:flex-row md:items-center md:justify-between">
+        <div v-if="total > 0" class="mt-3 flex flex-col gap-2 text-xs text-gray-600 md:flex-row md:items-center md:justify-between">
           <div>{{ showingRange }}</div>
           <div class="space-x-2">
             <button
-              class="px-3 py-1 text-sm border rounded-md disabled:opacity-50"
+              class="px-3 py-1 text-xs border rounded-md disabled:opacity-50"
               :disabled="page <= 1 || loading"
               @click="prevPage"
             >
               Prev
             </button>
             <button
-              class="px-3 py-1 text-sm border rounded-md disabled:opacity-50"
+              class="px-3 py-1 text-xs border rounded-md disabled:opacity-50"
               :disabled="page >= totalPages || loading"
               @click="nextPage"
             >
@@ -167,6 +168,7 @@
         </div>
       </div>
     </div>
+    </div>
 
     <!-- Individual review modal -->
     <Modal
@@ -175,26 +177,26 @@
       :close-on-backdrop="true"
       @close="closeReview"
     >
-      <div class="text-white flex flex-col max-h-[80vh]">
-        <div class="flex items-start gap-4 pb-4 border-b border-white/10 shrink-0">
+      <div class="text-white text-xs flex flex-col max-h-[80vh]">
+        <div class="flex items-start gap-3 pb-3 border-b border-white/10 shrink-0">
           <img
             v-if="selectedSuggestion.ctoon?.assetPath"
             :src="selectedSuggestion.ctoon.assetPath"
             :alt="selectedSuggestion.ctoon?.name || 'cToon'"
-            class="w-20 h-20 object-contain rounded bg-gray-900/40 p-2"
+            class="w-16 h-16 object-contain rounded bg-gray-900/40 p-2"
           />
           <div>
-            <h3 class="text-xl font-semibold">Review Suggestion</h3>
-            <p class="text-sm text-gray-300">{{ selectedSuggestion.ctoon?.name || 'cToon' }}</p>
-            <p class="text-xs text-gray-400">Submitted by {{ selectedSuggestion.user?.username || 'Unknown' }}</p>
+            <h3 class="text-sm font-semibold">Review Suggestion</h3>
+            <p class="text-xs text-gray-300">{{ selectedSuggestion.ctoon?.name || 'cToon' }}</p>
+            <p class="text-[10px] text-gray-400">Submitted by {{ selectedSuggestion.user?.username || 'Unknown' }}</p>
           </div>
         </div>
 
-        <div class="flex-1 min-h-0 overflow-y-auto py-4 space-y-4">
-          <div class="grid grid-cols-1 gap-4">
-            <div class="rounded bg-gray-700/60 p-3">
-              <div class="text-xs uppercase text-gray-300 mb-2">Current Values</div>
-              <div class="text-sm text-gray-100 space-y-1">
+        <div class="flex-1 min-h-0 overflow-y-auto py-3 space-y-3">
+          <div class="grid grid-cols-1 gap-3">
+            <div class="rounded bg-gray-700/60 p-2">
+              <div class="text-[10px] uppercase text-gray-300 mb-1.5">Current Values</div>
+              <div class="text-xs text-gray-100 space-y-1">
                 <div><strong>Name:</strong> {{ formatValue(selectedSuggestion.ctoon?.name) }}</div>
                 <div><strong>Series:</strong> {{ formatValue(selectedSuggestion.ctoon?.series) }}</div>
                 <div><strong>Set:</strong> {{ formatValue(selectedSuggestion.ctoon?.set) }}</div>
@@ -203,9 +205,9 @@
               </div>
             </div>
 
-            <div class="rounded bg-gray-700/60 p-3">
-              <div class="text-xs uppercase text-gray-300 mb-2">Suggested Values</div>
-              <div class="text-sm text-gray-100 space-y-1">
+            <div class="rounded bg-gray-700/60 p-2">
+              <div class="text-[10px] uppercase text-gray-300 mb-1.5">Suggested Values</div>
+              <div class="text-xs text-gray-100 space-y-1">
                 <div><strong>Name:</strong> {{ formatValue(selectedSuggestion.newValues?.name) }}</div>
                 <div><strong>Series:</strong> {{ formatValue(selectedSuggestion.newValues?.series) }}</div>
                 <div><strong>Set:</strong> {{ formatValue(selectedSuggestion.newValues?.set) }}</div>
@@ -215,45 +217,45 @@
             </div>
           </div>
 
-          <div class="text-xs text-gray-400">
+          <div class="text-[10px] text-gray-400">
             Submitted {{ formatDateTime(selectedSuggestion.createdAt) }}
           </div>
 
-          <div class="text-xs text-gray-300">
+          <div class="text-[10px] text-gray-300">
             Status: <span class="font-semibold">{{ formatStatus(selectedSuggestion.status) }}</span>
           </div>
 
-          <div v-if="canReview" class="rounded bg-gray-700/60 p-3">
-            <label class="block text-xs uppercase text-gray-300 mb-2" for="reject-reason">
+          <div v-if="canReview" class="rounded bg-gray-700/60 p-2">
+            <label class="block text-[10px] uppercase text-gray-300 mb-1.5" for="reject-reason">
               Rejection reason (sent via Discord)
             </label>
             <textarea
               id="reject-reason"
               v-model="rejectReason"
-              class="w-full rounded bg-gray-900/70 text-gray-100 p-2 text-sm border border-gray-600 focus:outline-none focus:ring-2 focus:ring-red-400/60"
+              class="w-full rounded-md bg-gray-900/70 text-gray-100 px-2 py-1.5 text-xs border border-gray-600 focus:outline-none focus:ring-2 focus:ring-red-400/60"
               rows="3"
               placeholder="Share the key reason for rejection..."
               :disabled="actionLoading"
             />
-            <div class="text-xs text-gray-400 mt-2">Required if you reject this suggestion.</div>
+            <div class="text-[10px] text-gray-400 mt-1.5">Required if you reject this suggestion.</div>
           </div>
 
           <div
             v-if="selectedSuggestion.status === 'REJECTED' && selectedSuggestion.rejectionReason"
-            class="rounded bg-gray-700/60 p-3"
+            class="rounded bg-gray-700/60 p-2"
           >
-            <div class="text-xs uppercase text-gray-300 mb-2">Saved rejection reason</div>
-            <div class="text-sm text-gray-100 whitespace-pre-line">{{ selectedSuggestion.rejectionReason }}</div>
+            <div class="text-[10px] uppercase text-gray-300 mb-1.5">Saved rejection reason</div>
+            <div class="text-xs text-gray-100 whitespace-pre-line">{{ selectedSuggestion.rejectionReason }}</div>
           </div>
 
-          <div v-if="actionError" class="text-sm text-red-300">
+          <div v-if="actionError" class="text-xs text-red-300">
             {{ actionError }}
           </div>
         </div>
 
-        <div class="pt-4 border-t border-white/10 flex items-center justify-end gap-3 shrink-0">
+        <div class="pt-3 border-t border-white/10 flex items-center justify-end gap-2 shrink-0">
           <button
-            class="bg-gray-600 hover:bg-gray-700 text-white px-3 py-2 rounded text-sm"
+            class="px-3 py-1 text-xs border border-gray-600 rounded-md hover:bg-gray-700"
             :disabled="actionLoading"
             @click="closeReview"
           >
@@ -261,14 +263,14 @@
           </button>
           <template v-if="canReview">
             <button
-              class="bg-red-600 hover:bg-red-700 text-white px-3 py-2 rounded text-sm disabled:opacity-50"
+              class="px-3 py-1 text-xs rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
               :disabled="actionLoading"
               @click="rejectSuggestion"
             >
               {{ actionLoading ? 'Working...' : 'Reject' }}
             </button>
             <button
-              class="bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded text-sm disabled:opacity-50"
+              class="px-3 py-1 text-xs rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
               :disabled="actionLoading"
               @click="acceptSuggestion"
             >
@@ -286,37 +288,37 @@
       :close-on-backdrop="!bulkActionLoading"
       @close="closeBulkRejectModal"
     >
-      <div class="text-white flex flex-col">
-        <div class="pb-4 border-b border-white/10">
-          <h3 class="text-xl font-semibold">
+      <div class="text-white text-xs flex flex-col">
+        <div class="pb-3 border-b border-white/10">
+          <h3 class="text-sm font-semibold">
             Bulk Reject {{ selectedIds.size }} Suggestion{{ selectedIds.size !== 1 ? 's' : '' }}
           </h3>
-          <p class="text-sm text-gray-300 mt-1">This rejection reason will be sent to each user via Discord.</p>
+          <p class="text-xs text-gray-300 mt-1">This rejection reason will be sent to each user via Discord.</p>
         </div>
-        <div class="py-4">
-          <label class="block text-xs uppercase text-gray-300 mb-2" for="bulk-reject-reason">
+        <div class="py-3">
+          <label class="block text-[10px] uppercase text-gray-300 mb-1.5" for="bulk-reject-reason">
             Rejection reason (required)
           </label>
           <textarea
             id="bulk-reject-reason"
             v-model="bulkRejectReason"
-            class="w-full rounded bg-gray-900/70 text-gray-100 p-2 text-sm border border-gray-600 focus:outline-none focus:ring-2 focus:ring-red-400/60"
+            class="w-full rounded-md bg-gray-900/70 text-gray-100 px-2 py-1.5 text-xs border border-gray-600 focus:outline-none focus:ring-2 focus:ring-red-400/60"
             rows="4"
             placeholder="Share the key reason for rejection..."
             :disabled="bulkActionLoading"
           />
-          <div v-if="bulkActionError" class="text-sm text-red-300 mt-2">{{ bulkActionError }}</div>
+          <div v-if="bulkActionError" class="text-xs text-red-300 mt-2">{{ bulkActionError }}</div>
         </div>
-        <div class="pt-4 border-t border-white/10 flex items-center justify-end gap-3">
+        <div class="pt-3 border-t border-white/10 flex items-center justify-end gap-2">
           <button
-            class="bg-gray-600 hover:bg-gray-700 text-white px-3 py-2 rounded text-sm disabled:opacity-50"
+            class="px-3 py-1 text-xs border border-gray-600 rounded-md hover:bg-gray-700 disabled:opacity-50"
             :disabled="bulkActionLoading"
             @click="closeBulkRejectModal"
           >
             Cancel
           </button>
           <button
-            class="bg-red-600 hover:bg-red-700 text-white px-3 py-2 rounded text-sm disabled:opacity-50"
+            class="px-3 py-1 text-xs rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
             :disabled="bulkActionLoading"
             @click="confirmBulkReject"
           >
@@ -330,9 +332,9 @@
     <Transition name="slide-up">
       <div
         v-if="activeTab === 'IN_REVIEW' && selectedIds.size > 0"
-        class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-xl bg-gray-900 px-5 py-3 shadow-2xl border border-gray-700"
+        class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 shadow-2xl border border-gray-700"
       >
-        <span class="text-sm text-white font-medium whitespace-nowrap">
+        <span class="text-xs text-white font-medium whitespace-nowrap">
           {{ selectedIds.size }} selected
         </span>
         <button
@@ -343,14 +345,14 @@
         </button>
         <div class="w-px h-5 bg-gray-600" />
         <button
-          class="bg-green-600 hover:bg-green-700 text-white px-4 py-1.5 rounded-md text-sm font-medium disabled:opacity-50 whitespace-nowrap"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 whitespace-nowrap"
           :disabled="bulkActionLoading"
           @click="bulkAccept"
         >
           {{ bulkActionLoading ? 'Working...' : 'Approve' }}
         </button>
         <button
-          class="bg-red-600 hover:bg-red-700 text-white px-4 py-1.5 rounded-md text-sm font-medium disabled:opacity-50 whitespace-nowrap"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 whitespace-nowrap"
           :disabled="bulkActionLoading"
           @click="openBulkRejectModal"
         >

--- a/components/newsite/admin/legacy/AdminLegacyCtoons.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCtoons.vue
@@ -1,20 +1,21 @@
 <template>
-  <div class="bg-gray-50 p-6">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
-    <div class="max-w-6xl mx-auto bg-white rounded-lg shadow p-6 ">
-      <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between mb-6 space-y-4 lg:space-y-0">
-        <h1 class="text-2xl font-semibold">All cToons</h1>
+      <div class="max-w-6xl mx-auto bg-white rounded-lg shadow p-3">
+      <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between mb-3 gap-2">
+        <h1 class="text-base font-semibold">All cToons</h1>
         <div class="flex flex-wrap gap-2">
           <NuxtLink
             to="/newsite/admin/ctoons/new"
-            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
           >
             Create cToon
           </NuxtLink>
 
           <NuxtLink
             to="/newsite/admin/ctoonsBulkUpload"
-            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
           >
             Bulk Upload cToons
           </NuxtLink>
@@ -23,7 +24,7 @@
             :disabled="!isSearching"
             @click="openBulkEdit"
             :class="[
-              'px-4 py-2 rounded font-medium transition-colors',
+              'px-3 py-1.5 text-xs font-semibold rounded-md transition-colors',
               isSearching
                 ? 'bg-indigo-600 text-white hover:bg-indigo-700'
                 : 'bg-gray-200 text-gray-400 cursor-not-allowed'
@@ -37,7 +38,7 @@
             :disabled="!isSearching"
             @click="openMakeSecondEdition"
             :class="[
-              'px-4 py-2 rounded font-medium transition-colors',
+              'px-3 py-1.5 text-xs font-semibold rounded-md transition-colors',
               isSearching
                 ? 'bg-purple-600 text-white hover:bg-purple-700'
                 : 'bg-gray-200 text-gray-400 cursor-not-allowed'
@@ -50,16 +51,16 @@
       </div>
 
       <!-- FILTER BAR -->
-      <div class="flex flex-col lg:flex-row gap-4 mb-6">
+      <div class="flex flex-col sm:flex-row gap-2 mb-3">
         <input
           type="text"
           v-model="searchTerm"
           placeholder="Search by name…"
-          class="flex-1 border border-gray-300 rounded px-3 py-2 focus:ring-indigo-500 focus:border-indigo-500"
+          class="flex-1 border rounded-md px-2 py-1.5 text-sm focus:ring-indigo-500 focus:border-indigo-500"
         />
         <select
           v-model="selectedSet"
-          class="border border-gray-300 rounded px-3 py-2 focus:ring-indigo-500 focus:border-indigo-500 max-w-[350px]"
+          class="border rounded-md px-2 py-1.5 text-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-[280px]"
         >
           <option value="">All Sets</option>
           <option v-for="set in setsOptions" :key="set" :value="set">
@@ -68,7 +69,7 @@
         </select>
         <select
           v-model="selectedSeries"
-          class="border border-gray-300 rounded px-3 py-2 focus:ring-indigo-500 focus:border-indigo-500 max-w-[350px]"
+          class="border rounded-md px-2 py-1.5 text-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-[280px]"
         >
           <option value="">All Series</option>
           <option v-for="series in seriesOptions" :key="series" :value="series">
@@ -79,44 +80,44 @@
 
       <!-- TABLE VIEW (desktop) -->
       <div class="overflow-x-auto hidden lg:block">
-        <table class="min-w-full table-auto border-collapse">
+        <table class="min-w-full table-auto border-collapse text-xs">
           <thead>
             <tr class="bg-gray-100">
-              <th class="px-4 py-2 text-left">Asset</th>
-              <th class="px-4 py-2 text-left">Name</th>
-              <th class="px-4 py-2 text-left">Release Date (CDT)</th>
-              <th class="px-4 py-2 text-left">Rarity</th>
-              <th class="px-4 py-2 text-right">Highest Mint</th>
-              <th class="px-4 py-2 text-right">Quantity</th>
-              <th class="px-4 py-2 text-center">In C-mart</th>
-              <th class="px-4 py-2 text-right">Edit</th>
+              <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Asset</th>
+              <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Name</th>
+              <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Release Date (CDT)</th>
+              <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Rarity</th>
+              <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600">Highest Mint</th>
+              <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600">Quantity</th>
+              <th class="px-2 py-1.5 text-center text-[11px] font-semibold text-gray-600">In C-mart</th>
+              <th class="px-2 py-1.5 text-right text-[11px] font-semibold text-gray-600">Edit</th>
             </tr>
           </thead>
           <!-- Skeleton rows while loading or searching -->
           <tbody v-if="loading || (isSearching && searching)">
             <tr v-for="n in 8" :key="`skeleton-desktop-${n}`" class="border-b">
-              <td class="px-4 py-2">
+              <td class="px-2 py-1.5">
                 <div class="h-16 w-24 bg-gray-200 rounded animate-pulse"></div>
               </td>
-              <td class="px-4 py-2">
+              <td class="px-2 py-1.5">
                 <div class="h-4 w-40 bg-gray-200 rounded animate-pulse"></div>
               </td>
-              <td class="px-4 py-2">
+              <td class="px-2 py-1.5">
                 <div class="h-4 w-56 bg-gray-200 rounded animate-pulse"></div>
               </td>
-              <td class="px-4 py-2">
+              <td class="px-2 py-1.5">
                 <div class="h-4 w-24 bg-gray-200 rounded animate-pulse"></div>
               </td>
-              <td class="px-4 py-2 text-right">
+              <td class="px-2 py-1.5 text-right">
                 <div class="h-4 w-14 ml-auto bg-gray-200 rounded animate-pulse"></div>
               </td>
-              <td class="px-4 py-2 text-right">
+              <td class="px-2 py-1.5 text-right">
                 <div class="h-4 w-16 ml-auto bg-gray-200 rounded animate-pulse"></div>
               </td>
-              <td class="px-4 py-2 text-center">
+              <td class="px-2 py-1.5 text-center">
                 <div class="h-4 w-10 mx-auto bg-gray-200 rounded animate-pulse"></div>
               </td>
-              <td class="px-4 py-2 text-right">
+              <td class="px-2 py-1.5 text-right">
                 <div class="h-4 w-10 ml-auto bg-gray-200 rounded animate-pulse"></div>
               </td>
             </tr>
@@ -128,7 +129,7 @@
               :key="c.id"
               class="border-b hover:bg-gray-50"
             >
-              <td class="px-4 py-2">
+              <td class="px-2 py-1.5">
                 <div class="relative w-fit mx-auto">
                   <img
                     loading="lazy"
@@ -139,8 +140,8 @@
                   <SecondEditionOverlay :ctoon="c" />
                 </div>
               </td>
-              <td class="px-4 py-2">{{ c.name }}</td>
-              <td class="px-4 py-2 whitespace-nowrap">
+              <td class="px-2 py-1.5">{{ c.name }}</td>
+              <td class="px-2 py-1.5 whitespace-nowrap">
                 {{
                   new Date(c.releaseDate).toLocaleString('en-US', {
                     year: 'numeric',
@@ -153,15 +154,15 @@
                   })
                 }}
               </td>
-              <td class="px-4 py-2">{{ c.rarity }}</td>
-              <td class="px-4 py-2 text-right">{{ c.highestMint }}</td>
-              <td class="px-4 py-2 text-right">
+              <td class="px-2 py-1.5">{{ c.rarity }}</td>
+              <td class="px-2 py-1.5 text-right">{{ c.highestMint }}</td>
+              <td class="px-2 py-1.5 text-right">
                 {{ formatQuantity(c.quantity) }}
               </td>
-              <td class="px-4 py-2 text-center">
+              <td class="px-2 py-1.5 text-center">
                 {{ c.inCmart ? 'Yes' : 'No' }}
               </td>
-              <td class="px-4 py-2 text-right">
+              <td class="px-2 py-1.5 text-right">
                 <NuxtLink
                   :to="`/newsite/admin/ctoons/edit/${c.id}`"
                   class="text-blue-600 hover:text-blue-800"
@@ -173,35 +174,35 @@
       </div>
 
       <!-- CARD VIEW (mobile) -->
-      <div class="space-y-4 block lg:hidden">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 lg:hidden">
         <!-- Skeleton cards while loading or searching -->
         <template v-if="loading || (isSearching && searching)">
           <div
             v-for="n in 6"
             :key="`skeleton-mobile-${n}`"
-            class="bg-gray-100 rounded-lg p-4 flex flex-col animate-pulse"
+            class="bg-white border rounded-lg shadow p-2 flex flex-col animate-pulse"
           >
-            <div class="flex items-start space-x-4">
-              <div class="w-[80px] h-[80px] bg-gray-200 rounded"></div>
+            <div class="flex items-start gap-2">
+              <div class="w-[80px] h-[80px] bg-gray-200 rounded flex-shrink-0"></div>
               <div class="flex-1 space-y-2">
-                <div class="h-5 w-2/3 bg-gray-200 rounded"></div>
-                <div class="h-4 w-1/2 bg-gray-200 rounded"></div>
-                <div class="h-4 w-1/3 bg-gray-200 rounded"></div>
-                <div class="h-4 w-1/4 bg-gray-200 rounded"></div>
-                <div class="h-4 w-1/3 bg-gray-200 rounded"></div>
+                <div class="h-4 w-2/3 bg-gray-200 rounded"></div>
+                <div class="h-3 w-1/2 bg-gray-200 rounded"></div>
+                <div class="h-3 w-1/3 bg-gray-200 rounded"></div>
+                <div class="h-3 w-1/4 bg-gray-200 rounded"></div>
+                <div class="h-3 w-1/3 bg-gray-200 rounded"></div>
               </div>
             </div>
-            <div class="mt-4 h-8 w-24 bg-gray-200 rounded self-end"></div>
+            <div class="mt-2 h-6 w-20 bg-gray-200 rounded self-end"></div>
           </div>
         </template>
         <!-- Data cards -->
         <template v-else>
-          <div
+          <article
             v-for="c in displayedCtoons"
             :key="c.id"
-            class="bg-gray-100 rounded-lg p-4 flex flex-col"
+            class="bg-white border rounded-lg shadow p-2 flex flex-col"
           >
-            <div class="flex items-start space-x-4">
+            <div class="flex items-start gap-2">
               <div class="relative w-fit flex-shrink-0">
                 <img
                   loading="lazy"
@@ -211,9 +212,9 @@
                 />
                 <SecondEditionOverlay :ctoon="c" />
               </div>
-              <div class="flex-1 space-y-1">
-                <h2 class="text-lg font-semibold">{{ c.name }}</h2>
-                <p class="text-sm text-gray-600">
+              <div class="flex-1 min-w-0 space-y-0.5">
+                <h2 class="text-xs font-semibold truncate">{{ c.name }}</h2>
+                <p class="text-[11px] text-gray-500">
                   {{
                     new Date(c.releaseDate).toLocaleString('en-US', {
                       year: 'numeric',
@@ -225,21 +226,21 @@
                     })
                   }}
                 </p>
-                <p class="text-sm"><strong>Rarity:</strong> {{ c.rarity }}</p>
-                <p class="text-sm"><strong>Highest Mint:</strong> {{ c.highestMint }}</p>
-                <p class="text-sm"><strong>Quantity:</strong> {{ formatQuantity(c.quantity) }}</p>
-                <p class="text-sm"><strong>In C-mart:</strong> {{ c.inCmart ? 'Yes' : 'No' }}</p>
-                <p class="text-sm"><strong>Set:</strong> {{ c.set }}</p>
-                <p class="text-sm"><strong>Series:</strong> {{ c.series }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">Rarity:</span> {{ c.rarity }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">Highest Mint:</span> {{ c.highestMint }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">Quantity:</span> {{ formatQuantity(c.quantity) }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">In C-mart:</span> {{ c.inCmart ? 'Yes' : 'No' }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">Set:</span> {{ c.set }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">Series:</span> {{ c.series }}</p>
               </div>
             </div>
             <NuxtLink
               :to="`/newsite/admin/ctoons/edit/${c.id}`"
-              class="mt-4 inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-center text-sm font-medium self-end"
+              class="mt-2 inline-block px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 text-center self-end"
             >
               Edit
             </NuxtLink>
-          </div>
+          </article>
         </template>
       </div>
 
@@ -249,25 +250,26 @@
       </div>
 
       <!-- PAGINATION (browse only) -->
-      <div v-if="!isSearching" class="mt-6 flex items-center justify-between">
+      <div v-if="!isSearching" class="mt-3 flex items-center justify-between">
         <button
-          class="px-4 py-2 border rounded disabled:opacity-50"
+          class="px-3 py-1.5 text-xs border rounded-md disabled:opacity-50"
           @click="prevPage"
           :disabled="currentPage===1 || loading"
         >
           Previous
         </button>
-        <div class="text-sm text-gray-600">
+        <div class="text-[11px] text-gray-600">
           Page {{ currentPage }}
           <span v-if="loading" class="ml-2">Loading…</span>
         </div>
         <button
-          class="px-4 py-2 border rounded disabled:opacity-50"
+          class="px-3 py-1.5 text-xs border rounded-md disabled:opacity-50"
           @click="nextPage"
           :disabled="!hasNextPage || loading"
         >
           Next
         </button>
+      </div>
       </div>
     </div>
 

--- a/components/newsite/admin/legacy/AdminLegacyCtoonsBulkUpload.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCtoonsBulkUpload.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="bg-gray-50 p-6">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
     <!-- Toast notifications -->
     <Toast
@@ -9,24 +10,26 @@
       :type="t.type"
     />
 
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded-lg shadow ">
-      <h1 class="text-2xl font-semibold mb-4">Bulk Upload cToons</h1>
+    <div class="max-w-6xl mx-auto bg-white rounded-lg shadow p-3">
+      <h1 class="text-base font-semibold mb-3">Bulk Upload cToons</h1>
 
       <!-- STEP 1: Image Upload -->
-      <div v-if="step === 1" class="space-y-4">
-        <label class="block font-medium">Select Images</label>
-        <input
-          type="file"
-          accept="image/png,image/gif"
-          multiple
-          @change="handleFiles"
-          class="w-full"
-        />
-        <div class="flex flex-wrap gap-4">
+      <div v-if="step === 1" class="space-y-3">
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Select Images</label>
+          <input
+            type="file"
+            accept="image/png,image/gif"
+            multiple
+            @change="handleFiles"
+            class="text-xs"
+          />
+        </div>
+        <div class="flex flex-wrap gap-2">
           <div
             v-for="(file, i) in imageFiles"
             :key="i"
-            class="w-24 h-24 border rounded overflow-hidden"
+            class="w-20 h-20 border rounded overflow-hidden"
           >
             <img
               :src="file.preview"
@@ -39,7 +42,7 @@
           <button
             @click="step = 2"
             :disabled="!imageFiles.length"
-            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
           >
             Next: Details
           </button>
@@ -47,174 +50,193 @@
       </div>
 
       <!-- STEP 2: Metadata & Table -->
-      <div v-else class="space-y-6">
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div>
-            <label class="block mb-1 font-medium">Set</label>
-            <input
-              v-model="bulkSet"
-              list="sets-list"
-              required
-              class="w-full border rounded p-2"
-            />
-            <datalist v-if="bulkSet.length >= 2" id="sets-list">
-              <option
-                v-for="opt in filteredBulkSetsOptions"
-                :key="opt"
-                :value="opt"
-              />
-            </datalist>
-          </div>
-          <div>
-            <label class="block mb-1 font-medium">Series</label>
-            <input
-              v-model="bulkSeries"
-              list="bulk-series-list"
-              required
-              class="w-full border rounded p-2"
-            />
-            <datalist v-if="bulkSeries.length >= 2" id="bulk-series-list">
-              <option
-                v-for="opt in filteredBulkSeriesOptions"
-                :key="opt"
-                :value="opt"
-              />
-            </datalist>
-          </div>
-          <div>
-            <label class="block mb-1 font-medium">Release Date</label>
-            <input
-              v-model="bulkReleaseDate"
-              type="datetime-local"
-              required
-              class="w-full border rounded p-2"
-            />
-          </div>
-        </div>
+      <div v-else class="space-y-3">
 
-        <!-- Mint Limit Type -->
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <!-- ── Batch Identity ────────────────────────────────────── -->
+        <section class="border rounded-lg p-3 space-y-3">
           <div>
-            <label class="block mb-1 font-medium">Mint Limit</label>
-            <select v-model="bulkMintLimitType" class="w-full border rounded p-2 bg-white">
-              <option value="defined">Defined Number Limit</option>
-              <option value="timeBased">Time Based Limit</option>
-            </select>
-            <p class="text-sm text-gray-500">
-              <template v-if="bulkMintLimitType === 'defined'">Fixed quantity per cToon.</template>
-              <template v-else>Unlimited minting until Mint End Date.</template>
-            </p>
+            <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Batch Identity</h2>
+            <p class="text-[11px] text-gray-500 mt-0.5">Set, series, and release date applied to every cToon in this batch.</p>
           </div>
-          <div v-if="bulkMintLimitType === 'timeBased'">
-            <label class="block mb-1 font-medium">Mint End Date/Time (CST)</label>
-            <input
-              v-model="bulkMintEndDate"
-              type="datetime-local"
-              required
-              class="w-full border rounded p-2"
-            />
-            <p class="text-sm text-gray-500">Minting open until this date/time.</p>
-            <p v-if="bulkMintEndDateLocal" class="text-sm text-blue-600 mt-1">
-              (Your time: {{ bulkMintEndDateLocal }})
-            </p>
-          </div>
-        </div>
-
-        <!-- Time-Based Purchase Limit Override (bulk, only for timeBased) -->
-        <div v-if="bulkMintLimitType === 'timeBased'" class="border rounded bg-indigo-50 p-4 space-y-3">
-          <div>
-            <h3 class="font-medium text-sm text-gray-800">Purchase Limit Override
-              <span class="text-xs font-normal text-gray-500 ml-1">— applied to all cToons in this batch; leave blank to use each rarity's default</span>
-            </h3>
-            <p class="text-xs text-gray-500 mt-1">Window blank = full release window (release date → mint end date).</p>
-          </div>
-          <div class="grid grid-cols-2 gap-4">
-            <div>
-              <label class="block mb-1 text-sm font-medium">Limit Count</label>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Set</label>
               <input
-                type="number"
-                min="1"
-                :value="bulkTimeBasedLimitCountStr"
-                @input="bulkTimeBasedLimitCountStr = $event.target.value"
-                placeholder="Use rarity default"
-                class="w-full border rounded p-2"
+                v-model="bulkSet"
+                list="sets-list"
+                required
+                class="border rounded-md px-2 py-1.5 text-sm"
               />
-              <p class="text-xs text-gray-500 mt-1">Max purchases per user for each cToon.</p>
+              <datalist v-if="bulkSet.length >= 2" id="sets-list">
+                <option
+                  v-for="opt in filteredBulkSetsOptions"
+                  :key="opt"
+                  :value="opt"
+                />
+              </datalist>
             </div>
-            <div>
-              <label class="block mb-1 text-sm font-medium">Window (days)</label>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Series</label>
               <input
-                type="number"
-                min="1"
-                :value="bulkTimeBasedLimitWindowDaysStr"
-                @input="bulkTimeBasedLimitWindowDaysStr = $event.target.value"
-                placeholder="Full duration"
-                class="w-full border rounded p-2"
+                v-model="bulkSeries"
+                list="bulk-series-list"
+                required
+                class="border rounded-md px-2 py-1.5 text-sm"
               />
-              <p class="text-xs text-gray-500 mt-1">Rolling window. Blank = full release window.</p>
+              <datalist v-if="bulkSeries.length >= 2" id="bulk-series-list">
+                <option
+                  v-for="opt in filteredBulkSeriesOptions"
+                  :key="opt"
+                  :value="opt"
+                />
+              </datalist>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Release Date</label>
+              <input
+                v-model="bulkReleaseDate"
+                type="datetime-local"
+                required
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
             </div>
           </div>
-        </div>
+        </section>
 
-        <!-- Release schedule preview (applies to each row based on its Total Qty) -->
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4" v-if="bulkReleaseDate">
+        <!-- ── Mint Limit & Purchase Limits ─────────────────────── -->
+        <section class="border rounded-lg p-3 space-y-3">
           <div>
-            <label class="block mb-1 font-medium">Initial Release %</label>
-            <input
-              v-model.number="releasePercent"
-              type="number"
-              min="1"
-              max="100"
-              @input="clampReleasePercent"
-              class="w-full border rounded p-2"
-            />
+            <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Mint Limit &amp; Purchase Limits</h2>
+            <p class="text-[11px] text-gray-500 mt-0.5">How many total mints happen, and any per-user purchase override, for every cToon in this batch.</p>
           </div>
+
+          <!-- Mint Limit Type -->
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Mint Limit</label>
+              <select v-model="bulkMintLimitType" class="border rounded-md px-2 py-1.5 text-sm bg-white">
+                <option value="defined">Defined Number Limit</option>
+                <option value="timeBased">Time Based Limit</option>
+              </select>
+              <p class="text-[11px] text-gray-500">
+                <template v-if="bulkMintLimitType === 'defined'">Fixed quantity per cToon.</template>
+                <template v-else>Unlimited minting until Mint End Date.</template>
+              </p>
+            </div>
+            <div v-if="bulkMintLimitType === 'timeBased'" class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Mint End Date/Time (CST)</label>
+              <input
+                v-model="bulkMintEndDate"
+                type="datetime-local"
+                required
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
+              <p class="text-[11px] text-gray-500">Minting open until this date/time.</p>
+              <p v-if="bulkMintEndDateLocal" class="text-[11px] text-blue-600 mt-1">
+                (Your time: {{ bulkMintEndDateLocal }})
+              </p>
+            </div>
+          </div>
+
+          <!-- Time-Based Purchase Limit Override (bulk, only for timeBased) -->
+          <div v-if="bulkMintLimitType === 'timeBased'" class="border rounded-md bg-indigo-50 p-3 space-y-2">
+            <div>
+              <h3 class="text-xs font-semibold text-gray-800">Purchase Limit Override
+                <span class="text-[11px] font-normal text-gray-500 ml-1">— applied to all cToons in this batch; leave blank to use each rarity's default</span>
+              </h3>
+              <p class="text-[11px] text-gray-500 mt-1">Window blank = full release window (release date → mint end date).</p>
+            </div>
+            <div class="grid grid-cols-2 gap-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Limit Count</label>
+                <input
+                  type="number"
+                  min="1"
+                  :value="bulkTimeBasedLimitCountStr"
+                  @input="bulkTimeBasedLimitCountStr = $event.target.value"
+                  placeholder="Use rarity default"
+                  class="border rounded-md px-2 py-1.5 text-sm"
+                />
+                <p class="text-[11px] text-gray-500">Max purchases per user for each cToon.</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Window (days)</label>
+                <input
+                  type="number"
+                  min="1"
+                  :value="bulkTimeBasedLimitWindowDaysStr"
+                  @input="bulkTimeBasedLimitWindowDaysStr = $event.target.value"
+                  placeholder="Full duration"
+                  class="border rounded-md px-2 py-1.5 text-sm"
+                />
+                <p class="text-[11px] text-gray-500">Rolling window. Blank = full release window.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- ── Release Schedule (applies to each row based on its Total Qty) ─ -->
+        <section v-if="bulkReleaseDate" class="border rounded-lg p-3 space-y-3">
           <div>
-            <label class="block mb-1 font-medium">Final Release At (CST/CDT)</label>
-            <input :value="new Date(new Date(bulkReleaseDate).getTime() + delayHours*3600000).toLocaleString('en-US',{timeZone:'America/Chicago',hour12:false})" disabled class="w-full border rounded p-2 bg-gray-100" />
+            <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Release Schedule</h2>
+            <p class="text-[11px] text-gray-500 mt-0.5">Initial/Final quantities are computed per row from each Total Qty.</p>
           </div>
-          <div>
-            <p class="text-xs text-gray-500 mt-8">Initial/Final quantities are computed per row from each Total Qty.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Initial Release %</label>
+              <input
+                v-model.number="releasePercent"
+                type="number"
+                min="1"
+                max="100"
+                @input="clampReleasePercent"
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Final Release At (CST/CDT)</label>
+              <input :value="new Date(new Date(bulkReleaseDate).getTime() + delayHours*3600000).toLocaleString('en-US',{timeZone:'America/Chicago',hour12:false})" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+            </div>
           </div>
-        </div>
+        </section>
 
         <!-- Desktop Table -->
         <div class="overflow-x-auto hidden sm:block">
-          <table class="min-w-max table-auto border-separate border-spacing-0">
+          <table class="min-w-max table-auto border-separate border-spacing-0 text-xs">
             <thead>
               <tr class="bg-gray-100">
-                <th class="px-4 py-2">Preview</th>
-                <th class="px-4 py-2">Duplicate</th>
-                <th class="px-4 py-2">2nd Ed.</th>
-                <th class="px-4 py-2">Name</th>
-                <th class="px-4 py-2">Series</th>
-                <th class="px-4 py-2">Rarity</th>
-                <th class="px-4 py-2">Characters</th>
-                <th v-if="bulkMintLimitType === 'defined'" class="px-4 py-2">Total Qty</th>
-                <th v-if="bulkMintLimitType === 'defined'" class="px-4 py-2">Initial Qty</th>
-                <th class="px-4 py-2">Per-User Limit</th>
-                <th class="px-4 py-2">In cMart</th>
-                <th class="px-4 py-2">Price</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Preview</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Duplicate</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">2nd Ed.</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Name</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Series</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Rarity</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Characters</th>
+                <th v-if="bulkMintLimitType === 'defined'" class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Total Qty</th>
+                <th v-if="bulkMintLimitType === 'defined'" class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Initial Qty</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Per-User Limit</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">In cMart</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600">Price</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="(f, i) in imageFiles" :key="f.id" class="border-b">
-                <td class="px-4 py-2">
-                  <img :src="f.preview" alt class="h-12 w-auto rounded" />
+                <td class="px-2 py-1.5">
+                  <img :src="f.preview" alt class="h-10 w-auto rounded" />
                 </td>
-                <td class="px-4 py-2">
-                  <div v-if="f.duplicateStatus === 'checking'" class="text-xs text-gray-500">Checking...</div>
-                  <div v-else-if="f.duplicateStatus === 'error'" class="text-xs text-red-600">
+                <td class="px-2 py-1.5">
+                  <div v-if="f.duplicateStatus === 'checking'" class="text-[11px] text-gray-500">Checking...</div>
+                  <div v-else-if="f.duplicateStatus === 'error'" class="text-[11px] text-red-600">
                     {{ f.duplicateError || 'Duplicate check failed.' }}
                   </div>
-                  <div v-else-if="f.duplicateMatch" class="text-xs">
+                  <div v-else-if="f.duplicateMatch" class="text-[11px]">
                     <div class="text-amber-700 font-medium">Possible duplicate</div>
                     <div class="flex items-center gap-2 mt-1">
                       <img
                         v-if="f.duplicateMatch.ctoon?.assetPath"
                         :src="f.duplicateMatch.ctoon.assetPath"
                         alt="Possible duplicate"
-                        class="w-10 h-10 object-contain border rounded bg-white"
+                        class="w-9 h-9 object-contain border rounded bg-white"
                       />
                       <div class="text-[11px] leading-tight">
                         <div class="font-medium truncate max-w-[140px]">
@@ -226,9 +248,9 @@
                       </div>
                     </div>
                   </div>
-                  <div v-else-if="f.duplicateStatus === 'done'" class="text-xs text-green-600">No duplicates</div>
+                  <div v-else-if="f.duplicateStatus === 'done'" class="text-[11px] text-green-600">No duplicates</div>
                 </td>
-                <td class="px-4 py-2" style="min-width:180px;">
+                <td class="px-2 py-1.5" style="min-width:180px;">
                   <SecondEditionFields
                     :model-value="rowSecondEdition(f)"
                     :exclude-ctoon-id="''"
@@ -236,14 +258,14 @@
                     @update:model-value="val => applyRowSecondEdition(f, val)"
                   />
                 </td>
-                <td class="px-4 py-2">
-                  <input v-model="f.nameField" class="w-full border rounded p-1" />
+                <td class="px-2 py-1.5">
+                  <input v-model="f.nameField" class="border rounded px-1.5 py-1 text-xs w-full" />
                 </td>
-                <td class="px-4 py-2">
+                <td class="px-2 py-1.5">
                   <input
                     v-model="f.series"
                     :list="`row-series-list-desktop-${f.id}`"
-                    class="w-full border rounded p-1"
+                    class="border rounded px-1.5 py-1 text-xs w-full"
                     @input="lockRowSeries(f)"
                   />
                   <datalist
@@ -257,30 +279,30 @@
                     />
                   </datalist>
                 </td>
-                <td class="px-4 py-2">
-                  <select v-model="f.rarity" class="w-full border rounded p-1" @change="updateDefaults(f)">
+                <td class="px-2 py-1.5">
+                  <select v-model="f.rarity" class="border rounded px-1.5 py-1 text-xs w-full bg-white" @change="updateDefaults(f)">
                     <option v-for="opt in rarityOptions" :key="opt" :value="opt">
                       {{ opt }}
                     </option>
                   </select>
                 </td>
-                <td class="px-4 py-2">
-                  <input v-model="f.characters" class="w-full border rounded p-1" placeholder="e.g. Amy,Bob"/>
+                <td class="px-2 py-1.5">
+                  <input v-model="f.characters" class="border rounded px-1.5 py-1 text-xs w-full" placeholder="e.g. Amy,Bob"/>
                 </td>
-                <td v-if="bulkMintLimitType === 'defined'" class="px-4 py-2">
-                  <input v-model.number="f.totalQuantity" type="number" min="1" class="w-full border rounded p-1" />
+                <td v-if="bulkMintLimitType === 'defined'" class="px-2 py-1.5">
+                  <input v-model.number="f.totalQuantity" type="number" min="1" class="border rounded px-1.5 py-1 text-xs w-full" />
                 </td>
-                <td v-if="bulkMintLimitType === 'defined'" class="px-4 py-2">
-                  <input v-model.number="f.initialQuantity" type="number" min="0" class="w-full border rounded p-1" />
+                <td v-if="bulkMintLimitType === 'defined'" class="px-2 py-1.5">
+                  <input v-model.number="f.initialQuantity" type="number" min="0" class="border rounded px-1.5 py-1 text-xs w-full" />
                 </td>
-                <td class="px-4 py-2">
-                  <input v-model.number="f.perUserLimit" type="number" min="0" class="w-full border rounded p-1" />
+                <td class="px-2 py-1.5">
+                  <input v-model.number="f.perUserLimit" type="number" min="0" class="border rounded px-1.5 py-1 text-xs w-full" />
                 </td>
-                <td class="px-4 py-2 text-center">
+                <td class="px-2 py-1.5 text-center">
                   <input type="checkbox" v-model="f.inCmart" />
                 </td>
-                <td class="px-4 py-2">
-                  <input v-model.number="f.price" type="number" class="w-full border rounded p-1" />
+                <td class="px-2 py-1.5">
+                  <input v-model.number="f.price" type="number" class="border rounded px-1.5 py-1 text-xs w-full" />
                 </td>
               </tr>
             </tbody>
@@ -288,31 +310,31 @@
         </div>
 
         <!-- Mobile Cards -->
-        <div class="space-y-4 block sm:hidden">
+        <div class="space-y-3 block sm:hidden">
           <div
             v-for="(f, i) in imageFiles"
             :key="f.id"
-            class="bg-gray-100 rounded-lg p-4"
+            class="bg-gray-100 rounded-lg p-3"
           >
             <!-- Image on top -->
             <img
               :src="f.preview"
               :alt="f.nameField"
-              class="w-full h-40 object-cover rounded mb-4"
+              class="w-full h-32 object-cover rounded mb-3"
             />
-            <div class="mb-4">
-              <div v-if="f.duplicateStatus === 'checking'" class="text-xs text-gray-500">Checking for duplicates...</div>
-              <div v-else-if="f.duplicateStatus === 'error'" class="text-xs text-red-600">
+            <div class="mb-3">
+              <div v-if="f.duplicateStatus === 'checking'" class="text-[11px] text-gray-500">Checking for duplicates...</div>
+              <div v-else-if="f.duplicateStatus === 'error'" class="text-[11px] text-red-600">
                 {{ f.duplicateError || 'Duplicate check failed.' }}
               </div>
-              <div v-else-if="f.duplicateMatch" class="text-xs bg-amber-50 border rounded p-2">
+              <div v-else-if="f.duplicateMatch" class="text-[11px] bg-amber-50 border rounded p-2">
                 <div class="text-amber-700 font-medium">Possible duplicate found</div>
                 <div class="flex items-center gap-2 mt-2">
                   <img
                     v-if="f.duplicateMatch.ctoon?.assetPath"
                     :src="f.duplicateMatch.ctoon.assetPath"
                     alt="Possible duplicate"
-                    class="w-12 h-12 object-contain border rounded bg-white"
+                    class="w-10 h-10 object-contain border rounded bg-white"
                   />
                   <div class="text-[11px] leading-tight">
                     <div class="font-medium">
@@ -324,7 +346,7 @@
                   </div>
                 </div>
               </div>
-              <div v-else-if="f.duplicateStatus === 'done'" class="text-xs text-green-600">No duplicates found.</div>
+              <div v-else-if="f.duplicateStatus === 'done'" class="text-[11px] text-green-600">No duplicates found.</div>
             </div>
 
             <SecondEditionFields
@@ -335,27 +357,27 @@
             />
 
             <!-- Fields underneath -->
-            <div class="space-y-4">
+            <div class="space-y-3">
               <!-- Name -->
-              <div>
-                <label class="block mb-1 font-medium">Name</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Name</label>
                 <input
                   v-model="f.nameField"
-                  class="w-full border rounded p-2"
+                  class="border rounded-md px-2 py-1.5 text-sm"
                   placeholder="Enter cToon name"
                 />
-                <p class="text-sm text-gray-500">
+                <p class="text-[11px] text-gray-500">
                   The display name for this cToon.
                 </p>
               </div>
 
               <!-- Series -->
-              <div>
-                <label class="block mb-1 font-medium">Series</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Series</label>
                 <input
                   v-model="f.series"
                   :list="`row-series-list-mobile-${f.id}`"
-                  class="w-full border rounded p-2"
+                  class="border rounded-md px-2 py-1.5 text-sm"
                   placeholder="Enter series"
                   @input="lockRowSeries(f)"
                 />
@@ -369,18 +391,18 @@
                     :value="opt"
                   />
                 </datalist>
-                <p class="text-sm text-gray-500">
+                <p class="text-[11px] text-gray-500">
                   Defaults to the bulk series unless overridden.
                 </p>
               </div>
 
               <!-- Rarity -->
-              <div>
-                <label class="block mb-1 font-medium">Rarity</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Rarity</label>
                 <select
                   v-model="f.rarity"
                   @change="updateDefaults(f)"
-                  class="w-full border rounded p-2 bg-white"
+                  class="border rounded-md px-2 py-1.5 text-sm bg-white"
                 >
                   <option disabled value="">Select rarity</option>
                   <option
@@ -389,94 +411,93 @@
                     :value="opt"
                   >{{ opt }}</option>
                 </select>
-                <p class="text-sm text-gray-500">
+                <p class="text-[11px] text-gray-500">
                   Choose the rarity tier for this cToon.
                 </p>
               </div>
 
               <!-- Characters -->
-              <div>
-                <label class="block mb-1 font-medium">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">
                   Characters (comma-separated)
                 </label>
                 <input
                   v-model="f.characters"
-                  class="w-full border rounded p-2"
+                  class="border rounded-md px-2 py-1.5 text-sm"
                   placeholder="e.g. Amy,Bob"
                 />
-                <p class="text-sm text-gray-500">
+                <p class="text-[11px] text-gray-500">
                   List all characters featured in this cToon.
                 </p>
               </div>
 
               <!-- Total Quantity (only for Defined Number Limit) -->
-              <div v-if="bulkMintLimitType === 'defined'">
-                <label class="block mb-1 font-medium">Total Quantity</label>
+              <div v-if="bulkMintLimitType === 'defined'" class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Total Quantity</label>
                 <input
                   v-model.number="f.totalQuantity"
                   type="number"
                   min="1"
-                  class="w-full border rounded p-2"
+                  class="border rounded-md px-2 py-1.5 text-sm"
                   placeholder="Leave blank for unlimited"
                 />
-                <p class="text-sm text-gray-500">
+                <p class="text-[11px] text-gray-500">
                   Maximum number that can be minted. Leave blank for unlimited.
                 </p>
               </div>
 
               <!-- Initial Quantity (only for Defined Number Limit) -->
-              <div v-if="bulkMintLimitType === 'defined'">
-                <label class="block mb-1 font-medium">Initial Quantity</label>
+              <div v-if="bulkMintLimitType === 'defined'" class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Quantity</label>
                 <input
                   v-model.number="f.initialQuantity"
                   type="number"
                   min="0"
-                  class="w-full border rounded p-2"
+                  class="border rounded-md px-2 py-1.5 text-sm"
                   placeholder="Number of first editions"
                 />
-                <p class="text-sm text-gray-500">
+                <p class="text-[11px] text-gray-500">
                   Number of first editions available. Must be ≤ total quantity.
                 </p>
               </div>
 
               <!-- Per-User Limit -->
-              <div>
-                <label class="block mb-1 font-medium">Per-User Limit</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Per-User Limit</label>
                 <input
                   v-model.number="f.perUserLimit"
                   type="number"
                   min="0"
-                  class="w-full border rounded p-2"
+                  class="border rounded-md px-2 py-1.5 text-sm"
                   placeholder="Limit per user"
                 />
-                <p class="text-sm text-gray-500">
+                <p class="text-[11px] text-gray-500">
                   Limit on how many each user can mint within the first 48 hours of
                   release. Leave blank for no limit.
                 </p>
               </div>
 
               <!-- In cMart -->
-              <div class="flex items-center space-x-2">
+              <label class="flex items-center gap-2">
                 <input
                   type="checkbox"
                   v-model="f.inCmart"
-                  class="mr-2"
                 />
-                <label class="font-medium">In cMart</label>
-              </div>
-              <p class="text-sm text-gray-500">
+                <span class="text-xs font-medium">In cMart</span>
+              </label>
+              <p class="text-[11px] text-gray-500">
                 Check to list this cToon in the shop.
               </p>
 
               <!-- Price -->
-              <div>
-                <label class="block mb-1 font-medium">Price</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Price</label>
                 <input
                   v-model.number="f.price"
                   type="number"
-                  class="w-full border rounded p-2"
+                  class="border rounded-md px-2 py-1.5 text-sm"
                 />
-                <p class="text-sm text-gray-500">
+                <p class="text-[11px] text-gray-500">
                   Defaults based on rarity, but you can adjust it here.
                 </p>
               </div>
@@ -489,12 +510,13 @@
           <button
             @click="uploadAll"
             :disabled="uploading || !canUpload"
-            class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+            class="px-4 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
           >
             {{ uploading ? 'Uploading cToons...' : 'Upload cToons' }}
           </button>
         </div>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyCtoonsEdit.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCtoonsEdit.vue
@@ -1,285 +1,313 @@
 <template>
-  <div class="bg-gray-50 p-6">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
-    <div class="max-w-2xl mx-auto bg-white p-6 rounded-lg shadow relative">
-      <h1 class="text-2xl font-semibold mb-4">Edit cToon</h1>
+      <div class="max-w-2xl mx-auto bg-white rounded-lg shadow p-3 relative">
+        <h1 class="text-base font-semibold mb-3">Edit cToon</h1>
 
-      <form @submit.prevent="submitForm" class="space-y-4">
-        <!-- Image Display -->
-        <div>
-          <label class="block mb-1 font-medium">Current Image</label>
-          <img :src="assetPath" alt="cToon" class="h-32" />
-        </div>
+        <form @submit.prevent="submitForm" class="space-y-3">
 
-        <!-- Upload New Image -->
-        <div>
-          <label class="block mb-1 font-medium">Upload New Image (PNG or GIF)</label>
-          <input type="file" accept="image/png,image/gif" @change="handleNewFile" class="w-full" />
-          <p class="text-sm text-gray-500">Optional. If set, the image and type will update. A timestamped filename will bypass cache.</p>
-          <p v-if="err.image" class="text-red-600 text-sm mt-1">{{ err.image }}</p>
-          <div v-if="newImagePreview" class="mt-2">
-            <label class="block mb-1 font-medium">Preview</label>
-            <img :src="newImagePreview" class="h-32" />
-          </div>
-        </div>
-
-        <!-- Sound Upload -->
-        <div>
-          <label class="block mb-1 font-medium">cToon Sound (optional)</label>
-          <div v-if="currentSoundPath && !clearSound" class="flex items-center gap-3 mb-2">
-            <audio :src="currentSoundPath" controls class="h-8"></audio>
-            <button type="button" @click="clearSound = true" class="text-sm text-red-600 hover:underline">Remove sound</button>
-          </div>
-          <p v-else-if="clearSound" class="text-sm text-amber-600 mb-2">Sound will be removed on save. <button type="button" @click="clearSound = false" class="underline">Undo</button></p>
-          <input type="file" accept="audio/mpeg,audio/mp3,audio/wav,audio/ogg" @change="handleSoundFile" class="w-full" />
-          <p class="text-sm text-gray-500">MP3, WAV, or OGG. Leave blank to keep existing. Uploading a new file replaces the current sound.</p>
-          <p v-if="err.sound" class="text-red-600 text-sm mt-1">{{ err.sound }}</p>
-          <p v-if="newSoundFile" class="text-sm text-green-600 mt-1">Selected: {{ newSoundFile.name }}</p>
-        </div>
-
-        <!-- Type (read-only) -->
-        <div>
-          <label class="block mb-1 font-medium">Type</label>
-          <input v-model="type" disabled class="w-full border rounded p-2 bg-gray-100" />
-        </div>
-
-        <!-- Name -->
-        <div>
-          <label class="block mb-1 font-medium">Name</label>
-          <input v-model="name" required class="w-full border rounded p-2" />
-        </div>
-
-        <!-- Series -->
-        <div>
-          <label class="block mb-1 font-medium">Series</label>
-          <input v-model="series" list="series-list" required class="w-full border rounded p-2" />
-          <datalist id="series-list">
-            <option v-for="opt in seriesOptions" :key="opt" :value="opt" />
-          </datalist>
-        </div>
-
-        <!-- Rarity -->
-        <div>
-          <label class="block mb-1 font-medium">Rarity</label>
-          <select v-model="rarity" required class="w-full border rounded p-2">
-            <option disabled value="">Select rarity</option>
-            <option v-for="opt in rarityOptions" :key="opt" :value="opt">{{ opt }}</option>
-          </select>
-        </div>
-
-        <!-- Price -->
-        <div>
-          <label class="block mb-1 font-medium">Price</label>
-          <input type="number" min="0" v-model.number="price" class="w-full border rounded p-2" />
-          <p class="text-sm text-gray-500">Defaults based on rarity, but you can adjust it here.</p>
-        </div>
-
-        <!-- Release Date (CDT) -->
-        <div>
-          <label class="block mb-1 font-medium">Release Date &amp; Time (CDT)</label>
-          <input type="datetime-local" v-model="releaseDate" required class="w-full border rounded p-2" />
-        </div>
-
-        <!-- Mint Limit Type -->
-        <div>
-          <label class="block mb-1 font-medium">Mint Limit</label>
-          <select v-model="mintLimitType" class="w-full border rounded p-2 bg-white">
-            <option value="defined">Defined Number Limit</option>
-            <option value="timeBased">Time Based Limit</option>
-          </select>
-          <p class="text-sm text-gray-500">
-            <template v-if="mintLimitType === 'defined'">Set a fixed quantity. cToon sells out when all are minted.</template>
-            <template v-else>Allow unlimited minting until the Mint End Date, then cap based on demand.</template>
-          </p>
-        </div>
-
-        <!-- Mint End Date (only for Time Based Limit) -->
-        <div v-if="mintLimitType === 'timeBased'">
-          <label class="block mb-1 font-medium">Mint End Date/Time (CST)</label>
-          <input v-model="mintEndDate" type="datetime-local" required class="w-full border rounded p-2" />
-          <p class="text-sm text-gray-500">Minting will be open until this date/time, then the quantity will be capped.</p>
-          <p v-if="mintEndDateLocal" class="text-sm text-blue-600 mt-1">
-            (Your time: {{ mintEndDateLocal }})
-          </p>
-        </div>
-
-        <!-- Time-Based Purchase Limit Override (only for Time Based Limit) -->
-        <div v-if="mintLimitType === 'timeBased'" class="border rounded bg-indigo-50 p-4 space-y-3">
-          <div>
-            <h3 class="font-medium text-sm text-gray-800">Purchase Limit Override
-              <span class="text-xs font-normal text-gray-500 ml-1">— optional, overrides the rarity default from Global Settings</span>
-            </h3>
-            <p class="text-xs text-gray-500 mt-1">Leave either field blank to use the rarity default. Window blank = full release window.</p>
-          </div>
-          <div class="grid grid-cols-2 gap-4">
+          <!-- ── Media ─────────────────────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
             <div>
-              <label class="block mb-1 text-sm font-medium">Limit Count</label>
-              <input
-                type="number"
-                min="1"
-                :value="timeBasedLimitCountStr"
-                @input="timeBasedLimitCountStr = $event.target.value"
-                placeholder="Use rarity default"
-                class="w-full border rounded p-2"
-              />
-              <p class="text-xs text-gray-500 mt-1">Max purchases per user.</p>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Media</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">The image and (optional) sound that represent this cToon in the c-mart and inventory.</p>
             </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Current Image</label>
+              <img :src="assetPath" alt="cToon" class="h-32" />
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Upload New Image (PNG or GIF)</label>
+              <input type="file" accept="image/png,image/gif" @change="handleNewFile" class="text-xs" />
+              <p class="text-[11px] text-gray-500">Optional. If set, the image and type will update. A timestamped filename will bypass cache.</p>
+              <p v-if="err.image" class="text-red-600 text-[11px] mt-1">{{ err.image }}</p>
+              <div v-if="newImagePreview" class="mt-1">
+                <label class="text-xs font-medium">Preview</label>
+                <img :src="newImagePreview" class="h-32 mt-1" />
+              </div>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">cToon Sound (optional)</label>
+              <div v-if="currentSoundPath && !clearSound" class="flex items-center gap-3">
+                <audio :src="currentSoundPath" controls class="h-8"></audio>
+                <button type="button" @click="clearSound = true" class="text-[11px] text-red-600 hover:underline">Remove sound</button>
+              </div>
+              <p v-else-if="clearSound" class="text-[11px] text-amber-600">Sound will be removed on save. <button type="button" @click="clearSound = false" class="underline">Undo</button></p>
+              <input type="file" accept="audio/mpeg,audio/mp3,audio/wav,audio/ogg" @change="handleSoundFile" class="text-xs" />
+              <p class="text-[11px] text-gray-500">MP3, WAV, or OGG. Leave blank to keep existing. Uploading a new file replaces the current sound.</p>
+              <p v-if="err.sound" class="text-red-600 text-[11px] mt-1">{{ err.sound }}</p>
+              <p v-if="newSoundFile" class="text-[11px] text-green-600 mt-1">Selected: {{ newSoundFile.name }}</p>
+            </div>
+          </section>
+
+          <!-- ── Identity & Classification ────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
             <div>
-              <label class="block mb-1 text-sm font-medium">Window (days)</label>
-              <input
-                type="number"
-                min="1"
-                :value="timeBasedLimitWindowDaysStr"
-                @input="timeBasedLimitWindowDaysStr = $event.target.value"
-                placeholder="Full duration"
-                class="w-full border rounded p-2"
-              />
-              <p class="text-xs text-gray-500 mt-1">Rolling window. Blank = full release window.</p>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Identity &amp; Classification</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">What this cToon is called and how it's grouped/priced by rarity.</p>
             </div>
-          </div>
-        </div>
 
-        <!-- Per-User Limit / Quantities -->
-        <div class="grid grid-cols-2 gap-4">
-          <div>
-            <label class="block mb-1 font-medium">Per-User Limit</label>
-            <input v-model.number="perUserLimit" type="number" min="0" class="w-full border rounded p-2" />
-          </div>
-          <div v-if="mintLimitType === 'defined'">
-            <label class="block mb-1 font-medium">Total Quantity</label>
-            <input v-model.number="quantity" type="number" min="0" class="w-full border rounded p-2" />
-          </div>
-          <div v-if="mintLimitType === 'defined'">
-            <label class="block mb-1 font-medium">Initial Quantity</label>
-            <input v-model.number="initialQuantity" type="number" min="0" class="w-full border rounded p-2" />
-          </div>
-        </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Type</label>
+              <input v-model="type" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              <p class="text-[11px] text-gray-500">Set automatically from the image file — read only.</p>
+            </div>
 
-        <!-- Release schedule (computed, read-only) -->
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4" v-if="schedule.initialQty != null && schedule.finalAtDisplay">
-          <div>
-            <label class="block mb-1 font-medium">Initial Release %</label>
-            <input
-              v-model.number="releasePercent"
-              type="number"
-              min="1"
-              max="100"
-              @input="clampReleasePercent"
-              class="w-full border rounded p-2"
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Name</label>
+              <input v-model="name" required class="border rounded-md px-2 py-1.5 text-sm" />
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Series</label>
+              <input v-model="series" list="series-list" required class="border rounded-md px-2 py-1.5 text-sm" />
+              <datalist id="series-list">
+                <option v-for="opt in seriesOptions" :key="opt" :value="opt" />
+              </datalist>
+              <p class="text-[11px] text-gray-500">Used to group similar cToons.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Set</label>
+              <input v-model="setField" required class="border rounded-md px-2 py-1.5 text-sm" />
+              <p class="text-[11px] text-gray-500">Which collectible set this cToon belongs to.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Rarity</label>
+              <select v-model="rarity" required class="border rounded-md px-2 py-1.5 text-sm">
+                <option disabled value="">Select rarity</option>
+                <option v-for="opt in rarityOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+              <p class="text-[11px] text-gray-500">Drives the default price, quantity, and c-mart placement below.</p>
+            </div>
+          </section>
+
+          <!-- ── Pricing ───────────────────────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Pricing</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">Point cost to mint/purchase this cToon.</p>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Price</label>
+              <input type="number" min="0" v-model.number="price" class="border rounded-md px-2 py-1.5 text-sm" />
+              <p class="text-[11px] text-gray-500">Defaults based on rarity, but you can adjust it here.</p>
+            </div>
+          </section>
+
+          <!-- ── Availability & Mint Limits ───────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Availability &amp; Mint Limits</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">When this cToon goes live, how many can be minted, and where it can be obtained.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Release Date &amp; Time (CDT)</label>
+              <input type="datetime-local" v-model="releaseDate" required class="border rounded-md px-2 py-1.5 text-sm" />
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Mint Limit</label>
+              <select v-model="mintLimitType" class="border rounded-md px-2 py-1.5 text-sm bg-white">
+                <option value="defined">Defined Number Limit</option>
+                <option value="timeBased">Time Based Limit</option>
+              </select>
+              <p class="text-[11px] text-gray-500">
+                <template v-if="mintLimitType === 'defined'">Set a fixed quantity. cToon sells out when all are minted.</template>
+                <template v-else>Allow unlimited minting until the Mint End Date, then cap based on demand.</template>
+              </p>
+            </div>
+
+            <div v-if="mintLimitType === 'timeBased'" class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Mint End Date/Time (CST)</label>
+              <input v-model="mintEndDate" type="datetime-local" required class="border rounded-md px-2 py-1.5 text-sm" />
+              <p class="text-[11px] text-gray-500">Minting will be open until this date/time, then the quantity will be capped.</p>
+              <p v-if="mintEndDateLocal" class="text-[11px] text-blue-600 mt-1">
+                (Your time: {{ mintEndDateLocal }})
+              </p>
+            </div>
+
+            <div v-if="mintLimitType === 'timeBased'" class="border rounded-md bg-indigo-50 p-3 space-y-2">
+              <div>
+                <h3 class="text-xs font-semibold text-gray-800">Purchase Limit Override
+                  <span class="text-[11px] font-normal text-gray-500 ml-1">— optional, overrides the rarity default from Global Settings</span>
+                </h3>
+                <p class="text-[11px] text-gray-500 mt-1">Leave either field blank to use the rarity default. Window blank = full release window.</p>
+              </div>
+              <div class="grid grid-cols-2 gap-3">
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Limit Count</label>
+                  <input
+                    type="number"
+                    min="1"
+                    :value="timeBasedLimitCountStr"
+                    @input="timeBasedLimitCountStr = $event.target.value"
+                    placeholder="Use rarity default"
+                    class="border rounded-md px-2 py-1.5 text-sm"
+                  />
+                  <p class="text-[11px] text-gray-500">Max purchases per user.</p>
+                </div>
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Window (days)</label>
+                  <input
+                    type="number"
+                    min="1"
+                    :value="timeBasedLimitWindowDaysStr"
+                    @input="timeBasedLimitWindowDaysStr = $event.target.value"
+                    placeholder="Full duration"
+                    class="border rounded-md px-2 py-1.5 text-sm"
+                  />
+                  <p class="text-[11px] text-gray-500">Rolling window. Blank = full release window.</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Per-User Limit</label>
+                <input v-model.number="perUserLimit" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+              </div>
+              <div v-if="mintLimitType === 'defined'" class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Total Quantity</label>
+                <input v-model.number="quantity" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+              </div>
+              <div v-if="mintLimitType === 'defined'" class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Quantity</label>
+                <input v-model.number="initialQuantity" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+              </div>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3" v-if="schedule.initialQty != null && schedule.finalAtDisplay">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Release %</label>
+                <input
+                  v-model.number="releasePercent"
+                  type="number"
+                  min="1"
+                  max="100"
+                  @input="clampReleasePercent"
+                  class="border rounded-md px-2 py-1.5 text-sm"
+                />
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Release Qty</label>
+                <input :value="schedule.initialQty" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Final Release At (CST/CDT)</label>
+                <input :value="schedule.finalAtDisplay" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Final Release Qty</label>
+                <input :value="schedule.finalQty" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              </div>
+            </div>
+
+            <label class="flex items-center gap-2">
+              <input v-model="inCmart" type="checkbox"
+                     :disabled="rarity === 'Prize Only' || rarity === 'Auction Only' || (rarity === 'Code Only' && !inCmart)" />
+              <span class="text-xs font-medium">In C-mart</span>
+            </label>
+            <p class="text-[11px] text-gray-500">Whether this cToon is purchasable in the c-mart shop. Disabled automatically for Prize/Auction Only rarities.</p>
+          </section>
+
+          <!-- ── Description & Characters ─────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Description &amp; Characters</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">Flavor text and character tags shown to players.</p>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Description</label>
+              <textarea v-model="description" rows="3" class="border rounded-md px-2 py-1.5 text-sm" placeholder="Optional description"></textarea>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Characters (comma-separated)</label>
+              <textarea v-model="characters" rows="2" class="border rounded-md px-2 py-1.5 text-sm"></textarea>
+            </div>
+          </section>
+
+          <!-- ── G-toon Gameplay ───────────────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">G-toon Gameplay</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">Only needed if this cToon is playable as a card in Clash.</p>
+            </div>
+
+            <label class="flex items-center gap-2">
+              <input type="checkbox" v-model="isGtoon" />
+              <span class="text-xs font-medium">Is this a G-toon?</span>
+            </label>
+
+            <div v-if="isGtoon" class="border rounded-md bg-indigo-50 p-3 space-y-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Type (gToon)</label>
+                <input v-model="gtoonType" type="text" class="border rounded-md px-2 py-1.5 text-sm" placeholder="e.g. Beast, Robot, Support" />
+                <p class="text-[11px] text-gray-500">Optional. Leave blank if none.</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Cost <span class="text-[11px] font-normal">(0–6)</span></label>
+                <input v-model.number="cost" type="number" min="0" max="6" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p v-if="err.cost" class="text-red-600 text-[11px]">{{ err.cost }}</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Power <span class="text-[11px] font-normal">(0–12)</span></label>
+                <input v-model.number="power" type="number" min="0" max="12" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p v-if="err.power" class="text-red-600 text-[11px]">{{ err.power }}</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Ability</label>
+                <select v-model="abilityKey" class="border rounded-md px-2 py-1.5 text-sm bg-white">
+                  <option value="">None</option>
+                  <option v-for="a in abilityKeyOptions" :key="a.key" :value="a.key">{{ a.label }}</option>
+                </select>
+              </div>
+              <div v-if="selectedAbility && selectedAbility.params?.length" class="flex flex-col gap-1">
+                <label class="text-xs font-medium">{{ selectedAbility.paramLabel }}</label>
+                <select v-model="abilityParam" class="border rounded-md px-2 py-1.5 text-sm bg-white">
+                  <option disabled :value="null">Select value</option>
+                  <option v-for="p in selectedAbility.params" :key="p" :value="p">{{ p }}</option>
+                </select>
+              </div>
+              <div class="text-[11px] text-gray-600">
+                <p class="font-semibold">Ability cheat-sheet:</p>
+                <ul class="list-disc list-inside">
+                  <li><strong>Flame Bug</strong> – Deals X damage to a random enemy on play.</li>
+                  <li><strong>Heal Ally</strong> – Heals all friendlies in lane by X.</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <!-- ── Second Edition ────────────────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Second Edition</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">Mark this cToon as a reprint of an existing one, with an overlay badge.</p>
+            </div>
+            <SecondEditionFields
+              v-model="secondEdition"
+              :ctoon-image-src="newImagePreview || assetPath"
+              :exclude-ctoon-id="id"
             />
+          </section>
+
+          <!-- Submit -->
+          <div class="text-right">
+            <button class="px-4 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700">
+              Update cToon
+            </button>
           </div>
-          <div>
-            <label class="block mb-1 font-medium">Initial Release Qty</label>
-            <input :value="schedule.initialQty" disabled class="w-full border rounded p-2 bg-gray-100" />
-          </div>
-          <div>
-            <label class="block mb-1 font-medium">Final Release At (CST/CDT)</label>
-            <input :value="schedule.finalAtDisplay" disabled class="w-full border rounded p-2 bg-gray-100" />
-          </div>
-          <div>
-            <label class="block mb-1 font-medium">Final Release Qty</label>
-            <input :value="schedule.finalQty" disabled class="w-full border rounded p-2 bg-gray-100" />
-          </div>
-        </div>
+        </form>
 
-        <!-- In C-mart -->
-        <div class="flex items-center">
-          <input v-model="inCmart" type="checkbox" class="mr-2"
-                 :disabled="rarity === 'Prize Only' || rarity === 'Auction Only' || (rarity === 'Code Only' && !inCmart)" />
-          <span>In C-mart</span>
-        </div>
-
-        <!-- Set -->
-        <div>
-          <label class="block mb-1 font-medium">Set</label>
-          <input v-model="setField" required class="w-full border rounded p-2" />
-        </div>
-
-        <!-- Description -->
-        <div>
-          <label class="block mb-1 font-medium">Description</label>
-          <textarea v-model="description" rows="3" class="w-full border rounded p-2" placeholder="Optional description"></textarea>
-        </div>
-
-        <!-- Characters -->
-        <div>
-          <label class="block mb-1 font-medium">Characters (comma-separated)</label>
-          <textarea v-model="characters" rows="2" class="w-full border rounded p-2"></textarea>
-        </div>
-
-        <!-- ── G-toon section ───────────────────────────────────── -->
-        <div class="flex items-center space-x-4">
-          <label class="flex items-center font-medium">
-            <input type="checkbox" v-model="isGtoon" class="mr-2" />
-            Is this a <strong>G-toon</strong>?
-          </label>
-        </div>
-
-        <div v-if="isGtoon" class="border p-4 rounded bg-indigo-50 space-y-4">
-          <!-- G-toon Type (free text, optional) -->
-          <div>
-            <label class="block mb-1 font-medium">Type (gToon)</label>
-            <input v-model="gtoonType" type="text" class="w-full border rounded p-2" placeholder="e.g. Beast, Robot, Support" />
-            <p class="text-sm text-gray-500">Optional. Leave blank if none.</p>
-          </div>
-          <!-- Cost -->
-          <div>
-            <label class="block mb-1 font-medium">Cost <span class="text-xs">(0–6)</span></label>
-            <input v-model.number="cost" type="number" min="0" max="6" class="w-full border rounded p-2" />
-            <p v-if="err.cost" class="text-red-600 text-sm">{{ err.cost }}</p>
-          </div>
-
-          <!-- Power -->
-          <div>
-            <label class="block mb-1 font-medium">Power <span class="text-xs">(0–12)</span></label>
-            <input v-model.number="power" type="number" min="0" max="12" class="w-full border rounded p-2" />
-            <p v-if="err.power" class="text-red-600 text-sm">{{ err.power }}</p>
-          </div>
-
-          <!-- Ability Key -->
-          <div>
-            <label class="block mb-1 font-medium">Ability</label>
-            <select v-model="abilityKey" class="w-full border rounded p-2 bg-white">
-              <option value="">None</option>
-              <option v-for="a in abilityKeyOptions" :key="a.key" :value="a.key">{{ a.label }}</option>
-            </select>
-          </div>
-
-          <!-- Ability Param -->
-          <div v-if="selectedAbility && selectedAbility.params?.length">
-            <label class="block mb-1 font-medium">{{ selectedAbility.paramLabel }}</label>
-            <select v-model="abilityParam" class="w-full border rounded p-2 bg-white">
-              <option disabled :value="null">Select value</option>
-              <option v-for="p in selectedAbility.params" :key="p" :value="p">{{ p }}</option>
-            </select>
-          </div>
-
-          <!-- Cheat-sheet -->
-          <div class="text-xs text-gray-600">
-            <p class="font-semibold">Ability cheat-sheet:</p>
-            <ul class="list-disc list-inside">
-              <li><strong>Flame Bug</strong> – Deals X damage to a random enemy on play.</li>
-              <li><strong>Heal Ally</strong> – Heals all friendlies in lane by X.</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Second Edition -->
-        <SecondEditionFields
-          v-model="secondEdition"
-          :ctoon-image-src="newImagePreview || assetPath"
-          :exclude-ctoon-id="id"
-        />
-
-        <!-- Submit -->
-        <div class="text-right">
-          <button class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">
-            Update cToon
-          </button>
-        </div>
-      </form>
-
-      <Toast v-if="showToast" :message="toastMessage" :type="toastType" />
+        <Toast v-if="showToast" :message="toastMessage" :type="toastType" />
+      </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyCtoonsNew.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCtoonsNew.vue
@@ -1,320 +1,328 @@
 <template>
-  <div class="bg-gray-50 p-6">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
-    <div class="max-w-2xl mx-auto bg-white p-6 rounded-lg shadow ">
-      <h1 class="text-2xl font-semibold mb-4">Add New cToon</h1>
-      <form @submit.prevent="submitForm" class="space-y-4">
-        <!-- Image Upload -->
-        <div>
-          <label class="block mb-1 font-medium">Upload Image (PNG or GIF)</label>
-          <input type="file" accept="image/png,image/gif" @change="handleFile" required class="w-full" />
-          <p class="text-sm text-gray-500">This image will represent the cToon visually. PNG or GIF only.</p>
-          <p v-if="errors.image" class="text-red-600 text-sm mt-1">{{ errors.image }}</p>
-          <div v-if="duplicateStatus !== 'idle'" class="mt-2">
-            <p v-if="duplicateStatus === 'checking'" class="text-sm text-gray-500">Checking for duplicates...</p>
-            <p v-else-if="duplicateStatus === 'error'" class="text-sm text-red-600">{{ duplicateError }}</p>
-            <div v-else-if="duplicateMatch" class="border rounded p-3 bg-amber-50">
-              <p class="text-sm text-amber-700 font-medium">Possible duplicate found</p>
-              <div class="flex items-center gap-3 mt-2">
-                <img
-                  v-if="duplicateMatch.ctoon && duplicateMatch.ctoon.assetPath"
-                  :src="duplicateMatch.ctoon.assetPath"
-                  alt="Possible duplicate"
-                  class="w-20 h-20 object-contain border rounded bg-white"
-                />
-                <div class="text-sm">
-                  <p class="font-medium">{{ duplicateMatch.ctoon?.name || 'Unknown cToon' }}</p>
-                  <p class="text-gray-600">
-                    pHash distance: {{ duplicateMatch.phashDist }}, dHash distance: {{ duplicateMatch.dhashDist }}
-                  </p>
+      <div class="max-w-2xl mx-auto bg-white rounded-lg shadow p-3">
+        <h1 class="text-base font-semibold mb-3">Add New cToon</h1>
+
+        <form @submit.prevent="submitForm" class="space-y-3">
+
+          <!-- ── Media ─────────────────────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Media</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">The image and (optional) sound that represent this cToon in the c-mart and inventory.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Upload Image (PNG or GIF)</label>
+              <input type="file" accept="image/png,image/gif" @change="handleFile" required class="text-xs" />
+              <p class="text-[11px] text-gray-500">This image will represent the cToon visually. PNG or GIF only.</p>
+              <p v-if="errors.image" class="text-red-600 text-[11px] mt-1">{{ errors.image }}</p>
+              <div v-if="duplicateStatus !== 'idle'" class="mt-1">
+                <p v-if="duplicateStatus === 'checking'" class="text-[11px] text-gray-500">Checking for duplicates...</p>
+                <p v-else-if="duplicateStatus === 'error'" class="text-[11px] text-red-600">{{ duplicateError }}</p>
+                <div v-else-if="duplicateMatch" class="border rounded-md p-2 bg-amber-50">
+                  <p class="text-[11px] text-amber-700 font-medium">Possible duplicate found</p>
+                  <div class="flex items-center gap-3 mt-2">
+                    <img
+                      v-if="duplicateMatch.ctoon && duplicateMatch.ctoon.assetPath"
+                      :src="duplicateMatch.ctoon.assetPath"
+                      alt="Possible duplicate"
+                      class="w-20 h-20 object-contain border rounded bg-white"
+                    />
+                    <div class="text-[11px]">
+                      <p class="font-medium">{{ duplicateMatch.ctoon?.name || 'Unknown cToon' }}</p>
+                      <p class="text-gray-600">
+                        pHash distance: {{ duplicateMatch.phashDist }}, dHash distance: {{ duplicateMatch.dhashDist }}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <p v-else class="text-[11px] text-green-600">No duplicates found.</p>
+              </div>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Upload cToon Sound (optional)</label>
+              <input type="file" accept="audio/mpeg,audio/mp3,audio/wav,audio/ogg" @change="handleSoundFile" class="text-xs" />
+              <p class="text-[11px] text-gray-500">MP3, WAV, or OGG. Plays when the cToon info modal is opened.</p>
+              <p v-if="errors.sound" class="text-red-600 text-[11px] mt-1">{{ errors.sound }}</p>
+              <p v-if="soundFile" class="text-[11px] text-green-600 mt-1">Selected: {{ soundFile.name }}</p>
+            </div>
+          </section>
+
+          <!-- ── Identity & Classification ────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Identity &amp; Classification</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">What this cToon is called and how it's grouped/priced by rarity.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Type</label>
+              <input type="text" v-model="type" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              <p class="text-[11px] text-gray-500">Automatically determined from uploaded file.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Rarity</label>
+              <select v-model="rarity" required class="border rounded-md px-2 py-1.5 text-sm bg-white">
+                <option disabled value="">Select rarity</option>
+                <option v-for="opt in rarityOptions" :key="opt" :value="opt">
+                  {{ opt }}
+                </option>
+              </select>
+              <p class="text-[11px] text-gray-500">Choose the rarity tier for this cToon. Drives the default price, quantity, and c-mart placement below.</p>
+              <p v-if="errors.rarity" class="text-red-600 text-[11px] mt-1">{{ errors.rarity }}</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Name</label>
+              <input v-model="name" type="text" required class="border rounded-md px-2 py-1.5 text-sm" placeholder="Enter cToon name" />
+              <p class="text-[11px] text-gray-500">The display name for this cToon.</p>
+              <p v-if="errors.name" class="text-red-600 text-[11px] mt-1">{{ errors.name }}</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Series</label>
+              <input v-model="series" list="series-list" required class="border rounded-md px-2 py-1.5 text-sm" />
+              <datalist v-if="series.length >= 2" id="series-list">
+                <option v-for="opt in filteredSeriesOptions" :key="opt" :value="opt" />
+              </datalist>
+              <p class="text-[11px] text-gray-500">Used to group similar cToons. Choose from existing or enter a new one.</p>
+              <p v-if="errors.series" class="text-red-600 text-[11px] mt-1">{{ errors.series }}</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Set</label>
+              <input v-model="set" list="sets-list" required class="border rounded-md px-2 py-1.5 text-sm" />
+              <datalist v-if="set.length >= 2" id="sets-list">
+                <option v-for="opt in filteredSetsOptions" :key="opt" :value="opt" />
+              </datalist>
+              <p class="text-[11px] text-gray-500">Which collectible set this cToon belongs to. Choose from existing or enter a new one.</p>
+            </div>
+          </section>
+
+          <!-- ── Pricing ───────────────────────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Pricing</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">Point cost to mint/purchase this cToon.</p>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Price</label>
+              <input type="number" v-model.number="price" class="border rounded-md px-2 py-1.5 text-sm" />
+              <p class="text-[11px] text-gray-500">Defaults based on rarity, but you can adjust it here.</p>
+            </div>
+          </section>
+
+          <!-- ── Availability & Mint Limits ───────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Availability &amp; Mint Limits</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">When this cToon goes live, how many can be minted, and where it can be obtained.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Release Date</label>
+              <input v-model="releaseDate" type="datetime-local" required class="border rounded-md px-2 py-1.5 text-sm" />
+              <p class="text-[11px] text-gray-500">Must be set in the future. Determines when the cToon becomes available.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Mint Limit</label>
+              <select v-model="mintLimitType" class="border rounded-md px-2 py-1.5 text-sm bg-white">
+                <option value="defined">Defined Number Limit</option>
+                <option value="timeBased">Time Based Limit</option>
+              </select>
+              <p class="text-[11px] text-gray-500">
+                <template v-if="mintLimitType === 'defined'">Set a fixed quantity. cToon sells out when all are minted.</template>
+                <template v-else>Allow unlimited minting until the Mint End Date, then cap based on demand.</template>
+              </p>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3" v-if="mintLimitType === 'defined'">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Total Quantity</label>
+                <input v-model.number="totalQuantity" type="number" min="1" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[11px] text-gray-500">Maximum number that can be minted. Leave blank for unlimited.</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Quantity</label>
+                <input v-model.number="initialQuantity" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[11px] text-gray-500">Number of First Editions available. Must be ≤ total quantity.</p>
+              </div>
+            </div>
+
+            <div v-if="mintLimitType === 'timeBased'" class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Mint End Date/Time (CST)</label>
+              <input v-model="mintEndDate" type="datetime-local" required class="border rounded-md px-2 py-1.5 text-sm" />
+              <p class="text-[11px] text-gray-500">
+                Minting will be open until this date/time, then the quantity will be capped.
+              </p>
+              <p v-if="mintEndDateLocal" class="text-[11px] text-blue-600 mt-1">
+                (Your time: {{ mintEndDateLocal }})
+              </p>
+            </div>
+
+            <div v-if="mintLimitType === 'timeBased'" class="border rounded-md bg-indigo-50 p-3 space-y-2">
+              <div>
+                <h3 class="text-xs font-semibold text-gray-800">Purchase Limit Override
+                  <span class="text-[11px] font-normal text-gray-500 ml-1">— optional, overrides the rarity default from Global Settings</span>
+                </h3>
+                <p class="text-[11px] text-gray-500 mt-1">Leave either field blank to use the rarity default. Window blank = full release window.</p>
+              </div>
+              <div class="grid grid-cols-2 gap-3">
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Limit Count</label>
+                  <input
+                    type="number"
+                    min="1"
+                    :value="timeBasedLimitCountStr"
+                    @input="timeBasedLimitCountStr = $event.target.value"
+                    placeholder="Use rarity default"
+                    class="border rounded-md px-2 py-1.5 text-sm"
+                  />
+                  <p class="text-[11px] text-gray-500">Max purchases per user.</p>
+                </div>
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Window (days)</label>
+                  <input
+                    type="number"
+                    min="1"
+                    :value="timeBasedLimitWindowDaysStr"
+                    @input="timeBasedLimitWindowDaysStr = $event.target.value"
+                    placeholder="Full duration"
+                    class="border rounded-md px-2 py-1.5 text-sm"
+                  />
+                  <p class="text-[11px] text-gray-500">Rolling window. Blank = full release window.</p>
                 </div>
               </div>
             </div>
-            <p v-else class="text-sm text-green-600">No duplicates found.</p>
-          </div>
-        </div>
 
-        <!-- Second Edition -->
-        <SecondEditionFields
-          v-model="secondEdition"
-          :ctoon-image-src="imagePreview"
-          :auto-note="autoSecondEditionNote"
-        />
-
-        <!-- Sound Upload (optional) -->
-        <div>
-          <label class="block mb-1 font-medium">Upload cToon Sound (optional)</label>
-          <input type="file" accept="audio/mpeg,audio/mp3,audio/wav,audio/ogg" @change="handleSoundFile" class="w-full" />
-          <p class="text-sm text-gray-500">MP3, WAV, or OGG. Plays when the cToon info modal is opened.</p>
-          <p v-if="errors.sound" class="text-red-600 text-sm mt-1">{{ errors.sound }}</p>
-          <p v-if="soundFile" class="text-sm text-green-600 mt-1">Selected: {{ soundFile.name }}</p>
-        </div>
-
-        <!-- Type (auto-filled) -->
-        <div>
-          <label class="block mb-1 font-medium">Type</label>
-          <input type="text" v-model="type" disabled class="w-full border rounded p-2 bg-gray-100" />
-          <p class="text-sm text-gray-500">Automatically determined from uploaded file.</p>
-        </div>
-
-        <!-- Rarity -->
-        <div>
-          <label class="block mb-1 font-medium">Rarity</label>
-          <select v-model="rarity" required class="w-full border rounded p-2 bg-white">
-            <option disabled value="">Select rarity</option>
-            <option v-for="opt in rarityOptions" :key="opt" :value="opt">
-              {{ opt }}
-            </option>
-          </select>
-          <p class="text-sm text-gray-500">Choose the rarity tier for this cToon.</p>
-          <p v-if="errors.rarity" class="text-red-600 text-sm mt-1">{{ errors.rarity }}</p>
-        </div>
-
-        <!-- Name -->
-        <div>
-          <label class="block mb-1 font-medium">Name</label>
-          <input v-model="name" type="text" required class="w-full border rounded p-2" placeholder="Enter cToon name" />
-          <p class="text-sm text-gray-500">The display name for this cToon.</p>
-          <p v-if="errors.name" class="text-red-600 text-sm mt-1">{{ errors.name }}</p>
-        </div>
-
-        <!-- Series -->
-        <div>
-          <label class="block mb-1 font-medium">Series</label>
-          <input v-model="series" list="series-list" required class="w-full border rounded p-2" />
-          <datalist v-if="series.length >= 2" id="series-list">
-            <option v-for="opt in filteredSeriesOptions" :key="opt" :value="opt" />
-          </datalist>
-          <p class="text-sm text-gray-500">Used to group similar cToons. Choose from existing or enter a new one.</p>
-          <p v-if="errors.series" class="text-red-600 text-sm mt-1">{{ errors.series }}</p>
-        </div>
-
-        <!-- Set -->
-        <div>
-          <label class="block mb-1 font-medium">Set</label>
-          <input v-model="set" list="sets-list" required class="w-full border rounded p-2" />
-          <datalist v-if="set.length >= 2" id="sets-list">
-            <option v-for="opt in filteredSetsOptions" :key="opt" :value="opt" />
-          </datalist>
-          <p class="text-sm text-gray-500">Which collectible set this cToon belongs to. Choose from existing or enter a new one.</p>
-        </div>
-
-        <!-- Characters -->
-        <div>
-          <label class="block mb-1 font-medium">Characters (comma-separated)</label>
-          <input v-model="characters" required class="w-full border rounded p-2" placeholder="e.g. Amy,Bob" />
-          <p class="text-sm text-gray-500">List all characters featured in this cToon.</p>
-        </div>
-
-        <!-- Release Date -->
-        <div>
-          <label class="block mb-1 font-medium">Release Date</label>
-          <input v-model="releaseDate" type="datetime-local" required class="w-full border rounded p-2" />
-          <p class="text-sm text-gray-500">Must be set in the future. Determines when the cToon becomes available.</p>
-        </div>
-
-        <!-- Mint Limit Type -->
-        <div>
-          <label class="block mb-1 font-medium">Mint Limit</label>
-          <select v-model="mintLimitType" class="w-full border rounded p-2 bg-white">
-            <option value="defined">Defined Number Limit</option>
-            <option value="timeBased">Time Based Limit</option>
-          </select>
-          <p class="text-sm text-gray-500">
-            <template v-if="mintLimitType === 'defined'">Set a fixed quantity. cToon sells out when all are minted.</template>
-            <template v-else>Allow unlimited minting until the Mint End Date, then cap based on demand.</template>
-          </p>
-        </div>
-
-        <!-- Quantities (only for Defined Number Limit) -->
-        <div class="grid grid-cols-2 gap-4" v-if="mintLimitType === 'defined'">
-          <div>
-            <label class="block mb-1 font-medium">Total Quantity</label>
-            <input v-model.number="totalQuantity" type="number" min="1" class="w-full border rounded p-2" />
-            <p class="text-sm text-gray-500">Maximum number that can be minted. Leave blank for unlimited.</p>
-          </div>
-          <div>
-            <label class="block mb-1 font-medium">Initial Quantity</label>
-            <input v-model.number="initialQuantity" type="number" min="0" class="w-full border rounded p-2" />
-            <p class="text-sm text-gray-500">Number of First Editions available. Must be ≤ total quantity.</p>
-          </div>
-        </div>
-
-        <!-- Mint End Date (only for Time Based Limit) -->
-        <div v-if="mintLimitType === 'timeBased'">
-          <label class="block mb-1 font-medium">Mint End Date/Time (CST)</label>
-          <input v-model="mintEndDate" type="datetime-local" required class="w-full border rounded p-2" />
-          <p class="text-sm text-gray-500">
-            Minting will be open until this date/time, then the quantity will be capped.
-          </p>
-          <p v-if="mintEndDateLocal" class="text-sm text-blue-600 mt-1">
-            (Your time: {{ mintEndDateLocal }})
-          </p>
-        </div>
-
-        <!-- Time-Based Purchase Limit Override (only for Time Based Limit) -->
-        <div v-if="mintLimitType === 'timeBased'" class="border rounded bg-indigo-50 p-4 space-y-3">
-          <div>
-            <h3 class="font-medium text-sm text-gray-800">Purchase Limit Override
-              <span class="text-xs font-normal text-gray-500 ml-1">— optional, overrides the rarity default from Global Settings</span>
-            </h3>
-            <p class="text-xs text-gray-500 mt-1">Leave either field blank to use the rarity default. Window blank = full release window.</p>
-          </div>
-          <div class="grid grid-cols-2 gap-4">
-            <div>
-              <label class="block mb-1 text-sm font-medium">Limit Count</label>
-              <input
-                type="number"
-                min="1"
-                :value="timeBasedLimitCountStr"
-                @input="timeBasedLimitCountStr = $event.target.value"
-                placeholder="Use rarity default"
-                class="w-full border rounded p-2"
-              />
-              <p class="text-xs text-gray-500 mt-1">Max purchases per user.</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3" v-if="schedule.initialQty != null && schedule.finalAtDisplay">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Release %</label>
+                <input :value="releasePercent + '%'" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Release Qty</label>
+                <input :value="schedule.initialQty" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Final Release At (CST/CDT)</label>
+                <input :value="schedule.finalAtDisplay" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Final Release Qty</label>
+                <input :value="schedule.finalQty" disabled class="border rounded-md px-2 py-1.5 text-sm bg-gray-100" />
+              </div>
             </div>
-            <div>
-              <label class="block mb-1 text-sm font-medium">Window (days)</label>
-              <input
-                type="number"
-                min="1"
-                :value="timeBasedLimitWindowDaysStr"
-                @input="timeBasedLimitWindowDaysStr = $event.target.value"
-                placeholder="Full duration"
-                class="w-full border rounded p-2"
-              />
-              <p class="text-xs text-gray-500 mt-1">Rolling window. Blank = full release window.</p>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Per-User Limit</label>
+              <input v-model.number="perUserLimit" type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" />
+              <p class="text-[11px] text-gray-500">Limit on how many each user can mint within the first 48 hours of release. Leave blank for no limit.</p>
             </div>
-          </div>
-        </div>
 
-        <!-- Release schedule (computed, read-only) -->
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4" v-if="schedule.initialQty != null && schedule.finalAtDisplay">
-          <div>
-            <label class="block mb-1 font-medium">Initial Release %</label>
-            <input :value="releasePercent + '%'" disabled class="w-full border rounded p-2 bg-gray-100" />
-          </div>
-          <div>
-            <label class="block mb-1 font-medium">Initial Release Qty</label>
-            <input :value="schedule.initialQty" disabled class="w-full border rounded p-2 bg-gray-100" />
-          </div>
-          <div>
-            <label class="block mb-1 font-medium">Final Release At (CST/CDT)</label>
-            <input :value="schedule.finalAtDisplay" disabled class="w-full border rounded p-2 bg-gray-100" />
-          </div>
-          <div>
-            <label class="block mb-1 font-medium">Final Release Qty</label>
-            <input :value="schedule.finalQty" disabled class="w-full border rounded p-2 bg-gray-100" />
-          </div>
-        </div>
-
-        <!-- Per User Limit -->
-        <div>
-          <label class="block mb-1 font-medium">Per-User Limit</label>
-          <input v-model.number="perUserLimit" type="number" min="0" class="w-full border rounded p-2" />
-          <p class="text-sm text-gray-500">Limit on how many each user can mint within the first 48 hours of release. Leave blank for no limit.</p>
-        </div>
-
-        <!-- Code Only / In Cmart -->
-        <div class="flex items-center space-x-4">
-          <label class="flex items-center">
-            <input type="checkbox" v-model="inCmart" class="mr-2" /> In Cmart
-          </label>
-        </div>
-        <p class="text-sm text-gray-500">Check "Code Only" for exclusive reward drops. Check "In Cmart" to list in shop.</p>
-
-        <!-- ── Is this a G-toon? ─────────────────────────────── -->
-        <div class="flex items-center space-x-4 mt-6">
-          <label class="flex items-center font-medium">
-            <input type="checkbox" v-model="isGtoon" class="mr-2" />
-            Is this a gToon?
-          </label>
-        </div>
-        <p class="text-sm text-gray-500 mb-4">
-          Check if this cToon will be playable in Clash.
-        </p>
-
-        <!-- ── G-toon-specific fields (shown only if checked) ── -->
-        <div v-if="isGtoon" class="border p-4 rounded bg-indigo-50 space-y-4">
-          <!-- G-toon Type (free text, optional) -->
-          <div>
-            <label class="block mb-1 font-medium">Type (gToon)</label>
-            <input v-model="gtoonType" type="text" class="w-full border rounded p-2" placeholder="e.g. Beast, Robot, Support" />
-            <p class="text-sm text-gray-500">Optional. Leave blank if none.</p>
-          </div>
-          <!-- Cost -->
-          <div>
-            <label class="block mb-1 font-medium">Cost <span class="text-xs text-gray-500">(1 – 6)</span></label>
-            <input v-model.number="cost" type="number" min="0" max="6"
-                  required class="w-full border rounded p-2" />
-            <p class="text-sm text-gray-500">Energy needed to play this card in Clash.</p>
-            <p v-if="errors.cost" class="text-red-600 text-sm mt-1">{{ errors.cost }}</p>
-          </div>
-
-          <!-- Power -->
-          <div>
-            <label class="block mb-1 font-medium">Power <span class="text-xs text-gray-500">(≥ 0)</span></label>
-            <input v-model.number="power" type="number" min="0" max="12"
-                  required class="w-full border rounded p-2" />
-            <p class="text-sm text-gray-500">Base lane power the card contributes.</p>
-            <p v-if="errors.power" class="text-red-600 text-sm mt-1">{{ errors.power }}</p>
-          </div>
-
-          <!-- Ability Key -->
-          <div>
-            <label class="block mb-1 font-medium">Ability</label>
-            <select v-model="abilityKey" class="w-full border rounded p-2 bg-white">
-              <option disabled value="">Select an ability</option>
-              <option v-for="a in abilityKeyOptions" :key="a.key" :value="a.key">
-                {{ a.label }}
-              </option>
-            </select>
-            <p class="text-sm text-gray-500">
-              Determines the on-play effect. See the tips below for how each ability works.
-            </p>
-          </div>
-
-          <!-- Ability Data (parameter) -->
-          <div v-if="selectedAbility && selectedAbility.params?.length">
-            <label class="block mb-1 font-medium">
-              {{ selectedAbility.paramLabel }}
+            <label class="flex items-center gap-2">
+              <input type="checkbox" v-model="inCmart" />
+              <span class="text-xs font-medium">In Cmart</span>
             </label>
-            <select v-model="abilityParam" class="w-full border rounded p-2 bg-white">
-              <option :value="null" disabled>Select a value</option>
-              <option v-for="opt in selectedAbility.params" :key="opt" :value="opt">
-                {{ opt }}
-              </option>
-            </select>
-            <p class="text-sm text-gray-500">
-              {{ selectedAbility.paramHelp }}
-            </p>
+            <p class="text-[11px] text-gray-500">Whether this cToon is purchasable in the c-mart shop. Select "Code Only" rarity for exclusive reward drops instead.</p>
+          </section>
+
+          <!-- ── G-toon Gameplay ───────────────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">G-toon Gameplay</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">Only needed if this cToon will be playable as a card in Clash.</p>
+            </div>
+
+            <label class="flex items-center gap-2">
+              <input type="checkbox" v-model="isGtoon" />
+              <span class="text-xs font-medium">Is this a gToon?</span>
+            </label>
+
+            <div v-if="isGtoon" class="border rounded-md bg-indigo-50 p-3 space-y-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Type (gToon)</label>
+                <input v-model="gtoonType" type="text" class="border rounded-md px-2 py-1.5 text-sm" placeholder="e.g. Beast, Robot, Support" />
+                <p class="text-[11px] text-gray-500">Optional. Leave blank if none.</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Cost <span class="text-[11px] font-normal text-gray-500">(1 – 6)</span></label>
+                <input v-model.number="cost" type="number" min="0" max="6"
+                      required class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[11px] text-gray-500">Energy needed to play this card in Clash.</p>
+                <p v-if="errors.cost" class="text-red-600 text-[11px] mt-1">{{ errors.cost }}</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Power <span class="text-[11px] font-normal text-gray-500">(≥ 0)</span></label>
+                <input v-model.number="power" type="number" min="0" max="12"
+                      required class="border rounded-md px-2 py-1.5 text-sm" />
+                <p class="text-[11px] text-gray-500">Base lane power the card contributes.</p>
+                <p v-if="errors.power" class="text-red-600 text-[11px] mt-1">{{ errors.power }}</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Ability</label>
+                <select v-model="abilityKey" class="border rounded-md px-2 py-1.5 text-sm bg-white">
+                  <option disabled value="">Select an ability</option>
+                  <option v-for="a in abilityKeyOptions" :key="a.key" :value="a.key">
+                    {{ a.label }}
+                  </option>
+                </select>
+                <p class="text-[11px] text-gray-500">
+                  Determines the on-play effect. See the tips below for how each ability works.
+                </p>
+              </div>
+              <div v-if="selectedAbility && selectedAbility.params?.length" class="flex flex-col gap-1">
+                <label class="text-xs font-medium">
+                  {{ selectedAbility.paramLabel }}
+                </label>
+                <select v-model="abilityParam" class="border rounded-md px-2 py-1.5 text-sm bg-white">
+                  <option :value="null" disabled>Select a value</option>
+                  <option v-for="opt in selectedAbility.params" :key="opt" :value="opt">
+                    {{ opt }}
+                  </option>
+                </select>
+                <p class="text-[11px] text-gray-500">
+                  {{ selectedAbility.paramHelp }}
+                </p>
+              </div>
+              <div class="text-[11px] text-left text-gray-600">
+                <p class="font-semibold">Ability cheat-sheet:</p>
+                <ul class="list-disc list-inside">
+                  <li><strong>Flame Bug</strong> – Deals the selected damage to a random enemy
+                      in the lane when played.</li>
+                  <li><strong>Heal Ally</strong> – Heals all friendly cToons in the lane for
+                      the selected amount.</li>
+                  <!-- add more as you add registry entries -->
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <!-- ── Second Edition ────────────────────────────────────── -->
+          <section class="border rounded-lg p-3 space-y-3">
+            <div>
+              <h2 class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Second Edition</h2>
+              <p class="text-[11px] text-gray-500 mt-0.5">Mark this cToon as a reprint of an existing one, with an overlay badge.</p>
+            </div>
+            <SecondEditionFields
+              v-model="secondEdition"
+              :ctoon-image-src="imagePreview"
+              :auto-note="autoSecondEditionNote"
+            />
+          </section>
+
+          <!-- Submit -->
+          <div class="text-right">
+            <button class="px-4 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700">Create cToon</button>
           </div>
-
-          <!-- Inline guidance -->
-          <div class="text-xs text-left text-gray-600">
-            <p class="font-semibold">Ability cheat-sheet:</p>
-            <ul class="list-disc list-inside">
-              <li><strong>Flame Bug</strong> – Deals the selected damage to a random enemy
-                  in the lane when played.</li>
-              <li><strong>Heal Ally</strong> – Heals all friendly cToons in the lane for
-                  the selected amount.</li>
-              <!-- add more as you add registry entries -->
-            </ul>
-          </div>
-        </div>
-
-        <!-- Price -->
-        <div>
-          <label class="block mb-1 font-medium">Price</label>
-          <input type="number" v-model.number="price" class="w-full border rounded p-2" />
-          <p class="text-sm text-gray-500">Defaults based on rarity, but you can adjust it here.</p>
-        </div>
-
-        <!-- Submit -->
-        <div class="text-right">
-          <button class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">Create cToon</button>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyCzoneEdit.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCzoneEdit.vue
@@ -1,14 +1,14 @@
 <template>
 
-  <div class="px-4 py-6 mx-auto flex flex-col items-center gap-4 w-full max-w-[900px]">
+  <div class="admin-legacy-czone-edit bg-gray-50 text-xs px-2 py-2 mx-auto flex flex-col items-center gap-3 w-full max-w-[900px]">
     <!-- Header -->
-    <div class="w-full flex items-center justify-between">
+    <div class="w-full flex items-center justify-between flex-wrap gap-2">
       <div>
-        <h1 class="text-xl font-bold">Admin: Edit cZone for <span class="text-indigo-600">{{ username }}</span></h1>
-        <p class="text-sm text-gray-500 mt-0.5">Click the X on a cToon to remove it, then save.</p>
+        <h1 class="text-base font-semibold">Admin: Edit cZone for <span class="text-indigo-600">{{ username }}</span></h1>
+        <p class="text-xs text-gray-500 mt-0.5">Click the X on a cToon to remove it, then save.</p>
       </div>
       <button
-        class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+        class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
         @click="cancel"
       >
         Cancel
@@ -16,17 +16,17 @@
     </div>
 
     <!-- Zone pager -->
-    <div class="flex items-center gap-4">
+    <div class="flex items-center gap-3">
       <button
-        class="bg-gray-500 text-white px-3 py-1 rounded hover:bg-gray-600 disabled:opacity-50"
+        class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50 disabled:opacity-50"
         :disabled="currentZoneIndex === 0"
         @click="prevZone"
       >
         ← Zone {{ currentZoneIndex }}
       </button>
-      <span class="text-sm font-medium">Zone {{ currentZoneIndex + 1 }} of {{ zones.length }}</span>
+      <span class="text-xs font-medium">Zone {{ currentZoneIndex + 1 }} of {{ zones.length }}</span>
       <button
-        class="bg-gray-500 text-white px-3 py-1 rounded hover:bg-gray-600 disabled:opacity-50"
+        class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50 disabled:opacity-50"
         :disabled="currentZoneIndex === zones.length - 1"
         @click="nextZone"
       >
@@ -65,22 +65,22 @@
           </div>
         </div>
 
-        <div v-if="currentToons.length === 0 && !loading" class="absolute inset-0 flex items-center justify-center text-gray-400 text-sm">
+        <div v-if="currentToons.length === 0 && !loading" class="absolute inset-0 flex items-center justify-center text-gray-400 text-xs">
           No cToons in this zone
         </div>
       </div>
     </div>
 
     <!-- Save button -->
-    <div class="flex gap-3">
+    <div class="flex gap-2">
       <button
-        class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+        class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
         @click="cancel"
       >
         Cancel
       </button>
       <button
-        class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700 disabled:opacity-50"
+        class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
         :disabled="saving"
         @click="save"
       >

--- a/components/newsite/admin/legacy/AdminLegacyCzoneSearch.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCzoneSearch.vue
@@ -1,39 +1,40 @@
 <template>
-  <div class="bg-gray-50 p-6 ">
+  <div class="admin-legacy-czone-search bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
-    <div class="max-w-6xl mx-auto bg-white rounded-lg shadow p-6 mt-6">
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
+    <div class="max-w-6xl mx-auto bg-white rounded border shadow p-3">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-3">
         <div>
-          <h1 class="text-2xl font-semibold">Manage cZone Search</h1>
-          <p class="text-sm text-gray-500">Times display in Central Time (CST/CDT).</p>
+          <h1 class="text-base font-semibold">Manage cZone Search</h1>
+          <p class="text-xs text-gray-500">Times display in Central Time (CST/CDT).</p>
         </div>
         <button
-          class="w-full sm:w-auto bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          class="w-full sm:w-auto px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
           @click="openCreate"
         >
           Create Search
         </button>
       </div>
 
-      <div class="flex items-center gap-2 mb-4">
+      <div class="flex items-center gap-2 mb-3">
         <input id="show-all" type="checkbox" v-model="showAll" class="h-4 w-4" />
-        <label for="show-all" class="text-sm text-gray-700">Show All Searches</label>
+        <label for="show-all" class="text-xs text-gray-700">Show All Searches</label>
       </div>
 
-      <div v-if="error" class="text-red-600 mb-4">
+      <div v-if="error" class="text-red-600 text-xs mb-3">
         {{ error.message || 'Failed to load cZone Searches' }}
       </div>
-      <div v-if="pending" class="text-gray-500">Loading...</div>
+      <div v-if="pending" class="text-xs text-gray-500">Loading...</div>
 
       <div v-if="searches.length">
         <!-- Mobile cards -->
-        <div class="space-y-4 sm:hidden">
-          <div v-for="row in searches" :key="row.id" class="border rounded-lg p-4 bg-white">
-            <div class="text-sm font-semibold text-gray-900">{{ displayName(row.name) }}</div>
+        <div class="space-y-2 sm:hidden">
+          <div v-for="row in searches" :key="row.id" class="bg-white border rounded-lg shadow p-2">
+            <div class="font-semibold text-xs text-gray-900">{{ displayName(row.name) }}</div>
             <div class="text-xs text-gray-500">Start (CST)</div>
-            <div class="font-medium text-gray-900">{{ formatCentral(row.startAt) }}</div>
+            <div class="font-medium text-xs text-gray-900">{{ formatCentral(row.startAt) }}</div>
             <div class="mt-2 text-xs text-gray-500">End (CST)</div>
-            <div class="font-medium text-gray-900">{{ formatCentral(row.endAt) }}</div>
+            <div class="font-medium text-xs text-gray-900">{{ formatCentral(row.endAt) }}</div>
             <div class="mt-3 grid grid-cols-2 gap-2 text-xs text-gray-600">
               <div><span class="font-semibold">Appearance:</span> {{ row.appearanceRatePercent }}%</div>
               <div><span class="font-semibold">Reset:</span> {{ resetLabel(row) }}</div>
@@ -45,97 +46,97 @@
               <div class="col-span-2"><span class="font-semibold">Prize Pool:</span> {{ row.prizePool.length }} cToons</div>
             </div>
             <div class="mt-3 flex gap-3">
-              <NuxtLink class="text-blue-600 hover:text-blue-800" :to="`/czonesearch/${row.id}`">View</NuxtLink>
-              <button class="text-blue-600 hover:text-blue-800" @click="openEdit(row)">Edit</button>
-              <button class="text-red-600 hover:text-red-800" @click="remove(row)">Delete</button>
+              <NuxtLink class="text-blue-600 hover:text-blue-800 text-xs" :to="`/czonesearch/${row.id}`">View</NuxtLink>
+              <button class="text-blue-600 hover:text-blue-800 text-xs" @click="openEdit(row)">Edit</button>
+              <button class="text-red-600 hover:text-red-800 text-xs" @click="remove(row)">Delete</button>
             </div>
           </div>
         </div>
 
         <!-- Desktop table -->
         <div class="hidden sm:block overflow-x-auto">
-          <table class="w-full text-sm">
+          <table class="w-full text-xs">
             <thead>
               <tr class="text-left border-b">
-                <th class="py-2 pr-4">Name</th>
-                <th class="py-2 pr-4">Start (CST)</th>
-                <th class="py-2 pr-4">End (CST)</th>
-                <th class="py-2 pr-4">Appearance %</th>
-                <th class="py-2 pr-4">Reset</th>
-                <th class="py-2 pr-4">Collection</th>
-                <th class="py-2 pr-4">Prize Pool</th>
-                <th class="py-2 pr-4">Actions</th>
+                <th class="px-2 py-1.5 pr-4 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Name</th>
+                <th class="px-2 py-1.5 pr-4 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Start (CST)</th>
+                <th class="px-2 py-1.5 pr-4 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">End (CST)</th>
+                <th class="px-2 py-1.5 pr-4 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Appearance %</th>
+                <th class="px-2 py-1.5 pr-4 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Reset</th>
+                <th class="px-2 py-1.5 pr-4 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Collection</th>
+                <th class="px-2 py-1.5 pr-4 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Prize Pool</th>
+                <th class="px-2 py-1.5 pr-4 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Actions</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="row in searches" :key="row.id" class="border-b last:border-b-0">
-                <td class="py-3 pr-4 font-medium">{{ displayName(row.name) }}</td>
-                <td class="py-3 pr-4 whitespace-nowrap">{{ formatCentral(row.startAt) }}</td>
-                <td class="py-3 pr-4 whitespace-nowrap">{{ formatCentral(row.endAt) }}</td>
-                <td class="py-3 pr-4">{{ row.appearanceRatePercent }}%</td>
-                <td class="py-3 pr-4">
+                <td class="px-2 py-1.5 pr-4 font-medium">{{ displayName(row.name) }}</td>
+                <td class="px-2 py-1.5 pr-4 whitespace-nowrap">{{ formatCentral(row.startAt) }}</td>
+                <td class="px-2 py-1.5 pr-4 whitespace-nowrap">{{ formatCentral(row.endAt) }}</td>
+                <td class="px-2 py-1.5 pr-4">{{ row.appearanceRatePercent }}%</td>
+                <td class="px-2 py-1.5 pr-4">
                   <div>{{ resetLabel(row) }}</div>
                   <div v-if="isDailyReset(row)" class="text-xs text-gray-500">
                     Able To Collect Daily: {{ dailyLimitLabel(row) }}
                   </div>
                   <div v-else class="text-xs text-gray-500">{{ row.cooldownHours }}h</div>
                 </td>
-                <td class="py-3 pr-4">{{ collectionLabel(row.collectionType) }}</td>
-                <td class="py-3 pr-4">{{ row.prizePool.length }} cToons</td>
-                <td class="py-3 pr-4 whitespace-nowrap">
-                  <NuxtLink class="text-blue-600 hover:text-blue-800 mr-3" :to="`/czonesearch/${row.id}`">View</NuxtLink>
-                  <button class="text-blue-600 hover:text-blue-800 mr-3" @click="openEdit(row)">Edit</button>
-                  <button class="text-red-600 hover:text-red-800" @click="remove(row)">Delete</button>
+                <td class="px-2 py-1.5 pr-4">{{ collectionLabel(row.collectionType) }}</td>
+                <td class="px-2 py-1.5 pr-4">{{ row.prizePool.length }} cToons</td>
+                <td class="px-2 py-1.5 pr-4 whitespace-nowrap">
+                  <NuxtLink class="text-blue-600 hover:text-blue-800 mr-3 text-xs" :to="`/czonesearch/${row.id}`">View</NuxtLink>
+                  <button class="text-blue-600 hover:text-blue-800 mr-3 text-xs" @click="openEdit(row)">Edit</button>
+                  <button class="text-red-600 hover:text-red-800 text-xs" @click="remove(row)">Delete</button>
                 </td>
               </tr>
             </tbody>
           </table>
         </div>
       </div>
-      <div v-else-if="!pending" class="text-gray-500">No cZone Searches found.</div>
+      <div v-else-if="!pending" class="text-xs text-gray-500">No cZone Searches found.</div>
     </div>
 
     <!-- Create/Edit Modal -->
-    <div v-if="showModal" class="fixed inset-0 z-50 flex items-center justify-center">
+    <div v-if="showModal" class="fixed inset-0 z-50 flex items-center justify-center p-2">
       <div class="absolute inset-0 bg-black/50" @click="closeModal"></div>
-      <div class="relative bg-white rounded-lg shadow-lg w-full max-w-3xl max-h-[90vh] flex flex-col">
-        <div class="p-4 border-b flex items-center justify-between flex-shrink-0">
-          <h2 class="text-lg font-semibold">{{ modalTitle }}</h2>
-          <button class="text-gray-600 hover:text-gray-800" @click="closeModal">Close</button>
+      <div class="relative bg-white w-full max-w-3xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="px-4 py-3 border-b flex items-center justify-between flex-shrink-0">
+          <h2 class="text-sm font-semibold">{{ modalTitle }}</h2>
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeModal">Close</button>
         </div>
 
-        <div class="p-4 overflow-y-auto flex-1">
-          <div class="space-y-4">
+        <div class="px-4 py-3 overflow-y-auto flex-1">
+          <div class="space-y-3">
             <div>
-              <label class="block mb-1 font-medium">Search Name</label>
-              <input v-model="form.name" type="text" class="w-full border rounded px-3 py-2" placeholder="e.g. Fall Gold Hunt" />
+              <label class="block text-xs font-medium mb-1">Search Name</label>
+              <input v-model="form.name" type="text" class="w-full border rounded-md px-2 py-1.5 text-sm" placeholder="e.g. Fall Gold Hunt" />
             </div>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
-                <label class="block mb-1 font-medium">Start (CST)</label>
-                <input v-model="form.startAt" type="datetime-local" class="w-full border rounded px-3 py-2" />
+                <label class="block text-xs font-medium mb-1">Start (CST)</label>
+                <input v-model="form.startAt" type="datetime-local" class="w-full border rounded-md px-2 py-1.5 text-sm" />
               </div>
               <div>
-                <label class="block mb-1 font-medium">End (CST)</label>
-                <input v-model="form.endAt" type="datetime-local" class="w-full border rounded px-3 py-2" />
+                <label class="block text-xs font-medium mb-1">End (CST)</label>
+                <input v-model="form.endAt" type="datetime-local" class="w-full border rounded-md px-2 py-1.5 text-sm" />
               </div>
             </div>
 
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div>
-                <label class="block mb-1 font-medium">Appearance Rate %</label>
-                <input v-model.number="form.appearanceRatePercent" type="number" min="0" max="100" step="0.01" class="w-full border rounded px-3 py-2" />
+                <label class="block text-xs font-medium mb-1">Appearance Rate %</label>
+                <input v-model.number="form.appearanceRatePercent" type="number" min="0" max="100" step="0.01" class="w-full border rounded-md px-2 py-1.5 text-sm" />
               </div>
               <div>
-                <label class="block mb-1 font-medium">Reset Type</label>
-                <select v-model="form.resetType" class="w-full border rounded px-3 py-2">
+                <label class="block text-xs font-medium mb-1">Reset Type</label>
+                <select v-model="form.resetType" class="w-full border rounded-md px-2 py-1.5 text-sm">
                   <option value="COOLDOWN_HOURS">Cooldown in Hours</option>
                   <option value="DAILY_AT_RESET">Daily at 8pm CT</option>
                 </select>
               </div>
               <div>
-                <label class="block mb-1 font-medium">Collection Type</label>
-                <select v-model="form.collectionType" class="w-full border rounded px-3 py-2">
+                <label class="block text-xs font-medium mb-1">Collection Type</label>
+                <select v-model="form.collectionType" class="w-full border rounded-md px-2 py-1.5 text-sm">
                   <option value="ONCE">Collect Each cToon Once</option>
                   <option value="MULTIPLE">Collect Each cToon Multiple Times</option>
                   <option value="CUSTOM_PER_CTOON">Custom Per cToon</option>
@@ -145,44 +146,44 @@
 
             <div class="flex items-center gap-2">
               <input id="link-in-onboarding" v-model="form.linkInOnboarding" type="checkbox" class="h-4 w-4" />
-              <label for="link-in-onboarding" class="text-sm text-gray-700">Link in Onboarding</label>
+              <label for="link-in-onboarding" class="text-xs text-gray-700">Link in Onboarding</label>
             </div>
 
-            <div v-if="form.resetType === 'COOLDOWN_HOURS'" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div v-if="form.resetType === 'COOLDOWN_HOURS'" class="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div>
-                <label class="block mb-1 font-medium">Cooldown (Hours)</label>
-                <input v-model.number="form.cooldownHours" type="number" min="0" step="1" class="w-full border rounded px-3 py-2" />
+                <label class="block text-xs font-medium mb-1">Cooldown (Hours)</label>
+                <input v-model.number="form.cooldownHours" type="number" min="0" step="1" class="w-full border rounded-md px-2 py-1.5 text-sm" />
               </div>
             </div>
-            <div v-else class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div v-else class="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div>
-                <label class="block mb-1 font-medium">Able To Collect Daily</label>
-                <input v-model="form.dailyCollectLimit" type="number" min="1" step="1" class="w-full border rounded px-3 py-2" />
+                <label class="block text-xs font-medium mb-1">Able To Collect Daily</label>
+                <input v-model="form.dailyCollectLimit" type="number" min="1" step="1" class="w-full border rounded-md px-2 py-1.5 text-sm" />
                 <p class="text-xs text-gray-500 mt-1">Leave blank for unlimited.</p>
               </div>
             </div>
 
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div class="sm:col-span-2">
-                <label class="block mb-1 font-medium">Mass Update Set Names</label>
+                <label class="block text-xs font-medium mb-1">Mass Update Set Names</label>
                 <div class="flex gap-2">
                   <div class="relative flex-1">
                     <input
                       v-model="massUpdateSetTerm"
                       type="text"
                       placeholder="Type 3+ characters to search set names"
-                      class="w-full border rounded px-3 py-2"
+                      class="w-full border rounded-md px-2 py-1.5 text-sm"
                       @focus="massUpdateSetFocused = true"
                       @blur="massUpdateSetFocused = false"
                       @input="searchMassUpdateSets"
                     />
                     <ul v-if="massUpdateSetTerm.length >= 3 && massUpdateSetFocused" class="absolute z-10 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
-                      <li v-if="massUpdateSetSearching" class="px-3 py-2 text-gray-500">Searching...</li>
-                      <li v-else-if="!massUpdateSetResults.length" class="px-3 py-2 text-gray-500">No results found.</li>
+                      <li v-if="massUpdateSetSearching" class="px-2 py-1.5 text-xs text-gray-500">Searching...</li>
+                      <li v-else-if="!massUpdateSetResults.length" class="px-2 py-1.5 text-xs text-gray-500">No results found.</li>
                       <li
                         v-for="setName in massUpdateSetResults"
                         :key="setName"
-                        class="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+                        class="px-2 py-1.5 text-xs hover:bg-gray-100 cursor-pointer"
                         @mousedown.prevent="selectMassUpdateSet(setName)"
                       >
                         {{ setName }}
@@ -191,7 +192,7 @@
                   </div>
                   <button
                     type="button"
-                    class="px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 whitespace-nowrap"
+                    class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 whitespace-nowrap"
                     :disabled="!massUpdateSetSelected"
                     @click="applyMassUpdateSetName"
                   >
@@ -203,7 +204,7 @@
             </div>
 
             <div>
-              <label class="block mb-1 font-medium">Prize Pool</label>
+              <label class="block text-xs font-medium mb-1">Prize Pool</label>
               <p v-if="form.collectionType === 'CUSTOM_PER_CTOON'" class="text-xs text-gray-500 mb-2">
                 Max Captures: leave blank for unlimited.
               </p>
@@ -212,17 +213,17 @@
                   v-model="ctoonSearchTerm"
                   type="text"
                   placeholder="Type 3+ characters to search cToons"
-                  class="w-full border rounded px-3 py-2"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
                   @focus="searchFocused = true"
                   @blur="searchFocused = false"
                 />
                 <ul v-if="ctoonSearchTerm.length >= 3 && searchFocused" class="absolute z-10 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
-                  <li v-if="searchingCtoons" class="px-3 py-2 text-gray-500">Searching...</li>
-                  <li v-else-if="!ctoonSearchResults.length" class="px-3 py-2 text-gray-500">No results found.</li>
+                  <li v-if="searchingCtoons" class="px-2 py-1.5 text-xs text-gray-500">Searching...</li>
+                  <li v-else-if="!ctoonSearchResults.length" class="px-2 py-1.5 text-xs text-gray-500">No results found.</li>
                   <li
                     v-for="ctoon in ctoonSearchResults"
                     :key="ctoon.id"
-                    class="px-3 py-2 hover:bg-gray-100 cursor-pointer flex items-center gap-3"
+                    class="px-2 py-1.5 text-xs hover:bg-gray-100 cursor-pointer flex items-center gap-3"
                     @mousedown.prevent="addCtoonToPool(ctoon)"
                   >
                     <img :src="ctoon.assetPath" class="h-10 w-auto rounded" />
@@ -239,12 +240,12 @@
                 </ul>
               </div>
 
-              <div v-if="!form.prizePool.length" class="text-sm text-gray-500 mt-2">Add at least one cToon to the prize pool.</div>
+              <div v-if="!form.prizePool.length" class="text-xs text-gray-500 mt-2">Add at least one cToon to the prize pool.</div>
               <div class="mt-3 space-y-2">
                 <div
                   v-for="(row, idx) in form.prizePool"
                   :key="row.ctoonId"
-                  class="bg-gray-50 rounded p-2 space-y-3"
+                  class="bg-gray-50 rounded-md p-2 space-y-2"
                 >
                   <div class="flex flex-col sm:flex-row sm:items-center gap-3">
                     <button type="button" class="flex items-center gap-3 flex-1 text-left" @click="togglePrizeRow(row)">
@@ -259,29 +260,29 @@
                     </button>
                     <div class="flex items-center gap-2">
                       <label class="text-xs text-gray-500">Chance %</label>
-                      <input v-model.number="row.chancePercent" type="number" min="0" max="100" step="0.01" class="w-28 border rounded px-2 py-1" />
+                      <input v-model.number="row.chancePercent" type="number" min="0" max="100" step="0.01" class="w-24 border rounded-md px-2 py-1 text-xs" />
                     </div>
                     <div v-if="form.collectionType === 'CUSTOM_PER_CTOON'" class="flex items-center gap-2">
                       <label class="text-xs text-gray-500">Max Captures</label>
-                      <input v-model="row.maxCaptures" type="number" min="1" step="1" placeholder="Unlimited" class="w-28 border rounded px-2 py-1" />
+                      <input v-model="row.maxCaptures" type="number" min="1" step="1" placeholder="Unlimited" class="w-24 border rounded-md px-2 py-1 text-xs" />
                     </div>
-                    <button class="text-red-600 hover:text-red-800 text-sm" @click="removeCtoon(idx)">Remove</button>
+                    <button class="text-red-600 hover:text-red-800 text-xs" @click="removeCtoon(idx)">Remove</button>
                   </div>
 
-                  <div v-if="expandedPrizeId === row.ctoonId" class="border-t pt-3 space-y-4">
+                  <div v-if="expandedPrizeId === row.ctoonId" class="border-t pt-2 space-y-3">
                     <div class="flex items-start gap-3">
                       <input v-model="row.conditionDateEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'date')" />
                       <div class="flex-1">
-                        <div class="text-sm font-medium">Date</div>
+                        <div class="text-xs font-medium">Date</div>
                         <p class="text-xs text-gray-500">Must be within the search start/end date.</p>
                         <div v-if="row.conditionDateEnabled" class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
                           <div>
                             <label class="text-xs text-gray-500">Start Date</label>
-                            <input v-model="row.conditionDateStart" type="date" :min="searchDateBounds.start" :max="searchDateBounds.end" class="w-full border rounded px-2 py-1" />
+                            <input v-model="row.conditionDateStart" type="date" :min="searchDateBounds.start" :max="searchDateBounds.end" class="w-full border rounded-md px-2 py-1 text-xs" />
                           </div>
                           <div>
                             <label class="text-xs text-gray-500">End Date</label>
-                            <input v-model="row.conditionDateEnd" type="date" :min="searchDateBounds.start" :max="searchDateBounds.end" class="w-full border rounded px-2 py-1" />
+                            <input v-model="row.conditionDateEnd" type="date" :min="searchDateBounds.start" :max="searchDateBounds.end" class="w-full border rounded-md px-2 py-1 text-xs" />
                           </div>
                         </div>
                       </div>
@@ -290,10 +291,10 @@
                     <div class="flex items-start gap-3">
                       <input v-model="row.conditionTimeEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'time')" />
                       <div class="flex-1">
-                        <div class="text-sm font-medium">Time of Day</div>
+                        <div class="text-xs font-medium">Time of Day</div>
                         <p class="text-xs text-gray-500">Based on the viewer's local timezone.</p>
                         <div v-if="row.conditionTimeEnabled" class="mt-2">
-                          <select v-model="row.conditionTimeOfDay" class="w-full border rounded px-2 py-1">
+                          <select v-model="row.conditionTimeOfDay" class="w-full border rounded-md px-2 py-1 text-xs">
                             <option value="">Select a time of day</option>
                             <option value="MORNING">Morning (6am–11:59am)</option>
                             <option value="AFTERNOON">Afternoon (12pm–4:59pm)</option>
@@ -307,7 +308,7 @@
                     <div class="flex items-start gap-3">
                       <input v-model="row.conditionBackgroundEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'background')" />
                       <div class="flex-1">
-                        <div class="text-sm font-medium">cZone Background</div>
+                        <div class="text-xs font-medium">cZone Background</div>
                         <p class="text-xs text-gray-500">Select one or more backgrounds.</p>
                         <div v-if="row.conditionBackgroundEnabled" class="mt-2">
                           <div v-if="backgroundsLoading" class="text-xs text-gray-500">Loading backgrounds...</div>
@@ -332,7 +333,7 @@
                     <div class="flex items-start gap-3">
                       <input v-model="row.conditionCtoonInZoneEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'ctoonInZone')" />
                       <div class="flex-1">
-                        <div class="text-sm font-medium">cToon in cZone</div>
+                        <div class="text-xs font-medium">cToon in cZone</div>
                         <p class="text-xs text-gray-500">Select one cToon that must appear in the viewed cZone.</p>
                         <div v-if="row.conditionCtoonInZoneEnabled" class="mt-2">
                           <div class="relative">
@@ -340,18 +341,18 @@
                               v-model="row.conditionCtoonInZoneTerm"
                               type="text"
                               placeholder="Type 3+ characters to search cToons"
-                              class="w-full border rounded px-2 py-1"
+                              class="w-full border rounded-md px-2 py-1 text-xs"
                               @focus="row.conditionCtoonInZoneFocused = true"
                               @blur="row.conditionCtoonInZoneFocused = false"
                               @input="searchConditionCtoons(row, 'zone')"
                             />
                             <ul v-if="row.conditionCtoonInZoneTerm.length >= 3 && row.conditionCtoonInZoneFocused" class="absolute z-10 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
-                              <li v-if="row.conditionCtoonInZoneSearching" class="px-3 py-2 text-gray-500">Searching...</li>
-                              <li v-else-if="!row.conditionCtoonInZoneResults.length" class="px-3 py-2 text-gray-500">No results found.</li>
+                              <li v-if="row.conditionCtoonInZoneSearching" class="px-2 py-1.5 text-xs text-gray-500">Searching...</li>
+                              <li v-else-if="!row.conditionCtoonInZoneResults.length" class="px-2 py-1.5 text-xs text-gray-500">No results found.</li>
                               <li
                                 v-for="ctoon in row.conditionCtoonInZoneResults"
                                 :key="ctoon.id"
-                                class="px-3 py-2 hover:bg-gray-100 cursor-pointer flex items-center gap-3"
+                                class="px-2 py-1.5 text-xs hover:bg-gray-100 cursor-pointer flex items-center gap-3"
                                 @mousedown.prevent="selectConditionCtoonInZone(row, ctoon)"
                               >
                                 <img :src="ctoon.assetPath" class="h-8 w-auto rounded" />
@@ -382,7 +383,7 @@
                     <div class="flex items-start gap-3">
                       <input v-model="row.conditionUserOwnsEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'userOwns')" />
                       <div class="flex-1">
-                        <div class="text-sm font-medium">User Owns cToon</div>
+                        <div class="text-xs font-medium">User Owns cToon</div>
                         <p class="text-xs text-gray-500">All selected cToons and counts must be met.</p>
                         <div v-if="row.conditionUserOwnsEnabled" class="mt-2 space-y-2">
                           <div class="relative">
@@ -390,18 +391,18 @@
                               v-model="row.conditionUserOwnsTerm"
                               type="text"
                               placeholder="Type 3+ characters to search cToons"
-                              class="w-full border rounded px-2 py-1"
+                              class="w-full border rounded-md px-2 py-1 text-xs"
                               @focus="row.conditionUserOwnsFocused = true"
                               @blur="row.conditionUserOwnsFocused = false"
                               @input="searchConditionCtoons(row, 'owns')"
                             />
                             <ul v-if="row.conditionUserOwnsTerm.length >= 3 && row.conditionUserOwnsFocused" class="absolute z-10 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
-                              <li v-if="row.conditionUserOwnsSearching" class="px-3 py-2 text-gray-500">Searching...</li>
-                              <li v-else-if="!row.conditionUserOwnsResults.length" class="px-3 py-2 text-gray-500">No results found.</li>
+                              <li v-if="row.conditionUserOwnsSearching" class="px-2 py-1.5 text-xs text-gray-500">Searching...</li>
+                              <li v-else-if="!row.conditionUserOwnsResults.length" class="px-2 py-1.5 text-xs text-gray-500">No results found.</li>
                               <li
                                 v-for="ctoon in row.conditionUserOwnsResults"
                                 :key="ctoon.id"
-                                class="px-3 py-2 hover:bg-gray-100 cursor-pointer flex items-center gap-3"
+                                class="px-2 py-1.5 text-xs hover:bg-gray-100 cursor-pointer flex items-center gap-3"
                                 @mousedown.prevent="addConditionUserOwns(row, ctoon)"
                               >
                                 <img :src="ctoon.assetPath" class="h-8 w-auto rounded" />
@@ -426,7 +427,7 @@
                               </div>
                               <div class="flex items-center gap-2">
                                 <label class="text-xs text-gray-500"># Owned</label>
-                                <input v-model.number="entry.count" type="number" min="1" step="1" class="w-20 border rounded px-2 py-1" />
+                                <input v-model.number="entry.count" type="number" min="1" step="1" class="w-20 border rounded-md px-2 py-1 text-xs" />
                               </div>
                               <button type="button" class="text-xs text-red-600" @click="removeConditionUserOwns(row, entry.ctoonId)">Remove</button>
                             </div>
@@ -435,13 +436,13 @@
                       </div>
                     </div>
 
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
                       <div class="flex items-start gap-3">
                         <input v-model="row.conditionUserPointsEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'userPoints')" />
                         <div class="flex-1">
-                          <div class="text-sm font-medium">User Points</div>
+                          <div class="text-xs font-medium">User Points</div>
                           <div v-if="row.conditionUserPointsEnabled" class="mt-1">
-                            <input v-model.number="row.conditionUserPointsMin" type="number" min="1" step="1" class="w-full border rounded px-2 py-1" />
+                            <input v-model.number="row.conditionUserPointsMin" type="number" min="1" step="1" class="w-full border rounded-md px-2 py-1 text-xs" />
                           </div>
                         </div>
                       </div>
@@ -449,9 +450,9 @@
                       <div class="flex items-start gap-3">
                         <input v-model="row.conditionUserTotalCountEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'userTotal')" />
                         <div class="flex-1">
-                          <div class="text-sm font-medium">User Total cToon Count</div>
+                          <div class="text-xs font-medium">User Total cToon Count</div>
                           <div v-if="row.conditionUserTotalCountEnabled" class="mt-1">
-                            <input v-model.number="row.conditionUserTotalCountMin" type="number" min="1" step="1" class="w-full border rounded px-2 py-1" />
+                            <input v-model.number="row.conditionUserTotalCountMin" type="number" min="1" step="1" class="w-full border rounded-md px-2 py-1 text-xs" />
                           </div>
                         </div>
                       </div>
@@ -459,9 +460,9 @@
                       <div class="flex items-start gap-3">
                         <input v-model="row.conditionUserUniqueCountEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'userUnique')" />
                         <div class="flex-1">
-                          <div class="text-sm font-medium">User Unique cToon Count</div>
+                          <div class="text-xs font-medium">User Unique cToon Count</div>
                           <div v-if="row.conditionUserUniqueCountEnabled" class="mt-1">
-                            <input v-model.number="row.conditionUserUniqueCountMin" type="number" min="1" step="1" class="w-full border rounded px-2 py-1" />
+                            <input v-model.number="row.conditionUserUniqueCountMin" type="number" min="1" step="1" class="w-full border rounded-md px-2 py-1 text-xs" />
                           </div>
                         </div>
                       </div>
@@ -469,26 +470,26 @@
                       <div class="flex items-start gap-3">
                         <input v-model="row.conditionSetUniqueCountEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'setUnique')" />
                         <div class="flex-1">
-                          <div class="text-sm font-medium"># of unique cToons from set</div>
+                          <div class="text-xs font-medium"># of unique cToons from set</div>
                           <div v-if="row.conditionSetUniqueCountEnabled" class="mt-1 space-y-1">
-                            <input v-model.number="row.conditionSetUniqueCountMin" type="number" min="1" step="1" class="w-full border rounded px-2 py-1" />
+                            <input v-model.number="row.conditionSetUniqueCountMin" type="number" min="1" step="1" class="w-full border rounded-md px-2 py-1 text-xs" />
                             <div class="relative">
                               <input
                                 v-model="row.conditionSetUniqueCountSet"
                                 type="text"
                                 placeholder="Type 3+ characters for set"
-                                class="w-full border rounded px-2 py-1"
+                                class="w-full border rounded-md px-2 py-1 text-xs"
                                 @focus="row.conditionSetUniqueCountFocused = true"
                                 @blur="row.conditionSetUniqueCountFocused = false"
                                 @input="searchConditionSets(row, 'unique')"
                               />
                               <ul v-if="row.conditionSetUniqueCountSet.length >= 3 && row.conditionSetUniqueCountFocused" class="absolute z-10 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
-                                <li v-if="row.conditionSetUniqueCountSearching" class="px-3 py-2 text-gray-500">Searching...</li>
-                                <li v-else-if="!row.conditionSetUniqueCountResults.length" class="px-3 py-2 text-gray-500">No results found.</li>
+                                <li v-if="row.conditionSetUniqueCountSearching" class="px-2 py-1.5 text-xs text-gray-500">Searching...</li>
+                                <li v-else-if="!row.conditionSetUniqueCountResults.length" class="px-2 py-1.5 text-xs text-gray-500">No results found.</li>
                                 <li
                                   v-for="setName in row.conditionSetUniqueCountResults"
                                   :key="setName"
-                                  class="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+                                  class="px-2 py-1.5 text-xs hover:bg-gray-100 cursor-pointer"
                                   @mousedown.prevent="selectConditionSet(row, 'unique', setName)"
                                 >
                                   {{ setName }}
@@ -502,26 +503,26 @@
                       <div class="flex items-start gap-3">
                         <input v-model="row.conditionSetTotalCountEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'setTotal')" />
                         <div class="flex-1">
-                          <div class="text-sm font-medium"># of total cToons from set</div>
+                          <div class="text-xs font-medium"># of total cToons from set</div>
                           <div v-if="row.conditionSetTotalCountEnabled" class="mt-1 space-y-1">
-                            <input v-model.number="row.conditionSetTotalCountMin" type="number" min="1" step="1" class="w-full border rounded px-2 py-1" />
+                            <input v-model.number="row.conditionSetTotalCountMin" type="number" min="1" step="1" class="w-full border rounded-md px-2 py-1 text-xs" />
                             <div class="relative">
                               <input
                                 v-model="row.conditionSetTotalCountSet"
                                 type="text"
                                 placeholder="Type 3+ characters for set"
-                                class="w-full border rounded px-2 py-1"
+                                class="w-full border rounded-md px-2 py-1 text-xs"
                                 @focus="row.conditionSetTotalCountFocused = true"
                                 @blur="row.conditionSetTotalCountFocused = false"
                                 @input="searchConditionSets(row, 'total')"
                               />
                               <ul v-if="row.conditionSetTotalCountSet.length >= 3 && row.conditionSetTotalCountFocused" class="absolute z-10 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
-                                <li v-if="row.conditionSetTotalCountSearching" class="px-3 py-2 text-gray-500">Searching...</li>
-                                <li v-else-if="!row.conditionSetTotalCountResults.length" class="px-3 py-2 text-gray-500">No results found.</li>
+                                <li v-if="row.conditionSetTotalCountSearching" class="px-2 py-1.5 text-xs text-gray-500">Searching...</li>
+                                <li v-else-if="!row.conditionSetTotalCountResults.length" class="px-2 py-1.5 text-xs text-gray-500">No results found.</li>
                                 <li
                                   v-for="setName in row.conditionSetTotalCountResults"
                                   :key="setName"
-                                  class="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+                                  class="px-2 py-1.5 text-xs hover:bg-gray-100 cursor-pointer"
                                   @mousedown.prevent="selectConditionSet(row, 'total', setName)"
                                 >
                                   {{ setName }}
@@ -536,10 +537,10 @@
                     <div class="flex items-start gap-3">
                       <input v-model="row.conditionOwnsLessThanEnabled" type="checkbox" class="mt-1" @change="onConditionToggle(row, 'ownsLessThan')" />
                       <div class="flex-1">
-                        <div class="text-sm font-medium">User Owns This cToon Less Than X</div>
+                        <div class="text-xs font-medium">User Owns This cToon Less Than X</div>
                         <p class="text-xs text-gray-500">This cToon is eligible only if the user owns fewer than X copies (ignoring burned).</p>
                         <div v-if="row.conditionOwnsLessThanEnabled" class="mt-1">
-                          <input v-model.number="row.conditionOwnsLessThanCount" type="number" min="1" step="1" placeholder="X (e.g. 1)" class="w-full border rounded px-2 py-1" />
+                          <input v-model.number="row.conditionOwnsLessThanCount" type="number" min="1" step="1" placeholder="X (e.g. 1)" class="w-full border rounded-md px-2 py-1 text-xs" />
                         </div>
                       </div>
                     </div>
@@ -547,9 +548,9 @@
                     <div class="flex items-start gap-3 border-t pt-3 mt-1">
                       <input v-model="row.glitchEffect" type="checkbox" class="mt-1" id="glitch-effect" />
                       <div class="flex-1">
-                        <div class="text-sm font-medium flex items-center gap-2">
+                        <div class="text-xs font-medium flex items-center gap-2">
                           <span>⚡ Glitch Effect</span>
-                          <span class="px-1.5 py-0.5 rounded text-xs font-semibold bg-green-100 text-green-800">Matrix</span>
+                          <span class="px-1.5 py-0 rounded text-[10px] font-medium border bg-green-100 text-green-800 border-green-200">Matrix</span>
                         </div>
                         <p class="text-xs text-gray-500 mt-0.5">When selected in cZone Search, triggers a full-page TV glitch → static snow → Matrix green code effect before the cToon appears for capture.</p>
                       </div>
@@ -562,12 +563,12 @@
           </div>
         </div>
 
-        <div class="p-4 border-t flex items-center justify-between gap-2 flex-shrink-0">
-          <div class="text-red-600 text-sm flex-1 mr-4">{{ formError }}</div>
+        <div class="px-4 py-3 border-t flex items-center justify-between gap-2 flex-shrink-0">
+          <div class="text-red-600 text-xs flex-1 mr-4">{{ formError }}</div>
           <div class="flex gap-2 flex-shrink-0">
-            <button class="px-4 py-2 rounded border" @click="closeModal">Cancel</button>
+            <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeModal">Cancel</button>
             <button
-              class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
               :disabled="saving"
               @click="saveSearch"
             >
@@ -577,6 +578,7 @@
           </div>
         </div>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyDissolveQueue.vue
+++ b/components/newsite/admin/legacy/AdminLegacyDissolveQueue.vue
@@ -1,22 +1,22 @@
 <template>
-  <div class="bg-gray-50 p-3 sm:p-6 ">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-5xl mx-auto mt-6 space-y-6">
-      <div class="flex items-center justify-between">
-        <h1 class="text-2xl font-semibold">Dissolve Queue</h1>
-        <div class="flex items-center gap-4">
-          <button @click="openFeaturedModal" class="text-sm text-blue-600 underline">Edit Featured</button>
-          <button @click="loadData" class="text-sm text-blue-600 underline">Refresh</button>
+    <div class="px-2 py-2 max-w-5xl mx-auto space-y-3">
+      <div class="flex items-center justify-between flex-wrap gap-2">
+        <h1 class="text-base font-semibold">Dissolve Queue</h1>
+        <div class="flex items-center gap-3">
+          <button @click="openFeaturedModal" class="text-xs text-blue-600 hover:underline">Edit Featured</button>
+          <button @click="loadData" class="text-xs text-blue-600 hover:underline">Refresh</button>
         </div>
       </div>
 
       <!-- Summary cards -->
-      <div v-if="stats" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div v-if="stats" class="grid grid-cols-1 sm:grid-cols-3 gap-2">
         <div v-for="cat in categories" :key="cat.key"
-             class="bg-white rounded-lg shadow p-4">
-          <div class="text-sm font-semibold text-gray-500 mb-1">{{ cat.label }}</div>
-          <div class="text-2xl font-bold">{{ stats.byCategory[cat.key]?.total ?? 0 }}</div>
-          <div class="text-xs text-gray-500 mt-1">
+             class="bg-white border rounded-lg shadow p-2">
+          <div class="text-xs font-semibold text-gray-500 mb-1">{{ cat.label }}</div>
+          <div class="text-lg font-bold">{{ stats.byCategory[cat.key]?.total ?? 0 }}</div>
+          <div class="text-[10px] text-gray-500 mt-1">
             <span class="text-emerald-600">{{ stats.byCategory[cat.key]?.scheduled ?? 0 }} scheduled</span>
             <span class="mx-1">·</span>
             <span class="text-orange-500">{{ stats.byCategory[cat.key]?.unscheduled ?? 0 }} unscheduled</span>
@@ -25,69 +25,69 @@
       </div>
 
       <!-- Upcoming scheduled auctions -->
-      <div class="bg-white rounded-lg shadow">
-        <div class="p-4 border-b">
-          <h2 class="font-semibold">Upcoming Scheduled Auctions</h2>
-          <p class="text-xs text-gray-500 mt-0.5">Next 20 entries, times in CST</p>
+      <div class="bg-white rounded-lg shadow border">
+        <div class="px-3 py-2 border-b">
+          <h2 class="text-sm font-semibold">Upcoming Scheduled Auctions</h2>
+          <p class="text-[10px] text-gray-500 mt-0.5">Next 20 entries, times in CST</p>
         </div>
         <div v-if="upcoming.length" class="divide-y">
           <div v-for="entry in upcoming" :key="entry.id"
-               class="px-4 py-3 text-sm">
-            <div class="flex items-start gap-3">
-              <div class="shrink-0 w-10 h-10 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
+               class="px-3 py-2 text-xs">
+            <div class="flex items-start gap-2">
+              <div class="shrink-0 w-9 h-9 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
                 <img v-if="entry.ctoonImage" :src="entry.ctoonImage" :alt="entry.ctoonName"
                      class="w-full h-full object-contain" loading="lazy" />
-                <span v-else class="text-gray-300 text-lg">?</span>
+                <span v-else class="text-gray-300 text-base">?</span>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="font-medium truncate" :title="entry.ctoonName">{{ entry.ctoonName || '—' }}</div>
-                <div class="text-xs text-gray-500 mt-0.5">
+                <div class="text-[10px] text-gray-500 mt-0.5">
                   {{ entry.rarity }}
                   <span v-if="entry.series"> · {{ entry.series }}</span>
                   <span v-if="entry.set"> · {{ entry.set }}</span>
                   <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>
-                  <span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium"
+                  <span class="ml-2 px-1.5 py-0 rounded text-[10px] font-medium"
                         :class="categoryChip(entry.category)">{{ entry.category }}</span>
-                  <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
-                  <span v-if="entry.fromInactive" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">From Inactive</span>
+                  <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0 rounded text-[10px] font-medium bg-yellow-100 text-yellow-700">Featured</span>
+                  <span v-if="entry.fromInactive" class="ml-1 px-1.5 py-0 rounded text-[10px] font-medium bg-red-100 text-red-700">From Inactive</span>
                 </div>
-                <div v-if="entry.sourceUsername" class="text-xs text-gray-400 mt-0.5">From: {{ entry.sourceUsername }}</div>
-                <div class="text-xs text-gray-500 mt-1 sm:hidden">{{ fmtCST(entry.scheduledFor) }}</div>
+                <div v-if="entry.sourceUsername" class="text-[10px] text-gray-400 mt-0.5">From: {{ entry.sourceUsername }}</div>
+                <div class="text-[10px] text-gray-500 mt-1 sm:hidden">{{ fmtCST(entry.scheduledFor) }}</div>
               </div>
               <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 shrink-0">
-                <div class="hidden sm:block text-xs text-gray-600">{{ fmtCST(entry.scheduledFor) }}</div>
+                <div class="hidden sm:block text-[10px] text-gray-600">{{ fmtCST(entry.scheduledFor) }}</div>
                 <button
                   @click="openReschedule(entry)"
-                  class="text-xs text-blue-600 hover:text-blue-800"
+                  class="text-[11px] text-blue-600 hover:text-blue-800"
                 >Reschedule</button>
                 <button
                   @click="cancelEntry(entry.id)"
-                  class="text-xs text-red-500 hover:text-red-700"
+                  class="text-[11px] text-red-500 hover:text-red-700"
                   :disabled="cancellingId === entry.id"
                 >{{ cancellingId === entry.id ? '…' : 'Unschedule' }}</button>
               </div>
             </div>
-            <div v-if="reschedulingId === entry.id" class="mt-3 flex flex-wrap items-center gap-2 pl-0 sm:pl-[52px]">
+            <div v-if="reschedulingId === entry.id" class="mt-2 flex flex-wrap items-center gap-2 pl-0 sm:pl-[44px]">
               <input v-model="rescheduleLocal" type="datetime-local"
-                     class="text-xs border rounded px-2 py-1.5" />
+                     class="text-xs border rounded-md px-2 py-1.5" />
               <button
                 @click="saveReschedule(entry.id)"
                 :disabled="reschedulingSaving"
-                class="px-3 py-1.5 text-xs rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+                class="px-3 py-1 text-xs rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
               >{{ reschedulingSaving ? 'Saving…' : 'Save' }}</button>
-              <button @click="cancelReschedule" class="px-3 py-1.5 text-xs rounded-md border border-gray-300 hover:bg-gray-50">Cancel</button>
-              <div v-if="rescheduleError" class="text-xs text-red-600 w-full">{{ rescheduleError }}</div>
+              <button @click="cancelReschedule" class="px-3 py-1 text-xs rounded-md border border-gray-300 hover:bg-gray-50">Cancel</button>
+              <div v-if="rescheduleError" class="text-[11px] text-red-600 w-full">{{ rescheduleError }}</div>
             </div>
           </div>
         </div>
-        <div v-else class="p-6 text-center text-sm text-gray-400">No upcoming scheduled auctions</div>
+        <div v-else class="p-6 text-center text-gray-400">No upcoming scheduled auctions</div>
       </div>
 
       <!-- All Queue Entries (search + pagination) -->
-      <div class="bg-white rounded-lg shadow">
-        <div class="p-4 border-b">
-          <h2 class="font-semibold">All Queue Entries</h2>
-          <p class="text-xs text-gray-500 mt-0.5">
+      <div class="bg-white rounded-lg shadow border">
+        <div class="px-3 py-2 border-b">
+          <h2 class="text-sm font-semibold">All Queue Entries</h2>
+          <p class="text-[10px] text-gray-500 mt-0.5">
             <template v-if="hasActiveFilters">
               {{ filteredEntries.length }} of {{ allEntries.length }} entries match
             </template>
@@ -98,11 +98,11 @@
         </div>
 
         <!-- Filters: category + search -->
-        <div class="p-4 border-b" ref="searchContainer">
-          <div class="flex flex-wrap items-center gap-3 mb-3">
+        <div class="px-3 py-2 border-b" ref="searchContainer">
+          <div class="flex flex-wrap items-center gap-2 mb-2">
             <select
               v-model="categoryFilter"
-              class="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="text-xs border rounded-md px-1.5 py-1 focus:outline-none focus:ring-2 focus:ring-blue-300"
             >
               <option value="ALL">All Categories</option>
               <option value="FEATURED">Featured</option>
@@ -110,21 +110,21 @@
             </select>
             <select
               v-model="rarityFilter"
-              class="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="text-xs border rounded-md px-1.5 py-1 focus:outline-none focus:ring-2 focus:ring-blue-300"
             >
               <option value="ALL">All Rarities</option>
               <option v-for="r in rarityOptions" :key="r" :value="r">{{ r }}</option>
             </select>
             <select
               v-model="seriesFilter"
-              class="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="text-xs border rounded-md px-1.5 py-1 focus:outline-none focus:ring-2 focus:ring-blue-300"
             >
               <option value="ALL">All Series</option>
               <option v-for="s in seriesOptions" :key="s" :value="s">{{ s }}</option>
             </select>
             <select
               v-model="setFilter"
-              class="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="text-xs border rounded-md px-1.5 py-1 focus:outline-none focus:ring-2 focus:ring-blue-300"
             >
               <option value="ALL">All Sets</option>
               <option v-for="s in setOptions" :key="s" :value="s">{{ s }}</option>
@@ -135,7 +135,7 @@
               v-model="searchQuery"
               type="text"
               placeholder="Search by cToon name…"
-              class="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 pr-8 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="w-full text-xs border rounded-md px-2 py-1.5 pr-8 focus:outline-none focus:ring-2 focus:ring-blue-300"
               @focus="showSuggestions = searchQuery.trim().length >= 3"
               @keydown.escape="showSuggestions = false"
             />
@@ -148,22 +148,22 @@
             <!-- Autocomplete dropdown -->
             <div
               v-if="showSuggestions && searchSuggestions.length"
-              class="absolute z-20 top-full mt-1 left-0 w-full sm:w-96 bg-white border border-gray-200 rounded-lg shadow-lg max-h-72 overflow-y-auto"
+              class="absolute z-20 top-full mt-1 left-0 w-full sm:w-96 bg-white border rounded-md shadow-lg max-h-72 overflow-y-auto"
             >
               <button
                 v-for="suggestion in searchSuggestions"
                 :key="suggestion.id"
                 @mousedown.prevent="selectSuggestion(suggestion)"
-                class="w-full flex items-center gap-3 px-3 py-2 hover:bg-gray-50 text-left"
+                class="w-full flex items-center gap-2 px-2 py-1.5 hover:bg-gray-50 text-left"
               >
-                <div class="shrink-0 w-9 h-9 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
+                <div class="shrink-0 w-8 h-8 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
                   <img v-if="suggestion.ctoonImage" :src="suggestion.ctoonImage" :alt="suggestion.ctoonName"
                        class="w-full h-full object-contain" loading="lazy" />
-                  <span v-else class="text-gray-300 text-sm">?</span>
+                  <span v-else class="text-gray-300 text-xs">?</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-sm font-medium truncate">{{ suggestion.ctoonName || '—' }}</div>
-                  <div class="text-xs text-gray-500">Mint #{{ suggestion.mintNumber ?? '?' }}</div>
+                  <div class="text-xs font-medium truncate">{{ suggestion.ctoonName || '—' }}</div>
+                  <div class="text-[10px] text-gray-500">Mint #{{ suggestion.mintNumber ?? '?' }}</div>
                 </div>
               </button>
             </div>
@@ -172,105 +172,105 @@
 
         <!-- Entries list -->
         <div v-if="paginatedEntries.length" class="divide-y">
-          <div v-for="entry in paginatedEntries" :key="entry.id" class="px-4 py-3 text-sm">
-            <div class="flex items-start gap-3">
-              <div class="shrink-0 w-10 h-10 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
+          <div v-for="entry in paginatedEntries" :key="entry.id" class="px-3 py-2 text-xs">
+            <div class="flex items-start gap-2">
+              <div class="shrink-0 w-9 h-9 rounded bg-gray-100 flex items-center justify-center overflow-hidden">
                 <img v-if="entry.ctoonImage" :src="entry.ctoonImage" :alt="entry.ctoonName"
                      class="w-full h-full object-contain" loading="lazy" />
-                <span v-else class="text-gray-300 text-lg">?</span>
+                <span v-else class="text-gray-300 text-base">?</span>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="font-medium truncate" :title="entry.ctoonName">{{ entry.ctoonName || '—' }}</div>
-                <div class="text-xs text-gray-500 mt-0.5">
+                <div class="text-[10px] text-gray-500 mt-0.5">
                   {{ entry.rarity }}
                   <span v-if="entry.series"> · {{ entry.series }}</span>
                   <span v-if="entry.set"> · {{ entry.set }}</span>
                   <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>
-                  <span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium"
+                  <span class="ml-2 px-1.5 py-0 rounded text-[10px] font-medium"
                         :class="categoryChip(entry.category)">{{ entry.category }}</span>
-                  <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
-                  <span v-if="entry.fromInactive" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">From Inactive</span>
+                  <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0 rounded text-[10px] font-medium bg-yellow-100 text-yellow-700">Featured</span>
+                  <span v-if="entry.fromInactive" class="ml-1 px-1.5 py-0 rounded text-[10px] font-medium bg-red-100 text-red-700">From Inactive</span>
                 </div>
-                <div v-if="entry.sourceUsername" class="text-xs text-gray-400 mt-0.5">From: {{ entry.sourceUsername }}</div>
-                <div class="text-xs text-gray-500 mt-1">
+                <div v-if="entry.sourceUsername" class="text-[10px] text-gray-400 mt-0.5">From: {{ entry.sourceUsername }}</div>
+                <div class="text-[10px] text-gray-500 mt-1">
                   {{ entry.scheduledFor ? fmtCST(entry.scheduledFor) : 'Not scheduled' }}
                 </div>
               </div>
               <div class="shrink-0 flex flex-col items-end gap-1">
                 <button
                   @click="openReschedule(entry)"
-                  class="text-xs text-blue-600 hover:text-blue-800"
+                  class="text-[11px] text-blue-600 hover:text-blue-800"
                 >Reschedule</button>
                 <button
                   @click="cancelEntry(entry.id)"
-                  class="text-xs text-red-500 hover:text-red-700"
+                  class="text-[11px] text-red-500 hover:text-red-700"
                   :disabled="cancellingId === entry.id"
                 >{{ cancellingId === entry.id ? '…' : (entry.scheduledFor ? 'Unschedule' : 'Remove') }}</button>
               </div>
             </div>
-            <div v-if="reschedulingId === entry.id" class="mt-3 flex flex-wrap items-center gap-2 pl-0 sm:pl-[52px]">
+            <div v-if="reschedulingId === entry.id" class="mt-2 flex flex-wrap items-center gap-2 pl-0 sm:pl-[44px]">
               <input v-model="rescheduleLocal" type="datetime-local"
-                     class="text-xs border rounded px-2 py-1.5" />
+                     class="text-xs border rounded-md px-2 py-1.5" />
               <button
                 @click="saveReschedule(entry.id)"
                 :disabled="reschedulingSaving"
-                class="px-3 py-1.5 text-xs rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+                class="px-3 py-1 text-xs rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
               >{{ reschedulingSaving ? 'Saving…' : 'Save' }}</button>
-              <button @click="cancelReschedule" class="px-3 py-1.5 text-xs rounded-md border border-gray-300 hover:bg-gray-50">Cancel</button>
-              <div v-if="rescheduleError" class="text-xs text-red-600 w-full">{{ rescheduleError }}</div>
+              <button @click="cancelReschedule" class="px-3 py-1 text-xs rounded-md border border-gray-300 hover:bg-gray-50">Cancel</button>
+              <div v-if="rescheduleError" class="text-[11px] text-red-600 w-full">{{ rescheduleError }}</div>
             </div>
           </div>
         </div>
-        <div v-else class="p-6 text-center text-sm text-gray-400">
+        <div v-else class="p-6 text-center text-gray-400">
           {{ hasActiveFilters ? 'No entries match your filters' : 'No entries in the dissolve queue' }}
         </div>
 
         <!-- Pagination -->
-        <div v-if="totalPages > 1" class="p-4 border-t flex items-center justify-between">
-          <div class="text-xs text-gray-500">
+        <div v-if="totalPages > 1" class="px-3 py-2 border-t flex items-center justify-between">
+          <div class="text-[10px] text-gray-500">
             Showing {{ (currentPage - 1) * pageSize + 1 }}–{{ Math.min(currentPage * pageSize, filteredEntries.length) }} of {{ filteredEntries.length }}
           </div>
           <div class="flex items-center gap-1">
             <button @click="goToPage(1)" :disabled="currentPage === 1"
-                    class="px-2 py-1 text-xs rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50 disabled:cursor-not-allowed">«</button>
+                    class="px-2 py-1 text-xs rounded-md border hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed">«</button>
             <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1"
-                    class="px-2 py-1 text-xs rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50 disabled:cursor-not-allowed">‹</button>
-            <span class="px-3 text-xs text-gray-600">{{ currentPage }} / {{ totalPages }}</span>
+                    class="px-2 py-1 text-xs rounded-md border hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed">‹</button>
+            <span class="px-2 text-xs text-gray-600">{{ currentPage }} / {{ totalPages }}</span>
             <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages"
-                    class="px-2 py-1 text-xs rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50 disabled:cursor-not-allowed">›</button>
+                    class="px-2 py-1 text-xs rounded-md border hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed">›</button>
             <button @click="goToPage(totalPages)" :disabled="currentPage === totalPages"
-                    class="px-2 py-1 text-xs rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50 disabled:cursor-not-allowed">»</button>
+                    class="px-2 py-1 text-xs rounded-md border hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed">»</button>
           </div>
         </div>
       </div>
 
       <!-- Reschedule All form -->
-      <div class="bg-white rounded-lg shadow p-4 sm:p-5">
-        <h2 class="font-semibold mb-1">Reschedule All</h2>
-        <p class="text-xs text-gray-500 mb-4">
+      <div class="bg-white rounded border p-3">
+        <h2 class="text-sm font-semibold mb-1">Reschedule All</h2>
+        <p class="text-[11px] text-gray-500 mb-3">
           Set a new schedule for all unscheduled entries. Toggle "Reschedule all" to also reset existing scheduled entries.
         </p>
 
-        <div class="space-y-3">
+        <div class="space-y-2">
           <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
             <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Start date (local)</label>
             <input v-model="form.startAtLocal" type="datetime-local"
-                   class="w-full sm:flex-1 text-xs border rounded px-2 py-1.5" />
+                   class="w-full sm:flex-1 border rounded-md px-2 py-1.5 text-sm" />
           </div>
           <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
             <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Cadence (days)</label>
             <input v-model.number="form.cadenceDays" type="number" min="1"
-                   class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
+                   class="w-full sm:w-24 border rounded-md px-2 py-1.5 text-sm" />
           </div>
           <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
             <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Featured / cadence</label>
             <input v-model.number="form.featuredPerCadence" type="number" min="1"
-                   class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
+                   class="w-full sm:w-24 border rounded-md px-2 py-1.5 text-sm" />
           </div>
           <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
             <label class="sm:w-40 text-xs text-gray-600 sm:shrink-0">Other / cadence</label>
             <input v-model.number="form.otherPerCadence" type="number" min="1"
-                   class="w-full sm:w-24 text-xs border rounded px-2 py-1.5" />
+                   class="w-full sm:w-24 border rounded-md px-2 py-1.5 text-sm" />
           </div>
           <div class="flex items-center gap-2">
             <input v-model="form.reschedule" type="checkbox" id="reschedule-all"
@@ -281,28 +281,28 @@
           </div>
         </div>
 
-        <div v-if="scheduleError" class="mt-3 text-xs text-red-600">{{ scheduleError }}</div>
-        <div v-if="scheduleSuccess" class="mt-3 text-xs text-emerald-600">{{ scheduleSuccess }}</div>
+        <div v-if="scheduleError" class="mt-2 text-xs text-red-600">{{ scheduleError }}</div>
+        <div v-if="scheduleSuccess" class="mt-2 text-xs text-emerald-600">{{ scheduleSuccess }}</div>
 
-        <div class="mt-4">
+        <div class="mt-3">
           <button
             @click="applySchedule"
             :disabled="scheduling"
-            class="w-full sm:w-auto px-4 py-2 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+            class="w-full sm:w-auto px-3 py-1.5 text-xs font-semibold rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
           >{{ scheduling ? 'Scheduling…' : 'Apply Schedule' }}</button>
         </div>
       </div>
     </div>
 
     <!-- Edit Featured modal -->
-    <div v-if="showFeaturedModal" class="fixed inset-0 z-30 flex items-center justify-center p-3 sm:p-6 bg-black/40" @click.self="closeFeaturedModal">
-      <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
-        <div class="p-4 sm:p-5 border-b">
+    <div v-if="showFeaturedModal" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50" @click.self="closeFeaturedModal">
+      <div class="relative bg-white w-full max-w-2xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="px-4 py-3 border-b flex-shrink-0">
           <div class="flex items-center justify-between">
-            <h2 class="font-semibold text-lg">Edit Featured</h2>
-            <button @click="closeFeaturedModal" class="text-gray-400 hover:text-gray-600 text-2xl leading-none">&times;</button>
+            <h2 class="text-sm font-semibold">Edit Featured</h2>
+            <button @click="closeFeaturedModal" class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
           </div>
-          <p class="text-xs text-gray-600 mt-2 leading-relaxed">
+          <p class="text-[11px] text-gray-600 mt-1.5 leading-relaxed">
             When an account is dissolved, its cToons are transferred to the official account and queued
             for auction. Any cToon that matches a checked rarity, series, or set below is marked as a
             <span class="font-medium">featured</span> auction when it's queued. Checking a box here does
@@ -311,13 +311,13 @@
           </p>
         </div>
 
-        <div class="p-4 sm:p-5 overflow-y-auto space-y-5 flex-1">
+        <div class="overflow-y-auto flex-1 px-4 py-3 space-y-3">
           <!-- Rarities -->
           <div>
-            <h3 class="text-sm font-semibold text-gray-700 mb-2">Rarities</h3>
-            <div class="border rounded-lg divide-y max-h-40 overflow-y-auto">
+            <h3 class="text-xs font-semibold text-gray-700 mb-1.5">Rarities</h3>
+            <div class="border rounded-md divide-y max-h-40 overflow-y-auto">
               <label v-for="r in orderedRarityOptions" :key="r"
-                     class="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 cursor-pointer">
+                     class="flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-gray-50 cursor-pointer">
                 <input type="checkbox" :value="r" v-model="featuredForm.rarities" class="rounded border-gray-300" />
                 {{ r }}
               </label>
@@ -326,52 +326,52 @@
 
           <!-- Series -->
           <div>
-            <h3 class="text-sm font-semibold text-gray-700 mb-2">Series</h3>
+            <h3 class="text-xs font-semibold text-gray-700 mb-1.5">Series</h3>
             <input
               v-model="seriesSearch"
               type="text"
               placeholder="Filter series… (3+ characters)"
-              class="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="w-full border rounded-md px-2 py-1.5 text-sm mb-1.5 focus:outline-none focus:ring-2 focus:ring-blue-300"
             />
-            <div class="border rounded-lg divide-y max-h-40 overflow-y-auto">
+            <div class="border rounded-md divide-y max-h-40 overflow-y-auto">
               <label v-for="s in orderedSeriesOptions" :key="s"
-                     class="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 cursor-pointer">
+                     class="flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-gray-50 cursor-pointer">
                 <input type="checkbox" :value="s" v-model="featuredForm.series" class="rounded border-gray-300" />
                 {{ s }}
               </label>
-              <div v-if="!orderedSeriesOptions.length" class="px-3 py-2 text-sm text-gray-400">No matches</div>
+              <div v-if="!orderedSeriesOptions.length" class="px-2 py-1.5 text-xs text-gray-400">No matches</div>
             </div>
           </div>
 
           <!-- Sets -->
           <div>
-            <h3 class="text-sm font-semibold text-gray-700 mb-2">Sets</h3>
+            <h3 class="text-xs font-semibold text-gray-700 mb-1.5">Sets</h3>
             <input
               v-model="setSearch"
               type="text"
               placeholder="Filter sets… (3+ characters)"
-              class="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="w-full border rounded-md px-2 py-1.5 text-sm mb-1.5 focus:outline-none focus:ring-2 focus:ring-blue-300"
             />
-            <div class="border rounded-lg divide-y max-h-40 overflow-y-auto">
+            <div class="border rounded-md divide-y max-h-40 overflow-y-auto">
               <label v-for="s in orderedSetOptions" :key="s"
-                     class="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 cursor-pointer">
+                     class="flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-gray-50 cursor-pointer">
                 <input type="checkbox" :value="s" v-model="featuredForm.sets" class="rounded border-gray-300" />
                 {{ s }}
               </label>
-              <div v-if="!orderedSetOptions.length" class="px-3 py-2 text-sm text-gray-400">No matches</div>
+              <div v-if="!orderedSetOptions.length" class="px-2 py-1.5 text-xs text-gray-400">No matches</div>
             </div>
           </div>
         </div>
 
-        <div class="p-4 sm:p-5 border-t">
-          <div v-if="featuredError" class="mb-3 text-xs text-red-600">{{ featuredError }}</div>
-          <div v-if="featuredSuccess" class="mb-3 text-xs text-emerald-600">{{ featuredSuccess }}</div>
-          <div class="flex items-center justify-end gap-3">
-            <button @click="closeFeaturedModal" class="px-4 py-2 text-sm rounded-md border border-gray-300 hover:bg-gray-50">Cancel</button>
+        <div class="px-4 py-3 border-t flex-shrink-0">
+          <div v-if="featuredError" class="mb-2 text-xs text-red-600">{{ featuredError }}</div>
+          <div v-if="featuredSuccess" class="mb-2 text-xs text-emerald-600">{{ featuredSuccess }}</div>
+          <div class="flex items-center justify-end gap-2">
+            <button @click="closeFeaturedModal" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50">Cancel</button>
             <button
               @click="saveFeaturedConfig"
               :disabled="savingFeatured"
-              class="px-4 py-2 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
             >{{ savingFeatured ? 'Saving…' : 'Save' }}</button>
           </div>
         </div>

--- a/components/newsite/admin/legacy/AdminLegacyGames.vue
+++ b/components/newsite/admin/legacy/AdminLegacyGames.vue
@@ -1,24 +1,25 @@
 <template>
 
-  <div class="bg-gray-100 p-6 ">
-    <h1 class="text-3xl font-bold mb-6">Admin: Game Configuration</h1>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+    <h1 class="text-base font-semibold mb-3">Admin: Game Configuration</h1>
 
-    <div class="bg-white rounded-lg shadow-md max-w-2xl mx-auto">
+    <div class="bg-white rounded-lg shadow border">
       <!-- Tabs -->
       <div
         ref="tabsScrollEl"
-        class="border-b px-4 pt-4 overflow-x-auto no-scrollbar"
+        class="border-b px-2 pt-2 overflow-x-auto no-scrollbar"
         role="tablist"
         aria-label="Game configuration sections"
         @wheel="onTabsWheel"
       >
-        <div class="flex gap-2 sm:gap-4 min-w-max">
+        <div class="flex gap-1 min-w-max">
           <button
             v-for="t in tabs"
             :key="t.key"
-            class="px-3 sm:px-4 py-2 text-sm font-medium rounded-t-md border-b-2"
+            class="px-2 py-1.5 text-xs font-medium rounded-t-md border-b-2"
             :class="activeTab === t.key
-              ? 'border-indigo-600 text-indigo-700'
+              ? 'border-blue-600 text-blue-700'
               : 'border-transparent text-gray-500 hover:text-gray-700'"
             role="tab"
             :aria-selected="activeTab === t.key"
@@ -30,30 +31,30 @@
       </div>
 
       <!-- Panels -->
-      <div class="p-6 space-y-8">
+      <div class="p-3 space-y-6">
         <!-- Global -->
         <section v-if="activeTab === 'Global'" role="tabpanel" aria-label="Global Settings">
-          <h2 class="text-2xl font-semibold mb-4">Global Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">Global Settings</h2>
           <div class="mb-6">
-            <label class="block text-sm font-medium text-gray-700">Daily Point Cap</label>
-            <input type="number" v-model.number="globalDailyPointLimit" class="input" />
+            <label class="block text-xs font-medium text-gray-700">Daily Point Cap</label>
+            <input type="number" v-model.number="globalDailyPointLimit" class="border rounded-md px-2 py-1.5 text-sm w-full" />
           </div>
           <div class="mb-6">
-            <label class="block text-sm font-medium text-gray-700">Head-to-Head Daily Points Cap (TKO + gToons Clash + Ed, Edd n Eddy RPS)</label>
-            <input type="number" v-model.number="globalTkoDailyPointLimit" class="input" />
+            <label class="block text-xs font-medium text-gray-700">Head-to-Head Daily Points Cap (TKO + gToons Clash + Ed, Edd n Eddy RPS)</label>
+            <input type="number" v-model.number="globalTkoDailyPointLimit" class="border rounded-md px-2 py-1.5 text-sm w-full" />
           </div>
-          <button @click="saveGlobalConfig" :disabled="loadingGlobal" class="btn-primary">
+          <button @click="saveGlobalConfig" :disabled="loadingGlobal" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingGlobal">Save Global Settings</span>
             <span v-else>Saving…</span>
           </button>
 
           <!-- Game Tile Images -->
-          <div class="mt-8 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Game Tile Images</h3>
+          <div class="mt-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Game Tile Images</h3>
             <p class="text-xs text-gray-500 mb-4">Upload an image for each game tile on the Games page. Images replace the colored background.</p>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div v-for="tile in gameTileSlots" :key="tile.slot" class="border rounded p-3 space-y-2">
-                <h4 class="text-sm font-semibold text-gray-700">{{ tile.label }}</h4>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div v-for="tile in gameTileSlots" :key="tile.slot" class="bg-white border rounded-md p-2 space-y-2">
+                <h4 class="text-xs font-semibold text-gray-700">{{ tile.label }}</h4>
                 <div class="w-full h-24 bg-gray-100 border rounded overflow-hidden flex items-center justify-center">
                   <img
                     v-if="gameTileImages[tile.slot]"
@@ -61,7 +62,7 @@
                     :alt="tile.label"
                     class="w-full h-full object-cover"
                   />
-                  <span v-else class="text-gray-400 text-xs">No image</span>
+                  <span v-else class="text-gray-500 text-xs">No image</span>
                 </div>
                 <input
                   type="file"
@@ -71,7 +72,7 @@
                 />
                 <div class="flex items-center gap-2">
                   <button
-                    class="btn-primary text-sm py-1 px-3"
+                    class="px-3 py-1 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                     @click="uploadGameTile(tile.slot)"
                     :disabled="!gameTileFiles[tile.slot] || uploadingGameTile[tile.slot]"
                   >
@@ -81,7 +82,7 @@
                   <button
                     v-if="gameTileImages[tile.slot]"
                     type="button"
-                    class="px-3 py-1 text-sm rounded border"
+                    class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
                     @click="removeGameTile(tile.slot)"
                   >Remove</button>
                 </div>
@@ -92,126 +93,126 @@
 
         <!-- Winball -->
         <section v-if="activeTab === 'Winball'" role="tabpanel" aria-label="Winball Settings">
-          <h2 class="text-2xl font-semibold mb-4">Winball Settings</h2>
-          <div class="mb-6 rounded border border-indigo-100 bg-indigo-50 p-4">
-            <p class="text-sm text-indigo-900 mb-3">
+          <h2 class="text-sm font-semibold mb-3">Winball Settings</h2>
+          <div class="mb-4 rounded border border-blue-100 bg-blue-50 p-3">
+            <p class="text-xs text-blue-900 mb-3">
               These settings are shared by the current Winball page and the new Winball page.
             </p>
             <NuxtLink
               to="/newsite/newwinball"
-              class="inline-flex items-center rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+              class="inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700"
             >
               Open New Winball
             </NuxtLink>
           </div>
 
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-3">Scoring</h3>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-2">Scoring</h3>
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Left Cup Points</label>
-              <input type="number" v-model.number="leftCupPoints" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Left Cup Points</label>
+              <input type="number" v-model.number="leftCupPoints" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Right Cup Points</label>
-              <input type="number" v-model.number="rightCupPoints" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Right Cup Points</label>
+              <input type="number" v-model.number="rightCupPoints" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Gold Cup Points</label>
-              <input type="number" v-model.number="goldCupPoints" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Gold Cup Points</label>
+              <input type="number" v-model.number="goldCupPoints" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             </div>
           </div>
 
-          <div class="mb-6 border rounded-lg p-4 bg-gray-50">
-            <h3 class="text-lg font-semibold mb-1">Playfield Layers</h3>
+          <div class="mb-4 border rounded-lg p-3 bg-gray-50">
+            <h3 class="text-xs font-semibold mb-1">Playfield Layers</h3>
             <p class="text-xs text-gray-500 mb-4">Layer order: base color → board image → color transform with intensity → overlay color with alpha.</p>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Base Board Color</label>
+                <label class="block text-xs font-medium text-gray-700 mb-1">Base Board Color</label>
                 <div class="flex items-center gap-2">
-                  <input type="color" v-model="winballBoardLayer.winballColorBackboard" class="h-9 w-14 rounded border cursor-pointer p-0.5" />
-                  <input type="text" v-model="winballBoardLayer.winballColorBackboard" class="input flex-1" maxlength="7" />
+                  <input type="color" v-model="winballBoardLayer.winballColorBackboard" class="h-7 w-10 rounded border cursor-pointer p-0.5" />
+                  <input type="text" v-model="winballBoardLayer.winballColorBackboard" class="border rounded-md px-2 py-1.5 text-sm flex-1" maxlength="7" />
                 </div>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Color Transform</label>
+                <label class="block text-xs font-medium text-gray-700 mb-1">Color Transform</label>
                 <div class="flex items-center gap-2">
-                  <input type="color" v-model="winballBoardLayer.winballColorTransform" class="h-9 w-14 rounded border cursor-pointer p-0.5" />
-                  <input type="text" v-model="winballBoardLayer.winballColorTransform" class="input flex-1" maxlength="7" />
+                  <input type="color" v-model="winballBoardLayer.winballColorTransform" class="h-7 w-10 rounded border cursor-pointer p-0.5" />
+                  <input type="text" v-model="winballBoardLayer.winballColorTransform" class="border rounded-md px-2 py-1.5 text-sm flex-1" maxlength="7" />
                 </div>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Transform Intensity</label>
-                <input type="number" min="0" max="1" step="0.01" v-model.number="winballBoardLayer.winballColorTransformIntensity" class="input" />
+                <label class="block text-xs font-medium text-gray-700 mb-1">Transform Intensity</label>
+                <input type="number" min="0" max="1" step="0.01" v-model.number="winballBoardLayer.winballColorTransformIntensity" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Overlay Color</label>
+                <label class="block text-xs font-medium text-gray-700 mb-1">Overlay Color</label>
                 <div class="flex items-center gap-2">
-                  <input type="color" v-model="winballBoardLayer.winballOverlayColor" class="h-9 w-14 rounded border cursor-pointer p-0.5" />
-                  <input type="text" v-model="winballBoardLayer.winballOverlayColor" class="input flex-1" maxlength="7" />
+                  <input type="color" v-model="winballBoardLayer.winballOverlayColor" class="h-7 w-10 rounded border cursor-pointer p-0.5" />
+                  <input type="text" v-model="winballBoardLayer.winballOverlayColor" class="border rounded-md px-2 py-1.5 text-sm flex-1" maxlength="7" />
                 </div>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Overlay Alpha</label>
-                <input type="number" min="0" max="1" step="0.01" v-model.number="winballBoardLayer.winballOverlayAlpha" class="input" />
+                <label class="block text-xs font-medium text-gray-700 mb-1">Overlay Alpha</label>
+                <input type="number" min="0" max="1" step="0.01" v-model.number="winballBoardLayer.winballOverlayAlpha" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Image Width (%)</label>
-                <input type="number" min="1" max="300" step="1" v-model.number="winballBoardLayer.winballImageWidthPercent" class="input" />
+                <label class="block text-xs font-medium text-gray-700 mb-1">Image Width (%)</label>
+                <input type="number" min="1" max="300" step="1" v-model.number="winballBoardLayer.winballImageWidthPercent" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Image Horizontal Offset (%)</label>
-                <input type="number" step="0.5" v-model.number="winballBoardLayer.winballImageOffsetXPercent" class="input" />
+                <label class="block text-xs font-medium text-gray-700 mb-1">Image Horizontal Offset (%)</label>
+                <input type="number" step="0.5" v-model.number="winballBoardLayer.winballImageOffsetXPercent" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Image Vertical Offset (%)</label>
-                <input type="number" step="0.5" v-model.number="winballBoardLayer.winballImageOffsetYPercent" class="input" />
+                <label class="block text-xs font-medium text-gray-700 mb-1">Image Vertical Offset (%)</label>
+                <input type="number" step="0.5" v-model.number="winballBoardLayer.winballImageOffsetYPercent" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
             </div>
           </div>
 
           <!-- Physics -->
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-3">Physics</h3>
-            <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-2">Physics</h3>
+            <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
               <div v-for="p in winballPhysicsFields" :key="p.key">
-                <label class="block text-sm font-medium text-gray-700 mb-1">{{ p.label }}</label>
-                <p class="text-xs text-gray-400 mb-1">{{ p.hint }}</p>
-                <input type="number" v-model.number="winballPhysics[p.key]" :step="p.step" class="input" />
+                <label class="block text-xs font-medium text-gray-700 mb-1">{{ p.label }}</label>
+                <p class="text-xs text-gray-500 mb-1">{{ p.hint }}</p>
+                <input type="number" v-model.number="winballPhysics[p.key]" :step="p.step" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
             </div>
           </div>
 
           <!-- Colors -->
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-3">Component Colors</h3>
-            <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-2">Component Colors</h3>
+            <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
               <div v-for="c in winballColorFields" :key="c.key">
-                <label class="block text-sm font-medium text-gray-700 mb-1">{{ c.label }}</label>
+                <label class="block text-xs font-medium text-gray-700 mb-1">{{ c.label }}</label>
                 <div class="flex items-center gap-2">
-                  <input type="color" v-model="winballColors[c.key]" class="h-9 w-14 rounded border cursor-pointer p-0.5" />
-                  <input type="text" v-model="winballColors[c.key]" class="input flex-1" maxlength="7" />
+                  <input type="color" v-model="winballColors[c.key]" class="h-7 w-10 rounded border cursor-pointer p-0.5" />
+                  <input type="text" v-model="winballColors[c.key]" class="border rounded-md px-2 py-1.5 text-sm flex-1" maxlength="7" />
                 </div>
               </div>
             </div>
           </div>
 
           <!-- Backboard image upload -->
-          <div class="space-y-3 mb-6 border rounded-lg p-4">
-            <label class="block text-sm font-medium text-gray-700">
+          <div class="space-y-2 mb-4 bg-white border rounded-lg p-3">
+            <label class="block text-xs font-medium text-gray-700">
               Backboard Image (SVG/PNG/JPEG)
             </label>
-            <p class="text-xs text-gray-400">Best size: 360 × 500 px (portrait, matches board proportions)</p>
+            <p class="text-xs text-gray-500">Best size: 360 × 500 px (portrait, matches board proportions)</p>
             <input
               type="file"
               accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png"
               @change="onWinballBackboardFileChange"
-              class="block w-full text-sm"
+              class="block w-full text-xs"
             />
             <div class="flex items-center gap-3">
               <button
-                class="btn-primary"
+                class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                 @click="uploadWinballBackboardImage"
                 :disabled="!winballBackboardFile || uploadingBackboard"
               >
@@ -221,34 +222,34 @@
               <button
                 v-if="winballBackboardImagePath"
                 type="button"
-                class="px-3 py-2 text-sm rounded border"
+                class="px-2 py-1 text-xs border rounded-md hover:bg-gray-50"
                 @click="removeWinballBackboardImage"
               >Remove Image</button>
             </div>
             <div v-if="winballBackboardImagePath" class="mt-2">
               <p class="text-xs text-gray-600 break-all">Saved path: {{ winballBackboardImagePath }}</p>
-              <div class="mt-2 border rounded p-2 bg-gray-50">
+              <div class="mt-2 border rounded-md p-2 bg-gray-50">
                 <img :src="winballBackboardImagePath" alt="Backboard image preview" class="max-h-40 mx-auto" />
               </div>
             </div>
           </div>
 
           <!-- Bumper image uploads -->
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-3">Bumper Images</h3>
-            <p class="text-xs text-gray-400 mb-3">Best size: 256 × 256 px (square). Image is displayed on the face of each bumper.</p>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-2">Bumper Images</h3>
+            <p class="text-xs text-gray-500 mb-3">Best size: 256 × 256 px (square). Image is displayed on the face of each bumper.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div v-for="(_, i) in [0, 1, 2]" :key="i" class="space-y-2">
-                <label class="block text-sm font-medium text-gray-700">Bumper {{ i + 1 }} (SVG/PNG/JPEG)</label>
+                <label class="block text-xs font-medium text-gray-700">Bumper {{ i + 1 }} (SVG/PNG/JPEG)</label>
                 <input
                   type="file"
                   accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png"
                   @change="onWinballBumperFileChange(i, $event)"
-                  class="block w-full text-sm"
+                  class="block w-full text-xs"
                 />
                 <div class="flex items-center gap-2">
                   <button
-                    class="btn-primary"
+                    class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                     @click="uploadWinballBumperImage(i)"
                     :disabled="!winballBumperFiles[i] || uploadingBumper[i]"
                   >
@@ -258,7 +259,7 @@
                   <button
                     v-if="winballBumperImagePaths[i]"
                     type="button"
-                    class="px-3 py-2 text-sm rounded border"
+                    class="px-2 py-1 text-xs border rounded-md hover:bg-gray-50"
                     @click="removeWinballBumperImage(i)"
                   >Remove</button>
                 </div>
@@ -271,28 +272,28 @@
           </div>
 
           <!-- Bumper Geometry -->
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Bumper Geometry</h3>
-            <p class="text-xs text-gray-400 mb-3">Set radius to 0 to remove a bumper. Z is the depth position on the board.</p>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Bumper Geometry</h3>
+            <p class="text-xs text-gray-500 mb-3">Set radius to 0 to remove a bumper. Z is the depth position on the board.</p>
             <div class="space-y-4">
-              <div v-for="(_, i) in [0, 1, 2]" :key="i" class="border rounded p-3">
-                <h4 class="text-sm font-semibold mb-2">Bumper {{ i + 1 }}</h4>
+              <div v-for="(_, i) in [0, 1, 2]" :key="i" class="bg-white border rounded-md p-2">
+                <h4 class="text-xs font-semibold mb-1.5">Bumper {{ i + 1 }}</h4>
                 <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Radius</label>
-                    <input type="number" v-model.number="winballBumperGeometry[i].radius" step="0.5" min="0" class="input" />
+                    <input type="number" v-model.number="winballBumperGeometry[i].radius" step="0.5" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Height</label>
-                    <input type="number" v-model.number="winballBumperGeometry[i].height" step="0.5" min="0" class="input" />
+                    <input type="number" v-model.number="winballBumperGeometry[i].height" step="0.5" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">X Position</label>
-                    <input type="number" v-model.number="winballBumperGeometry[i].x" step="0.5" class="input" />
+                    <input type="number" v-model.number="winballBumperGeometry[i].x" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Z Position (Depth)</label>
-                    <input type="number" v-model.number="winballBumperGeometry[i].z" step="0.5" class="input" />
+                    <input type="number" v-model.number="winballBumperGeometry[i].z" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                 </div>
               </div>
@@ -300,28 +301,28 @@
           </div>
 
           <!-- Triangle Geometry -->
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Triangle Geometry</h3>
-            <p class="text-xs text-gray-400 mb-3">Set radius to 0 to remove a triangle. Depth controls how far the triangle protrudes from the wall.</p>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Triangle Geometry</h3>
+            <p class="text-xs text-gray-500 mb-3">Set radius to 0 to remove a triangle. Depth controls how far the triangle protrudes from the wall.</p>
             <div class="space-y-4">
-              <div v-for="(_, i) in [0, 1]" :key="i" class="border rounded p-3">
-                <h4 class="text-sm font-semibold mb-2">Triangle {{ i + 1 }}</h4>
+              <div v-for="(_, i) in [0, 1]" :key="i" class="bg-white border rounded-md p-2">
+                <h4 class="text-xs font-semibold mb-1.5">Triangle {{ i + 1 }}</h4>
                 <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Radius</label>
-                    <input type="number" v-model.number="winballTriangleGeometry[i].radius" step="0.5" min="0" class="input" />
+                    <input type="number" v-model.number="winballTriangleGeometry[i].radius" step="0.5" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Depth</label>
-                    <input type="number" v-model.number="winballTriangleGeometry[i].depth" step="0.5" min="0" class="input" />
+                    <input type="number" v-model.number="winballTriangleGeometry[i].depth" step="0.5" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">X Position</label>
-                    <input type="number" v-model.number="winballTriangleGeometry[i].x" step="0.5" class="input" />
+                    <input type="number" v-model.number="winballTriangleGeometry[i].x" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Z Position (Depth)</label>
-                    <input type="number" v-model.number="winballTriangleGeometry[i].z" step="0.5" class="input" />
+                    <input type="number" v-model.number="winballTriangleGeometry[i].z" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                 </div>
               </div>
@@ -329,28 +330,28 @@
           </div>
 
           <!-- Peg Geometry -->
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Peg Geometry</h3>
-            <p class="text-xs text-gray-400 mb-3">12 small round pegs that dampen the ball on contact. Set radius to 0 to remove a peg.</p>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Peg Geometry</h3>
+            <p class="text-xs text-gray-500 mb-3">12 small round pegs that dampen the ball on contact. Set radius to 0 to remove a peg.</p>
             <div class="space-y-4">
-              <div v-for="(_, i) in Array(12).fill(0)" :key="i" class="border rounded p-3">
-                <h4 class="text-sm font-semibold mb-2">Peg {{ i + 1 }}</h4>
+              <div v-for="(_, i) in Array(12).fill(0)" :key="i" class="bg-white border rounded-md p-2">
+                <h4 class="text-xs font-semibold mb-1.5">Peg {{ i + 1 }}</h4>
                 <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Radius</label>
-                    <input type="number" v-model.number="winballPegGeometry[i].radius" step="0.5" min="0" class="input" />
+                    <input type="number" v-model.number="winballPegGeometry[i].radius" step="0.5" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Height</label>
-                    <input type="number" v-model.number="winballPegGeometry[i].height" step="0.5" min="0" class="input" />
+                    <input type="number" v-model.number="winballPegGeometry[i].height" step="0.5" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">X Position</label>
-                    <input type="number" v-model.number="winballPegGeometry[i].x" step="0.5" class="input" />
+                    <input type="number" v-model.number="winballPegGeometry[i].x" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                   <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Z Position (Depth)</label>
-                    <input type="number" v-model.number="winballPegGeometry[i].z" step="0.5" class="input" />
+                    <input type="number" v-model.number="winballPegGeometry[i].z" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                   </div>
                 </div>
               </div>
@@ -358,17 +359,17 @@
           </div>
 
           <!-- Grand Prize selection + preview (moved above schedule) -->
-          <div class="mb-8 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-3">Grand Prize</h3>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-2">Grand Prize</h3>
             <div class="mb-3 relative">
-              <label class="block text-sm font-medium text-gray-700 mb-1">Grand Prize cToon</label>
+              <label class="block text-xs font-medium text-gray-700 mb-1">Grand Prize cToon</label>
               <input
                 type="text"
                 v-model="searchTerm"
                 @focus="showDropdown = true"
                 @input="onSearchInput"
                 :placeholder="grandPrizeCtoon ? grandPrizeCtoon.name : 'Type a cToon name…'"
-                class="input"
+                class="border rounded-md px-2 py-1.5 text-sm w-full"
               />
               <ul
                 v-if="showDropdown && filteredMatches.length"
@@ -378,7 +379,7 @@
                   v-for="c in filteredMatches"
                   :key="c.id"
                   @mousedown.prevent="selectCtoon(c)"
-                  class="flex items-center px-3 py-2 cursor-pointer hover:bg-indigo-50"
+                  class="flex items-center px-3 py-2 cursor-pointer hover:bg-blue-50"
                 >
                   <img :src="c.assetPath" alt="" class="w-8 h-8 rounded mr-3 object-cover border" />
                   <div>
@@ -404,29 +405,29 @@
           </div>
 
           <!-- Schedule UI -->
-          <div class="mb-6 border rounded-lg p-4">
-          <h3 class="text-lg font-semibold mb-3">Grand Prize Schedule</h3>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+          <h3 class="text-xs font-semibold mb-2">Grand Prize Schedule</h3>
           <p class="text-sm text-gray-600 mb-2">
             All dates and times are interpreted as <strong>Central Time (US)</strong>. Default time is 8:00 PM (8:00 AM on Thursdays).
           </p>
 
           <div class="mb-4">
-            <button @click="openAddModal" class="px-3 py-2 rounded bg-indigo-600 text-white">Add schedule</button>
+            <button @click="openAddModal" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700">Add schedule</button>
           </div>
 
-          <div class="border rounded mb-6">
-            <table class="w-full text-sm">
-              <thead class="bg-gray-50">
+          <div class="border rounded-md mb-4 overflow-x-auto">
+            <table class="w-full text-xs">
+              <thead class="bg-gray-100">
                 <tr>
-                  <th class="text-left p-2">Start (Central)</th>
-                  <th class="text-left p-2">cToon</th>
-                  <th class="p-2">Actions</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Start (Central)</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">cToon</th>
+                  <th class="px-2 py-1.5">Actions</th>
                 </tr>
               </thead>
               <tbody>
                 <tr v-for="row in schedules" :key="row.id" class="border-t">
-                  <td class="p-2 whitespace-nowrap">{{ row.startsAtLocal }}</td>
-                  <td class="p-2">
+                  <td class="px-2 py-1.5 whitespace-nowrap">{{ row.startsAtLocal }}</td>
+                  <td class="px-2 py-1.5">
                     <div class="flex items-center gap-2">
                       <img :src="row.ctoon.assetPath" class="w-8 h-8 rounded border object-cover" alt="" />
                       <div>
@@ -435,34 +436,34 @@
                       </div>
                     </div>
                   </td>
-                  <td class="p-2">
+                  <td class="px-2 py-1.5">
                     <div class="flex justify-end gap-2">
-                      <button @click="openEditModal(row)" class="px-2 py-1 rounded border">Edit</button>
-                      <button @click="removeSchedule(row)" class="px-2 py-1 rounded border">Remove</button>
+                      <button @click="openEditModal(row)" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50">Edit</button>
+                      <button @click="removeSchedule(row)" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50">Remove</button>
                     </div>
                   </td>
                 </tr>
                 <tr v-if="!schedules.length">
-                  <td colspan="3" class="p-3 text-gray-500">No scheduled grand prizes.</td>
+                  <td colspan="3" class="px-2 py-3 text-gray-500">No scheduled grand prizes.</td>
                 </tr>
               </tbody>
             </table>
           </div>
 
           <!-- Add modal -->
-          <div v-if="showAddModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-            <div class="bg-white rounded-lg w-full max-w-md p-4">
-              <h3 class="text-lg font-semibold mb-3">Schedule Grand Prize</h3>
+          <div v-if="showAddModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-2">
+            <div class="relative bg-white w-full max-w-md rounded-lg shadow-lg p-4">
+              <h3 class="text-xs font-semibold mb-2">Schedule Grand Prize</h3>
               <!-- selector -->
               <div class="mb-4 relative">
-                <label class="block text-sm font-medium text-gray-700 mb-1">Grand Prize cToon</label>
+                <label class="block text-xs font-medium text-gray-700 mb-1">Grand Prize cToon</label>
                 <input
                   type="text"
                   v-model="modalSearch"
                   @focus="modalShowDropdown = true"
                   @input="onModalSearchInput"
                   :placeholder="modalSelectedCtoon ? modalSelectedCtoon.name : 'Type a cToon name…'"
-                  class="input"
+                  class="border rounded-md px-2 py-1.5 text-sm w-full"
                 />
                 <ul
                   v-if="modalShowDropdown && modalFiltered.length"
@@ -472,7 +473,7 @@
                     v-for="c in modalFiltered"
                     :key="c.id"
                     @mousedown.prevent="selectModalCtoon(c)"
-                    class="flex items-center px-3 py-2 cursor-pointer hover:bg-indigo-50"
+                    class="flex items-center px-3 py-2 cursor-pointer hover:bg-blue-50"
                   >
                     <img :src="c.assetPath" alt="" class="w-8 h-8 rounded mr-3 object-cover border" />
                     <div>
@@ -485,17 +486,17 @@
               <!-- date/time -->
               <div class="grid grid-cols-2 gap-3 mb-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700">Date (Central)</label>
-                  <input type="date" v-model="modalDate" class="input" @change="setModalTimeFromDate" />
+                  <label class="block text-xs font-medium text-gray-700">Date (Central)</label>
+                  <input type="date" v-model="modalDate" class="border rounded-md px-2 py-1.5 text-sm w-full" @change="setModalTimeFromDate" />
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700">Time (Central)</label>
-                  <input type="time" v-model="modalTime" class="input" />
+                  <label class="block text-xs font-medium text-gray-700">Time (Central)</label>
+                  <input type="time" v-model="modalTime" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                 </div>
               </div>
               <div class="flex justify-end gap-2">
-                <button @click="closeAddModal" class="px-3 py-2 rounded border">Cancel</button>
-                <button @click="createSchedule" :disabled="savingSchedule || !modalSelectedCtoon || !modalDate || !modalTime" class="px-3 py-2 rounded bg-indigo-600 text-white">
+                <button @click="closeAddModal" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50">Cancel</button>
+                <button @click="createSchedule" :disabled="savingSchedule || !modalSelectedCtoon || !modalDate || !modalTime" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700">
                   {{ savingSchedule ? 'Saving…' : 'Add' }}
                 </button>
               </div>
@@ -503,19 +504,19 @@
           </div>
 
           <!-- Edit modal -->
-          <div v-if="showEditModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-            <div class="bg-white rounded-lg w-full max-w-md p-4">
-              <h3 class="text-lg font-semibold mb-3">Edit Grand Prize Schedule</h3>
+          <div v-if="showEditModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-2">
+            <div class="relative bg-white w-full max-w-md rounded-lg shadow-lg p-4">
+              <h3 class="text-xs font-semibold mb-2">Edit Grand Prize Schedule</h3>
               <!-- selector -->
               <div class="mb-4 relative">
-                <label class="block text-sm font-medium text-gray-700 mb-1">Grand Prize cToon</label>
+                <label class="block text-xs font-medium text-gray-700 mb-1">Grand Prize cToon</label>
                 <input
                   type="text"
                   v-model="editSearch"
                   @focus="editShowDropdown = true"
                   @input="onEditSearchInput"
                   :placeholder="editSelectedCtoon ? editSelectedCtoon.name : 'Type a cToon name…'"
-                  class="input"
+                  class="border rounded-md px-2 py-1.5 text-sm w-full"
                 />
                 <ul
                   v-if="editShowDropdown && editFiltered.length"
@@ -525,7 +526,7 @@
                     v-for="c in editFiltered"
                     :key="c.id"
                     @mousedown.prevent="selectEditCtoon(c)"
-                    class="flex items-center px-3 py-2 cursor-pointer hover:bg-indigo-50"
+                    class="flex items-center px-3 py-2 cursor-pointer hover:bg-blue-50"
                   >
                     <img :src="c.assetPath" alt="" class="w-8 h-8 rounded mr-3 object-cover border" />
                     <div>
@@ -538,20 +539,20 @@
               <!-- date/time -->
               <div class="grid grid-cols-2 gap-3 mb-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700">Date (Central)</label>
-                  <input type="date" v-model="editDate" class="input" @change="setEditTimeFromDate" />
+                  <label class="block text-xs font-medium text-gray-700">Date (Central)</label>
+                  <input type="date" v-model="editDate" class="border rounded-md px-2 py-1.5 text-sm w-full" @change="setEditTimeFromDate" />
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700">Time (Central)</label>
-                  <input type="time" v-model="editTime" class="input" />
+                  <label class="block text-xs font-medium text-gray-700">Time (Central)</label>
+                  <input type="time" v-model="editTime" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                 </div>
               </div>
               <div class="flex justify-end gap-2">
-                <button @click="closeEditModal" class="px-3 py-2 rounded border">Cancel</button>
+                <button @click="closeEditModal" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50">Cancel</button>
                 <button
                   @click="updateSchedule"
                   :disabled="savingEditSchedule || !editSelectedCtoon || !editDate || !editTime"
-                  class="px-3 py-2 rounded bg-indigo-600 text-white"
+                  class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
                 >
                   {{ savingEditSchedule ? 'Saving…' : 'Save' }}
                 </button>
@@ -561,7 +562,7 @@
 
           </div>
 
-          <button @click="saveWinballConfig" :disabled="loadingWinball" class="btn-primary">
+          <button @click="saveWinballConfig" :disabled="loadingWinball" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingWinball">Save Winball Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -569,14 +570,14 @@
 
         <!-- gToon Clash -->
         <section v-if="activeTab === 'Clash'" role="tabpanel" aria-label="gToon Clash Settings">
-          <h2 class="text-2xl font-semibold mb-4">gToon Clash Settings</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <h2 class="text-sm font-semibold mb-3">gToon Clash Settings</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Per Win</label>
-              <input type="number" v-model.number="clashPointsPerWin" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Points Per Win</label>
+              <input type="number" v-model.number="clashPointsPerWin" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
-          <button @click="saveClashConfig" :disabled="loadingClash" class="btn-primary">
+          <button @click="saveClashConfig" :disabled="loadingClash" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingClash">Save Clash Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -584,7 +585,7 @@
 
         <!-- Ed, Edd n Eddy RPS -->
         <section v-if="activeTab === 'EdRps'" role="tabpanel" aria-label="Ed, Edd n Eddy RPS Settings">
-          <h2 class="text-2xl font-semibold mb-4">Ed, Edd n Eddy RPS Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">Ed, Edd n Eddy RPS Settings</h2>
           <p class="text-xs text-gray-500 mb-4">
             Wins here draw from the same daily pool as TKO and gToons Clash, set on the Global
             Settings tab. Only matches played to a natural finish pay out — forfeits, quits and
@@ -592,8 +593,8 @@
             game engine on read, so a bad number here cannot break a live match.
           </p>
 
-          <div v-if="edRpsConfigError" class="mb-4 p-3 border border-red-300 bg-red-50 rounded">
-            <p class="text-sm font-semibold text-red-800">These settings could not be loaded.</p>
+          <div v-if="edRpsConfigError" class="mb-3 p-2 border border-red-200 bg-red-50 rounded-md">
+            <p class="text-xs font-semibold text-red-800">These settings could not be loaded.</p>
             <p class="text-xs text-red-700 mt-1">{{ edRpsConfigError }}</p>
             <p class="text-xs text-red-700 mt-1">
               The values below are defaults, not what is saved. If this database hasn't had the
@@ -602,37 +603,37 @@
             </p>
           </div>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Per Win</label>
-              <input type="number" v-model.number="edRpsPointsPerWin" class="input" />
-              <p class="text-xs text-gray-400 mt-1">Paid to the winner of a completed head-to-head match.</p>
+              <label class="block text-xs font-medium text-gray-700">Points Per Win</label>
+              <input type="number" v-model.number="edRpsPointsPerWin" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+              <p class="text-xs text-gray-500 mt-1">Paid to the winner of a completed head-to-head match.</p>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Round Timer (seconds)</label>
-              <input type="number" v-model.number="edRpsRoundSeconds" class="input" min="5" max="60" />
-              <p class="text-xs text-gray-400 mt-1">
+              <label class="block text-xs font-medium text-gray-700">Round Timer (seconds)</label>
+              <input type="number" v-model.number="edRpsRoundSeconds" class="border rounded-md px-2 py-1.5 text-sm w-full" min="5" max="60" />
+              <p class="text-xs text-gray-500 mt-1">
                 A player who runs out of time has a hand thrown for them at random. Keep this
                 above 10 — a phone that briefly backgrounds itself would otherwise drop rounds.
               </p>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Round Wins Needed</label>
-              <input type="number" v-model.number="edRpsWinsNeeded" class="input" min="1" max="10" />
-              <p class="text-xs text-gray-400 mt-1">4 is best-of-seven. Ties replay and don't count toward either player.</p>
+              <label class="block text-xs font-medium text-gray-700">Round Wins Needed</label>
+              <input type="number" v-model.number="edRpsWinsNeeded" class="border rounded-md px-2 py-1.5 text-sm w-full" min="1" max="10" />
+              <p class="text-xs text-gray-500 mt-1">4 is best-of-seven. Ties replay and don't count toward either player.</p>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Max Rounds</label>
-              <input type="number" v-model.number="edRpsMaxRounds" class="input" min="1" max="21" />
-              <p class="text-xs text-gray-400 mt-1">
+              <label class="block text-xs font-medium text-gray-700">Max Rounds</label>
+              <input type="number" v-model.number="edRpsMaxRounds" class="border rounded-md px-2 py-1.5 text-sm w-full" min="1" max="21" />
+              <p class="text-xs text-gray-500 mt-1">
                 Must be at least {{ Math.max(1, (edRpsWinsNeeded || 1) * 2 - 1) }} for a
                 first-to-{{ edRpsWinsNeeded || 1 }} match, or a tied match could never finish.
               </p>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Paid Wins Per Pair Per Day</label>
-              <input type="number" v-model.number="edRpsPairDailyAwardLimit" class="input" min="0" max="50" />
-              <p class="text-xs text-gray-400 mt-1">
+              <label class="block text-xs font-medium text-gray-700">Paid Wins Per Pair Per Day</label>
+              <input type="number" v-model.number="edRpsPairDailyAwardLimit" class="border rounded-md px-2 py-1.5 text-sm w-full" min="0" max="50" />
+              <p class="text-xs text-gray-500 mt-1">
                 How many point-paying wins the same two players may trade in one daily window.
                 This is the main brake on win-trading between alts; 0 disables the limit.
               </p>
@@ -641,7 +642,7 @@
 
           <!-- Disabled while the load is broken: the inputs are showing defaults, so saving
                would overwrite whatever is actually stored. -->
-          <button @click="saveEdRpsConfig" :disabled="loadingEdRps || !!edRpsConfigError" class="btn-primary">
+          <button @click="saveEdRpsConfig" :disabled="loadingEdRps || !!edRpsConfigError" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingEdRps">Save Ed, Edd n Eddy RPS Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -649,37 +650,37 @@
 
         <!-- Win Wheel -->
         <section v-if="activeTab === 'Winwheel'" role="tabpanel" aria-label="Win Wheel Settings">
-          <h2 class="text-2xl font-semibold mb-4">Win Wheel Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">Win Wheel Settings</h2>
 
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Spin Cost (pts)</label>
-              <input type="number" v-model.number="spinCostWW" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Spin Cost (pts)</label>
+              <input type="number" v-model.number="spinCostWW" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Won</label>
-              <input type="number" v-model.number="pointsWonWW" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Points Won</label>
+              <input type="number" v-model.number="pointsWonWW" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Max Daily Spins</label>
-              <input type="number" v-model.number="maxDailySpinsWW" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Max Daily Spins</label>
+              <input type="number" v-model.number="maxDailySpinsWW" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
           <!-- Image upload for Win Wheel -->
           <div class="space-y-3 mb-6">
-            <label class="block text-sm font-medium text-gray-700">
+            <label class="block text-xs font-medium text-gray-700">
               Wheel Image (SVG/PNG/JPEG)
             </label>
             <input
               type="file"
               accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png"
               @change="onWinWheelFileChange"
-              class="block w-full text-sm"
+              class="block w-full text-xs"
             />
             <div class="flex items-center gap-3">
               <button
-                class="btn-primary"
+                class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                 @click="uploadWinWheelImage"
                 :disabled="!winWheelFile || uploadingImage"
               >
@@ -689,14 +690,14 @@
               <button
                 v-if="winWheelImagePath"
                 type="button"
-                class="px-3 py-2 text-sm rounded border"
+                class="px-2 py-1 text-xs border rounded-md hover:bg-gray-50"
                 @click="removeWinWheelImage"
               >Remove Image</button>
             </div>
 
             <div v-if="winWheelImagePath" class="mt-2">
               <p class="text-xs text-gray-600 break-all">Saved path: {{ winWheelImagePath }}</p>
-              <div class="mt-2 border rounded p-2 bg-gray-50">
+              <div class="mt-2 border rounded-md p-2 bg-gray-50">
                 <!-- preview with fallback -->
                 <img :src="previewSrc" alt="Win Wheel image preview" class="max-h-40 mx-auto" />
               </div>
@@ -706,24 +707,24 @@
           <!-- Sound upload for Win Wheel -->
           <div class="space-y-3 mb-6">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Spin Sound Behavior</label>
-              <select v-model="winWheelSoundMode" class="input">
+              <label class="block text-xs font-medium text-gray-700">Spin Sound Behavior</label>
+              <select v-model="winWheelSoundMode" class="border rounded-md px-2 py-1.5 text-sm w-full">
                 <option value="repeat">Repeat Sound</option>
                 <option value="once">Play Once</option>
               </select>
             </div>
-            <label class="block text-sm font-medium text-gray-700">
+            <label class="block text-xs font-medium text-gray-700">
               Wheel Sound (MP3/WAV/OGG)
             </label>
             <input
               type="file"
               accept="audio/mpeg,audio/mp3,audio/wav,audio/x-wav,audio/ogg,.mp3,.wav,.ogg"
               @change="onWinWheelSoundChange"
-              class="block w-full text-sm"
+              class="block w-full text-xs"
             />
             <div class="flex items-center gap-3">
               <button
-                class="btn-primary"
+                class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                 @click="uploadWinWheelSound"
                 :disabled="!winWheelSoundFile || uploadingSound"
               >
@@ -733,7 +734,7 @@
               <button
                 v-if="winWheelSoundPath"
                 type="button"
-                class="px-3 py-2 text-sm rounded border"
+                class="px-2 py-1 text-xs border rounded-md hover:bg-gray-50"
                 @click="removeWinWheelSound"
               >Remove Sound</button>
             </div>
@@ -745,14 +746,14 @@
           </div>
 
           <div class="mb-6 relative">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Exclusive cToon Pool</label>
+            <label class="block text-xs font-medium text-gray-700 mb-1">Exclusive cToon Pool</label>
             <input
               type="text"
               v-model="searchTermWW"
               @focus="showDropdownWW = true"
               @input="onSearchInputWW"
               placeholder="Type to search…"
-              class="input"
+              class="border rounded-md px-2 py-1.5 text-sm w-full"
             />
             <ul
               v-if="showDropdownWW && filteredMatchesWW.length"
@@ -762,7 +763,7 @@
                 v-for="c in filteredMatchesWW"
                 :key="c.id"
                 @mousedown.prevent="selectPoolCtoon(c)"
-                class="flex items-center px-3 py-2 cursor-pointer hover:bg-indigo-50"
+                class="flex items-center px-3 py-2 cursor-pointer hover:bg-blue-50"
               >
                 <img :src="c.assetPath" alt="" class="w-6 h-6 rounded mr-2 object-cover border" />
                 <div>
@@ -777,14 +778,14 @@
             <span
               v-for="c in poolCtoons"
               :key="c.id"
-              class="flex items-center bg-indigo-100 text-indigo-800 px-2 py-1 rounded-full text-sm"
+              class="flex items-center bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-xs"
             >
               {{ c.name }}
               <button class="ml-1" @click="removePoolCtoon(c)">✕</button>
             </span>
           </div>
 
-          <button @click="saveWinWheelConfig" :disabled="loadingWinWheel" class="btn-primary">
+          <button @click="saveWinWheelConfig" :disabled="loadingWinWheel" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingWinWheel">Save Win Wheel Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -792,51 +793,51 @@
 
         <!-- ReOrbit Match -->
         <section v-if="activeTab === 'ReOrbitMatch'" role="tabpanel" aria-label="ReOrbit Match Settings">
-          <h2 class="text-2xl font-semibold mb-4">ReOrbit Match Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">ReOrbit Match Settings</h2>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Plays Per Period</label>
-              <p class="text-xs text-gray-400 mb-1">Number of games per 24-hour period (resets 8 PM CT)</p>
-              <input type="number" v-model.number="reorbitPlaysPerPeriod" min="1" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Plays Per Period</label>
+              <p class="text-xs text-gray-500 mb-1">Number of games per 24-hour period (resets 8 PM CT)</p>
+              <input type="number" v-model.number="reorbitPlaysPerPeriod" min="1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
-              <p class="text-xs text-gray-400 mb-1">Points awarded toward daily cap on game completion</p>
-              <input type="number" v-model.number="reorbitPointsPerGame" min="0" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-500 mb-1">Points awarded toward daily cap on game completion</p>
+              <input type="number" v-model.number="reorbitPointsPerGame" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Time Per Game (seconds)</label>
-              <p class="text-xs text-gray-400 mb-1">Leave empty for unlimited time</p>
-              <input type="number" v-model="reorbitTimeSecondsInput" min="30" placeholder="Unlimited" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Time Per Game (seconds)</label>
+              <p class="text-xs text-gray-500 mb-1">Leave empty for unlimited time</p>
+              <input type="number" v-model="reorbitTimeSecondsInput" min="30" placeholder="Unlimited" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Grid Size (N×N)</label>
-              <p class="text-xs text-gray-400 mb-1">Board dimensions (4–10)</p>
-              <input type="number" v-model.number="reorbitGridSize" min="4" max="10" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Grid Size (N×N)</label>
+              <p class="text-xs text-gray-500 mb-1">Board dimensions (4–10)</p>
+              <input type="number" v-model.number="reorbitGridSize" min="4" max="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Combo Cooldown (ms)</label>
-              <p class="text-xs text-gray-400 mb-1">Time allowed between matches to keep the combo growing (1000–15000). Higher = combos are easier to hold.</p>
-              <input type="number" v-model.number="reorbitComboMs" min="1000" max="15000" step="500" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Combo Cooldown (ms)</label>
+              <p class="text-xs text-gray-500 mb-1">Time allowed between matches to keep the combo growing (1000–15000). Higher = combos are easier to hold.</p>
+              <input type="number" v-model.number="reorbitComboMs" min="1000" max="15000" step="500" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Emojis</h3>
-            <p class="text-xs text-gray-400 mb-3">Min 4, max min(gridSize, 10). Leave empty to use defaults: ⭐ 🌙 🚀 🌍 ⚡ 💫 🪐 🎯</p>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Emojis</h3>
+            <p class="text-xs text-gray-500 mb-3">Min 4, max min(gridSize, 10). Leave empty to use defaults: ⭐ 🌙 🚀 🌍 ⚡ 💫 🪐 🎯</p>
             <div class="flex gap-2 mb-3">
               <input
                 type="text"
                 v-model="reorbitEmojiInput"
                 placeholder="Paste an emoji…"
-                class="input flex-1"
+                class="border rounded-md px-2 py-1.5 text-sm flex-1"
                 @keydown.enter.prevent="addReorbitEmoji"
               />
               <button
                 type="button"
                 @click="addReorbitEmoji"
-                class="px-3 py-2 rounded bg-indigo-600 text-white text-sm"
+                class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
                 :disabled="reorbitEmojis.length >= Math.min(reorbitGridSize, 10)"
               >Add</button>
             </div>
@@ -844,16 +845,16 @@
               <span
                 v-for="(e, i) in reorbitEmojis"
                 :key="i"
-                class="flex items-center gap-1 bg-indigo-100 text-indigo-800 px-2 py-1 rounded-full text-lg"
+                class="flex items-center gap-1 bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm"
               >
                 {{ e }}
                 <button type="button" class="ml-1 text-sm leading-none" @click="removeReorbitEmoji(i)">✕</button>
               </span>
-              <span v-if="!reorbitEmojis.length" class="text-sm text-gray-400">Using defaults</span>
+              <span v-if="!reorbitEmojis.length" class="text-xs text-gray-500">Using defaults</span>
             </div>
           </div>
 
-          <button @click="saveReorbitConfig" :disabled="loadingReorbit" class="btn-primary">
+          <button @click="saveReorbitConfig" :disabled="loadingReorbit" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingReorbit">Save ReOrbit Match Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -861,47 +862,47 @@
 
         <!-- Tower Stack -->
         <section v-if="activeTab === 'TowerStack'" role="tabpanel" aria-label="Tower Stack Settings">
-          <h2 class="text-2xl font-semibold mb-4">Tower Stack Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">Tower Stack Settings</h2>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Plays Per Period</label>
-              <p class="text-xs text-gray-400 mb-1">Number of games per 24-hour period (resets 8 PM CT)</p>
-              <input type="number" v-model.number="towerPlaysPerPeriod" min="1" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Plays Per Period</label>
+              <p class="text-xs text-gray-500 mb-1">Number of games per 24-hour period (resets 8 PM CT)</p>
+              <input type="number" v-model.number="towerPlaysPerPeriod" min="1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
-              <p class="text-xs text-gray-400 mb-1">Points awarded toward daily cap on game completion</p>
-              <input type="number" v-model.number="towerPointsPerGame" min="0" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-500 mb-1">Points awarded toward daily cap on game completion</p>
+              <input type="number" v-model.number="towerPointsPerGame" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Base Speed</label>
-              <p class="text-xs text-gray-400 mb-1">Starting speed of the sliding block (world units/sec)</p>
-              <input type="number" v-model.number="towerBaseSpeed" min="1" step="1" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Base Speed</label>
+              <p class="text-xs text-gray-500 mb-1">Starting speed of the sliding block (world units/sec)</p>
+              <input type="number" v-model.number="towerBaseSpeed" min="1" step="1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Speed Growth Per Layer</label>
-              <p class="text-xs text-gray-400 mb-1">How much faster each layer gets (0.03 = +3% per layer)</p>
-              <input type="number" v-model.number="towerSpeedGrowthPerLayer" min="0" step="0.005" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Speed Growth Per Layer</label>
+              <p class="text-xs text-gray-500 mb-1">How much faster each layer gets (0.03 = +3% per layer)</p>
+              <input type="number" v-model.number="towerSpeedGrowthPerLayer" min="0" step="0.005" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Max Speed Multiplier</label>
-              <p class="text-xs text-gray-400 mb-1">Speed growth caps at this multiple of the base speed</p>
-              <input type="number" v-model.number="towerMaxSpeedMultiplier" min="1" step="0.1" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Max Speed Multiplier</label>
+              <p class="text-xs text-gray-500 mb-1">Speed growth caps at this multiple of the base speed</p>
+              <input type="number" v-model.number="towerMaxSpeedMultiplier" min="1" step="0.1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Perfect Alignment Tolerance</label>
-              <p class="text-xs text-gray-400 mb-1">Taps within this distance of dead-center don't trim the tower's width</p>
-              <input type="number" v-model.number="towerPerfectEpsilon" min="0" step="0.5" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Perfect Alignment Tolerance</label>
+              <p class="text-xs text-gray-500 mb-1">Taps within this distance of dead-center don't trim the tower's width</p>
+              <input type="number" v-model.number="towerPerfectEpsilon" min="0" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Max Layers</label>
-              <p class="text-xs text-gray-400 mb-1">Run ends automatically past this height (10–2000)</p>
-              <input type="number" v-model.number="towerMaxLayers" min="10" max="2000" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Max Layers</label>
+              <p class="text-xs text-gray-500 mb-1">Run ends automatically past this height (10–2000)</p>
+              <input type="number" v-model.number="towerMaxLayers" min="10" max="2000" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <button @click="saveTowerConfig" :disabled="loadingTower" class="btn-primary">
+          <button @click="saveTowerConfig" :disabled="loadingTower" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingTower">Save Tower Stack Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -909,280 +910,280 @@
 
         <!-- Operation A.S.T.E.R.O.I.D. -->
         <section v-if="activeTab === 'OperationAsteroid'" role="tabpanel" aria-label="Operation A.S.T.E.R.O.I.D. Settings">
-          <h2 class="text-2xl font-semibold mb-4">Operation A.S.T.E.R.O.I.D. Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">Operation A.S.T.E.R.O.I.D. Settings</h2>
           <p class="text-xs text-gray-500 mb-4">
             Plays are unlimited. Only the first few runs each day are ranked — those are the ones
             that record a score and award points. Timing values are in ticks; the game runs at 60
             ticks per second.
           </p>
 
-          <h3 class="text-lg font-semibold mb-2">Plays &amp; Points</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <h3 class="text-xs font-semibold mb-1.5">Plays &amp; Points</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Ranked Plays Per Period</label>
-              <p class="text-xs text-gray-400 mb-1">Runs per 24-hour period that count for the leaderboard (resets 8 PM CT). Set 0 to make every run practice.</p>
-              <input type="number" v-model.number="asteroidRankedPlaysPerPeriod" min="0" max="100" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Ranked Plays Per Period</label>
+              <p class="text-xs text-gray-500 mb-1">Runs per 24-hour period that count for the leaderboard (resets 8 PM CT). Set 0 to make every run practice.</p>
+              <input type="number" v-model.number="asteroidRankedPlaysPerPeriod" min="0" max="100" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
-              <p class="text-xs text-gray-400 mb-1">Points awarded toward the daily cap when a ranked run ends</p>
-              <input type="number" v-model.number="asteroidPointsPerGame" min="0" class="input" />
-            </div>
-          </div>
-
-          <h3 class="text-lg font-semibold mb-2">Difficulty</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Starting Lives</label>
-              <input type="number" v-model.number="asteroidStartingLives" min="1" max="9" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Starting Asteroids</label>
-              <p class="text-xs text-gray-400 mb-1">Large asteroids in wave 1 (1–12)</p>
-              <input type="number" v-model.number="asteroidStartAsteroids" min="1" max="12" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Asteroids Added Per Wave</label>
-              <input type="number" v-model.number="asteroidAsteroidsPerWave" min="0" max="4" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Asteroid Speed</label>
-              <p class="text-xs text-gray-400 mb-1">World units per tick for a large asteroid (0.2–4)</p>
-              <input type="number" v-model.number="asteroidAsteroidSpeed" min="0.2" max="4" step="0.05" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Wave Speed Growth</label>
-              <p class="text-xs text-gray-400 mb-1">0.06 = asteroids get 6% faster each wave</p>
-              <input type="number" v-model.number="asteroidWaveSpeedGrowth" min="0" max="0.5" step="0.01" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Max Speed Multiplier</label>
-              <p class="text-xs text-gray-400 mb-1">Wave speed growth caps here (1–5)</p>
-              <input type="number" v-model.number="asteroidMaxSpeedMultiplier" min="1" max="5" step="0.1" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Turn Rate</label>
-              <p class="text-xs text-gray-400 mb-1">Heading steps per tick out of 1024 (1–24). 6 ≈ a full turn in 1.7s.</p>
-              <input type="number" v-model.number="asteroidTurnRate" min="1" max="24" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Thrust Acceleration</label>
-              <input type="number" v-model.number="asteroidThrustAccel" min="0.02" max="1" step="0.005" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Max Ship Speed</label>
-              <input type="number" v-model.number="asteroidMaxShipSpeed" min="1" max="16" step="0.1" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Ship Drag</label>
-              <p class="text-xs text-gray-400 mb-1">Velocity kept each tick (0.9–1). 1 = no drag, pure inertia.</p>
-              <input type="number" v-model.number="asteroidShipDrag" min="0.9" max="1" step="0.001" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Extra Life Score</label>
-              <p class="text-xs text-gray-400 mb-1">Award a life every this many points. 0 disables.</p>
-              <input type="number" v-model.number="asteroidExtraLifeScore" min="0" max="1000000" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-500 mb-1">Points awarded toward the daily cap when a ranked run ends</p>
+              <input type="number" v-model.number="asteroidPointsPerGame" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <h3 class="text-lg font-semibold mb-2">Physics &amp; Geometry</h3>
+          <h3 class="text-xs font-semibold mb-1.5">Difficulty</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Starting Lives</label>
+              <input type="number" v-model.number="asteroidStartingLives" min="1" max="9" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Starting Asteroids</label>
+              <p class="text-xs text-gray-500 mb-1">Large asteroids in wave 1 (1–12)</p>
+              <input type="number" v-model.number="asteroidStartAsteroids" min="1" max="12" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Asteroids Added Per Wave</label>
+              <input type="number" v-model.number="asteroidAsteroidsPerWave" min="0" max="4" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Asteroid Speed</label>
+              <p class="text-xs text-gray-500 mb-1">World units per tick for a large asteroid (0.2–4)</p>
+              <input type="number" v-model.number="asteroidAsteroidSpeed" min="0.2" max="4" step="0.05" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Wave Speed Growth</label>
+              <p class="text-xs text-gray-500 mb-1">0.06 = asteroids get 6% faster each wave</p>
+              <input type="number" v-model.number="asteroidWaveSpeedGrowth" min="0" max="0.5" step="0.01" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Max Speed Multiplier</label>
+              <p class="text-xs text-gray-500 mb-1">Wave speed growth caps here (1–5)</p>
+              <input type="number" v-model.number="asteroidMaxSpeedMultiplier" min="1" max="5" step="0.1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Turn Rate</label>
+              <p class="text-xs text-gray-500 mb-1">Heading steps per tick out of 1024 (1–24). 6 ≈ a full turn in 1.7s.</p>
+              <input type="number" v-model.number="asteroidTurnRate" min="1" max="24" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Thrust Acceleration</label>
+              <input type="number" v-model.number="asteroidThrustAccel" min="0.02" max="1" step="0.005" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Max Ship Speed</label>
+              <input type="number" v-model.number="asteroidMaxShipSpeed" min="1" max="16" step="0.1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Ship Drag</label>
+              <p class="text-xs text-gray-500 mb-1">Velocity kept each tick (0.9–1). 1 = no drag, pure inertia.</p>
+              <input type="number" v-model.number="asteroidShipDrag" min="0.9" max="1" step="0.001" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Extra Life Score</label>
+              <p class="text-xs text-gray-500 mb-1">Award a life every this many points. 0 disables.</p>
+              <input type="number" v-model.number="asteroidExtraLifeScore" min="0" max="1000000" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+          </div>
+
+          <h3 class="text-xs font-semibold mb-1.5">Physics &amp; Geometry</h3>
           <p class="text-xs text-gray-500 mb-2">
             Sizes are in world units on the fixed 640&times;480 playfield. Durations are in ticks
             (60 per second). Changing these alters how the game feels but never how it is scored.
           </p>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Ship Collision Radius</label>
-              <p class="text-xs text-gray-400 mb-1">Bigger is easier to hit (4&ndash;40). The Green power-up halves this.</p>
-              <input type="number" v-model.number="asteroidShipRadius" min="4" max="40" step="0.5" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Ship Collision Radius</label>
+              <p class="text-xs text-gray-500 mb-1">Bigger is easier to hit (4&ndash;40). The Green power-up halves this.</p>
+              <input type="number" v-model.number="asteroidShipRadius" min="4" max="40" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Respawn Invulnerability (ticks)</label>
-              <p class="text-xs text-gray-400 mb-1">Grace period after losing a life (0&ndash;600). 96 &asymp; 1.6s.</p>
-              <input type="number" v-model.number="asteroidRespawnInvulnTicks" min="0" max="600" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Respawn Invulnerability (ticks)</label>
+              <p class="text-xs text-gray-500 mb-1">Grace period after losing a life (0&ndash;600). 96 &asymp; 1.6s.</p>
+              <input type="number" v-model.number="asteroidRespawnInvulnTicks" min="0" max="600" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Power-Up Pickup Radius</label>
-              <input type="number" v-model.number="asteroidPowerupRadius" min="5" max="40" step="0.5" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Power-Up Pickup Radius</label>
+              <input type="number" v-model.number="asteroidPowerupRadius" min="5" max="40" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Power-Up Lifetime (ticks)</label>
-              <p class="text-xs text-gray-400 mb-1">How long an uncollected power-up waits (60&ndash;3600). 600 = 10s.</p>
-              <input type="number" v-model.number="asteroidPowerupLifeTicks" min="60" max="3600" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Power-Up Lifetime (ticks)</label>
+              <p class="text-xs text-gray-500 mb-1">How long an uncollected power-up waits (60&ndash;3600). 600 = 10s.</p>
+              <input type="number" v-model.number="asteroidPowerupLifeTicks" min="60" max="3600" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Large Asteroid Radius</label>
-              <input type="number" v-model.number="asteroidLargeRadius" min="10" max="80" step="0.5" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Large Asteroid Radius</label>
+              <input type="number" v-model.number="asteroidLargeRadius" min="10" max="80" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Medium Asteroid Radius</label>
-              <input type="number" v-model.number="asteroidMediumRadius" min="6" max="60" step="0.5" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Medium Asteroid Radius</label>
+              <input type="number" v-model.number="asteroidMediumRadius" min="6" max="60" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Small Asteroid Radius</label>
-              <input type="number" v-model.number="asteroidSmallRadius" min="3" max="40" step="0.5" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Small Asteroid Radius</label>
+              <input type="number" v-model.number="asteroidSmallRadius" min="3" max="40" step="0.5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <h3 class="text-lg font-semibold mb-2">Ships &amp; Weapons</h3>
+          <h3 class="text-xs font-semibold mb-1.5">Ships &amp; Weapons</h3>
           <p class="text-xs text-gray-500 mb-3">
             Players pick one of three ships before each run. A ship is purely a weapon profile —
             everything else about flying is shared. Range is roughly projectile speed &times;
             range ticks, against a playfield 640 units wide, so a range under ~640 means shots
             fizzle before crossing the screen.
           </p>
-            <h4 class="text-sm font-bold text-gray-700 mt-2">M.O.S.Q.U.I.T.T.O.H. <span class="font-normal text-gray-400">— sniper</span></h4>
-            <p class="text-xs text-gray-400 mb-2 sm:col-span-2">Intended feel: one shot at a time, very long reach, slow cadence.</p>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
+            <h4 class="text-sm font-bold text-gray-700 mt-2">M.O.S.Q.U.I.T.T.O.H. <span class="font-normal text-gray-500">— sniper</span></h4>
+            <p class="text-xs text-gray-500 mb-2 sm:col-span-2">Intended feel: one shot at a time, very long reach, slow cadence.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700">Fire Interval (ticks)</label>
-                <p class="text-xs text-gray-400 mb-1">Ticks between shots (3&ndash;60). Lower is faster; the Blue power-up halves it.</p>
-                <input type="number" v-model.number="asteroidMosqFireInterval" min="3" max="60" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Fire Interval (ticks)</label>
+                <p class="text-xs text-gray-500 mb-1">Ticks between shots (3&ndash;60). Lower is faster; the Blue power-up halves it.</p>
+                <input type="number" v-model.number="asteroidMosqFireInterval" min="3" max="60" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700">Projectile Speed</label>
-                <p class="text-xs text-gray-400 mb-1">World units per tick (1&ndash;20)</p>
-                <input type="number" v-model.number="asteroidMosqBulletSpeed" min="1" max="20" step="0.1" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Projectile Speed</label>
+                <p class="text-xs text-gray-500 mb-1">World units per tick (1&ndash;20)</p>
+                <input type="number" v-model.number="asteroidMosqBulletSpeed" min="1" max="20" step="0.1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700">Range (ticks)</label>
-                <p class="text-xs text-gray-400 mb-1">How long a shot lives (10&ndash;300). Range &asymp; speed &times; this; the field is 640 units wide.</p>
-                <input type="number" v-model.number="asteroidMosqBulletLife" min="10" max="300" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Range (ticks)</label>
+                <p class="text-xs text-gray-500 mb-1">How long a shot lives (10&ndash;300). Range &asymp; speed &times; this; the field is 640 units wide.</p>
+                <input type="number" v-model.number="asteroidMosqBulletLife" min="10" max="300" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700">Projectiles Per Shot</label>
-                <p class="text-xs text-gray-400 mb-1">1&ndash;12. Above 1 gives a shotgun fan.</p>
-                <input type="number" v-model.number="asteroidMosqPellets" min="1" max="12" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Projectiles Per Shot</label>
+                <p class="text-xs text-gray-500 mb-1">1&ndash;12. Above 1 gives a shotgun fan.</p>
+                <input type="number" v-model.number="asteroidMosqPellets" min="1" max="12" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700">Spread</label>
-                <p class="text-xs text-gray-400 mb-1">Fan width, 0&ndash;512 (1024 = a full circle, so 96 &asymp; 34&deg;). Ignored with 1 projectile.</p>
-                <input type="number" v-model.number="asteroidMosqSpread" min="0" max="512" class="input" />
-              </div>
-            </div>
-            <h4 class="text-sm font-bold text-gray-700 mt-2">S.C.A.M.P.E.R. <span class="font-normal text-gray-400">— shotgun</span></h4>
-            <p class="text-xs text-gray-400 mb-2 sm:col-span-2">Intended feel: a wide spray of pellets that dies off almost immediately — strong up close, useless at range.</p>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Fire Interval (ticks)</label>
-                <p class="text-xs text-gray-400 mb-1">Ticks between shots (3&ndash;60). Lower is faster; the Blue power-up halves it.</p>
-                <input type="number" v-model.number="asteroidScamFireInterval" min="3" max="60" class="input" />
-              </div>
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Projectile Speed</label>
-                <p class="text-xs text-gray-400 mb-1">World units per tick (1&ndash;20)</p>
-                <input type="number" v-model.number="asteroidScamBulletSpeed" min="1" max="20" step="0.1" class="input" />
-              </div>
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Range (ticks)</label>
-                <p class="text-xs text-gray-400 mb-1">How long a shot lives (10&ndash;300). Range &asymp; speed &times; this; the field is 640 units wide.</p>
-                <input type="number" v-model.number="asteroidScamBulletLife" min="10" max="300" class="input" />
-              </div>
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Projectiles Per Shot</label>
-                <p class="text-xs text-gray-400 mb-1">1&ndash;12. Above 1 gives a shotgun fan.</p>
-                <input type="number" v-model.number="asteroidScamPellets" min="1" max="12" class="input" />
-              </div>
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Spread</label>
-                <p class="text-xs text-gray-400 mb-1">Fan width, 0&ndash;512 (1024 = a full circle, so 96 &asymp; 34&deg;). Ignored with 1 projectile.</p>
-                <input type="number" v-model.number="asteroidScamSpread" min="0" max="512" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Spread</label>
+                <p class="text-xs text-gray-500 mb-1">Fan width, 0&ndash;512 (1024 = a full circle, so 96 &asymp; 34&deg;). Ignored with 1 projectile.</p>
+                <input type="number" v-model.number="asteroidMosqSpread" min="0" max="512" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
             </div>
-            <h4 class="text-sm font-bold text-gray-700 mt-2">C.A.S.U.A.L. <span class="font-normal text-gray-400">— all-rounder</span></h4>
-            <p class="text-xs text-gray-400 mb-2 sm:col-span-2">Intended feel: medium range, medium cadence, single shot.</p>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
+            <h4 class="text-sm font-bold text-gray-700 mt-2">S.C.A.M.P.E.R. <span class="font-normal text-gray-500">— shotgun</span></h4>
+            <p class="text-xs text-gray-500 mb-2 sm:col-span-2">Intended feel: a wide spray of pellets that dies off almost immediately — strong up close, useless at range.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700">Fire Interval (ticks)</label>
-                <p class="text-xs text-gray-400 mb-1">Ticks between shots (3&ndash;60). Lower is faster; the Blue power-up halves it.</p>
-                <input type="number" v-model.number="asteroidCasFireInterval" min="3" max="60" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Fire Interval (ticks)</label>
+                <p class="text-xs text-gray-500 mb-1">Ticks between shots (3&ndash;60). Lower is faster; the Blue power-up halves it.</p>
+                <input type="number" v-model.number="asteroidScamFireInterval" min="3" max="60" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700">Projectile Speed</label>
-                <p class="text-xs text-gray-400 mb-1">World units per tick (1&ndash;20)</p>
-                <input type="number" v-model.number="asteroidCasBulletSpeed" min="1" max="20" step="0.1" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Projectile Speed</label>
+                <p class="text-xs text-gray-500 mb-1">World units per tick (1&ndash;20)</p>
+                <input type="number" v-model.number="asteroidScamBulletSpeed" min="1" max="20" step="0.1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700">Range (ticks)</label>
-                <p class="text-xs text-gray-400 mb-1">How long a shot lives (10&ndash;300). Range &asymp; speed &times; this; the field is 640 units wide.</p>
-                <input type="number" v-model.number="asteroidCasBulletLife" min="10" max="300" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Range (ticks)</label>
+                <p class="text-xs text-gray-500 mb-1">How long a shot lives (10&ndash;300). Range &asymp; speed &times; this; the field is 640 units wide.</p>
+                <input type="number" v-model.number="asteroidScamBulletLife" min="10" max="300" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700">Projectiles Per Shot</label>
-                <p class="text-xs text-gray-400 mb-1">1&ndash;12. Above 1 gives a shotgun fan.</p>
-                <input type="number" v-model.number="asteroidCasPellets" min="1" max="12" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Projectiles Per Shot</label>
+                <p class="text-xs text-gray-500 mb-1">1&ndash;12. Above 1 gives a shotgun fan.</p>
+                <input type="number" v-model.number="asteroidScamPellets" min="1" max="12" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700">Spread</label>
-                <p class="text-xs text-gray-400 mb-1">Fan width, 0&ndash;512 (1024 = a full circle, so 96 &asymp; 34&deg;). Ignored with 1 projectile.</p>
-                <input type="number" v-model.number="asteroidCasSpread" min="0" max="512" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Spread</label>
+                <p class="text-xs text-gray-500 mb-1">Fan width, 0&ndash;512 (1024 = a full circle, so 96 &asymp; 34&deg;). Ignored with 1 projectile.</p>
+                <input type="number" v-model.number="asteroidScamSpread" min="0" max="512" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+              </div>
+            </div>
+            <h4 class="text-sm font-bold text-gray-700 mt-2">C.A.S.U.A.L. <span class="font-normal text-gray-500">— all-rounder</span></h4>
+            <p class="text-xs text-gray-500 mb-2 sm:col-span-2">Intended feel: medium range, medium cadence, single shot.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
+              <div>
+                <label class="block text-xs font-medium text-gray-700">Fire Interval (ticks)</label>
+                <p class="text-xs text-gray-500 mb-1">Ticks between shots (3&ndash;60). Lower is faster; the Blue power-up halves it.</p>
+                <input type="number" v-model.number="asteroidCasFireInterval" min="3" max="60" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-700">Projectile Speed</label>
+                <p class="text-xs text-gray-500 mb-1">World units per tick (1&ndash;20)</p>
+                <input type="number" v-model.number="asteroidCasBulletSpeed" min="1" max="20" step="0.1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-700">Range (ticks)</label>
+                <p class="text-xs text-gray-500 mb-1">How long a shot lives (10&ndash;300). Range &asymp; speed &times; this; the field is 640 units wide.</p>
+                <input type="number" v-model.number="asteroidCasBulletLife" min="10" max="300" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-700">Projectiles Per Shot</label>
+                <p class="text-xs text-gray-500 mb-1">1&ndash;12. Above 1 gives a shotgun fan.</p>
+                <input type="number" v-model.number="asteroidCasPellets" min="1" max="12" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-gray-700">Spread</label>
+                <p class="text-xs text-gray-500 mb-1">Fan width, 0&ndash;512 (1024 = a full circle, so 96 &asymp; 34&deg;). Ignored with 1 projectile.</p>
+                <input type="number" v-model.number="asteroidCasSpread" min="0" max="512" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
             </div>
 
-          <h3 class="text-lg font-semibold mb-2">Scoring</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <h3 class="text-xs font-semibold mb-1.5">Scoring</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Large Asteroid</label>
-              <input type="number" v-model.number="asteroidPointsLarge" min="0" max="10000" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Large Asteroid</label>
+              <input type="number" v-model.number="asteroidPointsLarge" min="0" max="10000" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Medium Asteroid</label>
-              <input type="number" v-model.number="asteroidPointsMedium" min="0" max="10000" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Medium Asteroid</label>
+              <input type="number" v-model.number="asteroidPointsMedium" min="0" max="10000" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Small Asteroid</label>
-              <input type="number" v-model.number="asteroidPointsSmall" min="0" max="10000" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Small Asteroid</label>
+              <input type="number" v-model.number="asteroidPointsSmall" min="0" max="10000" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Wave Clear Bonus</label>
-              <input type="number" v-model.number="asteroidWaveClearBonus" min="0" max="100000" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Wave Clear Bonus</label>
+              <input type="number" v-model.number="asteroidWaveClearBonus" min="0" max="100000" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <h3 class="text-lg font-semibold mb-2">Power-Ups</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <h3 class="text-xs font-semibold mb-1.5">Power-Ups</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div class="sm:col-span-2 flex flex-wrap gap-4">
-              <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+              <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                 <input type="checkbox" v-model="asteroidPowerupsEnabled" /> Power-ups enabled
               </label>
-              <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+              <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                 <input type="checkbox" v-model="asteroidPowerupBlueEnabled" /> Blue (2x fire rate)
               </label>
-              <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+              <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                 <input type="checkbox" v-model="asteroidPowerupRedEnabled" /> Red (invincibility)
               </label>
-              <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+              <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                 <input type="checkbox" v-model="asteroidPowerupGreenEnabled" /> Green (half size)
               </label>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Spawn Interval (ticks)</label>
-              <p class="text-xs text-gray-400 mb-1">Ticks between spawn attempts (60–36000). 900 = every 15s.</p>
-              <input type="number" v-model.number="asteroidPowerupIntervalTicks" min="60" max="36000" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Spawn Interval (ticks)</label>
+              <p class="text-xs text-gray-500 mb-1">Ticks between spawn attempts (60–36000). 900 = every 15s.</p>
+              <input type="number" v-model.number="asteroidPowerupIntervalTicks" min="60" max="36000" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Spawn Chance (%)</label>
-              <p class="text-xs text-gray-400 mb-1">Chance each attempt actually drops a power-up</p>
-              <input type="number" v-model.number="asteroidPowerupChancePercent" min="0" max="100" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Spawn Chance (%)</label>
+              <p class="text-xs text-gray-500 mb-1">Chance each attempt actually drops a power-up</p>
+              <input type="number" v-model.number="asteroidPowerupChancePercent" min="0" max="100" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Blue Duration (ticks)</label>
-              <p class="text-xs text-gray-400 mb-1">600 = 10s</p>
-              <input type="number" v-model.number="asteroidPowerupBlueTicks" min="0" max="7200" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Blue Duration (ticks)</label>
+              <p class="text-xs text-gray-500 mb-1">600 = 10s</p>
+              <input type="number" v-model.number="asteroidPowerupBlueTicks" min="0" max="7200" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Red Duration (ticks)</label>
-              <p class="text-xs text-gray-400 mb-1">420 = 7s</p>
-              <input type="number" v-model.number="asteroidPowerupRedTicks" min="0" max="7200" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Red Duration (ticks)</label>
+              <p class="text-xs text-gray-500 mb-1">420 = 7s</p>
+              <input type="number" v-model.number="asteroidPowerupRedTicks" min="0" max="7200" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Green Duration (ticks)</label>
-              <p class="text-xs text-gray-400 mb-1">720 = 12s</p>
-              <input type="number" v-model.number="asteroidPowerupGreenTicks" min="0" max="7200" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Green Duration (ticks)</label>
+              <p class="text-xs text-gray-500 mb-1">720 = 12s</p>
+              <input type="number" v-model.number="asteroidPowerupGreenTicks" min="0" max="7200" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <button @click="saveAsteroidConfig" :disabled="loadingAsteroid" class="btn-primary">
+          <button @click="saveAsteroidConfig" :disabled="loadingAsteroid" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingAsteroid">Save Operation A.S.T.E.R.O.I.D. Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -1190,23 +1191,23 @@
 
         <!-- ReOrbit Memory -->
         <section v-if="activeTab === 'ReOrbitMemory'" role="tabpanel" aria-label="ReOrbit Memory Settings">
-          <h2 class="text-2xl font-semibold mb-4">ReOrbit Memory Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">ReOrbit Memory Settings</h2>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Plays Per Period</label>
-              <p class="text-xs text-gray-400 mb-1">Number of games per 24-hour period (resets 8 PM CT)</p>
-              <input type="number" v-model.number="reorbitMemoryPlaysPerPeriod" min="1" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Plays Per Period</label>
+              <p class="text-xs text-gray-500 mb-1">Number of games per 24-hour period (resets 8 PM CT)</p>
+              <input type="number" v-model.number="reorbitMemoryPlaysPerPeriod" min="1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
-              <p class="text-xs text-gray-400 mb-1">Points awarded toward daily cap on game completion</p>
-              <input type="number" v-model.number="reorbitMemoryPointsPerGame" min="0" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-500 mb-1">Points awarded toward daily cap on game completion</p>
+              <input type="number" v-model.number="reorbitMemoryPointsPerGame" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Number of Pairs</label>
-              <p class="text-xs text-gray-400 mb-1">Board size — kept small enough to stay tappable on phones</p>
-              <select v-model.number="reorbitMemoryPairs" class="input">
+              <label class="block text-xs font-medium text-gray-700">Number of Pairs</label>
+              <p class="text-xs text-gray-500 mb-1">Board size — kept small enough to stay tappable on phones</p>
+              <select v-model.number="reorbitMemoryPairs" class="border rounded-md px-2 py-1.5 text-sm w-full">
                 <option :value="6">6 pairs (3×4 — 12 cards)</option>
                 <option :value="8">8 pairs (4×4 — 16 cards)</option>
                 <option :value="10">10 pairs (4×5 — 20 cards)</option>
@@ -1214,19 +1215,19 @@
               </select>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Time Per Game (seconds)</label>
-              <p class="text-xs text-gray-400 mb-1">Leave empty for unlimited time</p>
-              <input type="number" v-model="reorbitMemoryTimeSecondsInput" min="30" placeholder="Unlimited" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Time Per Game (seconds)</label>
+              <p class="text-xs text-gray-500 mb-1">Leave empty for unlimited time</p>
+              <input type="number" v-model="reorbitMemoryTimeSecondsInput" min="30" placeholder="Unlimited" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Flip-back Delay (ms)</label>
-              <p class="text-xs text-gray-400 mb-1">How long a mismatched pair stays face up before flipping back (300–3000)</p>
-              <input type="number" v-model.number="reorbitMemoryFlipBackDelayMs" min="300" max="3000" step="100" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Flip-back Delay (ms)</label>
+              <p class="text-xs text-gray-500 mb-1">How long a mismatched pair stays face up before flipping back (300–3000)</p>
+              <input type="number" v-model.number="reorbitMemoryFlipBackDelayMs" min="300" max="3000" step="100" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Card Back Image</h3>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Card Back Image</h3>
             <p class="text-xs text-gray-500 mb-3">Shown on the back of every face-down card. Card fronts are random cToon images, chosen automatically each game.</p>
             <div class="w-24 h-32 bg-gray-100 border rounded overflow-hidden flex items-center justify-center mb-2">
               <img
@@ -1235,7 +1236,7 @@
                 alt="Card back"
                 class="w-full h-full object-cover"
               />
-              <span v-else class="text-gray-400 text-xs px-1 text-center">No image</span>
+              <span v-else class="text-gray-500 text-xs px-1 text-center">No image</span>
             </div>
             <input
               type="file"
@@ -1244,7 +1245,7 @@
               class="block w-full text-xs mb-2"
             />
             <button
-              class="btn-primary text-sm py-1 px-3"
+              class="px-3 py-1 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
               @click="uploadReorbitMemoryCardBack"
               :disabled="!reorbitMemoryCardBackFile || uploadingReorbitMemoryCardBack"
             >
@@ -1253,7 +1254,7 @@
             </button>
           </div>
 
-          <button @click="saveReorbitMemoryConfig" :disabled="loadingReorbitMemory" class="btn-primary">
+          <button @click="saveReorbitMemoryConfig" :disabled="loadingReorbitMemory" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingReorbitMemory">Save ReOrbit Memory Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -1261,7 +1262,7 @@
 
         <!-- Guess that cToon! -->
         <section v-if="activeTab === 'GuessCtoon'" role="tabpanel" aria-label="Guess that cToon Settings">
-          <h2 class="text-2xl font-semibold mb-4">Guess that cToon! Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">Guess that cToon! Settings</h2>
 
           <p class="text-sm text-gray-500 mb-4">
             Plays are unlimited. Only the first few runs each day count toward points and the
@@ -1270,29 +1271,29 @@
             already in progress.
           </p>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Scoring Plays Per Period</label>
-              <p class="text-xs text-gray-400 mb-1">
+              <label class="block text-xs font-medium text-gray-700">Scoring Plays Per Period</label>
+              <p class="text-xs text-gray-500 mb-1">
                 Runs per 24-hour period (resets 8 PM CT) that count for points and the
                 leaderboard. Set to 0 to make every run practice-only.
               </p>
-              <input type="number" v-model.number="guessCtoonScoredPlaysPerPeriod" min="0" max="100" class="input" />
+              <input type="number" v-model.number="guessCtoonScoredPlaysPerPeriod" min="0" max="100" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
-              <p class="text-xs text-gray-400 mb-1">Points awarded toward the shared daily cap when a scoring run ends</p>
-              <input type="number" v-model.number="guessCtoonPointsPerGame" min="0" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-500 mb-1">Points awarded toward the shared daily cap when a scoring run ends</p>
+              <input type="number" v-model.number="guessCtoonPointsPerGame" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Seconds Per cToon</label>
-              <p class="text-xs text-gray-400 mb-1">Countdown per question — running out counts as a wrong answer (4–120)</p>
-              <input type="number" v-model.number="guessCtoonSecondsPerQuestion" min="4" max="120" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Seconds Per cToon</label>
+              <p class="text-xs text-gray-500 mb-1">Countdown per question — running out counts as a wrong answer (4–120)</p>
+              <input type="number" v-model.number="guessCtoonSecondsPerQuestion" min="4" max="120" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Answer Choices</label>
-              <p class="text-xs text-gray-400 mb-1">How many names to pick from, including the correct one</p>
-              <select v-model.number="guessCtoonChoices" class="input">
+              <label class="block text-xs font-medium text-gray-700">Answer Choices</label>
+              <p class="text-xs text-gray-500 mb-1">How many names to pick from, including the correct one</p>
+              <select v-model.number="guessCtoonChoices" class="border rounded-md px-2 py-1.5 text-sm w-full">
                 <option :value="3">3 choices</option>
                 <option :value="4">4 choices</option>
                 <option :value="5">5 choices</option>
@@ -1300,18 +1301,18 @@
               </select>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Questions Per Run</label>
-              <p class="text-xs text-gray-400 mb-1">Longest possible streak — answering them all is a perfect run (5–100)</p>
-              <input type="number" v-model.number="guessCtoonMaxQuestions" min="5" max="100" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Questions Per Run</label>
+              <p class="text-xs text-gray-500 mb-1">Longest possible streak — answering them all is a perfect run (5–100)</p>
+              <input type="number" v-model.number="guessCtoonMaxQuestions" min="5" max="100" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Minimum Streak For Points</label>
-              <p class="text-xs text-gray-400 mb-1">Runs shorter than this record a score but earn no points</p>
-              <input type="number" v-model.number="guessCtoonMinStreakForPoints" min="0" max="100" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Minimum Streak For Points</label>
+              <p class="text-xs text-gray-500 mb-1">Runs shorter than this record a score but earn no points</p>
+              <input type="number" v-model.number="guessCtoonMinStreakForPoints" min="0" max="100" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <button @click="saveGuessCtoonConfig" :disabled="loadingGuessCtoon" class="btn-primary">
+          <button @click="saveGuessCtoonConfig" :disabled="loadingGuessCtoon" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingGuessCtoon">Save Guess that cToon! Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -1319,7 +1320,7 @@
 
         <!-- Flappy Powerpuff -->
         <section v-if="activeTab === 'FlappyPowerpuff'" role="tabpanel" aria-label="Flappy Powerpuff Settings">
-          <h2 class="text-2xl font-semibold mb-4">Flappy Powerpuff Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">Flappy Powerpuff Settings</h2>
           <p class="text-xs text-gray-500 mb-4">
             Distances and speeds are in <strong>world units</strong>, not pixels. The game runs in a
             fixed 480&times;760 world that is letterboxed into whatever screen the player has, so
@@ -1327,76 +1328,76 @@
             rejected, and the game engine clamps again on its own.
           </p>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Ranked Plays Per Period</label>
-              <p class="text-xs text-gray-400 mb-1">Runs per 24 hours that earn points and count for the leaderboard (resets 8 PM CT). Players can keep playing unranked after this.</p>
-              <input type="number" v-model.number="flappyPlaysPerPeriod" min="1" max="100" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Ranked Plays Per Period</label>
+              <p class="text-xs text-gray-500 mb-1">Runs per 24 hours that earn points and count for the leaderboard (resets 8 PM CT). Players can keep playing unranked after this.</p>
+              <input type="number" v-model.number="flappyPlaysPerPeriod" min="1" max="100" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Points Per Game</label>
-              <p class="text-xs text-gray-400 mb-1">Flat points for finishing a ranked run, capped by the global daily limit</p>
-              <input type="number" v-model.number="flappyPointsPerGame" min="0" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Points Per Game</label>
+              <p class="text-xs text-gray-500 mb-1">Flat points for finishing a ranked run, capped by the global daily limit</p>
+              <input type="number" v-model.number="flappyPointsPerGame" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Gravity (100–5000)</label>
-              <p class="text-xs text-gray-400 mb-1">How fast she accelerates downward. Higher = twitchier.</p>
-              <input type="number" v-model.number="flappyGravity" min="100" max="5000" step="50" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Gravity (100–5000)</label>
+              <p class="text-xs text-gray-500 mb-1">How fast she accelerates downward. Higher = twitchier.</p>
+              <input type="number" v-model.number="flappyGravity" min="100" max="5000" step="50" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Flap Strength (−1200 to −50)</label>
-              <p class="text-xs text-gray-400 mb-1">Upward speed set by each tap. Negative is up. Should be roughly gravity ÷ 3.4 for a comfortable rhythm.</p>
-              <input type="number" v-model.number="flappyFlapVelocity" min="-1200" max="-50" step="10" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Flap Strength (−1200 to −50)</label>
+              <p class="text-xs text-gray-500 mb-1">Upward speed set by each tap. Negative is up. Should be roughly gravity ÷ 3.4 for a comfortable rhythm.</p>
+              <input type="number" v-model.number="flappyFlapVelocity" min="-1200" max="-50" step="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Scroll Speed (20–1000)</label>
-              <p class="text-xs text-gray-400 mb-1">How fast the city moves past at the start of a run</p>
-              <input type="number" v-model.number="flappyScrollSpeed" min="20" max="1000" step="5" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Scroll Speed (20–1000)</label>
+              <p class="text-xs text-gray-500 mb-1">How fast the city moves past at the start of a run</p>
+              <input type="number" v-model.number="flappyScrollSpeed" min="20" max="1000" step="5" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Gap Height (60–600)</label>
-              <p class="text-xs text-gray-400 mb-1">Opening between the top and bottom skyscraper. She is 38 units tall.</p>
-              <input type="number" v-model.number="flappyPipeGap" min="60" max="600" step="10" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Gap Height (60–600)</label>
+              <p class="text-xs text-gray-500 mb-1">Opening between the top and bottom skyscraper. She is 38 units tall.</p>
+              <input type="number" v-model.number="flappyPipeGap" min="60" max="600" step="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Building Spacing (120–2000)</label>
-              <p class="text-xs text-gray-400 mb-1">Distance between consecutive skyscrapers</p>
-              <input type="number" v-model.number="flappyPipeSpacing" min="120" max="2000" step="10" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Building Spacing (120–2000)</label>
+              <p class="text-xs text-gray-500 mb-1">Distance between consecutive skyscrapers</p>
+              <input type="number" v-model.number="flappyPipeSpacing" min="120" max="2000" step="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Speed Growth Per Building (0–0.5)</label>
-              <p class="text-xs text-gray-400 mb-1">Fraction added to the scroll speed for each building passed</p>
-              <input type="number" v-model.number="flappySpeedGrowthPerPipe" min="0" max="0.5" step="0.005" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Speed Growth Per Building (0–0.5)</label>
+              <p class="text-xs text-gray-500 mb-1">Fraction added to the scroll speed for each building passed</p>
+              <input type="number" v-model.number="flappySpeedGrowthPerPipe" min="0" max="0.5" step="0.005" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Max Speed Multiplier (1–5)</label>
-              <p class="text-xs text-gray-400 mb-1">Ceiling the speed growth plateaus at</p>
-              <input type="number" v-model.number="flappyMaxSpeedMultiplier" min="1" max="5" step="0.1" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Max Speed Multiplier (1–5)</label>
+              <p class="text-xs text-gray-500 mb-1">Ceiling the speed growth plateaus at</p>
+              <input type="number" v-model.number="flappyMaxSpeedMultiplier" min="1" max="5" step="0.1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Max Score (1–100000)</label>
-              <p class="text-xs text-gray-400 mb-1">Safety cap — scores are clamped here. Bounds how much work one submission can ask of the server.</p>
-              <input type="number" v-model.number="flappyMaxScore" min="1" max="100000" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Max Score (1–100000)</label>
+              <p class="text-xs text-gray-500 mb-1">Safety cap — scores are clamped here. Bounds how much work one submission can ask of the server.</p>
+              <input type="number" v-model.number="flappyMaxScore" min="1" max="100000" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Max Session Length (30–1800s)</label>
-              <p class="text-xs text-gray-400 mb-1">How long a started game stays valid before it must be submitted</p>
-              <input type="number" v-model.number="flappyMaxSessionSeconds" min="30" max="1800" step="30" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Max Session Length (30–1800s)</label>
+              <p class="text-xs text-gray-500 mb-1">How long a started game stays valid before it must be submitted</p>
+              <input type="number" v-model.number="flappyMaxSessionSeconds" min="30" max="1800" step="30" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Game Artwork</h3>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Game Artwork</h3>
             <p class="text-xs text-gray-500 mb-3">
               Overrides the built-in artwork. Uploads are re-encoded to WebP and resized, so large
               files are fine to drop in. Leave a slot empty to use the default.
             </p>
-            <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
               <div v-for="s in flappyImageSlots" :key="s.slot">
-                <p class="text-sm font-medium text-gray-700 mb-1">{{ s.label }}</p>
+                <p class="text-xs font-medium text-gray-700 mb-1">{{ s.label }}</p>
                 <div class="w-full h-24 bg-gray-100 border rounded overflow-hidden flex items-center justify-center mb-2">
                   <img v-if="flappyImages[s.slot]" :src="flappyImages[s.slot]" :alt="s.label" class="w-full h-full object-contain" />
-                  <span v-else class="text-gray-400 text-xs px-1 text-center">Default</span>
+                  <span v-else class="text-gray-500 text-xs px-1 text-center">Default</span>
                 </div>
                 <input
                   type="file"
@@ -1405,7 +1406,7 @@
                   @change="onFlappyImageFile(s.slot, $event)"
                 />
                 <button
-                  class="btn-primary text-xs py-1 px-2"
+                  class="px-2 py-1 text-[11px] font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                   :disabled="!flappyImageFiles[s.slot] || uploadingFlappyImage[s.slot]"
                   @click="uploadFlappyImage(s.slot)"
                 >
@@ -1416,7 +1417,7 @@
             </div>
           </div>
 
-          <button @click="saveFlappyConfig" :disabled="loadingFlappy" class="btn-primary">
+          <button @click="saveFlappyConfig" :disabled="loadingFlappy" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingFlappy">Save Flappy Powerpuff Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -1424,7 +1425,7 @@
 
         <!-- Fruit Samurai -->
         <section v-if="activeTab === 'FruitSamurai'" role="tabpanel" aria-label="Fruit Samurai Settings">
-          <h2 class="text-2xl font-semibold mb-4">Fruit Samurai Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">Fruit Samurai Settings</h2>
           <p class="text-xs text-gray-500 mb-4">
             Timings are in <strong>ticks</strong>; the game runs at 60 ticks per second, so 60 ticks
             is one second. Every value here is a whole number — the simulation is integer-only by
@@ -1438,60 +1439,60 @@
             reach for the wave and spawn-interval settings before the speed ones.
           </p>
 
-          <div v-for="g in fruitSamuraiFieldGroups" :key="g.title" class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">{{ g.title }}</h3>
+          <div v-for="g in fruitSamuraiFieldGroups" :key="g.title" class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">{{ g.title }}</h3>
             <p v-if="g.note" class="text-xs text-gray-500 mb-3">{{ g.note }}</p>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div v-for="f in g.items" :key="f.key">
-                <label class="block text-sm font-medium text-gray-700 mb-1">{{ f.label }}</label>
-                <p class="text-xs text-gray-400 mb-1">{{ f.help }}</p>
+                <label class="block text-xs font-medium text-gray-700 mb-1">{{ f.label }}</label>
+                <p class="text-xs text-gray-500 mb-1">{{ f.help }}</p>
                 <input
                   type="number"
                   v-model.number="fruitSamurai[f.key]"
                   :min="f.min"
                   :max="f.max"
                   step="1"
-                  class="input"
+                  class="border rounded-md px-2 py-1.5 text-sm w-full"
                 />
               </div>
             </div>
           </div>
 
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Jack&rsquo;s Commentary</h3>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Jack&rsquo;s Commentary</h3>
             <p class="text-xs text-gray-500 mb-3">
               Jack occasionally speaks in character during a run. The lines themselves live in the
               client, so there is nothing to edit here — only how often he talks. Reactions to a
               power-up or a lost life always speak, ignoring the cooldown.
             </p>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div>
-                <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+                <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                   <input type="checkbox" v-model="fruitSamurai.fruitSamuraiJackChatterEnabled" />
                   <span>Jack speaks during a run</span>
                 </label>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Cooldown between lines</label>
-                <p class="text-xs text-gray-400 mb-1">Ticks. 420 is seven seconds.</p>
-                <input type="number" v-model.number="fruitSamurai.fruitSamuraiJackChatterCooldown" min="60" max="7200" step="1" class="input" />
+                <label class="block text-xs font-medium text-gray-700 mb-1">Cooldown between lines</label>
+                <p class="text-xs text-gray-500 mb-1">Ticks. 420 is seven seconds.</p>
+                <input type="number" v-model.number="fruitSamurai.fruitSamuraiJackChatterCooldown" min="60" max="7200" step="1" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
             </div>
           </div>
 
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-1">Game Artwork</h3>
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-1">Game Artwork</h3>
             <p class="text-xs text-gray-500 mb-3">
               The fruit, power-ups, juice and blade are all drawn by the game, so there is nothing to
               upload for them. Only Jack and the backdrop are images. Uploads are re-encoded to WebP
               and resized, so large files are fine to drop in. Leave a slot empty to use the default.
             </p>
-            <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
               <div v-for="s in fruitSamuraiImageSlots" :key="s.slot">
-                <p class="text-sm font-medium text-gray-700 mb-1">{{ s.label }}</p>
+                <p class="text-xs font-medium text-gray-700 mb-1">{{ s.label }}</p>
                 <div class="w-full h-24 bg-gray-100 border rounded overflow-hidden flex items-center justify-center mb-2">
                   <img v-if="fruitSamuraiImages[s.slot]" :src="fruitSamuraiImages[s.slot]" :alt="s.label" class="w-full h-full object-contain" />
-                  <span v-else class="text-gray-400 text-xs px-1 text-center">Default</span>
+                  <span v-else class="text-gray-500 text-xs px-1 text-center">Default</span>
                 </div>
                 <input
                   type="file"
@@ -1500,7 +1501,7 @@
                   @change="onFruitSamuraiImageFile(s.slot, $event)"
                 />
                 <button
-                  class="btn-primary text-xs py-1 px-2"
+                  class="px-2 py-1 text-[11px] font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                   :disabled="!fruitSamuraiImageFiles[s.slot] || uploadingFruitSamuraiImage[s.slot]"
                   @click="uploadFruitSamuraiImage(s.slot)"
                 >
@@ -1511,7 +1512,7 @@
             </div>
           </div>
 
-          <button @click="saveFruitSamuraiConfig" :disabled="loadingFruitSamurai" class="btn-primary">
+          <button @click="saveFruitSamuraiConfig" :disabled="loadingFruitSamurai" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingFruitSamurai">Save Fruit Samurai Settings</span>
             <span v-else>Saving&hellip;</span>
           </button>
@@ -1519,7 +1520,7 @@
 
         <!-- ReOrbit Blackjack -->
         <section v-if="activeTab === 'Blackjack'" role="tabpanel" aria-label="ReOrbit Blackjack Settings">
-          <h2 class="text-2xl font-semibold mb-4">ReOrbit Blackjack Settings</h2>
+          <h2 class="text-sm font-semibold mb-3">ReOrbit Blackjack Settings</h2>
           <p class="text-xs text-gray-500 mb-4">
             Blackjack is the only game that takes points as well as pays them. A player converts
             points into chips (up to the daily buy-in), plays, and cashes out. Winnings do
@@ -1528,80 +1529,80 @@
             here cannot break a live table.
           </p>
 
-          <h3 class="text-lg font-semibold mb-2">Daily Limits</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <h3 class="text-xs font-semibold mb-1.5">Daily Limits</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Daily Buy-In Limit</label>
-              <p class="text-xs text-gray-400 mb-1">Most points a player may turn into chips per day, across all their sessions (resets 8 PM CT). This is their maximum possible daily loss.</p>
-              <input type="number" v-model.number="blackjackDailyBuyInLimit" min="0" max="1000000" step="10" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Daily Buy-In Limit</label>
+              <p class="text-xs text-gray-500 mb-1">Most points a player may turn into chips per day, across all their sessions (resets 8 PM CT). This is their maximum possible daily loss.</p>
+              <input type="number" v-model.number="blackjackDailyBuyInLimit" min="0" max="1000000" step="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Daily Win Limit</label>
-              <p class="text-xs text-gray-400 mb-1">Net winnings that end the day. Bets are sized so even a split-and-doubled win cannot overshoot it, so this is a hard ceiling, not an approximate one.</p>
-              <input type="number" v-model.number="blackjackDailyWinLimit" min="0" max="1000000" step="10" class="input" />
-            </div>
-          </div>
-
-          <h3 class="text-lg font-semibold mb-2">Table Limits</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Minimum Bet</label>
-              <p class="text-xs text-gray-400 mb-1">Must be a multiple of 10, which keeps a 3:2 blackjack and a half-stake insurance bet on whole points.</p>
-              <input type="number" v-model.number="blackjackMinBet" min="10" max="10000" step="10" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Maximum Bet</label>
-              <p class="text-xs text-gray-400 mb-1">Multiple of 10, at least the min bet, and no more than the daily buy-in.</p>
-              <input type="number" v-model.number="blackjackMaxBet" min="10" max="100000" step="10" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Practice Chip Stack</label>
-              <p class="text-xs text-gray-400 mb-1">Free chips handed out in Practice mode, and restored by the Reset button. Never touches real points.</p>
-              <input type="number" v-model.number="blackjackPracticeStack" min="10" max="1000000" step="10" class="input" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Decks in the Shoe</label>
-              <p class="text-xs text-gray-400 mb-1">1&ndash;8. The shoe is reshuffled before every hand, so this changes the odds slightly but card counting is not possible either way.</p>
-              <input type="number" v-model.number="blackjackDeckCount" min="1" max="8" class="input" />
+              <label class="block text-xs font-medium text-gray-700">Daily Win Limit</label>
+              <p class="text-xs text-gray-500 mb-1">Net winnings that end the day. Bets are sized so even a split-and-doubled win cannot overshoot it, so this is a hard ceiling, not an approximate one.</p>
+              <input type="number" v-model.number="blackjackDailyWinLimit" min="0" max="1000000" step="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
             </div>
           </div>
 
-          <h3 class="text-lg font-semibold mb-2">Rules</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <h3 class="text-xs font-semibold mb-1.5">Table Limits</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Blackjack Pays</label>
-              <p class="text-xs text-gray-400 mb-1">As a ratio, e.g. 3 : 2. Stored as two whole numbers so payouts never land on half a point. Lowering it to 6 : 5 raises the house edge noticeably.</p>
+              <label class="block text-xs font-medium text-gray-700">Minimum Bet</label>
+              <p class="text-xs text-gray-500 mb-1">Must be a multiple of 10, which keeps a 3:2 blackjack and a half-stake insurance bet on whole points.</p>
+              <input type="number" v-model.number="blackjackMinBet" min="10" max="10000" step="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Maximum Bet</label>
+              <p class="text-xs text-gray-500 mb-1">Multiple of 10, at least the min bet, and no more than the daily buy-in.</p>
+              <input type="number" v-model.number="blackjackMaxBet" min="10" max="100000" step="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Practice Chip Stack</label>
+              <p class="text-xs text-gray-500 mb-1">Free chips handed out in Practice mode, and restored by the Reset button. Never touches real points.</p>
+              <input type="number" v-model.number="blackjackPracticeStack" min="10" max="1000000" step="10" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Decks in the Shoe</label>
+              <p class="text-xs text-gray-500 mb-1">1&ndash;8. The shoe is reshuffled before every hand, so this changes the odds slightly but card counting is not possible either way.</p>
+              <input type="number" v-model.number="blackjackDeckCount" min="1" max="8" class="border rounded-md px-2 py-1.5 text-sm w-full" />
+            </div>
+          </div>
+
+          <h3 class="text-xs font-semibold mb-1.5">Rules</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
+            <div>
+              <label class="block text-xs font-medium text-gray-700">Blackjack Pays</label>
+              <p class="text-xs text-gray-500 mb-1">As a ratio, e.g. 3 : 2. Stored as two whole numbers so payouts never land on half a point. Lowering it to 6 : 5 raises the house edge noticeably.</p>
               <div class="flex items-center gap-2">
-                <input type="number" v-model.number="blackjackPayoutNum" min="1" max="3" class="input" />
+                <input type="number" v-model.number="blackjackPayoutNum" min="1" max="3" class="border rounded-md px-2 py-1.5 text-sm w-full" />
                 <span class="text-gray-500">:</span>
-                <input type="number" v-model.number="blackjackPayoutDen" min="1" max="2" class="input" />
+                <input type="number" v-model.number="blackjackPayoutDen" min="1" max="2" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
             </div>
             <div class="flex flex-col justify-end gap-2">
-              <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+              <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                 <input type="checkbox" v-model="blackjackDealerHitsSoft17" />
                 Dealer hits soft 17
               </label>
-              <p class="text-xs text-gray-400">Off = dealer stands on all 17s, which is slightly better for the player.</p>
+              <p class="text-xs text-gray-500">Off = dealer stands on all 17s, which is slightly better for the player.</p>
             </div>
             <div class="flex flex-col gap-2">
-              <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+              <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                 <input type="checkbox" v-model="blackjackAllowDouble" />
                 Allow doubling down
               </label>
-              <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+              <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                 <input type="checkbox" v-model="blackjackAllowSplit" />
                 Allow splitting pairs
               </label>
-              <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+              <label class="flex items-center gap-2 text-xs font-medium text-gray-700">
                 <input type="checkbox" v-model="blackjackAllowInsurance" />
                 Offer insurance
               </label>
-              <p class="text-xs text-gray-400">Insurance is the most confusing bet on the table and the worst value; it is safe to leave off.</p>
+              <p class="text-xs text-gray-500">Insurance is the most confusing bet on the table and the worst value; it is safe to leave off.</p>
             </div>
           </div>
 
-          <button @click="saveBlackjackConfig" :disabled="loadingBlackjack" class="btn-primary">
+          <button @click="saveBlackjackConfig" :disabled="loadingBlackjack" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
             <span v-if="!loadingBlackjack">Save ReOrbit Blackjack Settings</span>
             <span v-else>Saving…</span>
           </button>
@@ -1609,17 +1610,17 @@
 
         <!-- TKO -->
         <section v-if="activeTab === 'TKO'" role="tabpanel" aria-label="TKO Events">
-          <h2 class="text-2xl font-semibold mb-4">TKO Events</h2>
+          <h2 class="text-sm font-semibold mb-3">TKO Events</h2>
 
-          <div class="mb-6 border rounded-lg p-4">
-            <h3 class="text-lg font-semibold mb-3">Settings</h3>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+          <div class="mb-4 bg-white border rounded-lg p-3">
+            <h3 class="text-xs font-semibold mb-2">Settings</h3>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
               <div>
-                <label class="block text-sm font-medium text-gray-700">Points Per Win</label>
-                <input type="number" v-model.number="tkoPointsPerWin" min="0" class="input" />
+                <label class="block text-xs font-medium text-gray-700">Points Per Win</label>
+                <input type="number" v-model.number="tkoPointsPerWin" min="0" class="border rounded-md px-2 py-1.5 text-sm w-full" />
               </div>
             </div>
-            <button @click="saveTkoConfig" :disabled="loadingTkoConfig" class="btn-primary">
+            <button @click="saveTkoConfig" :disabled="loadingTkoConfig" class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50">
               <span v-if="!loadingTkoConfig">Save TKO Settings</span>
               <span v-else>Saving…</span>
             </button>
@@ -1629,56 +1630,56 @@
 
           <template v-else>
             <!-- Stats -->
-            <div class="grid grid-cols-2 gap-4 mb-6">
-              <div class="border rounded-lg p-4 text-center">
-                <p class="text-3xl font-bold text-indigo-600">{{ tkoTotalEvents.toLocaleString() }}</p>
+            <div class="grid grid-cols-2 gap-3 mb-4">
+              <div class="border rounded-lg p-3 text-center">
+                <p class="text-2xl font-bold text-blue-600">{{ tkoTotalEvents.toLocaleString() }}</p>
                 <p class="text-sm text-gray-500 mt-1">Total Events</p>
               </div>
-              <div class="border rounded-lg p-4 text-center">
-                <p class="text-3xl font-bold text-indigo-600">{{ tkoUniqueUsers.toLocaleString() }}</p>
+              <div class="border rounded-lg p-3 text-center">
+                <p class="text-2xl font-bold text-blue-600">{{ tkoUniqueUsers.toLocaleString() }}</p>
                 <p class="text-sm text-gray-500 mt-1">Unique Reorbit Users</p>
               </div>
             </div>
 
-            <h3 class="text-lg font-semibold mb-3">Most Recent 20 Events</h3>
+            <h3 class="text-xs font-semibold mb-2">Most Recent 20 Events</h3>
 
             <div v-if="!tkoEvents.length" class="text-gray-500">No events recorded yet.</div>
 
             <!-- Desktop table -->
             <div v-else class="hidden md:block border rounded-lg overflow-x-auto">
-              <table class="w-full text-sm">
-                <thead class="bg-gray-50 text-left">
+              <table class="w-full text-xs">
+                <thead class="bg-gray-100 text-left">
                   <tr>
-                    <th class="px-3 py-2 font-medium text-gray-600">Date</th>
-                    <th class="px-3 py-2 font-medium text-gray-600">Match / Round</th>
-                    <th class="px-3 py-2 font-medium text-gray-600">Winner</th>
-                    <th class="px-3 py-2 font-medium text-gray-600">Loser</th>
-                    <th class="px-3 py-2 font-medium text-gray-600">Win Type</th>
-                    <th class="px-3 py-2 font-medium text-gray-600">Counted</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Date</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Match / Round</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Winner</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Loser</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Win Type</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Counted</th>
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-100">
                   <tr v-for="e in tkoEvents" :key="e.id" class="hover:bg-gray-50">
-                    <td class="px-3 py-2 whitespace-nowrap text-gray-700">{{ fmtDate(e.endedAt) }}</td>
-                    <td class="px-3 py-2">
+                    <td class="px-2 py-1.5 whitespace-nowrap text-gray-700">{{ fmtDate(e.endedAt) }}</td>
+                    <td class="px-2 py-1.5">
                       <div class="font-mono text-xs text-gray-500 truncate max-w-[140px]" :title="e.match.externalMatchId">{{ e.match.externalMatchId }}</div>
-                      <div class="text-xs text-gray-400">Round {{ e.roundNumber }} of {{ e.bestOf }} · {{ e.match.mode }}</div>
+                      <div class="text-xs text-gray-500">Round {{ e.roundNumber }} of {{ e.bestOf }} · {{ e.match.mode }}</div>
                     </td>
-                    <td class="px-3 py-2">
+                    <td class="px-2 py-1.5">
                       <div class="font-medium">{{ e.winnerUsername }}</div>
-                      <div class="text-xs text-gray-400">{{ e.winnerCharacterName }}</div>
+                      <div class="text-xs text-gray-500">{{ e.winnerCharacterName }}</div>
                       <div v-if="!e.winnerUserId" class="text-xs text-amber-500">no account</div>
                     </td>
-                    <td class="px-3 py-2">
+                    <td class="px-2 py-1.5">
                       <div class="font-medium">{{ e.loserUsername }}</div>
-                      <div class="text-xs text-gray-400">{{ e.loserCharacterName }}</div>
+                      <div class="text-xs text-gray-500">{{ e.loserCharacterName }}</div>
                       <div v-if="!e.loserUserId" class="text-xs text-amber-500">no account</div>
                     </td>
-                    <td class="px-3 py-2 capitalize">{{ e.winType }}</td>
-                    <td class="px-3 py-2">
+                    <td class="px-2 py-1.5 capitalize">{{ e.winType }}</td>
+                    <td class="px-2 py-1.5">
                       <span
-                        class="inline-block px-2 py-0.5 rounded-full text-xs font-medium"
-                        :class="e.counted ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'"
+                        class="px-1.5 py-0 rounded text-[10px] font-medium border"
+                        :class="e.counted ? 'bg-green-100 text-green-800 border-green-200' : 'bg-gray-100 text-gray-600 border-gray-300'"
                       >{{ e.counted ? 'Yes' : 'No' }}</span>
                     </td>
                   </tr>
@@ -1688,15 +1689,15 @@
 
             <!-- Mobile cards -->
             <div class="md:hidden space-y-3">
-              <div v-for="e in tkoEvents" :key="e.id" class="border rounded-lg p-4 bg-white space-y-2">
+              <div v-for="e in tkoEvents" :key="e.id" class="border rounded-lg p-2 bg-white space-y-2">
                 <div class="flex items-start justify-between gap-2">
                   <div>
-                    <div class="text-xs text-gray-400 font-mono truncate max-w-[200px]" :title="e.match.externalMatchId">{{ e.match.externalMatchId }}</div>
-                    <div class="text-xs text-gray-400">Round {{ e.roundNumber }}/{{ e.bestOf }} · {{ e.match.mode }}</div>
+                    <div class="text-xs text-gray-500 font-mono truncate max-w-[200px]" :title="e.match.externalMatchId">{{ e.match.externalMatchId }}</div>
+                    <div class="text-xs text-gray-500">Round {{ e.roundNumber }}/{{ e.bestOf }} · {{ e.match.mode }}</div>
                   </div>
                   <span
-                    class="shrink-0 inline-block px-2 py-0.5 rounded-full text-xs font-medium"
-                    :class="e.counted ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'"
+                    class="shrink-0 px-1.5 py-0 rounded text-[10px] font-medium border"
+                    :class="e.counted ? 'bg-green-100 text-green-800 border-green-200' : 'bg-gray-100 text-gray-600 border-gray-300'"
                   >{{ e.counted ? 'Counted' : 'Not counted' }}</span>
                 </div>
                 <div class="text-xs text-gray-500">{{ fmtDate(e.endedAt) }}</div>
@@ -1704,17 +1705,17 @@
                   <div>
                     <div class="text-xs font-semibold text-green-600 mb-0.5">Winner</div>
                     <div class="font-medium text-sm">{{ e.winnerUsername }}</div>
-                    <div class="text-xs text-gray-400">{{ e.winnerCharacterName }}</div>
+                    <div class="text-xs text-gray-500">{{ e.winnerCharacterName }}</div>
                     <div v-if="!e.winnerUserId" class="text-xs text-amber-500">no account</div>
                   </div>
                   <div>
                     <div class="text-xs font-semibold text-red-500 mb-0.5">Loser</div>
                     <div class="font-medium text-sm">{{ e.loserUsername }}</div>
-                    <div class="text-xs text-gray-400">{{ e.loserCharacterName }}</div>
+                    <div class="text-xs text-gray-500">{{ e.loserCharacterName }}</div>
                     <div v-if="!e.loserUserId" class="text-xs text-amber-500">no account</div>
                   </div>
                 </div>
-                <div class="text-xs text-gray-500 pt-1 border-t capitalize">Win type: <span class="font-medium text-gray-700">{{ e.winType }}</span></div>
+                <div class="text-xs text-gray-500 pt-1 border-t capitalize">Win type: <span class="font-medium text-xs text-gray-700">{{ e.winType }}</span></div>
               </div>
             </div>
           </template>
@@ -1728,6 +1729,7 @@
           {{ toastMessage }}
         </div>
       </div>
+    </div>
     </div>
   </div>
 </template>
@@ -3279,27 +3281,6 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.input {
-  margin-top: .25rem;
-  width: 100%;
-  border: 1px solid #D1D5DB;
-  border-radius: .375rem;
-  padding: .5rem;
-  outline: none;
-}
-.input:focus {
-  border-color: #6366F1;
-  box-shadow: 0 0 0 1px #6366F1;
-}
-.btn-primary {
-  margin-top: .25rem;
-  background-color: #6366F1;
-  color: white;
-  padding: .5rem 1.25rem;
-  border-radius: .375rem;
-}
-.btn-primary:disabled { opacity: .5; }
-
 /* hide horizontal scrollbar on mobile tab strip */
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }

--- a/components/newsite/admin/legacy/AdminLegacyGlobalSettings.vue
+++ b/components/newsite/admin/legacy/AdminLegacyGlobalSettings.vue
@@ -1,210 +1,211 @@
 <template>
-  <div class="bg-gray-100 p-6 ">
-    <h1 class="text-3xl font-bold mb-6">Admin: Global Settings</h1>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+    <h1 class="text-base font-semibold mb-3">Admin: Global Settings</h1>
 
-    <div class="bg-white rounded-lg shadow-md p-6 max-w-4xl mx-auto">
+    <div class="bg-white rounded-lg shadow p-3">
       <!-- Tabs -->
-      <div class="border-b mb-6">
-        <nav class="flex gap-4 overflow-x-auto whitespace-nowrap -mb-px hide-scrollbar">
+      <div class="border-b mb-3">
+        <nav class="flex gap-2 overflow-x-auto whitespace-nowrap -mb-px hide-scrollbar">
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-2 py-1.5 text-xs border-b-2"
             :class="activeTab==='Global Points' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Global Points'">Global Points</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-2 py-1.5 text-xs border-b-2"
             :class="activeTab==='Rarity Settings' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Rarity Settings'">Rarity Settings</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-2 py-1.5 text-xs border-b-2"
             :class="activeTab==='Image Duplicates' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Image Duplicates'">Image Duplicates</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-2 py-1.5 text-xs border-b-2"
             :class="activeTab==='Auctions' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Auctions'">Auctions</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-2 py-1.5 text-xs border-b-2"
             :class="activeTab==='cMart' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='cMart'">cMart</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-2 py-1.5 text-xs border-b-2"
             :class="activeTab==='Second Editions' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Second Editions'">Second Editions</button>
           <button
-            class="px-3 py-2 border-b-2"
+            class="px-2 py-1.5 text-xs border-b-2"
             :class="activeTab==='Discord' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Discord'">Discord</button>
         </nav>
       </div>
 
       <!-- Global Points tab -->
-      <section v-if="activeTab==='Global Points'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Global Points'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Configure global point awards. These values control daily login bonus, cZone visit points, and game cap.
         </p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Daily Login Points</label>
-            <input type="number" class="input" v-model.number="dailyLoginPoints" />
-            <p class="text-xs text-gray-500 mt-1">Awarded once per 24h window (8pm CST reset).</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Daily Login Points</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="dailyLoginPoints" />
+            <p class="text-[10px] text-gray-500">Awarded once per 24h window (8pm CST reset).</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Daily Login Points (New Users)</label>
-            <input type="number" class="input" v-model.number="dailyNewUserPoints" />
-            <p class="text-xs text-gray-500 mt-1">For accounts created within the last 7 days.</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Daily Login Points (New Users)</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="dailyNewUserPoints" />
+            <p class="text-[10px] text-gray-500">For accounts created within the last 7 days.</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">cZone Visit Points</label>
-            <input type="number" class="input" v-model.number="czoneVisitPoints" />
-            <p class="text-xs text-gray-500 mt-1">Awarded per unique zone owner within the daily window.</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">cZone Visit Points</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="czoneVisitPoints" />
+            <p class="text-[10px] text-gray-500">Awarded per unique zone owner within the daily window.</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Daily Game Point Cap</label>
-            <input type="number" class="input" v-model.number="dailyPointLimit" />
-            <p class="text-xs text-gray-500 mt-1">Max points from Winball, ReOrbit Match, and Monster scans per 24h window (excludes the head-to-head games: TKO, gToons Clash and Ed, Edd n Eddy RPS).</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Daily Game Point Cap</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="dailyPointLimit" />
+            <p class="text-[10px] text-gray-500">Max points from Winball, ReOrbit Match, and Monster scans per 24h window (excludes the head-to-head games: TKO, gToons Clash and Ed, Edd n Eddy RPS).</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Head-to-Head Daily Points Cap</label>
-            <input type="number" class="input" v-model.number="tkoDailyPointLimit" />
-            <p class="text-xs text-gray-500 mt-1">Combined max points from TKO, gToons Clash and Ed, Edd n Eddy RPS wins per 24h window (shared pool, same 8pm CST reset).</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Head-to-Head Daily Points Cap</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="tkoDailyPointLimit" />
+            <p class="text-[10px] text-gray-500">Combined max points from TKO, gToons Clash and Ed, Edd n Eddy RPS wins per 24h window (shared pool, same 8pm CST reset).</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">TKO Points Per Win</label>
-            <input type="number" min="0" class="input" v-model.number="tkoPointsPerWin" />
-            <p class="text-xs text-gray-500 mt-1">Points awarded to the winner of each TKO round.</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">TKO Points Per Win</label>
+            <input type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="tkoPointsPerWin" />
+            <p class="text-[10px] text-gray-500">Points awarded to the winner of each TKO round.</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Max cZone Visits Per Day</label>
-            <input type="number" class="input" v-model.number="czoneVisitMaxPerDay" />
-            <p class="text-xs text-gray-500 mt-1">Maximum unique cZones that award visit points per day.</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Max cZone Visits Per Day</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="czoneVisitMaxPerDay" />
+            <p class="text-[10px] text-gray-500">Maximum unique cZones that award visit points per day.</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Global cZone Count</label>
-            <input type="number" min="1" class="input" v-model.number="czoneCount" />
-            <p class="text-xs text-gray-500 mt-1">Base number of zones each user can have (before per-user additions).</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Global cZone Count</label>
+            <input type="number" min="1" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="czoneCount" />
+            <p class="text-[10px] text-gray-500">Base number of zones each user can have (before per-user additions).</p>
           </div>
         </div>
         <div>
-          <button class="btn-primary" :disabled="savingGlobal" @click="saveGlobal">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingGlobal" @click="saveGlobal">
             <span v-if="!savingGlobal">Save</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- Rarity Settings tab -->
-      <section v-if="activeTab==='Rarity Settings'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Rarity Settings'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Configure default values per rarity tier. These defaults prefill Add cToon and Bulk Upload forms.
         </p>
         <!-- Desktop table -->
         <div class="overflow-x-auto hidden sm:block">
-          <table class="min-w-full border-separate border-spacing-y-1">
+          <table class="min-w-full text-xs">
             <thead>
-              <tr class="text-left text-sm text-gray-600">
-                <th class="px-3 py-2">Rarity</th>
-                <th class="px-3 py-2">Total Qty</th>
-                <th class="px-3 py-2">Initial Qty</th>
-                <th class="px-3 py-2">Per-User Limit</th>
-                <th class="px-3 py-2">In cMart</th>
-                <th class="px-3 py-2">Price</th>
+              <tr>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Rarity</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Total Qty</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Initial Qty</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Per-User Limit</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">In cMart</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Price</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="r in rarityOrder" :key="r" class="bg-gray-50">
-                <td class="px-3 py-2 font-medium">{{ r }}</td>
-                <td class="px-3 py-2"><input type="number" class="input" v-model.number="rarityDefaults[r].totalQuantity" /></td>
-                <td class="px-3 py-2"><input type="number" class="input" v-model.number="rarityDefaults[r].initialQuantity" /></td>
-                <td class="px-3 py-2"><input type="number" class="input" v-model.number="rarityDefaults[r].perUserLimit" /></td>
-                <td class="px-3 py-2 text-center"><input type="checkbox" v-model="rarityDefaults[r].inCmart" /></td>
-                <td class="px-3 py-2"><input type="number" class="input" v-model.number="rarityDefaults[r].price" /></td>
+              <tr v-for="r in rarityOrder" :key="r" class="border-b">
+                <td class="px-2 py-1.5 font-medium">{{ r }}</td>
+                <td class="px-2 py-1.5"><input type="number" class="border rounded-md px-2 py-1 text-xs w-20" v-model.number="rarityDefaults[r].totalQuantity" /></td>
+                <td class="px-2 py-1.5"><input type="number" class="border rounded-md px-2 py-1 text-xs w-20" v-model.number="rarityDefaults[r].initialQuantity" /></td>
+                <td class="px-2 py-1.5"><input type="number" class="border rounded-md px-2 py-1 text-xs w-20" v-model.number="rarityDefaults[r].perUserLimit" /></td>
+                <td class="px-2 py-1.5 text-center"><input type="checkbox" v-model="rarityDefaults[r].inCmart" /></td>
+                <td class="px-2 py-1.5"><input type="number" class="border rounded-md px-2 py-1 text-xs w-20" v-model.number="rarityDefaults[r].price" /></td>
               </tr>
             </tbody>
           </table>
         </div>
 
         <!-- Mobile cards -->
-        <div class="space-y-3 sm:hidden">
+        <div class="space-y-2 sm:hidden">
           <div
             v-for="r in rarityOrder"
             :key="r"
-            class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3"
+            class="bg-white border rounded-lg shadow p-2"
           >
-            <div class="font-semibold text-gray-800 mb-2">{{ r }}</div>
-            <div class="grid grid-cols-1 gap-3">
-              <div>
-                <label class="block text-xs text-gray-600 mb-1">Total Qty</label>
-                <input type="number" class="input" v-model.number="rarityDefaults[r].totalQuantity" />
+            <div class="font-semibold text-xs text-gray-800 mb-1.5">{{ r }}</div>
+            <div class="grid grid-cols-1 gap-2">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Total Qty</label>
+                <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="rarityDefaults[r].totalQuantity" />
               </div>
-              <div>
-                <label class="block text-xs text-gray-600 mb-1">Initial Qty</label>
-                <input type="number" class="input" v-model.number="rarityDefaults[r].initialQuantity" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Qty</label>
+                <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="rarityDefaults[r].initialQuantity" />
               </div>
-              <div>
-                <label class="block text-xs text-gray-600 mb-1">Per-User Limit</label>
-                <input type="number" class="input" v-model.number="rarityDefaults[r].perUserLimit" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Per-User Limit</label>
+                <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="rarityDefaults[r].perUserLimit" />
               </div>
               <div class="flex items-center gap-2">
                 <input type="checkbox" v-model="rarityDefaults[r].inCmart" :id="`inCmart-${r}`" />
-                <label class="text-sm text-gray-700" :for="`inCmart-${r}`">In cMart</label>
+                <label class="text-xs text-gray-700" :for="`inCmart-${r}`">In cMart</label>
               </div>
-              <div>
-                <label class="block text-xs text-gray-600 mb-1">Price</label>
-                <input type="number" class="input" v-model.number="rarityDefaults[r].price" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Price</label>
+                <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="rarityDefaults[r].price" />
               </div>
             </div>
           </div>
         </div>
         <div>
-          <button class="btn-primary" :disabled="savingRarity" @click="saveRarity">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingRarity" @click="saveRarity">
             <span v-if="!savingRarity">Save</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- Image Duplicates tab -->
-      <section v-if="activeTab==='Image Duplicates'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Image Duplicates'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Tune how sensitive duplicate detection should be. Higher numbers flag more possible duplicates.
           Detection uses Hamming distance on 64-bit hashes and flags a match when
           <strong>pHash ≤ threshold</strong> or <strong>dHash ≤ threshold</strong>.
         </p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">pHash Threshold</label>
-            <input type="number" min="0" max="64" class="input" v-model.number="phashDuplicateThreshold" />
-            <p class="text-xs text-gray-500 mt-1">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">pHash Threshold</label>
+            <input type="number" min="0" max="64" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="phashDuplicateThreshold" />
+            <p class="text-[10px] text-gray-500">
               Lower = stricter (fewer matches), higher = more possible duplicates. Typical range: 10–20.
             </p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">dHash Threshold</label>
-            <input type="number" min="0" max="64" class="input" v-model.number="dhashDuplicateThreshold" />
-            <p class="text-xs text-gray-500 mt-1">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">dHash Threshold</label>
+            <input type="number" min="0" max="64" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="dhashDuplicateThreshold" />
+            <p class="text-[10px] text-gray-500">
               Lower = stricter (fewer matches), higher = more possible duplicates. Typical range: 12–22.
             </p>
           </div>
         </div>
         <div>
-          <button class="btn-primary" :disabled="savingDuplicates" @click="saveDuplicateSettings">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingDuplicates" @click="saveDuplicateSettings">
             <span v-if="!savingDuplicates">Save</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- Auctions tab -->
-      <section v-if="activeTab==='Auctions'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Auctions'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Configure the featured auction schedule. All times are in CST.
         </p>
 
         <!-- 24-hour grid -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">Featured Auction Hours (CST)</label>
+          <label class="block text-xs font-medium mb-1.5">Featured Auction Hours (CST)</label>
           <div class="grid grid-cols-6 gap-1">
             <label
               v-for="h in 24"
               :key="h - 1"
-              class="flex flex-col items-center gap-1 p-2 rounded border cursor-pointer select-none"
+              class="flex flex-col items-center gap-1 p-1.5 rounded-md border cursor-pointer select-none"
               :class="featuredAuctionHours.includes(h - 1)
                 ? 'bg-indigo-50 border-indigo-400 text-indigo-700'
                 : 'bg-gray-50 border-gray-200 text-gray-600'"
@@ -216,144 +217,144 @@
                 :checked="featuredAuctionHours.includes(h - 1)"
                 @change="toggleHour(h - 1)"
               />
-              <span class="text-sm font-mono font-semibold">{{ formatHour(h - 1) }}</span>
+              <span class="text-[11px] font-mono font-semibold">{{ formatHour(h - 1) }}</span>
             </label>
           </div>
-          <p class="text-xs text-gray-500 mt-2">
+          <p class="text-[10px] text-gray-500 mt-1.5">
             {{ featuredAuctionHours.length === 0
               ? 'No hours selected — featured auctions are disabled.'
               : `${featuredAuctionHours.length} hour(s) selected: ${featuredAuctionHours.slice().sort((a, b) => a - b).map(formatHour).join(', ')}` }}
           </p>
         </div>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Interval (every N days)</label>
-            <input type="number" min="1" class="input" v-model.number="featuredAuctionIntervalDays" />
-            <p class="text-xs text-gray-500 mt-1">1 = fire every day, 2 = every other day, etc.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Interval (every N days)</label>
+            <input type="number" min="1" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="featuredAuctionIntervalDays" />
+            <p class="text-[10px] text-gray-500">1 = fire every day, 2 = every other day, etc.</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Auctions Per Slot</label>
-            <input type="number" min="0" class="input" v-model.number="featuredAuctionsPerSlot" />
-            <p class="text-xs text-gray-500 mt-1">How many featured auctions to create each time a scheduled hour fires. Set to 0 to disable.</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Auctions Per Slot</label>
+            <input type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="featuredAuctionsPerSlot" />
+            <p class="text-[10px] text-gray-500">How many featured auctions to create each time a scheduled hour fires. Set to 0 to disable.</p>
           </div>
         </div>
 
         <div>
-          <button class="btn-primary" :disabled="savingAuctions" @click="saveAuctions">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingAuctions" @click="saveAuctions">
             <span v-if="!savingAuctions">Save</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- cMart tab -->
-      <section v-if="activeTab==='cMart'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='cMart'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Configure cMart upgrade pricing.
         </p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">First additional cZone cost</label>
-            <input type="number" min="0" class="input" v-model.number="firstAdditionalCzoneCost" />
-            <p class="text-xs text-gray-500 mt-1">Cost when a user has 0 additional cZones.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">First additional cZone cost</label>
+            <input type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="firstAdditionalCzoneCost" />
+            <p class="text-[10px] text-gray-500">Cost when a user has 0 additional cZones.</p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Subsequent additional cZone cost</label>
-            <input type="number" min="0" class="input" v-model.number="subsequentAdditionalCzoneCost" />
-            <p class="text-xs text-gray-500 mt-1">Cost when a user already has 1 or more additional cZones.</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Subsequent additional cZone cost</label>
+            <input type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="subsequentAdditionalCzoneCost" />
+            <p class="text-[10px] text-gray-500">Cost when a user already has 1 or more additional cZones.</p>
           </div>
         </div>
 
         <!-- Global Price Changes -->
-        <div class="border-t pt-5">
-          <h2 class="text-base font-semibold text-gray-800 mb-1">Global Price Changes</h2>
-          <p class="text-sm text-gray-500 mb-4">
+        <div class="border-t pt-3">
+          <h2 class="text-xs font-semibold text-gray-800 mb-1">Global Price Changes</h2>
+          <p class="text-[10px] text-gray-500 mb-2">
             When enabled, all cToon and pack prices in cMart will be cut in half at purchase time.
             Prices shown to users will reflect the discount.
           </p>
-          <label class="flex items-center gap-3 cursor-pointer select-none">
+          <label class="flex items-center gap-2 cursor-pointer select-none">
             <input
               type="checkbox"
               v-model="cmartHalfPriceEnabled"
               class="h-4 w-4 text-indigo-600 border-gray-300 rounded"
             />
-            <span class="text-sm font-medium text-gray-700">
+            <span class="text-xs font-medium text-gray-700">
               Enable 50% off all cToons &amp; packs
             </span>
           </label>
-          <p v-if="cmartHalfPriceEnabled" class="mt-2 text-xs text-indigo-600 font-medium">
+          <p v-if="cmartHalfPriceEnabled" class="mt-1.5 text-[10px] text-indigo-600 font-medium">
             Half-price mode is currently ON. Users will be charged half the listed price.
           </p>
         </div>
 
         <!-- Pack Pricing Decay -->
-        <div class="border-t pt-5">
-          <h2 class="text-base font-semibold text-gray-800 mb-1">Pack Pricing Decay</h2>
-          <p class="text-sm text-gray-500 mb-4">
+        <div class="border-t pt-3">
+          <h2 class="text-xs font-semibold text-gray-800 mb-1">Pack Pricing Decay</h2>
+          <p class="text-[10px] text-gray-500 mb-2">
             Pack prices automatically decrease over time after they go live in cMart.
             The price drops by the decay amount every N days until it hits the floor.
           </p>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Decay Amount (pts)</label>
-              <input type="number" min="0" class="input" v-model.number="packPriceDecayAmount" />
-              <p class="text-xs text-gray-500 mt-1">Points to drop per period (e.g. 100).</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Decay Amount (pts)</label>
+              <input type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="packPriceDecayAmount" />
+              <p class="text-[10px] text-gray-500">Points to drop per period (e.g. 100).</p>
             </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Decay Period (days)</label>
-              <input type="number" min="1" class="input" v-model.number="packPriceDecayDays" />
-              <p class="text-xs text-gray-500 mt-1">How many days between each price drop (e.g. 7).</p>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Decay Period (days)</label>
+              <input type="number" min="1" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="packPriceDecayDays" />
+              <p class="text-[10px] text-gray-500">How many days between each price drop (e.g. 7).</p>
             </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Price Floor (pts)</label>
-              <input type="number" min="0" class="input" v-model.number="packPriceFloor" />
-              <p class="text-xs text-gray-500 mt-1">Minimum price a pack can decay to (e.g. 700).</p>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Price Floor (pts)</label>
+              <input type="number" min="0" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="packPriceFloor" />
+              <p class="text-[10px] text-gray-500">Minimum price a pack can decay to (e.g. 700).</p>
             </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Max Default Pack Buys Per User</label>
-              <input type="number" min="1" class="input" v-model.number="packMaxDefaultBuysPerUser" />
-              <p class="text-xs text-gray-500 mt-1">Total times a user can buy a new pack (applied when pack is created).</p>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Max Default Pack Buys Per User</label>
+              <input type="number" min="1" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="packMaxDefaultBuysPerUser" />
+              <p class="text-[10px] text-gray-500">Total times a user can buy a new pack (applied when pack is created).</p>
             </div>
           </div>
         </div>
 
         <!-- Time-Based Release Purchase Limits -->
-        <div class="border-t pt-5">
-          <h2 class="text-base font-semibold text-gray-800 mb-1">Time-Based Release Purchase Limits</h2>
-          <p class="text-sm text-gray-500 mb-4">
+        <div class="border-t pt-3">
+          <h2 class="text-xs font-semibold text-gray-800 mb-1">Time-Based Release Purchase Limits</h2>
+          <p class="text-[10px] text-gray-500 mb-2">
             Default per-user purchase limits for time-based releases, applied by rarity tier.
             These are overridden per-cToon when a cToon has its own limit set.
             Leave <strong>Window (days)</strong> blank to use the full release window (release date → mint end date).
           </p>
 
           <!-- Desktop table -->
-          <div class="overflow-x-auto hidden sm:block mb-4">
-            <table class="min-w-full border-separate border-spacing-y-1">
+          <div class="overflow-x-auto hidden sm:block mb-3">
+            <table class="min-w-full text-xs">
               <thead>
-                <tr class="text-left text-sm text-gray-600">
-                  <th class="px-3 py-2">Rarity</th>
-                  <th class="px-3 py-2">Purchase Limit</th>
-                  <th class="px-3 py-2">Window (days)</th>
+                <tr>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Rarity</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Purchase Limit</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Window (days)</th>
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="r in timeBasedRarities" :key="r" class="bg-gray-50">
-                  <td class="px-3 py-2 font-medium">{{ r }}</td>
-                  <td class="px-3 py-2">
+                <tr v-for="r in timeBasedRarities" :key="r" class="border-b">
+                  <td class="px-2 py-1.5 font-medium">{{ r }}</td>
+                  <td class="px-2 py-1.5">
                     <input
                       type="number"
                       min="1"
-                      class="input"
+                      class="border rounded-md px-2 py-1 text-xs w-24"
                       :value="timeBasedLimits[r].countStr"
                       @input="timeBasedLimits[r].countStr = $event.target.value"
                       placeholder="No limit"
                     />
                   </td>
-                  <td class="px-3 py-2">
+                  <td class="px-2 py-1.5">
                     <input
                       type="number"
                       min="1"
-                      class="input"
+                      class="border rounded-md px-2 py-1 text-xs w-24"
                       :value="timeBasedLimits[r].windowDaysStr"
                       @input="timeBasedLimits[r].windowDaysStr = $event.target.value"
                       placeholder="Full duration"
@@ -365,31 +366,31 @@
           </div>
 
           <!-- Mobile cards -->
-          <div class="space-y-3 sm:hidden mb-4">
+          <div class="space-y-2 sm:hidden mb-3">
             <div
               v-for="r in timeBasedRarities"
               :key="r"
-              class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3"
+              class="bg-white border rounded-lg shadow p-2"
             >
-              <div class="font-semibold text-gray-800 mb-2">{{ r }}</div>
-              <div class="grid grid-cols-2 gap-3">
-                <div>
-                  <label class="block text-xs text-gray-600 mb-1">Purchase Limit</label>
+              <div class="font-semibold text-xs text-gray-800 mb-1.5">{{ r }}</div>
+              <div class="grid grid-cols-2 gap-2">
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Purchase Limit</label>
                   <input
                     type="number"
                     min="1"
-                    class="input"
+                    class="border rounded-md px-2 py-1.5 text-sm"
                     :value="timeBasedLimits[r].countStr"
                     @input="timeBasedLimits[r].countStr = $event.target.value"
                     placeholder="No limit"
                   />
                 </div>
-                <div>
-                  <label class="block text-xs text-gray-600 mb-1">Window (days)</label>
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Window (days)</label>
                   <input
                     type="number"
                     min="1"
-                    class="input"
+                    class="border rounded-md px-2 py-1.5 text-sm"
                     :value="timeBasedLimits[r].windowDaysStr"
                     @input="timeBasedLimits[r].windowDaysStr = $event.target.value"
                     placeholder="Full duration"
@@ -401,35 +402,35 @@
         </div>
 
         <div>
-          <button class="btn-primary" :disabled="savingCmart" @click="saveCmart">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingCmart" @click="saveCmart">
             <span v-if="!savingCmart">Save</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- Second Editions tab -->
-      <section v-if="activeTab==='Second Editions'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Second Editions'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Upload the icon overlaid on the bottom-right corner of every Second Edition cToon's image
           sitewide. Admins can adjust position and size per cToon on the Add/Edit cToon pages.
         </p>
-        <div class="flex items-start gap-6 flex-wrap">
+        <div class="flex items-start gap-3 flex-wrap">
           <div>
             <div class="w-32 h-32 border rounded bg-gray-50 flex items-center justify-center overflow-hidden">
               <img v-if="secondEditionOverlayPath" :src="secondEditionOverlayPath" alt="Second Edition overlay" class="max-w-full max-h-full object-contain" />
               <span v-else class="text-xs text-gray-400">No image set</span>
             </div>
-            <p v-if="secondEditionOverlayWidth" class="text-xs text-gray-500 mt-1 text-center">
+            <p v-if="secondEditionOverlayWidth" class="text-[10px] text-gray-500 mt-1 text-center">
               {{ secondEditionOverlayWidth }}×{{ secondEditionOverlayHeight }}px
             </p>
           </div>
           <div class="flex-1 min-w-[220px]">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Upload Overlay Icon (PNG or GIF)</label>
-            <input type="file" accept="image/png,image/gif" class="w-full" @change="handleOverlayFile" />
-            <p class="text-xs text-gray-500 mt-1">Max 3MB. Use a transparent PNG for best results.</p>
-            <p v-if="overlayUploadError" class="text-xs text-red-600 mt-1">{{ overlayUploadError }}</p>
+            <label class="block text-xs font-medium mb-1">Upload Overlay Icon (PNG or GIF)</label>
+            <input type="file" accept="image/png,image/gif" class="w-full text-xs" @change="handleOverlayFile" />
+            <p class="text-[10px] text-gray-500 mt-1">Max 3MB. Use a transparent PNG for best results.</p>
+            <p v-if="overlayUploadError" class="text-[10px] text-red-600 mt-1">{{ overlayUploadError }}</p>
             <button
-              class="btn-primary mt-3"
+              class="mt-2 px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
               :disabled="!overlayFile || savingOverlay"
               @click="uploadOverlay"
             >
@@ -440,13 +441,13 @@
       </section>
 
       <!-- Discord tab -->
-      <section v-if="activeTab==='Discord'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Discord'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Configure where Discord announcements for site events are posted. More announcement
           types may be added here over time.
         </p>
-        <div class="max-w-md">
-          <label for="czoneContestDiscordChannelId" class="block text-sm font-medium text-gray-700">
+        <div class="max-w-md flex flex-col gap-1">
+          <label for="czoneContestDiscordChannelId" class="text-xs font-medium">
             cZone Contest Winner Channel ID
           </label>
           <input
@@ -455,25 +456,26 @@
             type="text"
             inputmode="numeric"
             pattern="[0-9]*"
-            class="input"
+            class="border rounded-md px-2 py-1.5 text-sm"
             placeholder="123456789012345678"
           />
-          <p class="text-xs text-gray-500 mt-1">
+          <p class="text-[10px] text-gray-500">
             When an admin distributes cZone Contest prizes, an announcement is posted here.
             Leave blank to use the DISCORD_ANNOUNCEMENTS_CHANNEL environment variable.
           </p>
         </div>
         <div>
-          <button class="btn-primary" :disabled="savingDiscord" @click="saveDiscord">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingDiscord" @click="saveDiscord">
             {{ savingDiscord ? 'Saving…' : 'Save' }}
           </button>
         </div>
       </section>
 
-      <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded',
+      <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-3 py-2 text-xs rounded-md',
                                  toast.type==='error'?'bg-red-100 text-red-700':'bg-green-100 text-green-700']">
         {{ toast.msg }}
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyHolidayEvents.vue
+++ b/components/newsite/admin/legacy/AdminLegacyHolidayEvents.vue
@@ -1,86 +1,85 @@
 <template>
-  <div class="p-6 space-y-6 ">
-    <!-- Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-      <h1 class="text-2xl font-semibold tracking-tight">Holiday Events</h1>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+      <!-- Header -->
+      <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+        <h1 class="text-base font-semibold">Holiday Events</h1>
 
-      <!-- Create New Holiday Event -->
-      <NuxtLink
-        to="/newsite/admin/holidayEvents/new"
-        class="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-        </svg>
-        Create Holiday Event
-      </NuxtLink>
-    </div>
-
-    <!-- Content -->
-    <div>
-      <!-- Loading / error -->
-      <div v-if="pending" class="flex items-center justify-center py-10 text-gray-500">
-        Loading events…
-      </div>
-      <div v-else-if="error" class="flex items-center justify-center py-10 text-red-600">
-        {{ error.message || 'Failed to fetch holiday events' }}
+        <!-- Create New Holiday Event -->
+        <NuxtLink
+          to="/newsite/admin/holidayEvents/new"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
+        >
+          + Create Holiday Event
+        </NuxtLink>
       </div>
 
-      <!-- Data views -->
-      <div v-else>
-        <!-- TABLE VIEW (sm and up) -->
-        <div class="overflow-x-auto rounded-lg border border-gray-200 shadow-sm hidden sm:block">
-          <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50 text-left text-sm font-semibold text-gray-700">
-              <tr>
-                <th class="px-4 py-3">Name</th>
-                <th class="px-4 py-3">Start</th>
-                <th class="px-4 py-3">End</th>
-                <th class="px-4 py-3">Items</th>
-                <th class="px-4 py-3">Pool</th>
-                <th class="px-4 py-3">Action</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-200 text-sm">
-              <tr v-for="e in events" :key="e.id" class="hover:bg-gray-50">
-                <td class="px-4 py-3 font-medium text-gray-900">{{ e.name }}</td>
-                <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(e.startsAt) }}</td>
-                <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(e.endsAt) }}</td>
-                <td class="px-4 py-3 text-center">{{ countItems(e) }}</td>
-                <td class="px-4 py-3 text-center">{{ countPool(e) }}</td>
-                <td class="px-4 py-3">
-                  <NuxtLink
-                    :to="`/newsite/admin/holidayEvents/edit/${e.id}`"
-                    class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                  >
-                    Edit
-                  </NuxtLink>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+      <!-- Content -->
+      <div>
+        <!-- Loading / error -->
+        <div v-if="pending" class="text-gray-500 py-6 text-center">
+          Loading events…
+        </div>
+        <div v-else-if="error" class="text-red-600 py-6 text-center">
+          {{ error.message || 'Failed to fetch holiday events' }}
         </div>
 
-        <!-- CARD VIEW (below sm) -->
-        <div class="space-y-4 block sm:hidden">
-          <div
-            v-for="e in events"
-            :key="e.id"
-            class="bg-white rounded-lg p-4 shadow hover:shadow-md"
-          >
-            <div class="space-y-1">
-              <h2 class="text-lg font-semibold">{{ e.name }}</h2>
-              <p class="text-sm"><strong>Start:</strong> {{ formatDate(e.startsAt) }}</p>
-              <p class="text-sm"><strong>End:</strong> {{ formatDate(e.endsAt) }}</p>
-              <p class="text-sm"><strong>Items:</strong> {{ countItems(e) }}</p>
-              <p class="text-sm"><strong>Pool:</strong> {{ countPool(e) }}</p>
-            </div>
-            <NuxtLink
-              :to="`/newsite/admin/holidayEvents/edit/${e.id}`"
-              class="mt-4 inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-center text-sm font-medium"
+        <!-- Data views -->
+        <div v-else>
+          <!-- TABLE VIEW (sm and up) -->
+          <div class="overflow-x-auto rounded-lg border bg-white shadow hidden sm:block">
+            <table class="min-w-full text-xs">
+              <thead>
+                <tr>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Name</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Start</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">End</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Items</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Pool</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Action</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y">
+                <tr v-for="e in events" :key="e.id" class="hover:bg-gray-50">
+                  <td class="px-2 py-1.5 font-medium text-gray-900">{{ e.name }}</td>
+                  <td class="px-2 py-1.5 whitespace-nowrap">{{ formatDate(e.startsAt) }}</td>
+                  <td class="px-2 py-1.5 whitespace-nowrap">{{ formatDate(e.endsAt) }}</td>
+                  <td class="px-2 py-1.5 text-center">{{ countItems(e) }}</td>
+                  <td class="px-2 py-1.5 text-center">{{ countPool(e) }}</td>
+                  <td class="px-2 py-1.5">
+                    <NuxtLink
+                      :to="`/newsite/admin/holidayEvents/edit/${e.id}`"
+                      class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
+                    >
+                      Edit
+                    </NuxtLink>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- CARD VIEW (below sm) -->
+          <div class="grid grid-cols-1 gap-2 sm:hidden">
+            <div
+              v-for="e in events"
+              :key="e.id"
+              class="bg-white border rounded-lg shadow p-2"
             >
-              Edit
-            </NuxtLink>
+              <div class="space-y-0.5">
+                <h2 class="text-xs font-semibold">{{ e.name }}</h2>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">Start:</span> {{ formatDate(e.startsAt) }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">End:</span> {{ formatDate(e.endsAt) }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">Items:</span> {{ countItems(e) }}</p>
+                <p class="text-[11px] text-gray-600"><span class="text-gray-500">Pool:</span> {{ countPool(e) }}</p>
+              </div>
+              <NuxtLink
+                :to="`/newsite/admin/holidayEvents/edit/${e.id}`"
+                class="mt-2 block text-center px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
+              >
+                Edit
+              </NuxtLink>
+            </div>
           </div>
         </div>
       </div>

--- a/components/newsite/admin/legacy/AdminLegacyHolidayEventsEdit.vue
+++ b/components/newsite/admin/legacy/AdminLegacyHolidayEventsEdit.vue
@@ -1,49 +1,50 @@
 <!-- /pages/admin/edit-holidayevent/[id].vue -->
 <template>
 
-  <div class="p-8 max-w-6xl mx-auto space-y-14 ">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
     <!-- Back & Title -->
-    <div class="flex items-center gap-4">
-      <NuxtLink to="/newsite/admin/holidayEvents" class="text-blue-700 hover:underline focus-visible:outline-blue-700">
+    <div class="flex items-center gap-2 mb-3">
+      <NuxtLink to="/newsite/admin/holidayEvents" class="text-xs text-blue-700 hover:underline focus-visible:outline-blue-700">
         ← Back to Holiday Events
       </NuxtLink>
-      <h1 class="text-3xl font-semibold tracking-tight">Edit Holiday Event</h1>
+      <h1 class="text-base font-semibold">Edit Holiday Event</h1>
     </div>
 
     <!-- Status -->
-    <div v-if="pending" class="text-gray-600">Loading…</div>
-    <div v-else-if="error" class="text-red-600">{{ error.message || 'Failed to load event' }}</div>
+    <div v-if="pending" class="text-gray-500 py-6 text-center">Loading…</div>
+    <div v-else-if="error" class="text-red-600 py-6 text-center">{{ error.message || 'Failed to load event' }}</div>
 
-    <form v-else @submit.prevent="submit" class="space-y-12 bg-white shadow-lg rounded-xl p-8 border border-gray-200">
+    <form v-else @submit.prevent="submit" class="space-y-4 bg-white rounded border p-3">
       <!-- 1) BASIC INFO -->
-      <section class="grid lg:grid-cols-2 gap-6">
-        <div class="flex flex-col gap-1 lg:col-span-2">
-          <label for="ev-name" class="text-sm font-medium">Event name <span class="text-red-500">*</span></label>
-          <input id="ev-name" v-model.trim="name" type="text" class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" required />
+      <section class="grid sm:grid-cols-2 gap-3">
+        <div class="flex flex-col gap-1 sm:col-span-2">
+          <label for="ev-name" class="text-xs font-medium">Event name <span class="text-red-500">*</span></label>
+          <input id="ev-name" v-model.trim="name" type="text" class="border rounded-md px-2 py-1.5 text-sm" required />
         </div>
 
         <div class="flex flex-col gap-1">
-          <label for="ev-start" class="text-sm font-medium">Starts (CST date/time)<span class="text-red-500">*</span></label>
-          <input id="ev-start" v-model="startsAt" type="datetime-local" class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" required />
+          <label for="ev-start" class="text-xs font-medium">Starts (CST date/time)<span class="text-red-500">*</span></label>
+          <input id="ev-start" v-model="startsAt" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" required />
         </div>
 
         <div class="flex flex-col gap-1">
-          <label for="ev-end" class="text-sm font-medium">Ends (CST date/time)<span class="text-red-500">*</span></label>
-          <input id="ev-end" v-model="endsAt" type="datetime-local" class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" required />
+          <label for="ev-end" class="text-xs font-medium">Ends (CST date/time)<span class="text-red-500">*</span></label>
+          <input id="ev-end" v-model="endsAt" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" required />
         </div>
 
-        <div class="flex flex-col gap-1 lg:col-span-2">
-          <label for="ev-minreveal" class="text-sm font-medium">Minimum Reveal Date (optional)</label>
-          <input id="ev-minreveal" v-model="minRevealAt" type="datetime-local" class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" />
-          <p class="text-xs text-gray-500 ml-1">Holiday Items cannot reveal into pool results before this time. CST date/time.</p>
+        <div class="flex flex-col gap-1 sm:col-span-2">
+          <label for="ev-minreveal" class="text-xs font-medium">Minimum Reveal Date (optional)</label>
+          <input id="ev-minreveal" v-model="minRevealAt" type="datetime-local" class="border rounded-md px-2 py-1.5 text-sm" />
+          <p class="text-[10px] text-gray-500">Holiday Items cannot reveal into pool results before this time. CST date/time.</p>
         </div>
       </section>
 
       <!-- 2) HOLIDAY ITEMS -->
-      <section class="space-y-4">
+      <section class="space-y-2">
         <div class="flex items-center justify-between">
-          <h2 class="text-xl font-semibold">Holiday Items</h2>
-          <span class="text-sm text-gray-600">Selected: {{ itemIds.length }}</span>
+          <h2 class="text-xs font-semibold">Holiday Items</h2>
+          <span class="text-[11px] text-gray-600">Selected: {{ itemIds.length }}</span>
         </div>
 
         <div class="relative max-w-xl cto-autocomplete">
@@ -52,7 +53,7 @@
             v-model="itemSearch"
             type="text"
             placeholder="Search cToons to use as Holiday Items…"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+            class="w-full border rounded-md px-2 py-1.5 text-sm"
             @focus="itemsOpen = true"
             @keydown.down.prevent="itemsHighlightNext"
             @keydown.up.prevent="itemsHighlightPrev"
@@ -66,47 +67,47 @@
               v-for="(s, idx) in itemSuggestions"
               :key="s.id"
               @mousedown.prevent="toggleItem(s)"
-              :class="['flex items-center gap-3 px-3 py-2 cursor-pointer', idx === itemsHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
+              :class="['flex items-center gap-2 px-2 py-1.5 cursor-pointer', idx === itemsHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
             >
-              <img v-if="s.assetPath" :src="s.assetPath" class="w-8 h-8 object-cover rounded border border-gray-300" />
-              <div class="flex-1 truncate">
-                <p class="truncate font-medium flex items-center gap-2">
+              <img v-if="s.assetPath" :src="s.assetPath" class="w-7 h-7 object-cover rounded border flex-shrink-0" />
+              <div class="min-w-0 flex-1">
+                <p class="truncate font-medium flex items-center gap-1">
                   <span class="truncate">{{ s.name }}</span>
                   <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
                     {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
                   </span>
                 </p>
-                <p class="text-xs text-gray-500">{{ s.rarity }}</p>
+                <p class="text-[10px] text-gray-500">{{ s.rarity }}</p>
               </div>
             </li>
           </ul>
         </div>
 
-        <div v-if="itemIds.length" class="rounded-md border border-gray-200 divide-y">
-          <div v-for="id in itemIds" :key="id" class="flex items-center gap-3 px-4 py-2">
-            <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-10 h-10 object-cover rounded border border-gray-300" />
-            <div class="flex-1 truncate">
-              <p class="truncate font-medium flex items-center gap-2">
+        <div v-if="itemIds.length" class="rounded-md border divide-y">
+          <div v-for="id in itemIds" :key="id" class="flex items-center gap-2 px-2 py-1.5">
+            <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-8 h-8 object-cover rounded border flex-shrink-0" />
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-medium flex items-center gap-1">
                 <span class="truncate">{{ lookup[id]?.name }}</span>
                 <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
               </p>
-              <p class="text-xs text-gray-500">{{ lookup[id]?.rarity }}</p>
+              <p class="text-[10px] text-gray-500">{{ lookup[id]?.rarity }}</p>
             </div>
-            <button type="button" @click="toggleItem(lookup[id])" class="text-red-700 hover:underline text-sm focus-visible:outline-red-700">
+            <button type="button" @click="toggleItem(lookup[id])" class="text-red-700 hover:underline text-[11px] focus-visible:outline-red-700">
               Remove
             </button>
           </div>
         </div>
-        <p v-else class="text-sm text-gray-500">No Holiday Items.</p>
+        <p v-else class="text-[11px] text-gray-500">No Holiday Items.</p>
       </section>
 
       <!-- 3) HOLIDAY POOL -->
-      <section class="space-y-4">
+      <section class="space-y-2">
         <div class="flex items-center justify-between">
-          <h2 class="text-xl font-semibold">Holiday Pool</h2>
-          <div class="flex items-center gap-3">
-            <span class="text-sm">Total: <strong :class="poolTotal === 100 ? 'text-green-700' : 'text-red-700'">{{ poolTotal }}</strong>%</span>
-            <button type="button" class="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100" @click="splitEvenly" :disabled="!poolIds.length">
+          <h2 class="text-xs font-semibold">Holiday Pool</h2>
+          <div class="flex items-center gap-2">
+            <span class="text-[11px]">Total: <strong :class="poolTotal === 100 ? 'text-green-700' : 'text-red-700'">{{ poolTotal }}</strong>%</span>
+            <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="splitEvenly" :disabled="!poolIds.length">
               Split evenly
             </button>
           </div>
@@ -118,7 +119,7 @@
             v-model="poolSearch"
             type="text"
             placeholder="Search cToons to add to the Holiday Pool…"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+            class="w-full border rounded-md px-2 py-1.5 text-sm"
             @focus="poolOpen = true"
             @keydown.down.prevent="poolHighlightNext"
             @keydown.up.prevent="poolHighlightPrev"
@@ -132,58 +133,57 @@
               v-for="(s, idx) in poolSuggestions"
               :key="s.id"
               @mousedown.prevent="togglePool(s)"
-              :class="['flex items-center gap-3 px-3 py-2 cursor-pointer', idx === poolHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
+              :class="['flex items-center gap-2 px-2 py-1.5 cursor-pointer', idx === poolHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
             >
-              <img v-if="s.assetPath" :src="s.assetPath" class="w-8 h-8 object-cover rounded border border-gray-300" />
-              <div class="flex-1 truncate">
-                <p class="truncate font-medium flex items-center gap-2">
+              <img v-if="s.assetPath" :src="s.assetPath" class="w-7 h-7 object-cover rounded border flex-shrink-0" />
+              <div class="min-w-0 flex-1">
+                <p class="truncate font-medium flex items-center gap-1">
                   <span class="truncate">{{ s.name }}</span>
                   <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
                     {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
                   </span>
                 </p>
-                <p class="text-xs text-gray-500">{{ s.rarity }}</p>
+                <p class="text-[10px] text-gray-500">{{ s.rarity }}</p>
               </div>
             </li>
           </ul>
         </div>
 
-        <div v-if="poolIds.length" class="rounded-md border border-gray-200 divide-y">
-          <div v-for="id in poolIds" :key="id" class="flex items-center gap-3 px-4 py-2">
-            <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-10 h-10 object-cover rounded border border-gray-300" />
-            <div class="flex-1 truncate">
-              <p class="truncate font-medium flex items-center gap-2">
+        <div v-if="poolIds.length" class="rounded-md border divide-y">
+          <div v-for="id in poolIds" :key="id" class="flex items-center gap-2 px-2 py-1.5">
+            <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-8 h-8 object-cover rounded border flex-shrink-0" />
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-medium flex items-center gap-1">
                 <span class="truncate">{{ lookup[id]?.name }}</span>
                 <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
               </p>
             </div>
             <div class="flex items-center gap-1">
-              <input v-model.number="poolWeights[id]" type="number" min="0" max="100" class="w-20 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600" />
-              <span class="text-xs text-gray-500">%</span>
+              <input v-model.number="poolWeights[id]" type="number" min="0" max="100" class="w-16 border rounded px-1 py-0.5 text-xs" />
+              <span class="text-[10px] text-gray-500">%</span>
             </div>
-            <button type="button" @click="togglePool(lookup[id])" class="text-red-700 hover:underline text-sm focus-visible:outline-red-700">
+            <button type="button" @click="togglePool(lookup[id])" class="text-red-700 hover:underline text-[11px] focus-visible:outline-red-700">
               Remove
             </button>
           </div>
         </div>
-        <p v-else class="text-sm text-gray-500">No pool entries.</p>
+        <p v-else class="text-[11px] text-gray-500">No pool entries.</p>
       </section>
 
       <!-- 4) SAVE -->
-      <div class="flex items-center gap-3">
+      <div class="flex items-center gap-2">
         <button
           type="submit"
           :disabled="saving || !formValid"
           :title="!formValid ? invalidTooltip : ''"
-          class="inline-flex items-center gap-2 rounded-md px-6 py-2.5 font-semibold transition
-                 text-white disabled:cursor-not-allowed disabled:bg-gray-400
-                 bg-blue-700 hover:bg-blue-800 focus-visible:outline-2 focus-visible:outline-blue-700"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md text-white disabled:cursor-not-allowed disabled:bg-gray-400 bg-blue-600 hover:bg-blue-700"
         >
           Save Changes
         </button>
-        <span v-if="saving" class="text-gray-600 text-sm">Saving…</span>
+        <span v-if="saving" class="text-gray-500 text-xs">Saving…</span>
       </div>
     </form>
+    </div>
   </div>
 </template>
 

--- a/components/newsite/admin/legacy/AdminLegacyHolidayEventsNew.vue
+++ b/components/newsite/admin/legacy/AdminLegacyHolidayEventsNew.vue
@@ -1,17 +1,18 @@
 <!-- /pages/admin/addHolidayEvent.vue -->
 <template>
 
-  <div class="p-8 max-w-6xl mx-auto space-y-14 ">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
     <!-- Back & Title -->
-    <div class="flex items-center gap-4">
-      <NuxtLink to="/newsite/admin/holidayEvents" class="text-blue-700 hover:underline focus-visible:outline-blue-700">
+    <div class="flex items-center gap-2 mb-3">
+      <NuxtLink to="/newsite/admin/holidayEvents" class="text-xs text-blue-700 hover:underline focus-visible:outline-blue-700">
         ← Back to Holiday Events
       </NuxtLink>
-      <h1 class="text-3xl font-semibold tracking-tight">Create Holiday Event</h1>
+      <h1 class="text-base font-semibold">Create Holiday Event</h1>
     </div>
 
     <!-- Intro -->
-    <section class="prose prose-sm max-w-none text-gray-700">
+    <section class="text-xs text-gray-700 mb-3">
       <p>
         Define the event window, pick the cToons that act as <strong>Holiday Items</strong>, then build the
         <strong>Holiday Pool</strong> with per-cToon redemption chances that total <strong>100&nbsp;%</strong>.
@@ -20,40 +21,40 @@
     </section>
 
     <!-- FORM -->
-    <form @submit.prevent="submit" class="space-y-12 bg-white shadow-lg rounded-xl p-8 border border-gray-200">
+    <form @submit.prevent="submit" class="space-y-4 bg-white rounded border p-3">
       <!-- 1) BASIC INFO -->
-      <section class="grid lg:grid-cols-2 gap-6">
-        <div class="flex flex-col gap-1 lg:col-span-2">
-          <label for="ev-name" class="text-sm font-medium">Event name <span class="text-red-500">*</span></label>
+      <section class="grid sm:grid-cols-2 gap-3">
+        <div class="flex flex-col gap-1 sm:col-span-2">
+          <label for="ev-name" class="text-xs font-medium">Event name <span class="text-red-500">*</span></label>
           <input id="ev-name" v-model.trim="name" type="text" placeholder="e.g. Winter Fest 2025"
-                 class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" required />
+                 class="border rounded-md px-2 py-1.5 text-sm" required />
         </div>
 
         <div class="flex flex-col gap-1">
-          <label for="ev-start" class="text-sm font-medium">Starts (CST date/time) <span class="text-red-500">*</span></label>
+          <label for="ev-start" class="text-xs font-medium">Starts (CST date/time) <span class="text-red-500">*</span></label>
           <input id="ev-start" v-model="startsAt" type="datetime-local"
-                 class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" required />
+                 class="border rounded-md px-2 py-1.5 text-sm" required />
         </div>
 
         <div class="flex flex-col gap-1">
-          <label for="ev-end" class="text-sm font-medium">Ends (CST date/time) <span class="text-red-500">*</span></label>
+          <label for="ev-end" class="text-xs font-medium">Ends (CST date/time) <span class="text-red-500">*</span></label>
           <input id="ev-end" v-model="endsAt" type="datetime-local"
-                 class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" required />
+                 class="border rounded-md px-2 py-1.5 text-sm" required />
         </div>
 
-        <div class="flex flex-col gap-1 lg:col-span-2">
-          <label for="ev-minreveal" class="text-sm font-medium">Minimum Reveal Date (optional)</label>
+        <div class="flex flex-col gap-1 sm:col-span-2">
+          <label for="ev-minreveal" class="text-xs font-medium">Minimum Reveal Date (optional)</label>
           <input id="ev-minreveal" v-model="minRevealAt" type="datetime-local"
-                 class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600" />
-          <p class="text-xs text-gray-500 ml-1">Holiday Items cannot reveal into pool results before this time. CST date/time.</p>
+                 class="border rounded-md px-2 py-1.5 text-sm" />
+          <p class="text-[10px] text-gray-500">Holiday Items cannot reveal into pool results before this time. CST date/time.</p>
         </div>
       </section>
 
       <!-- 2) HOLIDAY ITEMS -->
-      <section class="space-y-4">
+      <section class="space-y-2">
         <div class="flex items-center justify-between">
-          <h2 class="text-xl font-semibold">Holiday Items</h2>
-          <span class="text-sm text-gray-600">Selected: {{ itemIds.length }}</span>
+          <h2 class="text-xs font-semibold">Holiday Items</h2>
+          <span class="text-[11px] text-gray-600">Selected: {{ itemIds.length }}</span>
         </div>
 
         <!-- Search + dropdown -->
@@ -63,7 +64,7 @@
             v-model="itemSearch"
             type="text"
             placeholder="Search cToons to use as Holiday Items…"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+            class="w-full border rounded-md px-2 py-1.5 text-sm"
             @focus="itemsOpen = true"
             @keydown.down.prevent="itemsHighlightNext"
             @keydown.up.prevent="itemsHighlightPrev"
@@ -77,48 +78,48 @@
               v-for="(s, idx) in itemSuggestions"
               :key="s.id"
               @mousedown.prevent="toggleItem(s)"
-              :class="['flex items-center gap-3 px-3 py-2 cursor-pointer', idx === itemsHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
+              :class="['flex items-center gap-2 px-2 py-1.5 cursor-pointer', idx === itemsHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
             >
-              <img v-if="s.assetPath" :src="s.assetPath" class="w-8 h-8 object-cover rounded border border-gray-300" />
-              <div class="flex-1 truncate">
-                <p class="truncate font-medium flex items-center gap-2">
+              <img v-if="s.assetPath" :src="s.assetPath" class="w-7 h-7 object-cover rounded border flex-shrink-0" />
+              <div class="min-w-0 flex-1">
+                <p class="truncate font-medium flex items-center gap-1">
                   <span class="truncate">{{ s.name }}</span>
                   <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
                     {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
                   </span>
                 </p>
-                <p class="text-xs text-gray-500">{{ s.rarity }}</p>
+                <p class="text-[10px] text-gray-500">{{ s.rarity }}</p>
               </div>
             </li>
           </ul>
         </div>
 
         <!-- Selected list -->
-        <div v-if="itemIds.length" class="rounded-md border border-gray-200 divide-y">
-          <div v-for="id in itemIds" :key="id" class="flex items-center gap-3 px-4 py-2">
-            <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-10 h-10 object-cover rounded border border-gray-300" />
-            <div class="flex-1 truncate">
-              <p class="truncate font-medium flex items-center gap-2">
+        <div v-if="itemIds.length" class="rounded-md border divide-y">
+          <div v-for="id in itemIds" :key="id" class="flex items-center gap-2 px-2 py-1.5">
+            <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-8 h-8 object-cover rounded border flex-shrink-0" />
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-medium flex items-center gap-1">
                 <span class="truncate">{{ lookup[id]?.name }}</span>
                 <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
               </p>
-              <p class="text-xs text-gray-500">{{ lookup[id]?.rarity }}</p>
+              <p class="text-[10px] text-gray-500">{{ lookup[id]?.rarity }}</p>
             </div>
-            <button type="button" @click="toggleItem(lookup[id])" class="text-red-700 hover:underline text-sm focus-visible:outline-red-700">
+            <button type="button" @click="toggleItem(lookup[id])" class="text-red-700 hover:underline text-[11px] focus-visible:outline-red-700">
               Remove
             </button>
           </div>
         </div>
-        <p v-else class="text-sm text-gray-500">No Holiday Items yet.</p>
+        <p v-else class="text-[11px] text-gray-500">No Holiday Items yet.</p>
       </section>
 
       <!-- 3) HOLIDAY POOL -->
-      <section class="space-y-4">
+      <section class="space-y-2">
         <div class="flex items-center justify-between">
-          <h2 class="text-xl font-semibold">Holiday Pool</h2>
-          <div class="flex items-center gap-3">
-            <span class="text-sm">Total: <strong :class="poolTotal === 100 ? 'text-green-700' : 'text-red-700'">{{ poolTotal }}</strong>%</span>
-            <button type="button" class="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100"
+          <h2 class="text-xs font-semibold">Holiday Pool</h2>
+          <div class="flex items-center gap-2">
+            <span class="text-[11px]">Total: <strong :class="poolTotal === 100 ? 'text-green-700' : 'text-red-700'">{{ poolTotal }}</strong>%</span>
+            <button type="button" class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
                     @click="splitEvenly" :disabled="!poolIds.length">
               Split evenly
             </button>
@@ -126,14 +127,14 @@
         </div>
 
         <!-- Set-to-pool controls -->
-        <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+        <div class="flex flex-col sm:flex-row sm:items-center gap-2">
           <div class="relative w-full sm:max-w-xs cto-autocomplete">
             <input
               ref="setSearchInput"
               v-model="setSearch"
               type="text"
               placeholder="Type Set name…"
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+              class="w-full border rounded-md px-2 py-1.5 text-sm"
               @focus="setsOpen = true"
               @keydown.down.prevent="setsHighlightNext"
               @keydown.up.prevent="setsHighlightPrev"
@@ -147,7 +148,7 @@
                 v-for="(s, idx) in setSuggestions"
                 :key="s"
                 @mousedown.prevent="chooseSet(s)"
-                :class="['px-3 py-2 cursor-pointer truncate', idx === setsHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
+                :class="['px-2 py-1.5 cursor-pointer truncate', idx === setsHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
               >
                 {{ s }}
               </li>
@@ -155,14 +156,14 @@
           </div>
           <button
             type="button"
-            class="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+            class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50"
             @click="addSetToPool"
             :disabled="!canAddSet"
             :title="!canAddSet ? 'Pick a Set (3+ chars)' : 'Add all cToons from Set to Holiday Pool'"
           >
             Add Set to Pool
           </button>
-          <p class="text-xs text-gray-500 sm:ml-1">Adds only cToons with remaining supply.</p>
+          <p class="text-[10px] text-gray-500">Adds only cToons with remaining supply.</p>
         </div>
 
         <!-- Search + dropdown -->
@@ -172,7 +173,7 @@
             v-model="poolSearch"
             type="text"
             placeholder="Search cToons to add to the Holiday Pool…"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+            class="w-full border rounded-md px-2 py-1.5 text-sm"
             @focus="poolOpen = true"
             @keydown.down.prevent="poolHighlightNext"
             @keydown.up.prevent="poolHighlightPrev"
@@ -186,44 +187,44 @@
               v-for="(s, idx) in poolSuggestions"
               :key="s.id"
               @mousedown.prevent="togglePool(s)"
-              :class="['flex items-center gap-3 px-3 py-2 cursor-pointer', idx === poolHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
+              :class="['flex items-center gap-2 px-2 py-1.5 cursor-pointer', idx === poolHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50']"
             >
-              <img v-if="s.assetPath" :src="s.assetPath" class="w-8 h-8 object-cover rounded border border-gray-300" />
-              <div class="flex-1 truncate">
-                <p class="truncate font-medium flex items-center gap-2">
+              <img v-if="s.assetPath" :src="s.assetPath" class="w-7 h-7 object-cover rounded border flex-shrink-0" />
+              <div class="min-w-0 flex-1">
+                <p class="truncate font-medium flex items-center gap-1">
                   <span class="truncate">{{ s.name }}</span>
                   <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
                     {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
                   </span>
                 </p>
-                <p class="text-xs text-gray-500">{{ s.rarity }}</p>
+                <p class="text-[10px] text-gray-500">{{ s.rarity }}</p>
               </div>
             </li>
           </ul>
         </div>
 
         <!-- Selected pool with weights -->
-        <div v-if="poolIds.length" class="rounded-md border border-gray-200 divide-y">
-          <div v-for="id in poolIds" :key="id" class="flex items-center gap-3 px-4 py-2">
-            <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-10 h-10 object-cover rounded border border-gray-300" />
-            <div class="flex-1 truncate">
-              <p class="truncate font-medium flex items-center gap-2">
+        <div v-if="poolIds.length" class="rounded-md border divide-y">
+          <div v-for="id in poolIds" :key="id" class="flex items-center gap-2 px-2 py-1.5">
+            <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath" class="w-8 h-8 object-cover rounded border flex-shrink-0" />
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-medium flex items-center gap-1">
                 <span class="truncate">{{ lookup[id]?.name }}</span>
                 <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
               </p>
             </div>
             <div class="flex items-center gap-1">
               <input v-model.number="poolWeights[id]" type="number" min="0" max="100"
-                     class="w-20 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"
+                     class="w-16 border rounded px-1 py-0.5 text-xs"
                      :title="'Chance for ' + (lookup[id]?.name || '') + ' (%)'" />
-              <span class="text-xs text-gray-500">%</span>
+              <span class="text-[10px] text-gray-500">%</span>
             </div>
-            <button type="button" @click="togglePool(lookup[id])" class="text-red-700 hover:underline text-sm focus-visible:outline-red-700">
+            <button type="button" @click="togglePool(lookup[id])" class="text-red-700 hover:underline text-[11px] focus-visible:outline-red-700">
               Remove
             </button>
           </div>
         </div>
-        <p v-else class="text-sm text-gray-500">No pool entries yet.</p>
+        <p v-else class="text-[11px] text-gray-500">No pool entries yet.</p>
       </section>
 
       <!-- 4) SUBMIT -->
@@ -232,14 +233,13 @@
           type="submit"
           :disabled="!formValid"
           :title="!formValid ? invalidTooltip : ''"
-          class="inline-flex items-center gap-2 rounded-md px-6 py-2.5 font-semibold transition
-                 text-white disabled:cursor-not-allowed disabled:bg-gray-400
-                 bg-blue-700 hover:bg-blue-800 focus-visible:outline-2 focus-visible:outline-blue-700"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md text-white disabled:cursor-not-allowed disabled:bg-gray-400 bg-blue-600 hover:bg-blue-700"
         >
           Create Holiday Event
         </button>
       </div>
     </form>
+    </div>
   </div>
 </template>
 

--- a/components/newsite/admin/legacy/AdminLegacyHomepage.vue
+++ b/components/newsite/admin/legacy/AdminLegacyHomepage.vue
@@ -1,118 +1,119 @@
 <template>
-  <div class="bg-gray-100 p-6 ">
-    <h1 class="text-3xl font-bold mb-6">Admin: Homepage &amp; Showcase</h1>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+    <h1 class="text-base font-semibold mb-3">Admin: Homepage &amp; Showcase</h1>
 
-    <div class="bg-white rounded-lg shadow-md p-6 max-w-4xl mx-auto">
+    <div class="bg-white rounded-lg shadow p-3">
       <!-- Tabs -->
-      <div class="border-b mb-6">
-        <nav class="flex gap-1 sm:gap-4 overflow-x-auto flex-nowrap -mb-px">
+      <div class="border-b mb-3">
+        <nav class="flex gap-1 sm:gap-3 overflow-x-auto flex-nowrap -mb-px">
           <button
-            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
+            class="px-2 py-1.5 text-xs border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Homepage' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Homepage'">Homepage</button>
           <button
-            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
+            class="px-2 py-1.5 text-xs border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Home' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Home'">Home</button>
           <button
-            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
+            class="px-2 py-1.5 text-xs border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Sidebar' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Sidebar'">Sidebar</button>
           <button
-            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
+            class="px-2 py-1.5 text-xs border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Release Settings' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Release Settings'">Release Settings</button>
           <button
-            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
+            class="px-2 py-1.5 text-xs border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Other' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Other'">Other</button>
           <button
-            class="px-3 py-2 border-b-2 whitespace-nowrap shrink-0"
+            class="px-2 py-1.5 text-xs border-b-2 whitespace-nowrap shrink-0"
             :class="activeTab==='Favicon' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'"
             @click="activeTab='Favicon'">Favicon</button>
         </nav>
       </div>
 
       <!-- Homepage tab -->
-      <section v-if="activeTab==='Homepage'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Homepage'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Upload SVG/PNG/JPEG/GIF/MP4. Files are stored on the server and paths saved in the database.
         </p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <!-- Top Left -->
-          <div class="space-y-3">
-            <h2 class="font-semibold">Top Left</h2>
-            <p class="text-xs text-gray-500">Max size is 374px by 292px</p>
+          <div class="space-y-2">
+            <h2 class="text-xs font-semibold">Top Left</h2>
+            <p class="text-[10px] text-gray-500">Max size is 374px by 292px</p>
             <div class="aspect-video bg-gray-50 border rounded flex items-center justify-center overflow-hidden">
               <video v-if="(files.topLeft && files.topLeft.type && files.topLeft.type.startsWith('video/')) || /\.mp4($|\?)/i.test(paths.topLeft || '')"
                 :src="previewUrls.topLeft || paths.topLeft" :poster="(previewUrls.topLeft && /\.(png|jpe?g|gif|svg)$/i.test(previewUrls.topLeft)) ? previewUrls.topLeft : (/\.(png|jpe?g|gif|svg)$/i.test(paths.topLeft||'') ? paths.topLeft : '')"
                 controls preload="metadata" playsinline class="max-h-full max-w-full"></video>
               <img v-else-if="previewUrls.topLeft || paths.topLeft" :src="previewUrls.topLeft || paths.topLeft" alt="Top Left" class="max-h-full max-w-full" />
-              <span v-else class="text-gray-400 text-sm">No image</span>
+              <span v-else class="text-gray-400 text-xs">No image</span>
             </div>
                  <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif,video/mp4,.mp4"
-                   @change="onFile('topLeft', $event)" class="block w-full text-sm" />
-            <div v-if="files.topLeft" class="text-xs text-gray-600 truncate">Selected: {{ files.topLeft.name }}</div>
-            <button type="button" class="px-3 py-1 text-sm rounded border"
+                   @change="onFile('topLeft', $event)" class="block w-full text-xs" />
+            <div v-if="files.topLeft" class="text-[10px] text-gray-600 truncate">Selected: {{ files.topLeft.name }}</div>
+            <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                     v-if="paths.topLeft" @click="clearPath('topLeft')">Clear</button>
           </div>
 
           <!-- Top Right -->
-          <div class="space-y-3">
-            <h2 class="font-semibold">Top Right</h2>
-            <p class="text-xs text-gray-500">Max size is 374px by 292px</p>
+          <div class="space-y-2">
+            <h2 class="text-xs font-semibold">Top Right</h2>
+            <p class="text-[10px] text-gray-500">Max size is 374px by 292px</p>
             <div class="aspect-video bg-gray-50 border rounded flex items-center justify-center overflow-hidden">
               <video v-if="(files.topRight && files.topRight.type && files.topRight.type.startsWith('video/')) || /\.mp4($|\?)/i.test(paths.topRight || '')"
                 :src="previewUrls.topRight || paths.topRight" :poster="(previewUrls.topRight && /\.(png|jpe?g|gif|svg)$/i.test(previewUrls.topRight)) ? previewUrls.topRight : (/\.(png|jpe?g|gif|svg)$/i.test(paths.topRight||'') ? paths.topRight : '')"
                 controls preload="metadata" playsinline class="max-h-full max-w-full"></video>
               <img v-else-if="previewUrls.topRight || paths.topRight" :src="previewUrls.topRight || paths.topRight" alt="Top Right" class="max-h-full max-w-full" />
-              <span v-else class="text-gray-400 text-sm">No image</span>
+              <span v-else class="text-gray-400 text-xs">No image</span>
             </div>
                  <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif,video/mp4,.mp4"
-                   @change="onFile('topRight', $event)" class="block w-full text-sm" />
-            <div v-if="files.topRight" class="text-xs text-gray-600 truncate">Selected: {{ files.topRight.name }}</div>
-            <button type="button" class="px-3 py-1 text-sm rounded border"
+                   @change="onFile('topRight', $event)" class="block w-full text-xs" />
+            <div v-if="files.topRight" class="text-[10px] text-gray-600 truncate">Selected: {{ files.topRight.name }}</div>
+            <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                     v-if="paths.topRight" @click="clearPath('topRight')">Clear</button>
           </div>
 
           <!-- Bottom Left -->
-          <div class="space-y-3">
-            <h2 class="font-semibold">Bottom Left</h2>
-            <p class="text-xs text-gray-500">Max size is 374px by 292px</p>
+          <div class="space-y-2">
+            <h2 class="text-xs font-semibold">Bottom Left</h2>
+            <p class="text-[10px] text-gray-500">Max size is 374px by 292px</p>
             <div class="aspect-video bg-gray-50 border rounded flex items-center justify-center overflow-hidden">
               <video v-if="(files.bottomLeft && files.bottomLeft.type && files.bottomLeft.type.startsWith('video/')) || /\.mp4($|\?)/i.test(paths.bottomLeft || '')"
                 :src="previewUrls.bottomLeft || paths.bottomLeft" :poster="(previewUrls.bottomLeft && /\.(png|jpe?g|gif|svg)$/i.test(previewUrls.bottomLeft)) ? previewUrls.bottomLeft : (/\.(png|jpe?g|gif|svg)$/i.test(paths.bottomLeft||'') ? paths.bottomLeft : '')"
                 controls preload="metadata" playsinline class="max-h-full max-w-full"></video>
               <img v-else-if="previewUrls.bottomLeft || paths.bottomLeft" :src="previewUrls.bottomLeft || paths.bottomLeft" alt="Bottom Left" class="max-h-full max-w-full" />
-              <span v-else class="text-gray-400 text-sm">No image</span>
+              <span v-else class="text-gray-400 text-xs">No image</span>
             </div>
                  <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif,video/mp4,.mp4"
-                   @change="onFile('bottomLeft', $event)" class="block w-full text-sm" />
-            <div v-if="files.bottomLeft" class="text-xs text-gray-600 truncate">Selected: {{ files.bottomLeft.name }}</div>
-            <button type="button" class="px-3 py-1 text-sm rounded border"
+                   @change="onFile('bottomLeft', $event)" class="block w-full text-xs" />
+            <div v-if="files.bottomLeft" class="text-[10px] text-gray-600 truncate">Selected: {{ files.bottomLeft.name }}</div>
+            <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                     v-if="paths.bottomLeft" @click="clearPath('bottomLeft')">Clear</button>
           </div>
 
           <!-- Bottom Right removed — now managed in the Sidebar tab -->
-          <div class="space-y-3 border rounded p-4 bg-gray-50">
-            <h2 class="font-semibold text-gray-400">Bottom Right</h2>
-            <p class="text-xs text-gray-400">The Bottom Right image has been moved to the <button type="button" class="underline text-indigo-500" @click="activeTab='Sidebar'">Sidebar tab</button> as "Bottom Spotlight".</p>
+          <div class="space-y-2 border rounded-md p-3 bg-gray-50">
+            <h2 class="text-xs font-semibold text-gray-400">Bottom Right</h2>
+            <p class="text-[10px] text-gray-400">The Bottom Right image has been moved to the <button type="button" class="underline text-indigo-500" @click="activeTab='Sidebar'">Sidebar tab</button> as "Bottom Spotlight".</p>
           </div>
         </div>
 
         <div class="mt-2">
-          <button class="btn-primary" :disabled="saving" @click="saveAll">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="saving" @click="saveAll">
             <span v-if="!saving">Save</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- Home tab (formerly Showcase) -->
-      <section v-if="activeTab==='Home'" class="space-y-6">
+      <section v-if="activeTab==='Home'" class="space-y-3">
         <!-- Showcase image — compact -->
-        <div class="border rounded p-4 space-y-2">
-          <h2 class="font-semibold text-sm">Showcase Image / Video</h2>
-          <div class="flex items-center gap-4">
+        <div class="border rounded-md p-3 space-y-1.5">
+          <h2 class="text-xs font-semibold">Showcase Image / Video</h2>
+          <div class="flex items-center gap-3">
             <div class="w-40 h-24 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
               <video v-if="(showcaseFile && showcaseFile.type && showcaseFile.type.startsWith('video/')) || /\.mp4($|\?)/i.test(showcasePath || '')"
                 :src="previewUrls.showcase || showcasePath"
@@ -124,11 +125,11 @@
             <div class="space-y-1 min-w-0">
               <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif,video/mp4,.mp4"
                 @change="onShowcaseFile($event)" class="block w-full text-xs" />
-              <div v-if="showcaseFile" class="text-xs text-gray-600 truncate">{{ showcaseFile.name }}</div>
+              <div v-if="showcaseFile" class="text-[10px] text-gray-600 truncate">{{ showcaseFile.name }}</div>
               <div class="flex gap-2">
-                <button type="button" class="px-2 py-0.5 text-xs rounded border"
+                <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                         v-if="showcasePath" @click="clearShowcase()">Clear</button>
-                <button class="btn-primary text-xs px-3 py-1" :disabled="saving" @click="saveShowcase">
+                <button class="px-3 py-1 text-[11px] font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="saving" @click="saveShowcase">
                   <span v-if="!saving">Save</span><span v-else>Saving…</span>
                 </button>
               </div>
@@ -138,12 +139,12 @@
 
         <!-- 4 Home Images -->
         <div>
-          <h2 class="font-semibold mb-3">Home Page Images</h2>
-          <p class="text-sm text-gray-500 mb-4">These 4 images display in the main content area of the newsite home page. Each can link to a page or custom URL.</p>
-          <div class="space-y-4">
-            <div v-for="n in 4" :key="n" class="border rounded p-4 space-y-3">
-              <h3 class="font-medium text-sm">Image {{ n }}</h3>
-              <div class="flex items-center gap-4">
+          <h2 class="text-xs font-semibold mb-2">Home Page Images</h2>
+          <p class="text-xs text-gray-500 mb-2">These 4 images display in the main content area of the newsite home page. Each can link to a page or custom URL.</p>
+          <div class="space-y-2">
+            <div v-for="n in 4" :key="n" class="border rounded-md p-2 space-y-2">
+              <h3 class="text-xs font-medium">Image {{ n }}</h3>
+              <div class="flex items-center gap-3">
                 <div class="w-32 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
                   <img v-if="previewUrls['homeImage' + n] || homeImages[n].path"
                     :src="previewUrls['homeImage' + n] || homeImages[n].path"
@@ -151,16 +152,16 @@
                     class="max-h-full max-w-full object-contain" />
                   <span v-else class="text-gray-400 text-xs">None</span>
                 </div>
-                <div class="space-y-2 flex-1 min-w-0">
+                <div class="space-y-1.5 flex-1 min-w-0">
                   <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
                     @change="onHomeImageFile(n, $event)" class="block w-full text-xs" />
-                  <p class="text-xs text-gray-500">Max size is 374px by 292px</p>
-                  <div v-if="homeImageFiles[n]" class="text-xs text-gray-600 truncate">{{ homeImageFiles[n].name }}</div>
-                  <button type="button" class="px-2 py-0.5 text-xs rounded border"
+                  <p class="text-[10px] text-gray-500">Max size is 374px by 292px</p>
+                  <div v-if="homeImageFiles[n]" class="text-[10px] text-gray-600 truncate">{{ homeImageFiles[n].name }}</div>
+                  <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                           v-if="homeImages[n].path" @click="clearHomeImage(n)">Clear</button>
-                  <div class="space-y-1">
-                    <label class="text-xs text-gray-600 font-medium">Link to</label>
-                    <select v-model="homeImages[n].linkPreset" @change="onLinkPresetChange(n)" class="block w-full text-sm border rounded p-1.5">
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs font-medium">Link to</label>
+                    <select v-model="homeImages[n].linkPreset" @change="onLinkPresetChange(n)" class="block w-full border rounded-md px-2 py-1.5 text-sm">
                       <option value="">— None —</option>
                       <option value="my-cworld">My cWorld</option>
                       <option value="cmart">cMart</option>
@@ -177,14 +178,14 @@
                     <input v-if="homeImages[n].linkPreset === 'custom'"
                       type="url" v-model="homeImages[n].link"
                       placeholder="https://example.com"
-                      class="block w-full text-sm border rounded p-1.5 mt-1" />
+                      class="block w-full border rounded-md px-2 py-1.5 text-sm mt-1" />
                   </div>
                 </div>
               </div>
             </div>
           </div>
-          <div class="mt-4">
-            <button class="btn-primary" :disabled="saving" @click="saveHomeImages">
+          <div class="mt-3">
+            <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="saving" @click="saveHomeImages">
               <span v-if="!saving">Save Home Images</span><span v-else>Saving…</span>
             </button>
           </div>
@@ -192,16 +193,16 @@
       </section>
 
       <!-- Sidebar tab -->
-      <section v-if="activeTab==='Sidebar'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Sidebar'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Configure the bottom spotlight image shown in the site sidebar.
         </p>
 
         <!-- Bottom Spotlight -->
-        <div class="border rounded p-4 space-y-3">
-          <h2 class="font-semibold">Bottom Spotlight</h2>
-          <p class="text-xs text-gray-500">Size should be 757px by 254px.</p>
-          <div class="flex items-center gap-4">
+        <div class="border rounded-md p-3 space-y-2">
+          <h2 class="text-xs font-semibold">Bottom Spotlight</h2>
+          <p class="text-[10px] text-gray-500">Size should be 757px by 254px.</p>
+          <div class="flex items-center gap-3">
             <div class="w-48 h-20 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
               <video v-if="(files.bottomRight && files.bottomRight.type && files.bottomRight.type.startsWith('video/')) || /\.mp4($|\?)/i.test(paths.bottomRight || '')"
                 :src="previewUrls.bottomRight || paths.bottomRight"
@@ -209,19 +210,19 @@
               <img v-else-if="previewUrls.bottomRight || paths.bottomRight" :src="previewUrls.bottomRight || paths.bottomRight" alt="Bottom Spotlight" class="max-h-full max-w-full object-contain" />
               <span v-else class="text-gray-400 text-xs">No image</span>
             </div>
-            <div class="space-y-2 flex-1 min-w-0">
+            <div class="space-y-1.5 flex-1 min-w-0">
               <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif,video/mp4,.mp4"
-                @change="onFile('bottomRight', $event)" class="block w-full text-sm" />
-              <div v-if="files.bottomRight" class="text-xs text-gray-600 truncate">Selected: {{ files.bottomRight.name }}</div>
-              <button type="button" class="px-3 py-1 text-sm rounded border"
+                @change="onFile('bottomRight', $event)" class="block w-full text-xs" />
+              <div v-if="files.bottomRight" class="text-[10px] text-gray-600 truncate">Selected: {{ files.bottomRight.name }}</div>
+              <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                       v-if="paths.bottomRight" @click="clearPath('bottomRight')">Clear</button>
             </div>
           </div>
 
           <!-- Link options -->
-          <div class="space-y-1 mt-2">
-            <label class="text-sm font-medium text-gray-700">Link to</label>
-            <select v-model="bottomSpotlightLinkPreset" @change="onBottomSpotlightPresetChange" class="block w-full text-sm border rounded p-1.5">
+          <div class="flex flex-col gap-1 mt-2">
+            <label class="text-xs font-medium">Link to</label>
+            <select v-model="bottomSpotlightLinkPreset" @change="onBottomSpotlightPresetChange" class="block w-full border rounded-md px-2 py-1.5 text-sm">
               <option value="">— None —</option>
               <option value="my-cworld">My cWorld</option>
               <option value="cmart">cMart</option>
@@ -236,22 +237,22 @@
             <input v-if="bottomSpotlightLinkPreset === 'custom'"
               type="url" v-model="bottomSpotlightLink"
               placeholder="https://example.com"
-              class="block w-full text-sm border rounded p-1.5 mt-1" />
-            <p v-if="bottomSpotlightLinkPreset === 'winball'" class="text-xs text-indigo-600 mt-1">
+              class="block w-full border rounded-md px-2 py-1.5 text-sm mt-1" />
+            <p v-if="bottomSpotlightLinkPreset === 'winball'" class="text-[10px] text-indigo-600 mt-1">
               The Winball prize cToon overlay will be shown on the frontend.
             </p>
           </div>
         </div>
 
         <!-- Middle Sidebar -->
-        <div class="border rounded p-4 space-y-3">
-          <h2 class="font-semibold">Middle Sidebar</h2>
-          <p class="text-sm text-gray-500">Up to 3 images displayed in the middle sidebar area. Each can link to a page or custom URL.</p>
-          <p class="text-sm text-gray-500">Images must be 757px wide. Total height across all uploaded images must equal 1668px. Split evenly: 1 image = 1668px tall, 2 images = 834px each, 3 images = 556px each. You don't have to do evenly split heights, they just need to total up to 1668px.</p>
-          <div class="space-y-4">
-            <div v-for="n in 3" :key="n" class="border rounded p-3 space-y-2">
-              <h3 class="font-medium text-sm">Image {{ n }}</h3>
-              <div class="flex items-center gap-4">
+        <div class="border rounded-md p-3 space-y-2">
+          <h2 class="text-xs font-semibold">Middle Sidebar</h2>
+          <p class="text-[10px] text-gray-500">Up to 3 images displayed in the middle sidebar area. Each can link to a page or custom URL.</p>
+          <p class="text-[10px] text-gray-500">Images must be 757px wide. Total height across all uploaded images must equal 1668px. Split evenly: 1 image = 1668px tall, 2 images = 834px each, 3 images = 556px each. You don't have to do evenly split heights, they just need to total up to 1668px.</p>
+          <div class="space-y-2">
+            <div v-for="n in 3" :key="n" class="border rounded-md p-2 space-y-1.5">
+              <h3 class="text-xs font-medium">Image {{ n }}</h3>
+              <div class="flex items-center gap-3">
                 <div class="w-32 h-20 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
                   <img v-if="previewUrls['middleSidebar' + n] || middleSidebarImages[n].path"
                     :src="previewUrls['middleSidebar' + n] || middleSidebarImages[n].path"
@@ -259,16 +260,16 @@
                     class="max-h-full max-w-full object-contain" />
                   <span v-else class="text-gray-400 text-xs">None</span>
                 </div>
-                <div class="space-y-2 flex-1 min-w-0">
+                <div class="space-y-1.5 flex-1 min-w-0">
                   <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
                     @change="onMiddleSidebarFile(n, $event)" class="block w-full text-xs" />
-                  <p class="text-xs text-gray-500">Max width of 757px.</p>
-                  <div v-if="middleSidebarFiles[n]" class="text-xs text-gray-600 truncate">{{ middleSidebarFiles[n].name }}</div>
-                  <button type="button" class="px-2 py-0.5 text-xs rounded border"
+                  <p class="text-[10px] text-gray-500">Max width of 757px.</p>
+                  <div v-if="middleSidebarFiles[n]" class="text-[10px] text-gray-600 truncate">{{ middleSidebarFiles[n].name }}</div>
+                  <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                           v-if="middleSidebarImages[n].path" @click="clearMiddleSidebar(n)">Clear</button>
-                  <div class="space-y-1">
-                    <label class="text-xs text-gray-600 font-medium">Link to</label>
-                    <select v-model="middleSidebarImages[n].linkPreset" @change="onMiddleSidebarPresetChange(n)" class="block w-full text-sm border rounded p-1.5">
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs font-medium">Link to</label>
+                    <select v-model="middleSidebarImages[n].linkPreset" @change="onMiddleSidebarPresetChange(n)" class="block w-full border rounded-md px-2 py-1.5 text-sm">
                       <option value="">— None —</option>
                       <option value="my-cworld">My cWorld</option>
                       <option value="cmart">cMart</option>
@@ -285,7 +286,7 @@
                     <input v-if="middleSidebarImages[n].linkPreset === 'custom'"
                       type="url" v-model="middleSidebarImages[n].link"
                       placeholder="https://example.com"
-                      class="block w-full text-sm border rounded p-1.5 mt-1" />
+                      class="block w-full border rounded-md px-2 py-1.5 text-sm mt-1" />
                   </div>
                 </div>
               </div>
@@ -294,113 +295,113 @@
         </div>
 
         <div class="mt-2">
-          <button class="btn-primary" :disabled="saving" @click="saveSidebar">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="saving" @click="saveSidebar">
             <span v-if="!saving">Save Sidebar</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- Release Settings tab -->
-      <section v-if="activeTab==='Release Settings'" class="space-y-6 max-w-md">
-        <p class="text-sm text-gray-600">Configure staged release defaults for all cToons.</p>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Initial Release %</label>
-          <input type="number" v-model.number="releasePercent" min="0" max="100" class="w-full border rounded p-2" />
-          <p class="text-xs text-gray-500">Percent of total released at the initial time (min 1 unit enforced at runtime).</p>
+      <section v-if="activeTab==='Release Settings'" class="space-y-3 max-w-md">
+        <p class="text-xs text-gray-600">Configure staged release defaults for all cToons.</p>
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Initial Release %</label>
+          <input type="number" v-model.number="releasePercent" min="0" max="100" class="border rounded-md px-2 py-1.5 text-sm" />
+          <p class="text-[10px] text-gray-500">Percent of total released at the initial time (min 1 unit enforced at runtime).</p>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium">Delay (hours) to Final Release</label>
+          <input type="number" v-model.number="delayHours" min="1" max="72" class="border rounded-md px-2 py-1.5 text-sm" />
+          <p class="text-[10px] text-gray-500">Hours after initial release when the remaining quantity is released.</p>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Delay (hours) to Final Release</label>
-          <input type="number" v-model.number="delayHours" min="1" max="72" class="w-full border rounded p-2" />
-          <p class="text-xs text-gray-500">Hours after initial release when the remaining quantity is released.</p>
-        </div>
-        <div>
-          <button class="btn-primary" :disabled="saving" @click="saveReleaseSettings">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="saving" @click="saveReleaseSettings">
             <span v-if="!saving">Save</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- Other tab -->
-      <section v-if="activeTab==='Other'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Other'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Configure additional page images.
         </p>
 
         <!-- News image -->
-        <div class="border rounded p-4 space-y-3">
-          <h2 class="font-semibold">News</h2>
-          <p class="text-xs text-gray-500">Image displayed on the News page.</p>
-          <div class="flex items-center gap-4">
+        <div class="border rounded-md p-3 space-y-2">
+          <h2 class="text-xs font-semibold">News</h2>
+          <p class="text-[10px] text-gray-500">Image displayed on the News page.</p>
+          <div class="flex items-center gap-3">
             <div class="w-48 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
               <img v-if="previewUrls.news || newsPath" :src="previewUrls.news || newsPath" alt="News" class="max-h-full max-w-full object-contain" />
               <span v-else class="text-gray-400 text-xs">No image</span>
             </div>
-            <div class="space-y-2 flex-1 min-w-0">
+            <div class="space-y-1.5 flex-1 min-w-0">
               <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
-                @change="onNewsFile($event)" class="block w-full text-sm" />
-              <div v-if="newsFile" class="text-xs text-gray-600 truncate">Selected: {{ newsFile.name }}</div>
-              <button type="button" class="px-3 py-1 text-sm rounded border"
+                @change="onNewsFile($event)" class="block w-full text-xs" />
+              <div v-if="newsFile" class="text-[10px] text-gray-600 truncate">Selected: {{ newsFile.name }}</div>
+              <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                       v-if="newsPath" @click="clearNews()">Clear</button>
             </div>
           </div>
         </div>
 
         <!-- Earn Points image -->
-        <div class="border rounded p-4 space-y-3">
-          <h2 class="font-semibold">Earn Points</h2>
-          <p class="text-xs text-gray-500">Image displayed on the Earn Points page.</p>
-          <div class="flex items-center gap-4">
+        <div class="border rounded-md p-3 space-y-2">
+          <h2 class="text-xs font-semibold">Earn Points</h2>
+          <p class="text-[10px] text-gray-500">Image displayed on the Earn Points page.</p>
+          <div class="flex items-center gap-3">
             <div class="w-48 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
               <img v-if="previewUrls.earnPoints || earnPointsPath" :src="previewUrls.earnPoints || earnPointsPath" alt="Earn Points" class="max-h-full max-w-full object-contain" />
               <span v-else class="text-gray-400 text-xs">No image</span>
             </div>
-            <div class="space-y-2 flex-1 min-w-0">
+            <div class="space-y-1.5 flex-1 min-w-0">
               <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
-                @change="onEarnPointsFile($event)" class="block w-full text-sm" />
-              <div v-if="earnPointsFile" class="text-xs text-gray-600 truncate">Selected: {{ earnPointsFile.name }}</div>
-              <button type="button" class="px-3 py-1 text-sm rounded border"
+                @change="onEarnPointsFile($event)" class="block w-full text-xs" />
+              <div v-if="earnPointsFile" class="text-[10px] text-gray-600 truncate">Selected: {{ earnPointsFile.name }}</div>
+              <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                       v-if="earnPointsPath" @click="clearEarnPoints()">Clear</button>
             </div>
           </div>
         </div>
 
         <!-- Label image -->
-        <div class="border rounded p-4 space-y-3">
-          <h2 class="font-semibold">Label Image</h2>
-          <p class="text-xs text-gray-500">Image displayed as the orbit label on the newsite template (replaces the default orbit-label.gif).</p>
-          <div class="flex items-center gap-4">
+        <div class="border rounded-md p-3 space-y-2">
+          <h2 class="text-xs font-semibold">Label Image</h2>
+          <p class="text-[10px] text-gray-500">Image displayed as the orbit label on the newsite template (replaces the default orbit-label.gif).</p>
+          <div class="flex items-center gap-3">
             <div class="w-48 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
               <img v-if="previewUrls.label || labelPath" :src="previewUrls.label || labelPath" alt="Label" class="max-h-full max-w-full object-contain" />
               <span v-else class="text-gray-400 text-xs">No image (uses default)</span>
             </div>
-            <div class="space-y-2 flex-1 min-w-0">
+            <div class="space-y-1.5 flex-1 min-w-0">
               <input type="file" accept=".svg,image/svg+xml,image/png,image/jpeg,.jpg,.jpeg,.png,image/gif,.gif"
-                @change="onLabelFile($event)" class="block w-full text-sm" />
-              <div v-if="labelFile" class="text-xs text-gray-600 truncate">Selected: {{ labelFile.name }}</div>
-              <button type="button" class="px-3 py-1 text-sm rounded border"
+                @change="onLabelFile($event)" class="block w-full text-xs" />
+              <div v-if="labelFile" class="text-[10px] text-gray-600 truncate">Selected: {{ labelFile.name }}</div>
+              <button type="button" class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                       v-if="labelPath" @click="clearLabel()">Clear</button>
             </div>
           </div>
         </div>
 
         <div class="mt-2">
-          <button class="btn-primary" :disabled="saving" @click="saveOther">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="saving" @click="saveOther">
             <span v-if="!saving">Save</span><span v-else>Saving…</span>
           </button>
         </div>
       </section>
 
       <!-- Favicon tab -->
-      <section v-if="activeTab==='Favicon'" class="space-y-6">
-        <p class="text-sm text-gray-600">
+      <section v-if="activeTab==='Favicon'" class="space-y-3">
+        <p class="text-xs text-gray-600">
           Upload one image (PNG, JPG, or WEBP) and it will replace the site's favicon and all
           meta/touch icons used site-wide. It will be automatically cropped to a centered square.
           Changes may take a minute to appear everywhere due to browser caching.
         </p>
 
-        <div class="border rounded p-4 space-y-3">
-          <h2 class="font-semibold">Master Icon Image</h2>
-          <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+        <div class="border rounded-md p-3 space-y-2">
+          <h2 class="text-xs font-semibold">Master Icon Image</h2>
+          <div class="flex flex-col sm:flex-row items-start sm:items-center gap-3">
             <div class="relative w-32 h-32 bg-gray-50 border rounded flex items-center justify-center overflow-hidden shrink-0">
               <img v-if="faviconPreviewUrl || faviconSourcePath" :src="faviconPreviewUrl || faviconSourcePath" alt="Favicon preview" class="max-h-full max-w-full object-contain" @load="onFaviconPreviewLoad" />
               <span v-else class="text-gray-400 text-xs">No image</span>
@@ -409,19 +410,19 @@
                 <div class="border-2 border-dashed border-indigo-500/80" :style="cropOverlayStyle"></div>
               </div>
             </div>
-            <div class="space-y-2 flex-1 min-w-0">
-              <label for="favicon-file-input" class="block text-sm font-medium text-gray-700">Choose image</label>
+            <div class="space-y-1.5 flex-1 min-w-0">
+              <label for="favicon-file-input" class="block text-xs font-medium">Choose image</label>
               <input id="favicon-file-input" type="file" accept="image/png,image/jpeg,.jpg,.jpeg,.png,image/webp,.webp"
-                @change="onFaviconFile($event)" class="block w-full text-sm" />
-              <p v-if="faviconPreviewUrl" class="text-xs text-gray-500">
+                @change="onFaviconFile($event)" class="block w-full text-xs" />
+              <p v-if="faviconPreviewUrl" class="text-[10px] text-gray-500">
                 Dashed box shows the centered square that will be used — anything outside it is cropped away.
               </p>
-              <div v-if="faviconFile" class="text-xs text-gray-600 truncate">Selected: {{ faviconFile.name }}</div>
+              <div v-if="faviconFile" class="text-[10px] text-gray-600 truncate">Selected: {{ faviconFile.name }}</div>
             </div>
           </div>
 
           <!-- A handful of representative generated sizes — not all ~20, to keep this usable on mobile -->
-          <div v-if="faviconPreviewUrl" class="flex items-end gap-4 pt-2">
+          <div v-if="faviconPreviewUrl" class="flex items-end gap-3 pt-2">
             <div v-for="s in [16, 32, 96, 180]" :key="s" class="flex flex-col items-center gap-1">
               <img :src="faviconPreviewUrl" :style="{ width: Math.min(s, 64) + 'px', height: Math.min(s, 64) + 'px' }" class="object-cover border rounded" :alt="s + 'px preview'" />
               <span class="text-[10px] text-gray-500">{{ s }}px</span>
@@ -429,7 +430,7 @@
           </div>
 
           <div class="mt-2">
-            <button class="btn-primary inline-flex items-center gap-2" :disabled="!faviconFile || faviconSaving" @click="saveFavicon">
+            <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 inline-flex items-center gap-2" :disabled="!faviconFile || faviconSaving" @click="saveFavicon">
               <svg v-if="faviconSaving" class="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
@@ -440,10 +441,11 @@
         </div>
       </section>
 
-      <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded',
+      <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-3 py-2 text-xs rounded-md',
                                  toast.type==='error'?'bg-red-100 text-red-700':'bg-green-100 text-green-700']">
         {{ toast.msg }}
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyInitiateTrade.vue
+++ b/components/newsite/admin/legacy/AdminLegacyInitiateTrade.vue
@@ -1,21 +1,22 @@
 <template>
-  <div class="px-4 max-w-7xl mx-auto ">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2 max-w-7xl mx-auto">
     <!-- Title -->
-    <div class="flex items-center justify-between mb-6">
+    <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
       <div>
-        <h1 class="text-2xl font-bold">Initiate Trade</h1>
-        <p v-if="officialUser" class="text-sm text-gray-600">Initiating as {{ officialUser.username }}</p>
+        <h1 class="text-base font-semibold">Initiate Trade</h1>
+        <p v-if="officialUser" class="text-[11px] text-gray-600">Initiating as {{ officialUser.username }}</p>
       </div>
-      <div v-if="officialUser" class="text-sm bg-indigo-100 text-indigo-800 font-semibold px-3 py-1 rounded">
+      <div v-if="officialUser" class="px-1.5 py-0 rounded text-[10px] font-medium border bg-indigo-100 text-indigo-800 border-indigo-200">
         Official Account: {{ officialUser.username }}
       </div>
     </div>
 
-    <p v-if="officialError" class="mb-4 text-sm text-red-600">{{ officialError }}</p>
+    <p v-if="officialError" class="mb-2 text-xs text-red-600">{{ officialError }}</p>
 
     <!-- Step 0: Pick a user -->
-    <section class="bg-white rounded-xl shadow-md p-4 mb-6">
-      <label class="block text-sm font-medium mb-2">Find a user to trade with</label>
+    <section class="bg-white rounded-lg shadow p-2 mb-3">
+      <label class="block text-xs font-medium mb-1.5">Find a user to trade with</label>
       <div class="relative">
         <input
           ref="userInputRef"
@@ -29,24 +30,24 @@
           aria-expanded="showUserSuggest"
           aria-controls="user-suggest-listbox"
           aria-autocomplete="list"
-          class="w-full border rounded px-3 py-2"
+          class="w-full border rounded-md px-2 py-1.5 text-sm"
         />
         <!-- suggestions -->
         <div
           v-if="showUserSuggest"
           ref="userSuggestRef"
           id="user-suggest-listbox"
-          class="absolute z-20 bg-white border rounded w-full mt-1 max-h-64 overflow-auto"
+          class="absolute z-20 bg-white border rounded-md w-full mt-1 max-h-64 overflow-y-auto"
           role="listbox"
         >
-          <div v-if="isSearching" class="px-3 py-2 text-sm text-gray-600">Searching...</div>
+          <div v-if="isSearching" class="px-2 py-1.5 text-gray-600">Searching...</div>
 
           <template v-else-if="userResults.length">
             <button
               v-for="(u, idx) in userResults"
               :key="u.username"
               :class="[
-                'w-full text-left px-3 py-2 flex items-center gap-2',
+                'w-full text-left px-2 py-1.5 flex items-center gap-2',
                 highlightedIndex === idx ? 'bg-indigo-50' : 'hover:bg-indigo-50'
               ]"
               role="option"
@@ -54,36 +55,36 @@
               @mouseenter="highlightedIndex = idx"
               @click="selectTargetUser(u)"
             >
-              <img :src="`/avatars/${u.avatar || 'default.png'}`" class="w-6 h-6 rounded-full border" />
+              <img :src="`/avatars/${u.avatar || 'default.png'}`" class="w-6 h-6 rounded-full border flex-shrink-0" />
               <span class="font-medium">{{ u.username }}</span>
-              <span v-if="u.isBooster" class="ml-auto text-xs px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-800">Booster</span>
+              <span v-if="u.isBooster" class="ml-auto px-1.5 py-0 rounded text-[10px] font-medium border bg-yellow-100 text-yellow-800 border-yellow-200">Booster</span>
             </button>
           </template>
 
-          <div v-else class="px-3 py-2 text-sm text-gray-600">No matches</div>
+          <div v-else class="px-2 py-1.5 text-gray-600">No matches</div>
         </div>
       </div>
-      <p v-if="targetError" class="mt-2 text-sm text-red-600">{{ targetError }}</p>
+      <p v-if="targetError" class="mt-1.5 text-xs text-red-600">{{ targetError }}</p>
 
-      <div v-if="targetUser" class="mt-4 flex items-center gap-3">
-        <img :src="`/avatars/${targetUser.avatar || 'default.png'}`" class="w-10 h-10 rounded-full border" />
+      <div v-if="targetUser" class="mt-3 flex items-center gap-2">
+        <img :src="`/avatars/${targetUser.avatar || 'default.png'}`" class="w-8 h-8 rounded-full border flex-shrink-0" />
         <div class="flex items-center gap-2">
-          <p class="font-semibold">Trading with {{ targetUser.username }}</p>
-          <button class="text-xs px-2 py-1 border rounded hover:bg-gray-50" @click="clearTarget(true)">Change</button>
+          <p class="font-semibold text-xs">Trading with {{ targetUser.username }}</p>
+          <button class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50" @click="clearTarget(true)">Change</button>
         </div>
       </div>
     </section>
 
     <!-- STEP 1: Other user's collection -->
-    <section v-if="targetUser && currentStep === 1" class="mb-6">
-      <div class="bg-white rounded-xl shadow-md p-4">
-        <div class="flex items-center justify-between mb-3">
+    <section v-if="targetUser && currentStep === 1" class="mb-3">
+      <div class="bg-white rounded-lg shadow p-2">
+        <div class="flex items-center justify-between flex-wrap gap-2 mb-2">
           <div>
-            <h2 class="text-lg font-semibold">1) {{ targetUser.username }}'s Collection</h2>
-            <span class="text-xs text-gray-500">Select one or more</span>
+            <h2 class="text-sm font-semibold">1) {{ targetUser.username }}'s Collection</h2>
+            <span class="text-[10px] text-gray-500">Select one or more</span>
           </div>
           <button
-            class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
             @click="currentStep = 2"
           >
             Next
@@ -114,7 +115,7 @@
         <div v-if="loading.target" class="py-16 text-center text-gray-500">Loading...</div>
         <div v-else>
           <EmptyState v-if="!targetItems.length" label="No cToons match your filters" />
-          <div v-else class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4">
+          <div v-else class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-2">
             <CtoonCard
               v-for="c in targetItems"
               :key="c.id"
@@ -128,20 +129,20 @@
           </div>
 
           <!-- Pagination -->
-          <div v-if="targetTotalPages > 1" class="mt-4 flex items-center justify-center gap-3">
+          <div v-if="targetTotalPages > 1" class="mt-3 flex items-center justify-center gap-2">
             <button
-              class="px-3 py-1 rounded border hover:bg-gray-50 disabled:opacity-50"
+              class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50 disabled:opacity-50"
               :disabled="targetPage === 1"
               @click="fetchTargetPage(targetPage - 1)"
             >
               Previous
             </button>
-            <span class="text-sm text-gray-600">
+            <span class="text-xs text-gray-600">
               Page {{ targetPage }} of {{ targetTotalPages }}
               <span class="text-gray-400">({{ targetTotal }} total)</span>
             </span>
             <button
-              class="px-3 py-1 rounded border hover:bg-gray-50 disabled:opacity-50"
+              class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50 disabled:opacity-50"
               :disabled="targetPage >= targetTotalPages"
               @click="fetchTargetPage(targetPage + 1)"
             >
@@ -150,9 +151,9 @@
           </div>
         </div>
 
-        <div class="mt-4 flex justify-end">
+        <div class="mt-3 flex justify-end">
           <button
-            class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
             @click="currentStep = 2"
           >
             Next
@@ -162,13 +163,13 @@
     </section>
 
     <!-- STEP 2: Official collection -->
-    <section v-if="targetUser && currentStep === 2" class="mb-6">
-      <div class="bg-white rounded-xl shadow-md p-4">
-        <div class="flex items-center justify-between mb-3">
-          <h2 class="text-lg font-semibold">2) {{ officialUsername }}'s Collection</h2>
-          <div class="flex items-center gap-3">
+    <section v-if="targetUser && currentStep === 2" class="mb-3">
+      <div class="bg-white rounded-lg shadow p-2">
+        <div class="flex items-center justify-between flex-wrap gap-2 mb-2">
+          <h2 class="text-sm font-semibold">2) {{ officialUsername }}'s Collection</h2>
+          <div class="flex items-center gap-2">
             <button
-              class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white disabled:opacity-50"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
               :disabled="!hasAnySelection"
               @click="currentStep = 3"
             >
@@ -206,11 +207,11 @@
               class="h-4 w-4 border rounded"
               @change="fetchOfficialPage(1)"
             />
-            <span class="text-base md:text-lg font-medium">Show Their Wishlist cToons</span>
+            <span class="text-xs font-medium">Show Their Wishlist cToons</span>
           </label>
 
-          <span v-if="loadingWishlist" class="text-xs text-gray-600">Loading...</span>
-          <span v-else-if="targetWishlistIds.size === 0" class="text-xs text-gray-600">
+          <span v-if="loadingWishlist" class="text-[10px] text-gray-600">Loading...</span>
+          <span v-else-if="targetWishlistIds.size === 0" class="text-[10px] text-gray-600">
             {{ targetUser.username }} has no wishlist items.
           </span>
         </FilterBar>
@@ -223,7 +224,7 @@
               ? `No cToons from ${targetUser?.username ?? 'user'}'s Wishlist in ${officialUsername}'s collection`
               : 'No cToons match your filters'"
           />
-          <div v-else class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4">
+          <div v-else class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-2">
             <CtoonCard
               v-for="c in officialItems"
               :key="c.id"
@@ -237,20 +238,20 @@
           </div>
 
           <!-- Pagination -->
-          <div v-if="officialTotalPages > 1" class="mt-4 flex items-center justify-center gap-3">
+          <div v-if="officialTotalPages > 1" class="mt-3 flex items-center justify-center gap-2">
             <button
-              class="px-3 py-1 rounded border hover:bg-gray-50 disabled:opacity-50"
+              class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50 disabled:opacity-50"
               :disabled="officialPage === 1"
               @click="fetchOfficialPage(officialPage - 1)"
             >
               Previous
             </button>
-            <span class="text-sm text-gray-600">
+            <span class="text-xs text-gray-600">
               Page {{ officialPage }} of {{ officialTotalPages }}
               <span class="text-gray-400">({{ officialTotal }} total)</span>
             </span>
             <button
-              class="px-3 py-1 rounded border hover:bg-gray-50 disabled:opacity-50"
+              class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50 disabled:opacity-50"
               :disabled="officialPage >= officialTotalPages"
               @click="fetchOfficialPage(officialPage + 1)"
             >
@@ -259,10 +260,10 @@
           </div>
         </div>
 
-        <div class="mt-4 flex items-center justify-between">
-          <button class="px-3 py-2 rounded border hover:bg-gray-50" @click="currentStep = 1">Back</button>
+        <div class="mt-3 flex items-center justify-between">
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="currentStep = 1">Back</button>
           <button
-            class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white disabled:opacity-50"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
             :disabled="!hasAnySelection"
             @click="currentStep = 3"
           >
@@ -273,24 +274,24 @@
     </section>
 
     <!-- STEP 3: Confirm Offer -->
-    <section v-if="targetUser && currentStep === 3" class="mb-6">
-      <div class="bg-white rounded-xl shadow-md p-4">
-        <div class="flex items-center justify-between mb-3">
+    <section v-if="targetUser && currentStep === 3" class="mb-3">
+      <div class="bg-white rounded-lg shadow p-2">
+        <div class="flex items-center justify-between mb-2">
           <div>
-            <h2 class="text-lg font-semibold">3) Confirm Offer</h2>
-            <span class="text-xs text-gray-500">Review before sending</span>
+            <h2 class="text-sm font-semibold">3) Confirm Offer</h2>
+            <span class="text-[10px] text-gray-500">Review before sending</span>
           </div>
         </div>
 
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
           <!-- Requested from other user -->
           <div>
-            <h3 class="font-semibold mb-2">Requesting from {{ targetUser.username }}</h3>
-            <div v-if="!selectedTargetCtoons.length" class="text-sm text-gray-600">
+            <h3 class="text-xs font-semibold mb-1.5">Requesting from {{ targetUser.username }}</h3>
+            <div v-if="!selectedTargetCtoons.length" class="text-xs text-gray-600">
               No cToons selected from {{ targetUser.username }}.
             </div>
-            <div v-else class="grid grid-cols-2 md:grid-cols-3 gap-3">
-              <div v-for="c in selectedTargetCtoons" :key="c.id" class="border rounded p-2">
+            <div v-else class="grid grid-cols-2 md:grid-cols-3 gap-2">
+              <div v-for="c in selectedTargetCtoons" :key="c.id" class="border rounded-md p-2">
                 <img :src="c.assetPath" :alt="c.name" class="w-full h-24 object-contain mb-1" />
                 <p class="text-xs font-medium truncate">{{ c.name }}</p>
                 <p class="text-[11px] text-gray-600">{{ c.rarity }}</p>
@@ -300,12 +301,12 @@
 
           <!-- Offering -->
           <div>
-            <h3 class="font-semibold mb-2">Offering from {{ officialUsername }}</h3>
-            <div v-if="!selectedOfficialCtoons.length" class="text-sm text-gray-600">
+            <h3 class="text-xs font-semibold mb-1.5">Offering from {{ officialUsername }}</h3>
+            <div v-if="!selectedOfficialCtoons.length" class="text-xs text-gray-600">
               No cToons offered.
             </div>
-            <div v-else class="grid grid-cols-2 md:grid-cols-3 gap-3">
-              <div v-for="c in selectedOfficialCtoons" :key="c.id" class="border rounded p-2">
+            <div v-else class="grid grid-cols-2 md:grid-cols-3 gap-2">
+              <div v-for="c in selectedOfficialCtoons" :key="c.id" class="border rounded-md p-2">
                 <img :src="c.assetPath" :alt="c.name" class="w-full h-24 object-contain mb-1" />
                 <p class="text-xs font-medium truncate">{{ c.name }}</p>
                 <p class="text-[11px] text-gray-600">{{ c.rarity }}</p>
@@ -314,10 +315,10 @@
           </div>
         </div>
 
-        <div class="mt-6 flex items-center justify-between">
-          <button class="px-3 py-2 rounded border hover:bg-gray-50" @click="currentStep = 2">Back</button>
+        <div class="mt-4 flex items-center justify-between">
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="currentStep = 2">Back</button>
           <button
-            class="px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-700 text-white disabled:opacity-50"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
             :disabled="!hasAnySelection || makingOffer"
             @click="sendOffer"
           >
@@ -330,10 +331,11 @@
 
     <!-- Toast -->
     <transition name="fade">
-      <div v-if="toast.show" class="fixed bottom-4 right-4 bg-black text-white px-4 py-2 rounded shadow">
+      <div v-if="toast.show" class="fixed bottom-4 right-4 bg-black text-white px-3 py-2 rounded-md shadow text-xs">
         {{ toast.message }}
       </div>
     </transition>
+    </div>
   </div>
 </template>
 

--- a/components/newsite/admin/legacy/AdminLegacyLotto.vue
+++ b/components/newsite/admin/legacy/AdminLegacyLotto.vue
@@ -1,47 +1,48 @@
 <template>
-  <div class="bg-gray-100 p-6 ">
-    <h1 class="text-3xl font-bold mb-6">Admin: Manage Lotto</h1>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+    <h1 class="text-base font-semibold mb-3">Admin: Manage Lotto</h1>
 
-    <div class="bg-white rounded-lg shadow-md p-6 max-w-2xl mx-auto">
-      <p class="text-sm text-gray-600 mb-4">View and update Lotto configuration values.</p>
+    <div class="bg-white rounded border p-3 max-w-2xl">
+      <p class="text-xs text-gray-600 mb-3">View and update Lotto configuration values.</p>
 
-      <div class="grid grid-cols-1 gap-4">
-        <div class="grid grid-cols-2 gap-4">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Base Odds</label>
-            <input type="number" step="0.01" class="input" v-model.number="baseOdds" />
-            <p class="text-xs text-gray-500 mt-1">Default: 1.00</p>
+      <div class="grid grid-cols-1 gap-3">
+        <div class="grid sm:grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Base Odds</label>
+            <input type="number" step="0.01" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="baseOdds" />
+            <p class="text-[10px] text-gray-500">Default: 1.00</p>
           </div>
 
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Increment Rate</label>
-            <input type="number" step="0.001" class="input" v-model.number="incrementRate" />
-            <p class="text-xs text-gray-500 mt-1">Default: 0.02</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Increment Rate</label>
+            <input type="number" step="0.001" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="incrementRate" />
+            <p class="text-[10px] text-gray-500">Default: 0.02</p>
           </div>
 
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Count Per Day</label>
-            <input type="number" class="input" v-model.number="countPerDay" />
-            <p class="text-xs text-gray-500 mt-1">Default: 5</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Count Per Day</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="countPerDay" />
+            <p class="text-[10px] text-gray-500">Default: 5</p>
           </div>
 
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Cost</label>
-            <input type="number" class="input" v-model.number="cost" />
-            <p class="text-xs text-gray-500 mt-1">Default: 50</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Cost</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="cost" />
+            <p class="text-[10px] text-gray-500">Default: 50</p>
           </div>
 
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Points Awarded on Win</label>
-            <input type="number" class="input" v-model.number="lottoPointsWinnings" />
-            <p class="text-xs text-gray-500 mt-1">Default: 5000</p>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Points Awarded on Win</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" v-model.number="lottoPointsWinnings" />
+            <p class="text-[10px] text-gray-500">Default: 5000</p>
           </div>
         </div>
 
         <!-- cToon Prize Pool -->
-        <div class="col-span-2 mt-6">
-          <h2 class="text-xl font-semibold mb-2">cToon Prize Pool</h2>
-          <p class="text-sm text-gray-600 mb-4">Search for cToons to add to the lottery prize pool. When a user wins, they will receive points AND one cToon randomly selected from this pool.</p>
+        <div class="mt-2">
+          <h2 class="text-xs font-semibold mb-1">cToon Prize Pool</h2>
+          <p class="text-[11px] text-gray-600 mb-2">Search for cToons to add to the lottery prize pool. When a user wins, they will receive points AND one cToon randomly selected from this pool.</p>
 
           <!-- Search Input -->
           <div class="relative">
@@ -49,24 +50,24 @@
               type="text"
               v-model="ctoonSearchTerm"
               placeholder="Search by name, rarity, or set..."
-              class="input w-full"
+              class="w-full border rounded-md px-2 py-1.5 text-sm"
               @focus="searchFocused = true"
               @blur="searchFocused = false"
             />
             <!-- Search Results Dropdown -->
             <ul v-if="ctoonSearchTerm && searchFocused" class="absolute z-10 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
-              <li v-if="searchingCtoons" class="px-3 py-2 text-gray-500">Searching...</li>
-              <li v-else-if="!ctoonSearchResults.length" class="px-3 py-2 text-gray-500">No results found.</li>
+              <li v-if="searchingCtoons" class="px-2 py-1.5 text-gray-500 text-[11px]">Searching...</li>
+              <li v-else-if="!ctoonSearchResults.length" class="px-2 py-1.5 text-gray-500 text-[11px]">No results found.</li>
               <li
                 v-for="ctoon in ctoonSearchResults"
                 :key="ctoon.id"
-                class="px-3 py-2 hover:bg-gray-100 cursor-pointer flex items-center gap-3"
+                class="px-2 py-1.5 hover:bg-gray-50 cursor-pointer flex items-center gap-2"
                 @mousedown.prevent="addCtoonToPool(ctoon)"
               >
-                <img :src="ctoon.assetPath" class="h-10 w-auto rounded" />
+                <img :src="ctoon.assetPath" class="h-8 w-auto rounded" />
                 <div>
-                  <p class="font-medium">{{ ctoon.name }}</p>
-                  <p class="text-xs text-gray-500">{{ ctoon.rarity }} • {{ ctoon.set }}</p>
+                  <p class="font-medium text-xs">{{ ctoon.name }}</p>
+                  <p class="text-[10px] text-gray-500">{{ ctoon.rarity }} • {{ ctoon.set }}</p>
                 </div>
               </li>
             </ul>
@@ -74,30 +75,31 @@
         </div>
 
         <!-- Selected Pool -->
-        <div class="col-span-2 mt-2 space-y-2">
-          <div v-for="ctoon in ctoonPool" :key="ctoon.id" class="flex items-center justify-between bg-gray-50 p-2 rounded">
-            <div class="flex items-center gap-3">
-              <img :src="ctoon.assetPath" class="h-10 w-auto rounded" />
+        <div class="mt-1 space-y-1">
+          <div v-for="ctoon in ctoonPool" :key="ctoon.id" class="flex items-center justify-between bg-white border rounded-md p-2">
+            <div class="flex items-center gap-2">
+              <img :src="ctoon.assetPath" class="h-8 w-auto rounded" />
               <div>
-                <p class="font-medium">{{ ctoon.name }}</p>
-                <p class="text-xs" :class="ctoon.inCmart ? 'text-green-600' : 'text-blue-600'">
+                <p class="font-medium text-xs">{{ ctoon.name }}</p>
+                <p class="text-[10px]" :class="ctoon.inCmart ? 'text-green-600' : 'text-blue-600'">
                   <span v-if="ctoon.inCmart">In cMart</span>
                   <span v-else>Not in cMart</span>
                   <span v-if="ctoon.quantity !== null"> • {{ ctoon.quantity === TIME_BASED_CAP ? '???' : ctoon.quantity - ctoon.totalMinted }} remaining</span>
                 </p>
               </div>
             </div>
-            <button @click="removeCtoonFromPool(ctoon.id)" class="text-red-500 hover:text-red-700 text-sm">Remove</button>
+            <button @click="removeCtoonFromPool(ctoon.id)" class="text-red-700 hover:underline text-[11px]">Remove</button>
           </div>
         </div>
-        <div class="pt-2">
-          <button class="btn-primary" :disabled="saving" @click="save">{{ saving ? 'Saving…' : 'Apply' }}</button>
+        <div class="pt-1">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="saving" @click="save">{{ saving ? 'Saving…' : 'Apply' }}</button>
         </div>
 
-        <div v-if="toast" :class="['rounded px-3 py-2', toast.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700']">
+        <div v-if="toast" :class="['rounded-md px-2 py-1.5 text-xs', toast.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700']">
           {{ toast.msg }}
         </div>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyMonsters.vue
+++ b/components/newsite/admin/legacy/AdminLegacyMonsters.vue
@@ -1,71 +1,74 @@
 <template>
-  <div class="bg-gray-100 p-6 ">
-    <h1 class="text-3xl font-bold mb-6">Admin: Manage Barcode Monsters</h1>
+  <div class="admin-legacy-monsters bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+    <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+      <h1 class="text-base font-semibold">Admin: Manage Barcode Monsters</h1>
+    </div>
 
-    <div class="bg-white rounded-lg shadow-md p-6 max-w-6xl mx-auto">
+    <div class="bg-white rounded border shadow p-3 max-w-6xl mx-auto">
       <!-- Tabs -->
-      <div class="border-b mb-6">
-        <nav class="flex flex-wrap gap-2 sm:gap-4">
-          <button class="px-3 py-2 border-b-2 text-sm sm:text-base whitespace-nowrap" :class="activeTab==='Game Config' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'" @click="activeTab='Game Config'">Game Config</button>
-          <button class="px-3 py-2 border-b-2 text-sm sm:text-base whitespace-nowrap" :class="activeTab==='Monsters' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'" @click="activeTab='Monsters'">Monsters</button>
-          <button class="px-3 py-2 border-b-2 text-sm sm:text-base whitespace-nowrap" :class="activeTab==='AI Monsters' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'" @click="activeTab='AI Monsters'">AI Monsters</button>
-          <button class="px-3 py-2 border-b-2 text-sm sm:text-base whitespace-nowrap" :class="activeTab==='Items' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'" @click="activeTab='Items'">Items</button>
+      <div class="border-b mb-3">
+        <nav class="flex flex-wrap gap-1">
+          <button class="px-3 py-1.5 text-xs border-b-2 whitespace-nowrap" :class="activeTab==='Game Config' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'" @click="activeTab='Game Config'">Game Config</button>
+          <button class="px-3 py-1.5 text-xs border-b-2 whitespace-nowrap" :class="activeTab==='Monsters' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'" @click="activeTab='Monsters'">Monsters</button>
+          <button class="px-3 py-1.5 text-xs border-b-2 whitespace-nowrap" :class="activeTab==='AI Monsters' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'" @click="activeTab='AI Monsters'">AI Monsters</button>
+          <button class="px-3 py-1.5 text-xs border-b-2 whitespace-nowrap" :class="activeTab==='Items' ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500'" @click="activeTab='Items'">Items</button>
         </nav>
       </div>
 
       <!-- Game Config -->
-      <section v-if="activeTab==='Game Config'" class="space-y-8">
-        <div class="text-sm text-gray-600">
+      <section v-if="activeTab==='Game Config'" class="space-y-6">
+        <div class="text-xs text-gray-600">
           Configure scanning odds and rarity distribution for the active barcode game version. Changes affect future scans immediately.
         </div>
 
         <!-- Odds -->
         <div>
-          <h2 class="text-lg font-semibold mb-2">Scan Outcome Odds</h2>
-          <p class="text-sm text-gray-600 mb-3">Odds must sum to 1.00. These control the chance of a scan yielding nothing, an item, or a monster.</p>
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <h2 class="text-xs font-semibold mb-2">Scan Outcome Odds</h2>
+          <p class="text-xs text-gray-600 mb-2">Odds must sum to 1.00. These control the chance of a scan yielding nothing, an item, or a monster.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Odds — Nothing</label>
-              <input type="number" class="input" step="0.01" min="0" max="1" v-model.number="oddsNothing" />
+              <label class="block text-xs font-medium">Odds — Nothing</label>
+              <input type="number" class="border rounded-md px-2 py-1.5 text-sm" step="0.01" min="0" max="1" v-model.number="oddsNothing" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Odds — Item</label>
-              <input type="number" class="input" step="0.01" min="0" max="1" v-model.number="oddsItem" />
+              <label class="block text-xs font-medium">Odds — Item</label>
+              <input type="number" class="border rounded-md px-2 py-1.5 text-sm" step="0.01" min="0" max="1" v-model.number="oddsItem" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Odds — Monster</label>
-              <input type="number" class="input" step="0.01" min="0" max="1" v-model.number="oddsMonster" />
+              <label class="block text-xs font-medium">Odds — Monster</label>
+              <input type="number" class="border rounded-md px-2 py-1.5 text-sm" step="0.01" min="0" max="1" v-model.number="oddsMonster" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700">Odds — Battle</label>
-              <input type="number" class="input" step="0.01" min="0" max="1" v-model.number="oddsBattle" />
+              <label class="block text-xs font-medium">Odds — Battle</label>
+              <input type="number" class="border rounded-md px-2 py-1.5 text-sm" step="0.01" min="0" max="1" v-model.number="oddsBattle" />
             </div>
           </div>
           <div class="text-xs mt-1" :class="sumOddsOk ? 'text-green-700' : 'text-red-700'">Sum: {{ sumOddsDisplay }}</div>
         </div>
 
         <!-- Distributions: side-by-side on large screens, stacked on mobile -->
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
           <!-- Monster Rarity Distribution -->
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
-            <h2 class="text-lg font-semibold mb-2">Monster Rarity Distribution</h2>
-            <p class="text-sm text-gray-600 mb-3">Percentages per monster rarity. Values are normalized; higher values increase selection odds when a scan yields a monster.</p>
+          <div class="rounded border p-3">
+            <h2 class="text-xs font-semibold mb-2">Monster Rarity Distribution</h2>
+            <p class="text-xs text-gray-600 mb-2">Percentages per monster rarity. Values are normalized; higher values increase selection odds when a scan yields a monster.</p>
             <!-- Desktop table -->
             <div class="overflow-x-auto hidden sm:block">
               <table class="min-w-full border-separate border-spacing-y-1">
                 <thead>
-                  <tr class="text-left text-sm text-gray-600">
-                    <th class="px-3 py-2">Rarity</th>
-                    <th class="px-3 py-2">Percent</th>
+                  <tr class="">
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Rarity</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Percent</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr v-for="r in rarityDisplayOrder" :key="r.key" class="bg-white">
-                    <td class="px-3 py-2 font-medium">{{ r.label }}</td>
-                    <td class="px-3 py-2 w-48">
+                    <td class="px-2 py-1.5 font-medium">{{ r.label }}</td>
+                    <td class="px-2 py-1.5 w-40">
                       <div class="flex items-center gap-2">
-                        <input type="number" class="input" min="0" max="100" step="1" v-model.number="rarityPercents[r.key]" />
-                        <span class="text-sm text-gray-600">%</span>
+                        <input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" step="1" v-model.number="rarityPercents[r.key]" />
+                        <span class="text-xs text-gray-600">%</span>
                       </div>
                     </td>
                   </tr>
@@ -73,95 +76,95 @@
               </table>
             </div>
             <!-- Mobile cards -->
-            <div class="space-y-3 sm:hidden">
-              <div v-for="r in rarityDisplayOrder" :key="r.key" class="rounded-lg border border-gray-200 bg-white px-4 py-3">
-                <div class="font-semibold text-gray-800 mb-2">{{ r.label }}</div>
+            <div class="space-y-2 sm:hidden">
+              <div v-for="r in rarityDisplayOrder" :key="r.key" class="bg-white border rounded-lg shadow p-2">
+                <div class="font-semibold text-xs text-gray-800 mb-2">{{ r.label }}</div>
                 <div class="flex items-center gap-2">
-                  <input type="number" class="input" min="0" max="100" step="1" v-model.number="rarityPercents[r.key]" />
-                  <span class="text-sm text-gray-600">%</span>
+                  <input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" step="1" v-model.number="rarityPercents[r.key]" />
+                  <span class="text-xs text-gray-600">%</span>
                 </div>
               </div>
             </div>
           </div>
 
           <!-- Item Rarity Distribution -->
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
-            <h2 class="text-lg font-semibold mb-2">Item Rarity Distribution</h2>
-            <p class="text-sm text-gray-600 mb-3">Percentages per item rarity. Item selection happens in two steps: pick rarity based on these weights, then pick uniformly among items of that rarity.</p>
+          <div class="rounded border p-3">
+            <h2 class="text-xs font-semibold mb-2">Item Rarity Distribution</h2>
+            <p class="text-xs text-gray-600 mb-2">Percentages per item rarity. Item selection happens in two steps: pick rarity based on these weights, then pick uniformly among items of that rarity.</p>
             <!-- Desktop table -->
             <div class="overflow-x-auto hidden sm:block">
               <table class="min-w-full border-separate border-spacing-y-1">
                 <thead>
-                  <tr class="text-left text-sm text-gray-600">
-                    <th class="px-3 py-2">Rarity</th>
-                    <th class="px-3 py-2">Percent</th>
+                  <tr class="">
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Rarity</th>
+                    <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Percent</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr class="bg-white">
-                    <td class="px-3 py-2 font-medium">Crazy Rare</td>
-                    <td class="px-3 py-2 w-48"><div class="flex items-center gap-2"><input type="number" class="input" min="0" max="100" step="1" v-model.number="itemRarityPercents.CrazyRare" /><span class="text-sm text-gray-600">%</span></div></td>
+                    <td class="px-2 py-1.5 font-medium">Crazy Rare</td>
+                    <td class="px-2 py-1.5 w-40"><div class="flex items-center gap-2"><input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" step="1" v-model.number="itemRarityPercents.CrazyRare" /><span class="text-xs text-gray-600">%</span></div></td>
                   </tr>
                   <tr class="bg-white">
-                    <td class="px-3 py-2 font-medium">Rare</td>
-                    <td class="px-3 py-2 w-48"><div class="flex items-center gap-2"><input type="number" class="input" min="0" max="100" step="1" v-model.number="itemRarityPercents.Rare" /><span class="text-sm text-gray-600">%</span></div></td>
+                    <td class="px-2 py-1.5 font-medium">Rare</td>
+                    <td class="px-2 py-1.5 w-40"><div class="flex items-center gap-2"><input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" step="1" v-model.number="itemRarityPercents.Rare" /><span class="text-xs text-gray-600">%</span></div></td>
                   </tr>
                   <tr class="bg-white">
-                    <td class="px-3 py-2 font-medium">Common</td>
-                    <td class="px-3 py-2 w-48"><div class="flex items-center gap-2"><input type="number" class="input" min="0" max="100" step="1" v-model.number="itemRarityPercents.Common" /><span class="text-sm text-gray-600">%</span></div></td>
+                    <td class="px-2 py-1.5 font-medium">Common</td>
+                    <td class="px-2 py-1.5 w-40"><div class="flex items-center gap-2"><input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" step="1" v-model.number="itemRarityPercents.Common" /><span class="text-xs text-gray-600">%</span></div></td>
                   </tr>
                 </tbody>
               </table>
             </div>
             <!-- Mobile cards -->
-            <div class="space-y-3 sm:hidden">
-              <div class="rounded-lg border border-gray-200 bg-white px-4 py-3">
-                <div class="font-semibold text-gray-800 mb-2">Crazy Rare</div>
-                <div class="flex items-center gap-2"><input type="number" class="input" min="0" max="100" step="1" v-model.number="itemRarityPercents.CrazyRare" /><span class="text-sm text-gray-600">%</span></div>
+            <div class="space-y-2 sm:hidden">
+              <div class="bg-white border rounded-lg shadow p-2">
+                <div class="font-semibold text-xs text-gray-800 mb-2">Crazy Rare</div>
+                <div class="flex items-center gap-2"><input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" step="1" v-model.number="itemRarityPercents.CrazyRare" /><span class="text-xs text-gray-600">%</span></div>
               </div>
-              <div class="rounded-lg border border-gray-200 bg-white px-4 py-3">
-                <div class="font-semibold text-gray-800 mb-2">Rare</div>
-                <div class="flex items-center gap-2"><input type="number" class="input" min="0" max="100" step="1" v-model.number="itemRarityPercents.Rare" /><span class="text-sm text-gray-600">%</span></div>
+              <div class="bg-white border rounded-lg shadow p-2">
+                <div class="font-semibold text-xs text-gray-800 mb-2">Rare</div>
+                <div class="flex items-center gap-2"><input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" step="1" v-model.number="itemRarityPercents.Rare" /><span class="text-xs text-gray-600">%</span></div>
               </div>
-              <div class="rounded-lg border border-gray-200 bg-white px-4 py-3">
-                <div class="font-semibold text-gray-800 mb-2">Common</div>
-                <div class="flex items-center gap-2"><input type="number" class="input" min="0" max="100" step="1" v-model.number="itemRarityPercents.Common" /><span class="text-sm text-gray-600">%</span></div>
+              <div class="bg-white border rounded-lg shadow p-2">
+                <div class="font-semibold text-xs text-gray-800 mb-2">Common</div>
+                <div class="flex items-center gap-2"><input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" step="1" v-model.number="itemRarityPercents.Common" /><span class="text-xs text-gray-600">%</span></div>
               </div>
             </div>
           </div>
         </div>
 
         <!-- Variance, Decay, Points, Daily Limit & Cooldown -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
           <div>
-            <label class="block text-sm font-medium text-gray-700">Monster Stat Variance</label>
-            <input type="number" class="input" min="0" max="50" step="1" v-model.number="variancePct" />
+            <label class="block text-xs font-medium">Monster Stat Variance</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="50" step="1" v-model.number="variancePct" />
             <p class="text-xs text-gray-500 mt-1">Percent variability applied per monster instance when rolled (e.g., 12 means ±12%).</p>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700">Inactivity HP Decay (hours)</label>
-            <input type="number" class="input" min="0" max="720" step="1" v-model.number="decayHours" />
+            <label class="block text-xs font-medium">Inactivity HP Decay (hours)</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="720" step="1" v-model.number="decayHours" />
             <p class="text-xs text-gray-500 mt-1">Hours until the last-selected monster reaches 0 HP with no activity. Set to 0 to disable.</p>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700">Scan Points Award</label>
-            <input type="number" class="input" min="0" max="1000000" step="1" v-model.number="scanPoints" />
+            <label class="block text-xs font-medium">Scan Points Award</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="1000000" step="1" v-model.number="scanPoints" />
             <p class="text-xs text-gray-500 mt-1">Points earned for each successful scan. Not counted toward daily point limits.</p>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700">Daily Scan Limit</label>
-            <input type="number" class="input" min="0" max="500" step="1" v-model.number="dailyScanLimit" />
+            <label class="block text-xs font-medium">Daily Scan Limit</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="500" step="1" v-model.number="dailyScanLimit" />
             <p class="text-xs text-gray-500 mt-1">Max scans per user per day. Resets at 8am CST. Set to 0 to disable.</p>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700">Barcode Cooldown (days)</label>
-            <input type="number" class="input" min="0" max="365" step="1" v-model.number="cooldownDays" />
+            <label class="block text-xs font-medium">Barcode Cooldown (days)</label>
+            <input type="number" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="365" step="1" v-model.number="cooldownDays" />
             <p class="text-xs text-gray-500 mt-1">Per-user cooldown per barcode mapping before scanning again grants a result.</p>
           </div>
         </div>
 
         <div>
-          <button class="btn-primary" :disabled="savingCfg || !sumOddsOk" @click="saveConfig">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingCfg || !sumOddsOk" @click="saveConfig">
             <span v-if="!savingCfg">Save</span><span v-else>Saving…</span>
           </button>
         </div>
@@ -169,84 +172,84 @@
 
       <!-- Monsters (Species) -->
       <section v-if="activeTab==='Monsters'" class="space-y-6">
-        <div class="text-sm text-gray-600">Create, edit, and delete species templates. New species indexes are assigned automatically.</div>
+        <div class="text-xs text-gray-600">Create, edit, and delete species templates. New species indexes are assigned automatically.</div>
 
         <!-- Add species toolbar -->
         <div class="flex justify-end">
-          <button class="btn-primary" @click="openAddSpeciesModal">Add Species</button>
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" @click="openAddSpeciesModal">Add Species</button>
         </div>
 
         <!-- Add Species Modal -->
         <transition name="fade">
           <div v-if="showAddSpeciesModal" class="fixed inset-0 z-50">
-            <div class="absolute inset-0 bg-black/40" @click="closeAddSpeciesModal" />
-            <div class="absolute inset-0 flex items-center justify-center p-4">
-              <div class="bg-white w-full max-w-2xl max-h-[90vh] rounded-lg shadow-xl flex flex-col" role="dialog" aria-modal="true" aria-labelledby="addSpeciesTitle">
-                <div class="px-6 py-4 border-b flex items-center justify-between">
-                  <h3 id="addSpeciesTitle" class="text-lg font-semibold">Add Species</h3>
-                  <button class="text-gray-500 hover:text-gray-700" @click="closeAddSpeciesModal" aria-label="Close">✕</button>
+            <div class="absolute inset-0 bg-black/50" @click="closeAddSpeciesModal" />
+            <div class="absolute inset-0 flex items-center justify-center p-2">
+              <div class="bg-white w-full max-w-2xl max-h-[92vh] rounded-lg shadow-lg flex flex-col" role="dialog" aria-modal="true" aria-labelledby="addSpeciesTitle">
+                <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+                  <h3 id="addSpeciesTitle" class="text-sm font-semibold">Add Species</h3>
+                  <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeAddSpeciesModal" aria-label="Close">✕</button>
                 </div>
-                <div class="p-6 space-y-5 flex-1 overflow-y-auto min-h-0">
+                <div class="px-4 py-3 space-y-4 flex-1 overflow-y-auto min-h-0">
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Species Name</label>
-                    <input class="input" placeholder="e.g., Zapling" v-model="newSpecies.name" />
+                    <label class="block text-xs font-medium">Species Name</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" placeholder="e.g., Zapling" v-model="newSpecies.name" />
                     <p class="text-xs text-gray-500 mt-1">Display name used in scan results and owned monster lists.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Monster Type</label>
-                    <input class="input" placeholder="e.g., Electric" v-model="newSpecies.type" />
+                    <label class="block text-xs font-medium">Monster Type</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" placeholder="e.g., Electric" v-model="newSpecies.type" />
                     <p class="text-xs text-gray-500 mt-1">Free-form category (e.g., Fire, Water). Shown to players for flavor and balancing.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Rarity</label>
-                    <select class="input" v-model="newSpecies.rarity">
+                    <label class="block text-xs font-medium">Rarity</label>
+                    <select class="border rounded-md px-2 py-1.5 text-sm" v-model="newSpecies.rarity">
                       <option v-for="r in monsterRarities" :key="r.key" :value="r.key">{{ r.label }}</option>
                     </select>
                     <p class="text-xs text-gray-500 mt-1">Affects how often this species is selected when a scan yields a monster. Final odds also depend on the Game Config rarity distribution.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Base Stats</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Base Stats</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600">Base HP</label>
-                        <input class="input" type="number" min="1" v-model.number="newSpecies.baseHp" />
+                        <label class="block text-xs font-medium">Base HP</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="newSpecies.baseHp" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600">Base ATK</label>
-                        <input class="input" type="number" min="1" v-model.number="newSpecies.baseAtk" />
+                        <label class="block text-xs font-medium">Base ATK</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="newSpecies.baseAtk" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600">Base DEF</label>
-                        <input class="input" type="number" min="1" v-model.number="newSpecies.baseDef" />
+                        <label class="block text-xs font-medium">Base DEF</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="newSpecies.baseDef" />
                       </div>
                     </div>
                     <p class="text-xs text-gray-500 mt-1">Players receive per-instance rolled stats based on these values, varied by the configured variance percent.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Images</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Images</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Walking</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'walking')" />
+                        <label class="block text-xs font-medium mb-1">Walking</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'walking')" />
                         <p class="text-xs text-gray-500 mt-1">PNG/JPG/GIF. Used for walking animation/frame.</p>
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Standing Still</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'standing')" />
+                        <label class="block text-xs font-medium mb-1">Standing Still</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'standing')" />
                         <p class="text-xs text-gray-500 mt-1">PNG/JPG/GIF. Used for idle pose.</p>
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Jumping</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'jumping')" />
+                        <label class="block text-xs font-medium mb-1">Jumping</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onFileChange($event, 'jumping')" />
                         <p class="text-xs text-gray-500 mt-1">PNG/JPG/GIF. Used for jumping animation/frame.</p>
                       </div>
                     </div>
                     <p class="text-xs text-gray-500 mt-2">All three images are required to create a species.</p>
                   </div>
                 </div>
-                <div class="px-6 py-4 border-t flex justify-end gap-2">
-                  <button class="px-3 py-2 rounded border" @click="closeAddSpeciesModal">Cancel</button>
-                  <button class="btn-primary" :disabled="addingSpecies" @click="confirmAddSpecies">
+                <div class="px-4 py-3 border-t flex-shrink-0 flex justify-end gap-2">
+                  <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeAddSpeciesModal">Cancel</button>
+                  <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="addingSpecies" @click="confirmAddSpecies">
                     <span v-if="!addingSpecies">Add Species</span>
                     <span v-else>Adding…</span>
                   </button>
@@ -259,66 +262,66 @@
         <!-- Edit Species Modal -->
         <transition name="fade">
           <div v-if="showEditSpeciesModal" class="fixed inset-0 z-50">
-            <div class="absolute inset-0 bg-black/40" @click="closeEditSpeciesModal" />
-            <div class="absolute inset-0 flex items-center justify-center p-4">
-              <div class="bg-white w-full max-w-2xl max-h-[90vh] rounded-lg shadow-xl flex flex-col" role="dialog" aria-modal="true" aria-labelledby="editSpeciesTitle">
-                <div class="px-6 py-4 border-b flex items-center justify-between">
-                  <h3 id="editSpeciesTitle" class="text-lg font-semibold">Edit Species</h3>
-                  <button class="text-gray-500 hover:text-gray-700" @click="closeEditSpeciesModal" aria-label="Close">✕</button>
+            <div class="absolute inset-0 bg-black/50" @click="closeEditSpeciesModal" />
+            <div class="absolute inset-0 flex items-center justify-center p-2">
+              <div class="bg-white w-full max-w-2xl max-h-[92vh] rounded-lg shadow-lg flex flex-col" role="dialog" aria-modal="true" aria-labelledby="editSpeciesTitle">
+                <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+                  <h3 id="editSpeciesTitle" class="text-sm font-semibold">Edit Species</h3>
+                  <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeEditSpeciesModal" aria-label="Close">✕</button>
                 </div>
-                <div class="p-6 space-y-5 flex-1 overflow-y-auto min-h-0">
+                <div class="px-4 py-3 space-y-4 flex-1 overflow-y-auto min-h-0">
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Species Name</label>
-                    <input class="input" v-model="editSpecies.name" />
+                    <label class="block text-xs font-medium">Species Name</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" v-model="editSpecies.name" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Monster Type</label>
-                    <input class="input" v-model="editSpecies.type" />
+                    <label class="block text-xs font-medium">Monster Type</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" v-model="editSpecies.type" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Rarity</label>
-                    <select class="input" v-model="editSpecies.rarity">
+                    <label class="block text-xs font-medium">Rarity</label>
+                    <select class="border rounded-md px-2 py-1.5 text-sm" v-model="editSpecies.rarity">
                       <option v-for="r in monsterRarities" :key="r.key" :value="r.key">{{ r.label }}</option>
                     </select>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Base Stats</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Base Stats</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600">Base HP</label>
-                        <input class="input" type="number" min="1" v-model.number="editSpecies.baseHp" />
+                        <label class="block text-xs font-medium">Base HP</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="editSpecies.baseHp" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600">Base ATK</label>
-                        <input class="input" type="number" min="1" v-model.number="editSpecies.baseAtk" />
+                        <label class="block text-xs font-medium">Base ATK</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="editSpecies.baseAtk" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600">Base DEF</label>
-                        <input class="input" type="number" min="1" v-model.number="editSpecies.baseDef" />
+                        <label class="block text-xs font-medium">Base DEF</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="editSpecies.baseDef" />
                       </div>
                     </div>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Replace Images (optional)</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Replace Images (optional)</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Walking</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditSpeciesFileChange($event, 'walking')" />
+                        <label class="block text-xs font-medium mb-1">Walking</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditSpeciesFileChange($event, 'walking')" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Standing Still</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditSpeciesFileChange($event, 'standing')" />
+                        <label class="block text-xs font-medium mb-1">Standing Still</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditSpeciesFileChange($event, 'standing')" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Jumping</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditSpeciesFileChange($event, 'jumping')" />
+                        <label class="block text-xs font-medium mb-1">Jumping</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditSpeciesFileChange($event, 'jumping')" />
                       </div>
                     </div>
                   </div>
                 </div>
-                <div class="px-6 py-4 border-t flex justify-end gap-2">
-                  <button class="px-3 py-2 rounded border" @click="closeEditSpeciesModal">Cancel</button>
-                  <button class="btn-primary" :disabled="savingSpecies" @click="saveSpecies(editSpeciesIndex)">Save</button>
+                <div class="px-4 py-3 border-t flex-shrink-0 flex justify-end gap-2">
+                  <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeEditSpeciesModal">Cancel</button>
+                  <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingSpecies" @click="saveSpecies(editSpeciesIndex)">Save</button>
                 </div>
               </div>
             </div>
@@ -329,30 +332,30 @@
         <div class="overflow-x-auto hidden sm:block">
           <table class="min-w-full border-separate border-spacing-y-1">
             <thead>
-              <tr class="text-left text-sm text-gray-600">
-                <th class="px-3 py-2">Index</th>
-                <th class="px-3 py-2">Name</th>
-                <th class="px-3 py-2">Type</th>
-                <th class="px-3 py-2">Rarity</th>
-                <th class="px-3 py-2">Base HP</th>
-                <th class="px-3 py-2">Base ATK</th>
-                <th class="px-3 py-2">Base DEF</th>
-                <th class="px-3 py-2">Actions</th>
+              <tr class="">
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Index</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Name</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Type</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Rarity</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Base HP</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Base ATK</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Base DEF</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Actions</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="s in species" :key="s.speciesIndex" class="bg-gray-50">
-                <td class="px-3 py-2">{{ s.speciesIndex }}</td>
-                <td class="px-3 py-2">{{ s.name }}</td>
-                <td class="px-3 py-2">{{ s.type }}</td>
-                <td class="px-3 py-2 w-48">{{ rarityLabel(s.rarity) }}</td>
-                <td class="px-3 py-2 w-28">{{ s.baseHp }}</td>
-                <td class="px-3 py-2 w-28">{{ s.baseAtk }}</td>
-                <td class="px-3 py-2 w-28">{{ s.baseDef }}</td>
-                <td class="px-3 py-2">
+                <td class="px-2 py-1.5">{{ s.speciesIndex }}</td>
+                <td class="px-2 py-1.5">{{ s.name }}</td>
+                <td class="px-2 py-1.5">{{ s.type }}</td>
+                <td class="px-2 py-1.5 w-40">{{ rarityLabel(s.rarity) }}</td>
+                <td class="px-2 py-1.5 w-24">{{ s.baseHp }}</td>
+                <td class="px-2 py-1.5 w-24">{{ s.baseAtk }}</td>
+                <td class="px-2 py-1.5 w-24">{{ s.baseDef }}</td>
+                <td class="px-2 py-1.5">
                   <div class="flex gap-2">
-                    <button class="px-3 py-2 rounded border" @click="startEditSpecies(s)">Edit</button>
-                    <button class="px-3 py-2 rounded border border-red-300 text-red-600" @click="removeSpecies(s.speciesIndex)" :disabled="deletingSpecies">Delete</button>
+                    <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="startEditSpecies(s)">Edit</button>
+                    <button class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="removeSpecies(s.speciesIndex)" :disabled="deletingSpecies">Delete</button>
                   </div>
                 </td>
               </tr>
@@ -360,17 +363,17 @@
           </table>
         </div>
         <!-- Mobile cards -->
-        <div class="space-y-3 sm:hidden">
-          <div v-for="s in species" :key="s.speciesIndex" class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+        <div class="space-y-2 sm:hidden">
+          <div v-for="s in species" :key="s.speciesIndex" class="rounded border p-2">
             <div class="flex justify-between items-center">
-              <div class="font-semibold text-gray-800">#{{ s.speciesIndex }} — {{ s.name }}</div>
-              <div class="text-sm text-gray-600">{{ rarityLabel(s.rarity) }}</div>
+              <div class="font-semibold text-xs text-gray-800">#{{ s.speciesIndex }} — {{ s.name }}</div>
+              <div class="text-xs text-gray-600">{{ rarityLabel(s.rarity) }}</div>
             </div>
-            <div class="text-sm text-gray-700">Type: {{ s.type }}</div>
-            <div class="text-sm text-gray-700">Stats: HP {{ s.baseHp }} • ATK {{ s.baseAtk }} • DEF {{ s.baseDef }}</div>
+            <div class="text-xs text-gray-700">Type: {{ s.type }}</div>
+            <div class="text-xs text-gray-700">Stats: HP {{ s.baseHp }} • ATK {{ s.baseAtk }} • DEF {{ s.baseDef }}</div>
             <div class="mt-3 flex gap-2">
-              <button class="px-3 py-2 rounded border" @click="startEditSpecies(s)">Edit</button>
-              <button class="px-3 py-2 rounded border border-red-300 text-red-600" @click="removeSpecies(s.speciesIndex)">Delete</button>
+              <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="startEditSpecies(s)">Edit</button>
+              <button class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="removeSpecies(s.speciesIndex)">Delete</button>
             </div>
           </div>
         </div>
@@ -378,74 +381,74 @@
 
       <!-- AI Monsters -->
       <section v-if="activeTab==='AI Monsters'" class="space-y-6">
-        <div class="text-sm text-gray-600">Create, edit, and delete AI monster templates used for battles.</div>
+        <div class="text-xs text-gray-600">Create, edit, and delete AI monster templates used for battles.</div>
 
         <div class="flex justify-end">
-          <button class="btn-primary" @click="openAddAiMonsterModal">Add AI Monster</button>
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" @click="openAddAiMonsterModal">Add AI Monster</button>
         </div>
 
         <transition name="fade">
           <div v-if="showAddAiMonsterModal" class="fixed inset-0 z-50">
-            <div class="absolute inset-0 bg-black/40" @click="closeAddAiMonsterModal" />
-            <div class="absolute inset-0 flex items-center justify-center p-4">
-              <div class="bg-white w-full max-w-2xl max-h-[90vh] rounded-lg shadow-xl flex flex-col" role="dialog" aria-modal="true" aria-labelledby="addAiMonsterTitle">
-                <div class="px-6 py-4 border-b flex items-center justify-between">
-                  <h3 id="addAiMonsterTitle" class="text-lg font-semibold">Add AI Monster</h3>
-                  <button class="text-gray-500 hover:text-gray-700" @click="closeAddAiMonsterModal" aria-label="Close">✕</button>
+            <div class="absolute inset-0 bg-black/50" @click="closeAddAiMonsterModal" />
+            <div class="absolute inset-0 flex items-center justify-center p-2">
+              <div class="bg-white w-full max-w-2xl max-h-[92vh] rounded-lg shadow-lg flex flex-col" role="dialog" aria-modal="true" aria-labelledby="addAiMonsterTitle">
+                <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+                  <h3 id="addAiMonsterTitle" class="text-sm font-semibold">Add AI Monster</h3>
+                  <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeAddAiMonsterModal" aria-label="Close">✕</button>
                 </div>
-                <div class="p-6 space-y-5 flex-1 overflow-y-auto min-h-0">
+                <div class="px-4 py-3 space-y-4 flex-1 overflow-y-auto min-h-0">
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Name</label>
-                    <input class="input" placeholder="e.g., Shockjaw" v-model="newAiMonster.name" />
+                    <label class="block text-xs font-medium">Name</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" placeholder="e.g., Shockjaw" v-model="newAiMonster.name" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Monster Type</label>
-                    <input class="input" placeholder="e.g., Electric" v-model="newAiMonster.type" />
+                    <label class="block text-xs font-medium">Monster Type</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" placeholder="e.g., Electric" v-model="newAiMonster.type" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Rarity</label>
-                    <select class="input" v-model="newAiMonster.rarity">
+                    <label class="block text-xs font-medium">Rarity</label>
+                    <select class="border rounded-md px-2 py-1.5 text-sm" v-model="newAiMonster.rarity">
                       <option v-for="r in monsterRarities" :key="r.key" :value="r.key">{{ r.label }}</option>
                     </select>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Base Stats</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Base Stats</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600">Base HP</label>
-                        <input class="input" type="number" min="1" v-model.number="newAiMonster.baseHp" />
+                        <label class="block text-xs font-medium">Base HP</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="newAiMonster.baseHp" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600">Base ATK</label>
-                        <input class="input" type="number" min="1" v-model.number="newAiMonster.baseAtk" />
+                        <label class="block text-xs font-medium">Base ATK</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="newAiMonster.baseAtk" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600">Base DEF</label>
-                        <input class="input" type="number" min="1" v-model.number="newAiMonster.baseDef" />
+                        <label class="block text-xs font-medium">Base DEF</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="newAiMonster.baseDef" />
                       </div>
                     </div>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Images</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Images</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Walking</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onAiMonsterFileChange($event, 'walking')" />
+                        <label class="block text-xs font-medium mb-1">Walking</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onAiMonsterFileChange($event, 'walking')" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Standing Still</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onAiMonsterFileChange($event, 'standing')" />
+                        <label class="block text-xs font-medium mb-1">Standing Still</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onAiMonsterFileChange($event, 'standing')" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Jumping</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onAiMonsterFileChange($event, 'jumping')" />
+                        <label class="block text-xs font-medium mb-1">Jumping</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onAiMonsterFileChange($event, 'jumping')" />
                       </div>
                     </div>
                   </div>
                 </div>
-                <div class="px-6 py-4 border-t flex justify-end gap-3">
-                  <button class="px-4 py-2 rounded border" @click="closeAddAiMonsterModal">Cancel</button>
-                  <button class="btn-primary" :disabled="addingAiMonster" @click="confirmAddAiMonster">
+                <div class="px-4 py-3 border-t flex-shrink-0 flex justify-end gap-2">
+                  <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeAddAiMonsterModal">Cancel</button>
+                  <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="addingAiMonster" @click="confirmAddAiMonster">
                     <span v-if="!addingAiMonster">Create</span><span v-else>Saving…</span>
                   </button>
                 </div>
@@ -456,66 +459,66 @@
 
         <transition name="fade">
           <div v-if="showEditAiMonsterModal" class="fixed inset-0 z-50">
-            <div class="absolute inset-0 bg-black/40" @click="closeEditAiMonsterModal" />
-            <div class="absolute inset-0 flex items-center justify-center p-4">
-              <div class="bg-white w-full max-w-2xl max-h-[90vh] rounded-lg shadow-xl flex flex-col" role="dialog" aria-modal="true" aria-labelledby="editAiMonsterTitle">
-                <div class="px-6 py-4 border-b flex items-center justify-between">
-                  <h3 id="editAiMonsterTitle" class="text-lg font-semibold">Edit AI Monster</h3>
-                  <button class="text-gray-500 hover:text-gray-700" @click="closeEditAiMonsterModal" aria-label="Close">✕</button>
+            <div class="absolute inset-0 bg-black/50" @click="closeEditAiMonsterModal" />
+            <div class="absolute inset-0 flex items-center justify-center p-2">
+              <div class="bg-white w-full max-w-2xl max-h-[92vh] rounded-lg shadow-lg flex flex-col" role="dialog" aria-modal="true" aria-labelledby="editAiMonsterTitle">
+                <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+                  <h3 id="editAiMonsterTitle" class="text-sm font-semibold">Edit AI Monster</h3>
+                  <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeEditAiMonsterModal" aria-label="Close">✕</button>
                 </div>
-                <div class="p-6 space-y-5 flex-1 overflow-y-auto min-h-0">
+                <div class="px-4 py-3 space-y-4 flex-1 overflow-y-auto min-h-0">
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Name</label>
-                    <input class="input" v-model="editAiMonster.name" />
+                    <label class="block text-xs font-medium">Name</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" v-model="editAiMonster.name" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Monster Type</label>
-                    <input class="input" v-model="editAiMonster.type" />
+                    <label class="block text-xs font-medium">Monster Type</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" v-model="editAiMonster.type" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Rarity</label>
-                    <select class="input" v-model="editAiMonster.rarity">
+                    <label class="block text-xs font-medium">Rarity</label>
+                    <select class="border rounded-md px-2 py-1.5 text-sm" v-model="editAiMonster.rarity">
                       <option v-for="r in monsterRarities" :key="r.key" :value="r.key">{{ r.label }}</option>
                     </select>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Base Stats</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Base Stats</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600">Base HP</label>
-                        <input class="input" type="number" min="1" v-model.number="editAiMonster.baseHp" />
+                        <label class="block text-xs font-medium">Base HP</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="editAiMonster.baseHp" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600">Base ATK</label>
-                        <input class="input" type="number" min="1" v-model.number="editAiMonster.baseAtk" />
+                        <label class="block text-xs font-medium">Base ATK</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="editAiMonster.baseAtk" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600">Base DEF</label>
-                        <input class="input" type="number" min="1" v-model.number="editAiMonster.baseDef" />
+                        <label class="block text-xs font-medium">Base DEF</label>
+                        <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="editAiMonster.baseDef" />
                       </div>
                     </div>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Replace Images (optional)</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Replace Images (optional)</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Walking</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditAiMonsterFileChange($event, 'walking')" />
+                        <label class="block text-xs font-medium mb-1">Walking</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditAiMonsterFileChange($event, 'walking')" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Standing Still</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditAiMonsterFileChange($event, 'standing')" />
+                        <label class="block text-xs font-medium mb-1">Standing Still</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditAiMonsterFileChange($event, 'standing')" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Jumping</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditAiMonsterFileChange($event, 'jumping')" />
+                        <label class="block text-xs font-medium mb-1">Jumping</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onEditAiMonsterFileChange($event, 'jumping')" />
                       </div>
                     </div>
                   </div>
                 </div>
-                <div class="px-6 py-4 border-t flex justify-end gap-3">
-                  <button class="px-4 py-2 rounded border" @click="closeEditAiMonsterModal">Cancel</button>
-                  <button class="btn-primary" :disabled="savingAiMonster" @click="saveAiMonster(editAiMonsterId)">
+                <div class="px-4 py-3 border-t flex-shrink-0 flex justify-end gap-2">
+                  <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeEditAiMonsterModal">Cancel</button>
+                  <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingAiMonster" @click="saveAiMonster(editAiMonsterId)">
                     <span v-if="!savingAiMonster">Save</span><span v-else>Saving…</span>
                   </button>
                 </div>
@@ -524,18 +527,18 @@
           </div>
         </transition>
 
-        <div v-if="!aiMonsters.length" class="text-sm text-gray-500">No AI monsters yet.</div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div v-for="m in aiMonsters" :key="m.id" class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <div v-if="!aiMonsters.length" class="text-xs text-gray-500">No AI monsters yet.</div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div v-for="m in aiMonsters" :key="m.id" class="rounded border p-3">
             <div class="flex items-start justify-between gap-3">
               <div>
-                <div class="text-lg font-semibold text-gray-800">{{ m.name }}</div>
-                <div class="text-sm text-gray-600">{{ m.type }} · {{ rarityLabel(m.rarity) }}</div>
-                <div class="text-sm text-gray-600 mt-1">HP {{ m.baseHp }} · ATK {{ m.baseAtk }} · DEF {{ m.baseDef }}</div>
+                <div class="text-xs font-semibold text-gray-800">{{ m.name }}</div>
+                <div class="text-xs text-gray-600">{{ m.type }} · {{ rarityLabel(m.rarity) }}</div>
+                <div class="text-xs text-gray-600 mt-1">HP {{ m.baseHp }} · ATK {{ m.baseAtk }} · DEF {{ m.baseDef }}</div>
               </div>
               <div class="flex gap-2">
-                <button class="px-3 py-2 rounded border border-gray-300 text-gray-700" @click="startEditAiMonster(m)">Edit</button>
-                <button class="px-3 py-2 rounded border border-red-300 text-red-600" @click="removeAiMonster(m.id)">Delete</button>
+                <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="startEditAiMonster(m)">Edit</button>
+                <button class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="removeAiMonster(m.id)">Delete</button>
               </div>
             </div>
           </div>
@@ -544,75 +547,75 @@
 
       <!-- Items -->
       <section v-if="activeTab==='Items'" class="space-y-6">
-        <div class="text-sm text-gray-600">Create, edit, and delete items.</div>
+        <div class="text-xs text-gray-600">Create, edit, and delete items.</div>
 
         <!-- Add item toolbar -->
         <div class="flex justify-end">
-          <button class="btn-primary" @click="openAddItemModal">Add Item</button>
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" @click="openAddItemModal">Add Item</button>
         </div>
 
         <!-- Add Item Modal -->
         <transition name="fade">
           <div v-if="showAddItemModal" class="fixed inset-0 z-50">
-            <div class="absolute inset-0 bg-black/40" @click="closeAddItemModal" />
-            <div class="absolute inset-0 flex items-center justify-center p-4">
-              <div class="bg-white w-full max-w-2xl max-h-[90vh] rounded-lg shadow-xl flex flex-col" role="dialog" aria-modal="true" aria-labelledby="addItemTitle">
-                <div class="px-6 py-4 border-b flex items-center justify-between">
-                  <h3 id="addItemTitle" class="text-lg font-semibold">Add Item</h3>
-                  <button class="text-gray-500 hover:text-gray-700" @click="closeAddItemModal" aria-label="Close">✕</button>
+            <div class="absolute inset-0 bg-black/50" @click="closeAddItemModal" />
+            <div class="absolute inset-0 flex items-center justify-center p-2">
+              <div class="bg-white w-full max-w-2xl max-h-[92vh] rounded-lg shadow-lg flex flex-col" role="dialog" aria-modal="true" aria-labelledby="addItemTitle">
+                <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+                  <h3 id="addItemTitle" class="text-sm font-semibold">Add Item</h3>
+                  <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeAddItemModal" aria-label="Close">✕</button>
                 </div>
-                <div class="p-6 space-y-5 flex-1 overflow-y-auto min-h-0">
+                <div class="px-4 py-3 space-y-4 flex-1 overflow-y-auto min-h-0">
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Item Code</label>
-                    <input class="input" type="number" min="1" placeholder="e.g., 1" v-model.number="newItem.code" />
+                    <label class="block text-xs font-medium">Item Code</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" placeholder="e.g., 1" v-model.number="newItem.code" />
                     <p class="text-xs text-gray-500 mt-1">Unique per active config. Used to identify items; duplicates are blocked.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Item Name</label>
-                    <input class="input" placeholder="e.g., Power Crystal" v-model="newItem.name" />
+                    <label class="block text-xs font-medium">Item Name</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" placeholder="e.g., Power Crystal" v-model="newItem.name" />
                     <p class="text-xs text-gray-500 mt-1">Displayed to players when they receive an item from a scan.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Rarity</label>
-                    <select class="input" v-model="newItem.rarity">
+                    <label class="block text-xs font-medium">Rarity</label>
+                    <select class="border rounded-md px-2 py-1.5 text-sm" v-model="newItem.rarity">
                       <option v-for="r in itemRarities" :key="r" :value="r">{{ r }}</option>
                     </select>
                     <p class="text-xs text-gray-500 mt-1">Rarity of the item to determine chances.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Power</label>
-                    <input class="input" type="number" min="0" placeholder="e.g., 25" v-model.number="newItem.power" />
+                    <label class="block text-xs font-medium">Power</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="0" placeholder="e.g., 25" v-model.number="newItem.power" />
                     <p class="text-xs text-gray-500 mt-1">Stat stored with the item and included in scan results. Non-negative integer.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Effect</label>
-                    <select class="input" v-model="newItem.effect">
+                    <label class="block text-xs font-medium">Effect</label>
+                    <select class="border rounded-md px-2 py-1.5 text-sm" v-model="newItem.effect">
                       <option v-for="e in itemEffects" :key="e" :value="e">{{ e }}</option>
                     </select>
                     <p class="text-xs text-gray-500 mt-1">Defines what the item does when used.</p>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Images</label>
+                    <label class="block text-xs font-medium">Images</label>
                     <p class="text-xs text-gray-500 mb-2">Upload up to three images. At least one is required.</p>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Image 0</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onNewItemFileChange($event, 'image0')" />
+                        <label class="block text-xs font-medium mb-1">Image 0</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onNewItemFileChange($event, 'image0')" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Image 1 (optional)</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onNewItemFileChange($event, 'image1')" />
+                        <label class="block text-xs font-medium mb-1">Image 1 (optional)</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onNewItemFileChange($event, 'image1')" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Image 2 (optional)</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onNewItemFileChange($event, 'image2')" />
+                        <label class="block text-xs font-medium mb-1">Image 2 (optional)</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="onNewItemFileChange($event, 'image2')" />
                       </div>
                     </div>
                   </div>
                 </div>
-                <div class="px-6 py-4 border-t flex justify-end gap-2">
-                  <button class="px-3 py-2 rounded border" @click="closeAddItemModal">Cancel</button>
-                  <button class="btn-primary" :disabled="addingItem" @click="confirmAddItem">
+                <div class="px-4 py-3 border-t flex-shrink-0 flex justify-end gap-2">
+                  <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeAddItemModal">Cancel</button>
+                  <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="addingItem" @click="confirmAddItem">
                     <span v-if="!addingItem">Add Item</span>
                     <span v-else>Adding…</span>
                   </button>
@@ -625,59 +628,59 @@
         <!-- Edit Item Modal -->
         <transition name="fade">
           <div v-if="showEditItemModal" class="fixed inset-0 z-50">
-            <div class="absolute inset-0 bg-black/40" @click="closeEditItemModal" />
-            <div class="absolute inset-0 flex items-center justify-center p-4">
-              <div class="bg-white w-full max-w-2xl max-h-[90vh] rounded-lg shadow-xl flex flex-col" role="dialog" aria-modal="true" aria-labelledby="editItemTitle">
-                <div class="px-6 py-4 border-b flex items-center justify-between">
-                  <h3 id="editItemTitle" class="text-lg font-semibold">Edit Item</h3>
-                  <button class="text-gray-500 hover:text-gray-700" @click="closeEditItemModal" aria-label="Close">✕</button>
+            <div class="absolute inset-0 bg-black/50" @click="closeEditItemModal" />
+            <div class="absolute inset-0 flex items-center justify-center p-2">
+              <div class="bg-white w-full max-w-2xl max-h-[92vh] rounded-lg shadow-lg flex flex-col" role="dialog" aria-modal="true" aria-labelledby="editItemTitle">
+                <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+                  <h3 id="editItemTitle" class="text-sm font-semibold">Edit Item</h3>
+                  <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeEditItemModal" aria-label="Close">✕</button>
                 </div>
-                <div class="p-6 space-y-5 flex-1 overflow-y-auto min-h-0">
+                <div class="px-4 py-3 space-y-4 flex-1 overflow-y-auto min-h-0">
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Item Code</label>
-                    <input class="input" type="number" min="1" v-model.number="editItem.code" />
+                    <label class="block text-xs font-medium">Item Code</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="1" v-model.number="editItem.code" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Item Name</label>
-                    <input class="input" v-model="editItem.name" />
+                    <label class="block text-xs font-medium">Item Name</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" v-model="editItem.name" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Rarity</label>
-                    <select class="input" v-model="editItem.rarity">
+                    <label class="block text-xs font-medium">Rarity</label>
+                    <select class="border rounded-md px-2 py-1.5 text-sm" v-model="editItem.rarity">
                       <option v-for="r in itemRarities" :key="r" :value="r">{{ r }}</option>
                     </select>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Power</label>
-                    <input class="input" type="number" min="0" v-model.number="editItem.power" />
+                    <label class="block text-xs font-medium">Power</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" type="number" min="0" v-model.number="editItem.power" />
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Effect</label>
-                    <select class="input" v-model="editItem.effect">
+                    <label class="block text-xs font-medium">Effect</label>
+                    <select class="border rounded-md px-2 py-1.5 text-sm" v-model="editItem.effect">
                       <option v-for="e in itemEffects" :key="e" :value="e">{{ e }}</option>
                     </select>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700">Replace Images (optional)</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-1">
+                    <label class="block text-xs font-medium">Replace Images (optional)</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-1">
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Image 0</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="e => editItemFiles.image0 = e?.target?.files?.[0] || null" />
+                        <label class="block text-xs font-medium mb-1">Image 0</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="e => editItemFiles.image0 = e?.target?.files?.[0] || null" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Image 1</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="e => editItemFiles.image1 = e?.target?.files?.[0] || null" />
+                        <label class="block text-xs font-medium mb-1">Image 1</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="e => editItemFiles.image1 = e?.target?.files?.[0] || null" />
                       </div>
                       <div>
-                        <label class="block text-xs text-gray-600 mb-1">Image 2</label>
-                        <input class="input" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="e => editItemFiles.image2 = e?.target?.files?.[0] || null" />
+                        <label class="block text-xs font-medium mb-1">Image 2</label>
+                        <input class="text-xs" type="file" accept="image/png,image/jpeg,image/jpg,image/gif" @change="e => editItemFiles.image2 = e?.target?.files?.[0] || null" />
                       </div>
                     </div>
                   </div>
                 </div>
-                <div class="px-6 py-4 border-t flex justify-end gap-2">
-                  <button class="px-3 py-2 rounded border" @click="closeEditItemModal">Cancel</button>
-                  <button class="btn-primary" :disabled="savingItem" @click="saveItem(editItemId)">Save</button>
+                <div class="px-4 py-3 border-t flex-shrink-0 flex justify-end gap-2">
+                  <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeEditItemModal">Cancel</button>
+                  <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingItem" @click="saveItem(editItemId)">Save</button>
                 </div>
               </div>
             </div>
@@ -688,24 +691,24 @@
         <div class="overflow-x-auto hidden sm:block">
           <table class="min-w-full border-separate border-spacing-y-1">
             <thead>
-              <tr class="text-left text-sm text-gray-600">
-                <th class="px-3 py-2">Code</th>
-                <th class="px-3 py-2">Name</th>
-                <th class="px-3 py-2">Rarity</th>
-                <th class="px-3 py-2">Power</th>
-                <th class="px-3 py-2">Actions</th>
+              <tr class="">
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Code</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Name</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Rarity</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Power</th>
+                <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Actions</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="it in items" :key="it.id" class="bg-gray-50">
-                <td class="px-3 py-2 w-24">{{ it.code }}</td>
-                <td class="px-3 py-2">{{ it.name }}</td>
-                <td class="px-3 py-2 w-40">{{ it.rarity }}</td>
-                <td class="px-3 py-2 w-28">{{ it.power }}</td>
-                <td class="px-3 py-2">
+                <td class="px-2 py-1.5 w-20">{{ it.code }}</td>
+                <td class="px-2 py-1.5">{{ it.name }}</td>
+                <td class="px-2 py-1.5 w-36">{{ it.rarity }}</td>
+                <td class="px-2 py-1.5 w-24">{{ it.power }}</td>
+                <td class="px-2 py-1.5">
                   <div class="flex gap-2">
-                    <button class="px-3 py-2 rounded border" @click="startEditItem(it)">Edit</button>
-                    <button class="px-3 py-2 rounded border border-red-300 text-red-600" @click="removeItem(it.id)" :disabled="deletingItem">Delete</button>
+                    <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="startEditItem(it)">Edit</button>
+                    <button class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="removeItem(it.id)" :disabled="deletingItem">Delete</button>
                   </div>
                 </td>
               </tr>
@@ -713,22 +716,23 @@
           </table>
         </div>
         <!-- Mobile cards -->
-        <div class="space-y-3 sm:hidden">
-          <div v-for="it in items" :key="it.id" class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+        <div class="space-y-2 sm:hidden">
+          <div v-for="it in items" :key="it.id" class="rounded border p-2">
             <div class="flex justify-between items-center">
-              <div class="font-semibold text-gray-800">#{{ it.code }} — {{ it.name }}</div>
-              <div class="text-sm text-gray-600">{{ it.rarity }}</div>
+              <div class="font-semibold text-xs text-gray-800">#{{ it.code }} — {{ it.name }}</div>
+              <div class="text-xs text-gray-600">{{ it.rarity }}</div>
             </div>
-            <div class="text-sm text-gray-700">Power: {{ it.power }}</div>
+            <div class="text-xs text-gray-700">Power: {{ it.power }}</div>
             <div class="mt-3 flex gap-2">
-              <button class="px-3 py-2 rounded border" @click="startEditItem(it)">Edit</button>
-              <button class="px-3 py-2 rounded border border-red-300 text-red-600" @click="removeItem(it.id)">Delete</button>
+              <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="startEditItem(it)">Edit</button>
+              <button class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="removeItem(it.id)">Delete</button>
             </div>
           </div>
         </div>
       </section>
 
       <div v-if="toast" :class="['fixed bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded', toast.type==='error'?'bg-red-100 text-red-700':'bg-green-100 text-green-700']">{{ toast.msg }}</div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyPacks.vue
+++ b/components/newsite/admin/legacy/AdminLegacyPacks.vue
@@ -1,153 +1,155 @@
 <template>
-  <div class="p-6 space-y-6 ">
-    <!-- Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-      <h1 class="text-2xl font-semibold tracking-tight">Packs</h1>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+      <!-- Header -->
+      <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+        <h1 class="text-base font-semibold">Packs</h1>
 
-      <!-- Create New Pack button -->
-      <NuxtLink
-        to="/newsite/admin/packs/new"
-        class="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-      >
-        <!-- Plus icon -->
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-        </svg>
-        Create New Pack
-      </NuxtLink>
-    </div>
-
-    <!-- Content -->
-    <div>
-      <!-- Loading / error states -->
-      <div v-if="pending" class="flex items-center justify-center py-10 text-gray-500">
-        Loading packs…
-      </div>
-      <div v-else-if="error" class="flex items-center justify-center py-10 text-red-600">
-        {{ error.message || 'Failed to fetch packs' }}
+        <!-- Create New Pack button -->
+        <NuxtLink
+          to="/newsite/admin/packs/new"
+          class="inline-flex items-center justify-center gap-1 px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
+        >
+          <!-- Plus icon -->
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-3.5 w-3.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+          </svg>
+          Create New Pack
+        </NuxtLink>
       </div>
 
-      <!-- Data views -->
-      <div v-else>
-        <div class="mb-4 text-sm text-gray-600">
-          Total Results: {{ total }} packs
+      <!-- Content -->
+      <div>
+        <!-- Loading / error states -->
+        <div v-if="pending" class="flex items-center justify-center py-10 text-gray-500">
+          Loading packs…
+        </div>
+        <div v-else-if="error" class="flex items-center justify-center py-10 text-red-600">
+          {{ error.message || 'Failed to fetch packs' }}
         </div>
 
-        <!-- TABLE VIEW (lg and up) -->
-        <div class="overflow-x-auto rounded-lg border border-gray-200 shadow-sm hidden lg:block">
-          <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50 text-left text-sm font-semibold text-gray-700">
-              <tr>
-                <th class="px-4 py-3">Asset</th>
-                <th class="px-4 py-3">Name</th>
-                <th class="px-4 py-3">Price</th>
-                <th class="px-4 py-3">Rarity Breakdown</th>
-                <th class="px-4 py-3">Status</th>
-                <th class="px-4 py-3">Schedule (CST)</th>
-                <th class="px-4 py-3">Purchased</th>
-                <th class="px-4 py-3">Limits / User</th>
-                <th class="px-4 py-3">Created</th>
-                <th class="px-4 py-3">Action</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-200 text-sm">
-              <tr v-for="pack in packs" :key="pack.id" class="hover:bg-gray-50">
-                <td class="px-4 py-3">
-                  <img
-                    v-if="pack.imagePath"
-                    :src="pack.imagePath"
-                    :alt="pack.name"
-                    class="h-16 w-auto mx-auto rounded"
-                  />
-                </td>
-                <td class="px-4 py-3 font-medium text-gray-900">{{ pack.name }}</td>
-                <td class="px-4 py-3">{{ formatPrice(pack.price) }}</td>
-                <td class="px-4 py-3 whitespace-nowrap">{{ formatRarity(pack.rarityConfigs) }}</td>
-                <td class="px-4 py-3">
-                  <span class="status-badge" :class="`status-${packStatus(pack).tone}`">
-                    {{ packStatus(pack).label }}
-                  </span>
-                </td>
-                <td class="px-4 py-3 whitespace-nowrap text-xs">
-                  <div><span class="text-gray-500">Start:</span> {{ formatCst(pack.scheduledAt) }}</div>
-                  <div><span class="text-gray-500">End:</span> {{ formatCst(pack.scheduledOffAt) }}</div>
-                </td>
-                <td class="px-4 py-3 whitespace-nowrap">{{ pack.purchasedCount.toLocaleString() }}</td>
-                <td class="px-4 py-3 whitespace-nowrap text-xs">
-                  <div>{{ pack.dailyPurchaseLimit != null ? `${pack.dailyPurchaseLimit}/day` : 'Unlimited/day' }}</div>
-                  <div>{{ pack.maxBuysPerUser != null ? `${pack.maxBuysPerUser} total` : 'Unlimited total' }}</div>
-                </td>
-                <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(pack.createdAt) }}</td>
-                <td class="px-4 py-3">
-                  <NuxtLink
-                    :to="`/newsite/admin/packs/edit/${pack.id}`"
-                    class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                  >
-                    Edit
-                  </NuxtLink>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <!-- Data views -->
+        <div v-else>
+          <div class="mb-2 text-[11px] text-gray-600">
+            Total Results: {{ total }} packs
+          </div>
 
-        <!-- CARD VIEW (below lg) -->
-        <div class="space-y-4 block lg:hidden">
-          <div
-            v-for="pack in packs"
-            :key="pack.id"
-            class="bg-white rounded-lg p-4 shadow hover:shadow-md"
-          >
-            <div class="flex space-x-4">
-              <!-- Pack Image -->
-              <img
-                v-if="pack.imagePath"
-                :src="pack.imagePath"
-                :alt="pack.name"
-                class="max-w-[80px] w-full object-contain rounded"
-              />
-              <div class="flex-1 flex flex-col justify-between">
-                <!-- Info -->
-                <div class="space-y-1">
-                  <h2 class="text-lg font-semibold">{{ pack.name }}</h2>
-                  <p class="text-sm flex items-center gap-2">
-                    <strong>Status:</strong>
+          <!-- TABLE VIEW (lg and up) -->
+          <div class="overflow-x-auto rounded-lg border bg-white shadow hidden lg:block">
+            <table class="min-w-full text-xs">
+              <thead>
+                <tr>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Asset</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Name</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Price</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Rarity Breakdown</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Status</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Schedule (CST)</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Purchased</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Limits / User</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Created</th>
+                  <th class="px-2 py-1.5 text-left text-[11px] font-semibold text-gray-600 bg-gray-100">Action</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y">
+                <tr v-for="pack in packs" :key="pack.id" class="hover:bg-gray-50">
+                  <td class="px-2 py-1.5">
+                    <img
+                      v-if="pack.imagePath"
+                      :src="pack.imagePath"
+                      :alt="pack.name"
+                      class="h-10 w-auto mx-auto rounded border"
+                    />
+                  </td>
+                  <td class="px-2 py-1.5 font-medium text-gray-900">{{ pack.name }}</td>
+                  <td class="px-2 py-1.5">{{ formatPrice(pack.price) }}</td>
+                  <td class="px-2 py-1.5 whitespace-nowrap">{{ formatRarity(pack.rarityConfigs) }}</td>
+                  <td class="px-2 py-1.5">
                     <span class="status-badge" :class="`status-${packStatus(pack).tone}`">
                       {{ packStatus(pack).label }}
                     </span>
-                  </p>
-                  <p class="text-sm"><strong>Price:</strong> {{ formatPrice(pack.price) }}</p>
-                  <p class="text-sm"><strong>Rarity:</strong> {{ formatRarity(pack.rarityConfigs) }}</p>
-                  <p class="text-sm"><strong>Start (CST):</strong> {{ formatCst(pack.scheduledAt) }}</p>
-                  <p class="text-sm"><strong>End (CST):</strong> {{ formatCst(pack.scheduledOffAt) }}</p>
-                  <p class="text-sm"><strong>Purchased:</strong> {{ pack.purchasedCount.toLocaleString() }}</p>
-                  <p class="text-sm">
-                    <strong>Limits:</strong>
-                    {{ pack.dailyPurchaseLimit != null ? `${pack.dailyPurchaseLimit}/day` : 'Unlimited/day' }},
-                    {{ pack.maxBuysPerUser != null ? `${pack.maxBuysPerUser} total` : 'Unlimited total' }}
-                  </p>
-                  <p class="text-sm"><strong>Created:</strong> {{ formatDate(pack.createdAt) }}</p>
+                  </td>
+                  <td class="px-2 py-1.5 whitespace-nowrap text-[11px]">
+                    <div><span class="text-gray-500">Start:</span> {{ formatCst(pack.scheduledAt) }}</div>
+                    <div><span class="text-gray-500">End:</span> {{ formatCst(pack.scheduledOffAt) }}</div>
+                  </td>
+                  <td class="px-2 py-1.5 whitespace-nowrap">{{ pack.purchasedCount.toLocaleString() }}</td>
+                  <td class="px-2 py-1.5 whitespace-nowrap text-[11px]">
+                    <div>{{ pack.dailyPurchaseLimit != null ? `${pack.dailyPurchaseLimit}/day` : 'Unlimited/day' }}</div>
+                    <div>{{ pack.maxBuysPerUser != null ? `${pack.maxBuysPerUser} total` : 'Unlimited total' }}</div>
+                  </td>
+                  <td class="px-2 py-1.5 whitespace-nowrap">{{ formatDate(pack.createdAt) }}</td>
+                  <td class="px-2 py-1.5">
+                    <NuxtLink
+                      :to="`/newsite/admin/packs/edit/${pack.id}`"
+                      class="inline-flex items-center gap-1 px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
+                    >
+                      Edit
+                    </NuxtLink>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- CARD VIEW (below lg) -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-2 block lg:hidden">
+            <div
+              v-for="pack in packs"
+              :key="pack.id"
+              class="bg-white border rounded-lg shadow p-2"
+            >
+              <div class="flex gap-2">
+                <!-- Pack Image -->
+                <img
+                  v-if="pack.imagePath"
+                  :src="pack.imagePath"
+                  :alt="pack.name"
+                  class="max-w-[60px] w-full object-contain rounded border flex-shrink-0"
+                />
+                <div class="flex-1 flex flex-col justify-between min-w-0">
+                  <!-- Info -->
+                  <div class="space-y-0.5">
+                    <h2 class="text-xs font-semibold truncate">{{ pack.name }}</h2>
+                    <p class="text-[11px] flex items-center gap-1.5">
+                      <strong>Status:</strong>
+                      <span class="status-badge" :class="`status-${packStatus(pack).tone}`">
+                        {{ packStatus(pack).label }}
+                      </span>
+                    </p>
+                    <p class="text-[11px]"><strong>Price:</strong> {{ formatPrice(pack.price) }}</p>
+                    <p class="text-[11px]"><strong>Rarity:</strong> {{ formatRarity(pack.rarityConfigs) }}</p>
+                    <p class="text-[11px]"><strong>Start (CST):</strong> {{ formatCst(pack.scheduledAt) }}</p>
+                    <p class="text-[11px]"><strong>End (CST):</strong> {{ formatCst(pack.scheduledOffAt) }}</p>
+                    <p class="text-[11px]"><strong>Purchased:</strong> {{ pack.purchasedCount.toLocaleString() }}</p>
+                    <p class="text-[11px]">
+                      <strong>Limits:</strong>
+                      {{ pack.dailyPurchaseLimit != null ? `${pack.dailyPurchaseLimit}/day` : 'Unlimited/day' }},
+                      {{ pack.maxBuysPerUser != null ? `${pack.maxBuysPerUser} total` : 'Unlimited total' }}
+                    </p>
+                    <p class="text-[11px]"><strong>Created:</strong> {{ formatDate(pack.createdAt) }}</p>
+                  </div>
+                  <!-- Edit Button -->
+                  <NuxtLink
+                    :to="`/newsite/admin/packs/edit/${pack.id}`"
+                    class="mt-2 inline-flex items-center justify-center px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
+                  >
+                    Edit
+                  </NuxtLink>
                 </div>
-                <!-- Edit Button -->
-                <NuxtLink
-                  :to="`/newsite/admin/packs/edit/${pack.id}`"
-                  class="mt-4 inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-center text-sm font-medium"
-                >
-                  Edit
-                </NuxtLink>
               </div>
             </div>
           </div>
-        </div>
 
-        <!-- Pagination -->
-        <div v-if="packs.length" class="mt-6 flex items-center justify-between">
-          <div class="text-sm text-gray-600">
-            Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
-          </div>
-          <div class="space-x-2">
-            <button class="px-3 py-1 text-sm border rounded-md" :disabled="page <= 1" @click="prevPage">Prev</button>
-            <button class="px-3 py-1 text-sm border rounded-md" :disabled="page >= totalPages" @click="nextPage">Next</button>
+          <!-- Pagination -->
+          <div v-if="packs.length" class="mt-3 flex items-center justify-between">
+            <div class="text-[11px] text-gray-600">
+              Page {{ page }} of {{ totalPages }} - Showing {{ showingRange }}
+            </div>
+            <div class="space-x-1">
+              <button class="px-2 py-0.5 text-[11px] border rounded-md" :disabled="page <= 1" @click="prevPage">Prev</button>
+              <button class="px-2 py-0.5 text-[11px] border rounded-md" :disabled="page >= totalPages" @click="nextPage">Next</button>
+            </div>
           </div>
         </div>
       </div>
@@ -241,10 +243,10 @@ onMounted(() => {
 <style scoped>
 .status-badge {
   display: inline-block;
-  border-radius: 9999px;
-  padding: 2px 10px;
-  font-size: 0.75rem;
-  font-weight: 600;
+  border-radius: 4px;
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 500;
   white-space: nowrap;
 }
 .status-green { background: #dcfce7; color: #15803d; }

--- a/components/newsite/admin/legacy/AdminLegacyPacksEdit.vue
+++ b/components/newsite/admin/legacy/AdminLegacyPacksEdit.vue
@@ -1,300 +1,301 @@
 <!-- pages/admin/edit-pack/[id].vue -->
 <template>
 
-  <div class="p-4 sm:p-8 max-w-6xl mx-auto space-y-10 sm:space-y-14 ">
-    <!-- 🡐 Back & title -->
-    <div class="flex items-center gap-4">
-      <NuxtLink
-        to="/newsite/admin/packs"
-        class="text-blue-700 hover:underline focus-visible:outline-blue-700"
-      >
-        ← Back to Packs
-      </NuxtLink>
-      <h1 class="text-3xl font-semibold tracking-tight">Edit Pack</h1>
-    </div>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2 max-w-4xl mx-auto">
+      <!-- 🡐 Back & title -->
+      <div class="flex items-center gap-3 mb-3">
+        <NuxtLink
+          to="/newsite/admin/packs"
+          class="text-blue-700 hover:underline text-xs"
+        >
+          ← Back to Packs
+        </NuxtLink>
+        <h1 class="text-base font-semibold">Edit Pack</h1>
+      </div>
 
-    <!-- loading / 404 states -->
-    <div v-if="pending" class="text-center text-gray-500">Loading…</div>
-    <div v-else-if="!loadedOk" class="text-center text-red-600">Pack not found.</div>
+      <!-- loading / 404 states -->
+      <div v-if="pending" class="text-center text-gray-500 py-6">Loading…</div>
+      <div v-else-if="!loadedOk" class="text-center text-red-600 py-6">Pack not found.</div>
 
-    <!-- ───────────── FORM ───────────── -->
-    <template v-else>
-      <p class="text-sm text-gray-600">
-        Change the thumbnail, counts or drop odds. All validation rules from the&nbsp;create form
-        still apply (card-counts between <code>1 – N</code> &amp; weights totalling 100 %).
-      </p>
+      <!-- ───────────── FORM ───────────── -->
+      <template v-else>
+        <p class="text-[11px] text-gray-600 mb-3">
+          Change the thumbnail, counts or drop odds. All validation rules from the&nbsp;create form
+          still apply (card-counts between <code>1 – N</code> &amp; weights totalling 100 %).
+        </p>
 
-      <form
-        @submit.prevent="submit"
-        class="space-y-16 bg-white shadow-lg rounded-xl p-4 sm:p-8 border border-gray-200"
-      >
-        <!-- 1️⃣  BASIC INFO --------------------------------------------------- -->
-        <section class="grid lg:grid-cols-2 gap-6">
-          <!-- name -->
-          <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium">Pack name</label>
-            <input v-model="name" required
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"/>
-          </div>
-
-          <!-- price -->
-          <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium">Price (points)</label>
-            <input v-model.number="price" type="number" min="0" required
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"/>
-          </div>
-
-          <!-- description -->
-          <div class="lg:col-span-2 flex flex-col gap-1">
-            <label class="text-sm font-medium">Short description</label>
-            <textarea v-model="description" rows="3"
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"/>
-          </div>
-
-          <!-- thumbnail -->
-          <div class="lg:col-span-2 flex flex-col gap-1">
-            <label class="text-sm font-medium">Thumbnail (png / jpeg)</label>
-
-            <img v-if="!newImageFile && imagePreview"
-                 :src="imagePreview"
-                 class="w-32 h-32 object-cover rounded border border-gray-300 mb-3"/>
-
-            <input ref="fileInput" type="file" accept="image/png,image/jpeg"
-              class="block w-full text-sm text-gray-700
-                     file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0
-                     file:text-sm file:font-semibold file:bg-blue-600 file:text-white
-                     hover:file:bg-blue-700"
-              @change="onFile"/>
-
-            <p class="text-xs text-gray-500 ml-1">Leave blank to keep current image.</p>
-
-            <img v-if="newImageFile" :src="imagePreview"
-                 class="mt-3 w-32 h-32 object-cover rounded border border-gray-300"/>
-          </div>
-
-          <!-- list in cmart -->
-          <div class="flex items-start gap-2 lg:col-span-2">
-            <input v-model="inCmart" type="checkbox"
-              class="mt-1 rounded border-gray-400 text-blue-600 focus:ring-blue-600"/>
-            <label class="select-none text-sm">List in cMart</label>
-          </div>
-
-          <!-- go live date/time -->
-          <div class="lg:col-span-2 flex flex-col gap-1">
-            <label for="pack-go-live" class="text-sm font-medium">
-              Pack go live (CST)
-            </label>
-            <input
-              id="pack-go-live"
-              v-model="scheduledAtLocal"
-              type="datetime-local"
-              step="3600"
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-            />
-            <p class="text-xs text-gray-500 ml-1">
-              Time must be on the hour. Leave blank to keep this pack out of cMart.
-            </p>
-          </div>
-
-          <div class="lg:col-span-2 flex flex-col gap-1">
-            <label for="pack-go-dark" class="text-sm font-medium">
-              Pack remove from cMart (CST)
-            </label>
-            <input
-              id="pack-go-dark"
-              v-model="scheduledOffAtLocal"
-              type="datetime-local"
-              step="3600"
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-            />
-            <p class="text-xs text-gray-500 ml-1">
-              Time must be on the hour. Leave blank to keep this pack listed.
-            </p>
-          </div>
-
-          <!-- daily purchase limit -->
-          <div class="lg:col-span-2 flex flex-col gap-1">
-            <label class="text-sm font-medium">Daily purchase limit per user</label>
-            <input
-              v-model.number="dailyPurchaseLimit"
-              type="number"
-              min="1"
-              placeholder="Leave blank for unlimited"
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-              @input="onDailyLimitInput"
-            />
-            <p class="text-xs text-gray-500 ml-1">
-              Max purchases per user per day (8pm–7:59pm CST window). Leave blank for unlimited.
-            </p>
-          </div>
-
-          <!-- total purchase limit -->
-          <div class="lg:col-span-2 flex flex-col gap-1">
-            <label class="text-sm font-medium">Total purchase limit per user</label>
-            <input
-              v-model.number="maxBuysPerUser"
-              type="number"
-              min="1"
-              placeholder="Leave blank for unlimited"
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-              @input="onMaxBuysInput"
-            />
-            <p class="text-xs text-gray-500 ml-1">
-              All-time cap on how many times a single user can buy this pack. Never resets. Leave blank for unlimited.
-            </p>
-          </div>
-
-          <!-- sell-out behavior -->
-          <div class="lg:col-span-2 space-y-2">
-            <p class="text-sm font-medium">Pack sell-out behavior</p>
-            <div class="flex flex-col gap-2 text-sm text-gray-700">
-              <label class="inline-flex items-start gap-2">
-                <input
-                  v-model="sellOutBehavior"
-                  type="radio"
-                  value="REMOVE_ON_ANY_RARITY_EMPTY"
-                  class="mt-1 rounded border-gray-400 text-blue-600 focus:ring-blue-600"
-                />
-                <span>Remove pack when any rarity sells out</span>
-              </label>
-              <label class="inline-flex items-start gap-2">
-                <input
-                  v-model="sellOutBehavior"
-                  type="radio"
-                  value="KEEP_IF_SINGLE_RARITY_EMPTY"
-                  class="mt-1 rounded border-gray-400 text-blue-600 focus:ring-blue-600"
-                />
-                <span>Keep pack even if a rarity is sold out</span>
-              </label>
+        <form
+          @submit.prevent="submit"
+          class="space-y-4 bg-white rounded border p-3"
+        >
+          <!-- 1️⃣  BASIC INFO --------------------------------------------------- -->
+          <section class="grid sm:grid-cols-2 gap-3">
+            <!-- name -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Pack name</label>
+              <input v-model="name" required
+                class="border rounded-md px-2 py-1.5 text-sm"/>
             </div>
-          </div>
-        </section>
 
-        <!-- 2️⃣  ADD / REMOVE CTOONS ---------------------------------------- -->
-        <section class="space-y-4">
-          <h2 class="text-xl font-semibold">Add / remove cToons</h2>
-          <div class="flex items-center gap-3">
-            <div class="relative flex-1 cto-autocomplete">
+            <!-- price -->
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Price (points)</label>
+              <input v-model.number="price" type="number" min="0" required
+                class="border rounded-md px-2 py-1.5 text-sm"/>
+            </div>
+
+            <!-- description -->
+            <div class="sm:col-span-2 flex flex-col gap-1">
+              <label class="text-xs font-medium">Short description</label>
+              <textarea v-model="description" rows="3"
+                class="border rounded-md px-2 py-1.5 text-sm"/>
+            </div>
+
+            <!-- thumbnail -->
+            <div class="sm:col-span-2 flex flex-col gap-1">
+              <label class="text-xs font-medium">Thumbnail (png / jpeg)</label>
+
+              <img v-if="!newImageFile && imagePreview"
+                   :src="imagePreview"
+                   class="w-20 h-20 object-cover rounded border mb-1"/>
+
+              <input ref="fileInput" type="file" accept="image/png,image/jpeg"
+                class="text-xs"
+                @change="onFile"/>
+
+              <p class="text-[10px] text-gray-500">Leave blank to keep current image.</p>
+
+              <img v-if="newImageFile" :src="imagePreview"
+                   class="mt-1 w-20 h-20 object-cover rounded border"/>
+            </div>
+
+            <!-- list in cmart -->
+            <div class="flex items-start gap-2 sm:col-span-2">
+              <input v-model="inCmart" type="checkbox"
+                class="mt-0.5"/>
+              <label class="select-none text-xs">List in cMart</label>
+            </div>
+
+            <!-- go live date/time -->
+            <div class="sm:col-span-2 flex flex-col gap-1">
+              <label for="pack-go-live" class="text-xs font-medium">
+                Pack go live (CST)
+              </label>
               <input
-                ref="searchInput"
-                v-model="search"
-                placeholder="Search cToons…"
-                class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-                @focus="onInputFocus"
-                @keydown.down.prevent="highlightNext"
-                @keydown.up.prevent="highlightPrev"
-                @keydown.enter.prevent="chooseHighlighted"/>
-
-              <ul v-if="suggestionsOpen && suggestions.length"
-                  class="absolute z-20 mt-1 w-full max-h-60 overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg divide-y">
-                <li v-for="(s,idx) in suggestions" :key="s.id"
-                    @mousedown.prevent="toggleSelect(s)"
-                    :class="['flex items-center gap-3 px-3 py-2 cursor-pointer',
-                             idx===highlighted?'bg-blue-50':'hover:bg-gray-50']">
-                  <div class="relative shrink-0 w-12 h-12">
-                    <img v-if="s.assetPath" :src="s.assetPath"
-                         class="w-full h-full object-contain rounded border border-gray-300 bg-white"/>
-                    <SecondEditionOverlay :ctoon="s"/>
-                  </div>
-                  <div class="flex-1 min-w-0">
-                    <p class="truncate font-medium flex flex-wrap items-center gap-1.5">
-                      <span class="truncate">{{ s.name }}</span>
-                      <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
-                        {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
-                      </span>
-                      <span v-if="s.inCmart === false" class="exclusive-badge">Pack Exclusive</span>
-                    </p>
-                    <p class="text-xs text-gray-500">{{ s.rarity }}</p>
-                  </div>
-                </li>
-              </ul>
-            </div>
-            <span class="text-sm text-gray-600">Selected: {{ selectedCount }}</span>
-          </div>
-        </section>
-
-        <!-- 3️⃣  GROUPED BY RARITY ------------------------------------------- -->
-        <section class="space-y-10">
-          <div v-for="(ids, rarity) in grouped" :key="rarity"
-               class="border border-gray-300 rounded-md">
-            <div class="flex flex-wrap items-center gap-3 bg-gray-50 px-4 py-3 rounded-t-md">
-              <h3 class="font-medium">{{ rarity }}</h3>
-
-              <!-- cards / pack -->
-              <div class="flex items-center gap-1">
-                <input v-model.number="countsByRarity[rarity].count" type="number"
-                       :min="1" :max="ids.length"
-                       class="w-16 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"/>
-                <span class="text-xs text-gray-500">cards</span>
-              </div>
-
-              <!-- probability -->
-              <div class="flex items-center gap-1">
-                <input v-model.number="countsByRarity[rarity].probabilityPercent" type="number"
-                       min="1" max="100"
-                       class="w-20 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"/>
-                <span class="text-xs text-gray-500">%</span>
-              </div>
-
-              <div class="flex items-center gap-2 ml-auto">
-                <button type="button" @click="rebalance(rarity)"
-                        class="even-out-btn">
-                  Even out
-                </button>
-                <span class="weight-badge"
-                      :class="sumWeights(rarity)===100?'weight-ok':'weight-bad'">
-                  {{ sumWeights(rarity) }} %
-                </span>
-              </div>
+                id="pack-go-live"
+                v-model="scheduledAtLocal"
+                type="datetime-local"
+                step="3600"
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
+              <p class="text-[10px] text-gray-500">
+                Time must be on the hour. Leave blank to keep this pack out of cMart.
+              </p>
             </div>
 
-            <div>
-              <div v-for="id in ids" :key="id"
-                   class="group-row flex flex-wrap items-center gap-3 px-4 py-3">
-                <div class="flex items-center gap-3 flex-1 min-w-[200px]">
-                  <div class="relative shrink-0 w-16 h-16">
-                    <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath"
-                         class="w-full h-full object-contain rounded border border-gray-300 bg-white"/>
-                    <SecondEditionOverlay :ctoon="lookup[id]"/>
-                  </div>
-                  <div class="min-w-0">
-                    <p class="font-medium flex flex-wrap items-center gap-1.5">
-                      <span class="truncate">{{ lookup[id]?.name }}</span>
-                      <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
-                      <span v-if="lookup[id]?.inCmart === false" class="exclusive-badge">Pack Exclusive</span>
-                    </p>
-                  </div>
+            <div class="sm:col-span-2 flex flex-col gap-1">
+              <label for="pack-go-dark" class="text-xs font-medium">
+                Pack remove from cMart (CST)
+              </label>
+              <input
+                id="pack-go-dark"
+                v-model="scheduledOffAtLocal"
+                type="datetime-local"
+                step="3600"
+                class="border rounded-md px-2 py-1.5 text-sm"
+              />
+              <p class="text-[10px] text-gray-500">
+                Time must be on the hour. Leave blank to keep this pack listed.
+              </p>
+            </div>
+
+            <!-- daily purchase limit -->
+            <div class="sm:col-span-2 flex flex-col gap-1">
+              <label class="text-xs font-medium">Daily purchase limit per user</label>
+              <input
+                v-model.number="dailyPurchaseLimit"
+                type="number"
+                min="1"
+                placeholder="Leave blank for unlimited"
+                class="border rounded-md px-2 py-1.5 text-sm"
+                @input="onDailyLimitInput"
+              />
+              <p class="text-[10px] text-gray-500">
+                Max purchases per user per day (8pm–7:59pm CST window). Leave blank for unlimited.
+              </p>
+            </div>
+
+            <!-- total purchase limit -->
+            <div class="sm:col-span-2 flex flex-col gap-1">
+              <label class="text-xs font-medium">Total purchase limit per user</label>
+              <input
+                v-model.number="maxBuysPerUser"
+                type="number"
+                min="1"
+                placeholder="Leave blank for unlimited"
+                class="border rounded-md px-2 py-1.5 text-sm"
+                @input="onMaxBuysInput"
+              />
+              <p class="text-[10px] text-gray-500">
+                All-time cap on how many times a single user can buy this pack. Never resets. Leave blank for unlimited.
+              </p>
+            </div>
+
+            <!-- sell-out behavior -->
+            <div class="sm:col-span-2 space-y-1">
+              <p class="text-xs font-medium">Pack sell-out behavior</p>
+              <div class="flex flex-col gap-1 text-xs text-gray-700">
+                <label class="inline-flex items-start gap-2">
+                  <input
+                    v-model="sellOutBehavior"
+                    type="radio"
+                    value="REMOVE_ON_ANY_RARITY_EMPTY"
+                    class="mt-0.5"
+                  />
+                  <span>Remove pack when any rarity sells out</span>
+                </label>
+                <label class="inline-flex items-start gap-2">
+                  <input
+                    v-model="sellOutBehavior"
+                    type="radio"
+                    value="KEEP_IF_SINGLE_RARITY_EMPTY"
+                    class="mt-0.5"
+                  />
+                  <span>Keep pack even if a rarity is sold out</span>
+                </label>
+              </div>
+            </div>
+          </section>
+
+          <hr />
+
+          <!-- 2️⃣  ADD / REMOVE CTOONS ---------------------------------------- -->
+          <section class="space-y-2">
+            <h2 class="text-xs font-semibold">Add / remove cToons</h2>
+            <div class="flex items-center gap-2">
+              <div class="relative flex-1 cto-autocomplete">
+                <input
+                  ref="searchInput"
+                  v-model="search"
+                  placeholder="Search cToons…"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
+                  @focus="onInputFocus"
+                  @keydown.down.prevent="highlightNext"
+                  @keydown.up.prevent="highlightPrev"
+                  @keydown.enter.prevent="chooseHighlighted"/>
+
+                <ul v-if="suggestionsOpen && suggestions.length"
+                    class="absolute z-20 mt-1 w-full max-h-60 overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg divide-y">
+                  <li v-for="(s,idx) in suggestions" :key="s.id"
+                      @mousedown.prevent="toggleSelect(s)"
+                      :class="['flex items-center gap-2 px-2 py-1.5 cursor-pointer',
+                               idx===highlighted?'bg-blue-50':'hover:bg-gray-50']">
+                    <div class="relative shrink-0 w-9 h-9">
+                      <img v-if="s.assetPath" :src="s.assetPath"
+                           class="w-full h-full object-contain rounded border bg-white"/>
+                      <SecondEditionOverlay :ctoon="s"/>
+                    </div>
+                    <div class="flex-1 min-w-0">
+                      <p class="truncate font-medium flex flex-wrap items-center gap-1">
+                        <span class="truncate">{{ s.name }}</span>
+                        <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                          {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                        </span>
+                        <span v-if="s.inCmart === false" class="exclusive-badge">Pack Exclusive</span>
+                      </p>
+                      <p class="text-[10px] text-gray-500">{{ s.rarity }}</p>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+              <span class="text-[11px] text-gray-600">Selected: {{ selectedCount }}</span>
+            </div>
+          </section>
+
+          <hr />
+
+          <!-- 3️⃣  GROUPED BY RARITY ------------------------------------------- -->
+          <section class="space-y-3">
+            <div v-for="(ids, rarity) in grouped" :key="rarity"
+                 class="border rounded-md">
+              <div class="flex flex-wrap items-center gap-2 bg-gray-100 px-2 py-1.5 rounded-t-md">
+                <h3 class="text-xs font-medium">{{ rarity }}</h3>
+
+                <!-- cards / pack -->
+                <div class="flex items-center gap-1">
+                  <input v-model.number="countsByRarity[rarity].count" type="number"
+                         :min="1" :max="ids.length"
+                         class="w-14 border rounded px-1 py-0.5 text-xs"/>
+                  <span class="text-[10px] text-gray-500">cards</span>
                 </div>
 
-                <div class="flex items-center gap-3 ml-auto">
-                  <div class="flex items-center gap-1">
-                    <input v-model.number="weights[id]" type="number" min="1" max="100"
-                           class="w-20 rounded-md border border-gray-400 px-2 py-1 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-                           @input="onManualWeight(rarity,id)"/>
-                    <span class="text-xs text-gray-500">%</span>
-                  </div>
+                <!-- probability -->
+                <div class="flex items-center gap-1">
+                  <input v-model.number="countsByRarity[rarity].probabilityPercent" type="number"
+                         min="1" max="100"
+                         class="w-16 border rounded px-1 py-0.5 text-xs"/>
+                  <span class="text-[10px] text-gray-500">%</span>
+                </div>
 
-                  <button type="button" @click="toggleSelect(lookup[id])"
-                          class="text-red-700 hover:underline text-sm shrink-0">
-                    Remove
+                <div class="flex items-center gap-2 ml-auto">
+                  <button type="button" @click="rebalance(rarity)"
+                          class="even-out-btn">
+                    Even out
                   </button>
+                  <span class="weight-badge"
+                        :class="sumWeights(rarity)===100?'weight-ok':'weight-bad'">
+                    {{ sumWeights(rarity) }} %
+                  </span>
+                </div>
+              </div>
+
+              <div>
+                <div v-for="id in ids" :key="id"
+                     class="group-row flex flex-wrap items-center gap-2 px-2 py-1.5">
+                  <div class="flex items-center gap-2 flex-1 min-w-[160px]">
+                    <div class="relative shrink-0 w-10 h-10">
+                      <img v-if="lookup[id]?.assetPath" :src="lookup[id].assetPath"
+                           class="w-full h-full object-contain rounded border bg-white"/>
+                      <SecondEditionOverlay :ctoon="lookup[id]"/>
+                    </div>
+                    <div class="min-w-0">
+                      <p class="text-xs font-medium flex flex-wrap items-center gap-1">
+                        <span class="truncate">{{ lookup[id]?.name }}</span>
+                        <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
+                        <span v-if="lookup[id]?.inCmart === false" class="exclusive-badge">Pack Exclusive</span>
+                      </p>
+                    </div>
+                  </div>
+
+                  <div class="flex items-center gap-2 ml-auto">
+                    <div class="flex items-center gap-1">
+                      <input v-model.number="weights[id]" type="number" min="1" max="100"
+                             class="w-16 border rounded px-1 py-0.5 text-xs"
+                             @input="onManualWeight(rarity,id)"/>
+                      <span class="text-[10px] text-gray-500">%</span>
+                    </div>
+
+                    <button type="button" @click="toggleSelect(lookup[id])"
+                            class="text-red-700 hover:underline text-[11px] shrink-0">
+                      Remove
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        <!-- 4️⃣  SUBMIT ------------------------------------------------------- -->
-        <div>
-          <button type="submit" :disabled="!allValid"
-                  class="inline-flex items-center gap-2 rounded-md px-6 py-2.5 font-semibold
-                         transition text-white disabled:bg-gray-400 bg-blue-700 hover:bg-blue-800
-                         disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-blue-700">
-            Save Changes
-          </button>
-        </div>
-      </form>
-    </template>
+          <!-- 4️⃣  SUBMIT ------------------------------------------------------- -->
+          <div>
+            <button type="submit" :disabled="!allValid"
+                    class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed">
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </template>
+    </div>
   </div>
 </template>
 
@@ -618,17 +619,17 @@ async function submit () {
 
 <style scoped>
 .cto-autocomplete ul { z-index: 60; }
-.weight-badge { @apply inline-block rounded-full px-2 py-0.5 text-xs font-semibold; }
+.weight-badge { @apply inline-block rounded px-1.5 py-0 text-[10px] font-medium; }
 .weight-ok  { @apply bg-green-100 text-green-700; }
 .weight-bad { @apply bg-red-100 text-red-700; }
 .edition-badge {
   display: inline-block;
   flex-shrink: 0;
-  font-size: 0.6rem;
+  font-size: 0.55rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  padding: 1px 6px;
+  padding: 1px 5px;
   border-radius: 10px;
 }
 .edition-badge-2nd { background: #7c3aed; color: #fff; }
@@ -636,16 +637,16 @@ async function submit () {
 .exclusive-badge {
   display: inline-block;
   flex-shrink: 0;
-  font-size: 0.6rem;
+  font-size: 0.55rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  padding: 1px 6px;
+  padding: 1px 5px;
   border-radius: 10px;
   background: #d97706;
   color: #fff;
 }
-.even-out-btn { @apply text-xs font-semibold text-blue-700 border border-blue-300 rounded-full px-2.5 py-1 hover:bg-blue-100 whitespace-nowrap; }
+.even-out-btn { @apply text-[11px] font-semibold text-blue-700 border border-blue-300 rounded-md px-2 py-0.5 hover:bg-blue-100 whitespace-nowrap; }
 .group-row:not(:last-child){ border-bottom:1px solid theme('colors.gray.200'); }
-input[type='number']{ min-width:4rem; }
+input[type='number']{ min-width:3.5rem; }
 </style>

--- a/components/newsite/admin/legacy/AdminLegacyPacksNew.vue
+++ b/components/newsite/admin/legacy/AdminLegacyPacksNew.vue
@@ -1,434 +1,428 @@
 <template>
 
-  <div class="p-8 max-w-6xl mx-auto space-y-14 ">
-    <!-- 🡐 Back & Title -->
-    <div class="flex items-center gap-4">
-      <NuxtLink
-        to="/newsite/admin/packs"
-        class="text-blue-700 hover:underline focus-visible:outline-blue-700"
-      >
-        ← Back to Packs
-      </NuxtLink>
-      <h1 class="text-3xl font-semibold tracking-tight">Create a New Pack</h1>
-    </div>
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2 max-w-4xl mx-auto">
+      <!-- 🡐 Back & Title -->
+      <div class="flex items-center gap-3 mb-3">
+        <NuxtLink
+          to="/newsite/admin/packs"
+          class="text-blue-700 hover:underline text-xs"
+        >
+          ← Back to Packs
+        </NuxtLink>
+        <h1 class="text-base font-semibold">Create a New Pack</h1>
+      </div>
 
-    <!-- ✨ Intro -->
-    <section class="prose prose-sm max-w-none text-gray-700">
-      <p>
+      <!-- ✨ Intro -->
+      <p class="text-[11px] text-gray-600 mb-3">
         Decide how many cards of each rarity the pack grants, then pick the eligible
         cToons. Weights auto-rebalance so each rarity totals <strong>100&nbsp;%</strong>.
       </p>
-    </section>
 
-    <!-- ╭──────────────────────── PACK FORM ─────────────────────────╮ -->
-    <form
-      @submit.prevent="submit"
-      class="space-y-16 bg-white shadow-lg rounded-xl p-8 border border-gray-200"
-    >
-      <!-- 1️⃣  BASIC INFO --------------------------------------------------- -->
-      <section class="grid lg:grid-cols-2 gap-6">
-        <!-- Name -->
-        <div class="flex flex-col gap-1">
-          <label for="pack-name" class="text-sm font-medium">
-            Pack name <span class="text-red-500">*</span>
-          </label>
-          <input
-            id="pack-name"
-            v-model="name"
-            type="text"
-            placeholder="e.g. Spring Starter Pack"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-            required
-          />
-        </div>
-
-        <!-- Price -->
-        <div class="flex flex-col gap-1">
-          <label for="pack-price" class="text-sm font-medium">
-            Price (points) <span class="text-red-500">*</span>
-          </label>
-          <input
-            id="pack-price"
-            v-model.number="price"
-            type="number"
-            min="0"
-            placeholder="900"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-            required
-          />
-        </div>
-
-        <!-- Description -->
-        <div class="lg:col-span-2 flex flex-col gap-1">
-          <label for="pack-desc" class="text-sm font-medium">Short description</label>
-          <textarea
-            id="pack-desc"
-            v-model="description"
-            rows="3"
-            placeholder="A curated set perfect for new collectors!"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-          ></textarea>
-        </div>
-
-        <!-- Thumbnail upload -->
-        <div class="lg:col-span-2 flex flex-col gap-1">
-          <label for="pack-img" class="text-sm font-medium">
-            Thumbnail image (PNG or JPEG) <span class="text-red-500">*</span>
-          </label>
-          <input
-            id="pack-img"
-            ref="fileInput"
-            type="file"
-            accept="image/png,image/jpeg"
-            class="block w-full text-sm text-gray-700
-                   file:mr-4 file:py-2 file:px-4
-                   file:rounded-md file:border-0
-                   file:text-sm file:font-semibold
-                   file:bg-blue-600 file:text-white
-                   hover:file:bg-blue-700"
-            @change="onFile"
-          />
-          <p class="text-xs text-gray-500 ml-1">
-            Square image ≥ 400 px. Smaller images will be up-scaled.
-          </p>
-
-          <!-- preview -->
-          <img
-            v-if="imagePreview"
-            :src="imagePreview"
-            alt="Preview"
-            class="mt-3 w-32 h-32 object-cover rounded border border-gray-300"
-          />
-        </div>
-
-        <!-- Visibility toggle -->
-        <div class="flex items-start gap-2 lg:col-span-2">
-          <input
-            id="incmart"
-            v-model="inCmart"
-            type="checkbox"
-            class="mt-1 rounded border-gray-400 text-blue-600 focus:ring-blue-600 focus:border-blue-600"
-          />
-          <label for="incmart" class="select-none text-sm">
-            List in cMart (uncheck to save as draft).
-          </label>
-        </div>
-
-        <!-- Go live date/time -->
-        <div class="lg:col-span-2 flex flex-col gap-1">
-          <label for="pack-go-live" class="text-sm font-medium">
-            Pack go live (CST)
-          </label>
-          <input
-            id="pack-go-live"
-            v-model="scheduledAtLocal"
-            type="datetime-local"
-            step="3600"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-          />
-          <p class="text-xs text-gray-500 ml-1">
-            Time must be on the hour. Leave blank to keep this pack out of cMart.
-          </p>
-        </div>
-
-        <!-- Go dark date/time -->
-        <div class="lg:col-span-2 flex flex-col gap-1">
-          <label for="pack-go-dark" class="text-sm font-medium">
-            Pack remove from cMart (CST)
-          </label>
-          <input
-            id="pack-go-dark"
-            v-model="scheduledOffAtLocal"
-            type="datetime-local"
-            step="3600"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-          />
-          <p class="text-xs text-gray-500 ml-1">
-            Time must be on the hour. Leave blank to keep this pack listed.
-          </p>
-        </div>
-
-        <!-- Daily purchase limit -->
-        <div class="lg:col-span-2 flex flex-col gap-1">
-          <label for="daily-limit" class="text-sm font-medium">Daily purchase limit per user</label>
-          <input
-            id="daily-limit"
-            v-model.number="dailyPurchaseLimit"
-            type="number"
-            min="1"
-            placeholder="Leave blank for unlimited"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-            @input="onDailyLimitInput"
-          />
-          <p class="text-xs text-gray-500 ml-1">
-            Max purchases per user per day (8pm–7:59pm CST window). Leave blank for unlimited.
-          </p>
-        </div>
-
-        <!-- Total purchase limit -->
-        <div class="lg:col-span-2 flex flex-col gap-1">
-          <label for="max-buys" class="text-sm font-medium">Total purchase limit per user</label>
-          <input
-            id="max-buys"
-            v-model.number="maxBuysPerUser"
-            type="number"
-            min="1"
-            :placeholder="`Default: ${globalDefaultMaxBuys ?? 5}`"
-            class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-            @input="onMaxBuysInput"
-          />
-          <p class="text-xs text-gray-500 ml-1">
-            All-time cap on how many times a single user can buy this pack. Never resets. Leave blank to use the site default.
-          </p>
-        </div>
-
-        <!-- Sell-out behavior -->
-        <div class="lg:col-span-2 space-y-2">
-          <p class="text-sm font-medium">Pack sell-out behavior</p>
-          <div class="flex flex-col gap-2 text-sm text-gray-700">
-            <label class="inline-flex items-start gap-2">
-              <input
-                v-model="sellOutBehavior"
-                type="radio"
-                value="REMOVE_ON_ANY_RARITY_EMPTY"
-                class="mt-1 rounded border-gray-400 text-blue-600 focus:ring-blue-600"
-              />
-              <span>Remove pack when any rarity sells out</span>
+      <!-- ╭──────────────────────── PACK FORM ─────────────────────────╮ -->
+      <form
+        @submit.prevent="submit"
+        class="space-y-4 bg-white rounded border p-3"
+      >
+        <!-- 1️⃣  BASIC INFO --------------------------------------------------- -->
+        <section class="grid sm:grid-cols-2 gap-3">
+          <!-- Name -->
+          <div class="flex flex-col gap-1">
+            <label for="pack-name" class="text-xs font-medium">
+              Pack name <span class="text-red-500">*</span>
             </label>
-            <label class="inline-flex items-start gap-2">
-              <input
-                v-model="sellOutBehavior"
-                type="radio"
-                value="KEEP_IF_SINGLE_RARITY_EMPTY"
-                class="mt-1 rounded border-gray-400 text-blue-600 focus:ring-blue-600"
-              />
-              <span>Keep pack even if a rarity is sold out</span>
+            <input
+              id="pack-name"
+              v-model="name"
+              type="text"
+              placeholder="e.g. Spring Starter Pack"
+              class="border rounded-md px-2 py-1.5 text-sm"
+              required
+            />
+          </div>
+
+          <!-- Price -->
+          <div class="flex flex-col gap-1">
+            <label for="pack-price" class="text-xs font-medium">
+              Price (points) <span class="text-red-500">*</span>
+            </label>
+            <input
+              id="pack-price"
+              v-model.number="price"
+              type="number"
+              min="0"
+              placeholder="900"
+              class="border rounded-md px-2 py-1.5 text-sm"
+              required
+            />
+          </div>
+
+          <!-- Description -->
+          <div class="sm:col-span-2 flex flex-col gap-1">
+            <label for="pack-desc" class="text-xs font-medium">Short description</label>
+            <textarea
+              id="pack-desc"
+              v-model="description"
+              rows="3"
+              placeholder="A curated set perfect for new collectors!"
+              class="border rounded-md px-2 py-1.5 text-sm"
+            ></textarea>
+          </div>
+
+          <!-- Thumbnail upload -->
+          <div class="sm:col-span-2 flex flex-col gap-1">
+            <label for="pack-img" class="text-xs font-medium">
+              Thumbnail image (PNG or JPEG) <span class="text-red-500">*</span>
+            </label>
+            <input
+              id="pack-img"
+              ref="fileInput"
+              type="file"
+              accept="image/png,image/jpeg"
+              class="text-xs"
+              @change="onFile"
+            />
+            <p class="text-[10px] text-gray-500">
+              Square image ≥ 400 px. Smaller images will be up-scaled.
+            </p>
+
+            <!-- preview -->
+            <img
+              v-if="imagePreview"
+              :src="imagePreview"
+              alt="Preview"
+              class="mt-1 w-20 h-20 object-cover rounded border"
+            />
+          </div>
+
+          <!-- Visibility toggle -->
+          <div class="flex items-start gap-2 sm:col-span-2">
+            <input
+              id="incmart"
+              v-model="inCmart"
+              type="checkbox"
+              class="mt-0.5"
+            />
+            <label for="incmart" class="select-none text-xs">
+              List in cMart (uncheck to save as draft).
             </label>
           </div>
-        </div>
-      </section>
 
-      <!-- 2️⃣  SEARCH / ADD CTOONS ---------------------------------------- -->
-      <section class="space-y-4">
-        <h2 class="text-xl font-semibold">Add cToons</h2>
-
-        <!-- NEW: Add by Set -->
-        <div class="flex items-center gap-3">
-          <div class="relative flex-1 set-autocomplete">
+          <!-- Go live date/time -->
+          <div class="sm:col-span-2 flex flex-col gap-1">
+            <label for="pack-go-live" class="text-xs font-medium">
+              Pack go live (CST)
+            </label>
             <input
-              id="set-name-input"
-              ref="setInput"
-              v-model="setSearch"
-              type="text"
-              placeholder="Type a Set name…"
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-              @focus="onSetFocus"
-              @keydown.down.prevent="setHighlightNext"
-              @keydown.up.prevent="setHighlightPrev"
-              @keydown.enter.prevent="addSetViaKeyboard"
+              id="pack-go-live"
+              v-model="scheduledAtLocal"
+              type="datetime-local"
+              step="3600"
+              class="border rounded-md px-2 py-1.5 text-sm"
             />
-            <!-- dropdown -->
-            <ul
-              v-if="setSuggestionsOpen && setSuggestions.length"
-              class="absolute z-20 mt-1 w-full max-h-60 overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg divide-y"
-            >
-              <li
-                v-for="(s, idx) in setSuggestions"
-                :key="s"
-                @mousedown.prevent="selectSetSuggestion(s)"
-                :class="[
-                  'flex items-center gap-3 px-3 py-2 cursor-pointer',
-                  idx === setHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50'
-                ]"
+            <p class="text-[10px] text-gray-500">
+              Time must be on the hour. Leave blank to keep this pack out of cMart.
+            </p>
+          </div>
+
+          <!-- Go dark date/time -->
+          <div class="sm:col-span-2 flex flex-col gap-1">
+            <label for="pack-go-dark" class="text-xs font-medium">
+              Pack remove from cMart (CST)
+            </label>
+            <input
+              id="pack-go-dark"
+              v-model="scheduledOffAtLocal"
+              type="datetime-local"
+              step="3600"
+              class="border rounded-md px-2 py-1.5 text-sm"
+            />
+            <p class="text-[10px] text-gray-500">
+              Time must be on the hour. Leave blank to keep this pack listed.
+            </p>
+          </div>
+
+          <!-- Daily purchase limit -->
+          <div class="sm:col-span-2 flex flex-col gap-1">
+            <label for="daily-limit" class="text-xs font-medium">Daily purchase limit per user</label>
+            <input
+              id="daily-limit"
+              v-model.number="dailyPurchaseLimit"
+              type="number"
+              min="1"
+              placeholder="Leave blank for unlimited"
+              class="border rounded-md px-2 py-1.5 text-sm"
+              @input="onDailyLimitInput"
+            />
+            <p class="text-[10px] text-gray-500">
+              Max purchases per user per day (8pm–7:59pm CST window). Leave blank for unlimited.
+            </p>
+          </div>
+
+          <!-- Total purchase limit -->
+          <div class="sm:col-span-2 flex flex-col gap-1">
+            <label for="max-buys" class="text-xs font-medium">Total purchase limit per user</label>
+            <input
+              id="max-buys"
+              v-model.number="maxBuysPerUser"
+              type="number"
+              min="1"
+              :placeholder="`Default: ${globalDefaultMaxBuys ?? 5}`"
+              class="border rounded-md px-2 py-1.5 text-sm"
+              @input="onMaxBuysInput"
+            />
+            <p class="text-[10px] text-gray-500">
+              All-time cap on how many times a single user can buy this pack. Never resets. Leave blank to use the site default.
+            </p>
+          </div>
+
+          <!-- Sell-out behavior -->
+          <div class="sm:col-span-2 space-y-1">
+            <p class="text-xs font-medium">Pack sell-out behavior</p>
+            <div class="flex flex-col gap-1 text-xs text-gray-700">
+              <label class="inline-flex items-start gap-2">
+                <input
+                  v-model="sellOutBehavior"
+                  type="radio"
+                  value="REMOVE_ON_ANY_RARITY_EMPTY"
+                  class="mt-0.5"
+                />
+                <span>Remove pack when any rarity sells out</span>
+              </label>
+              <label class="inline-flex items-start gap-2">
+                <input
+                  v-model="sellOutBehavior"
+                  type="radio"
+                  value="KEEP_IF_SINGLE_RARITY_EMPTY"
+                  class="mt-0.5"
+                />
+                <span>Keep pack even if a rarity is sold out</span>
+              </label>
+            </div>
+          </div>
+        </section>
+
+        <hr />
+
+        <!-- 2️⃣  SEARCH / ADD CTOONS ---------------------------------------- -->
+        <section class="space-y-2">
+          <h2 class="text-xs font-semibold">Add cToons</h2>
+
+          <!-- NEW: Add by Set -->
+          <div class="flex items-center gap-2">
+            <div class="relative flex-1 set-autocomplete">
+              <input
+                id="set-name-input"
+                ref="setInput"
+                v-model="setSearch"
+                type="text"
+                placeholder="Type a Set name…"
+                class="w-full border rounded-md px-2 py-1.5 text-sm"
+                @focus="onSetFocus"
+                @keydown.down.prevent="setHighlightNext"
+                @keydown.up.prevent="setHighlightPrev"
+                @keydown.enter.prevent="addSetViaKeyboard"
+              />
+              <!-- dropdown -->
+              <ul
+                v-if="setSuggestionsOpen && setSuggestions.length"
+                class="absolute z-20 mt-1 w-full max-h-60 overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg divide-y"
               >
-                <div class="flex-1 truncate">
-                  <p class="truncate font-medium">{{ s }}</p>
-                </div>
-              </li>
-            </ul>
-          </div>
+                <li
+                  v-for="(s, idx) in setSuggestions"
+                  :key="s"
+                  @mousedown.prevent="selectSetSuggestion(s)"
+                  :class="[
+                    'flex items-center gap-2 px-2 py-1.5 cursor-pointer',
+                    idx === setHighlighted ? 'bg-blue-50' : 'hover:bg-gray-50'
+                  ]"
+                >
+                  <div class="flex-1 truncate">
+                    <p class="truncate font-medium">{{ s }}</p>
+                  </div>
+                </li>
+              </ul>
+            </div>
 
-          <button
-            type="button"
-            @click="addSetToSelection"
-            class="rounded-md px-4 py-2 font-semibold bg-blue-700 text-white hover:bg-blue-800 focus-visible:outline-2 focus-visible:outline-blue-700"
-            :title="'Add all Common/Uncommon/Rare/Very Rare from the Set'"
-          >
-            Add Set
-          </button>
-        </div>
-        <p class="text-xs text-gray-500">
-          Only Common, Uncommon, Rare, and Very Rare are added from the Set.
-        </p>
-
-        <!-- Existing single cToon autocomplete -->
-        <p class="text-xs text-gray-500">
-          Leave the box empty then press <kbd>↓</kbd> / <kbd>↑</kbd> to browse all cToons.
-          Already-selected cToons are hidden.
-        </p>
-
-        <div class="flex items-center gap-3">
-          <div class="relative flex-1 cto-autocomplete">
-            <input
-              ref="searchInput"
-              v-model="search"
-              type="text"
-              placeholder="Search cToons…"
-              class="w-full rounded-md border border-gray-400 px-3 py-2 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-              @focus="onInputFocus"
-              @keydown.down.prevent="highlightNext"
-              @keydown.up.prevent="highlightPrev"
-              @keydown.enter.prevent="chooseHighlighted"
-            />
-
-            <!-- dropdown -->
-            <ul
-              v-if="suggestionsOpen && suggestions.length"
-              class="absolute z-20 mt-1 w-full max-h-60 overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg divide-y"
+            <button
+              type="button"
+              @click="addSetToSelection"
+              class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700"
+              :title="'Add all Common/Uncommon/Rare/Very Rare from the Set'"
             >
-              <li
-                v-for="(s, idx) in suggestions"
-                :key="s.id"
-                @mousedown.prevent="toggleSelect(s)"
-                :class="[
-                  'flex items-center gap-3 px-3 py-2 cursor-pointer',
-                  idx === highlighted ? 'bg-blue-50' : 'hover:bg-gray-50'
-                ]"
+              Add Set
+            </button>
+          </div>
+          <p class="text-[10px] text-gray-500">
+            Only Common, Uncommon, Rare, and Very Rare are added from the Set.
+          </p>
+
+          <!-- Existing single cToon autocomplete -->
+          <p class="text-[10px] text-gray-500">
+            Leave the box empty then press <kbd>↓</kbd> / <kbd>↑</kbd> to browse all cToons.
+            Already-selected cToons are hidden.
+          </p>
+
+          <div class="flex items-center gap-2">
+            <div class="relative flex-1 cto-autocomplete">
+              <input
+                ref="searchInput"
+                v-model="search"
+                type="text"
+                placeholder="Search cToons…"
+                class="w-full border rounded-md px-2 py-1.5 text-sm"
+                @focus="onInputFocus"
+                @keydown.down.prevent="highlightNext"
+                @keydown.up.prevent="highlightPrev"
+                @keydown.enter.prevent="chooseHighlighted"
+              />
+
+              <!-- dropdown -->
+              <ul
+                v-if="suggestionsOpen && suggestions.length"
+                class="absolute z-20 mt-1 w-full max-h-60 overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg divide-y"
+              >
+                <li
+                  v-for="(s, idx) in suggestions"
+                  :key="s.id"
+                  @mousedown.prevent="toggleSelect(s)"
+                  :class="[
+                    'flex items-center gap-2 px-2 py-1.5 cursor-pointer',
+                    idx === highlighted ? 'bg-blue-50' : 'hover:bg-gray-50'
+                  ]"
+                >
+                  <img
+                    v-if="s.assetPath"
+                    :src="s.assetPath"
+                    class="w-7 h-7 object-cover rounded border"
+                  />
+                  <div class="flex-1 truncate">
+                    <p class="truncate font-medium flex items-center gap-1">
+                      <span class="truncate">{{ s.name }}</span>
+                      <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
+                        {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
+                      </span>
+                    </p>
+                    <p class="text-[10px] text-gray-500">{{ s.rarity }}</p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <span class="text-[11px] text-gray-600">Selected: {{ selectedCount }}</span>
+          </div>
+        </section>
+
+        <hr />
+
+        <!-- 3️⃣  SELECTED CTOONS GROUPED BY RARITY --------------------------- -->
+        <section class="space-y-3">
+          <div
+            v-for="(ids, rarity) in grouped"
+            :key="rarity"
+            class="border rounded-md"
+          >
+            <!-- header -->
+            <div class="flex items-center justify-between bg-gray-100 px-2 py-1.5 rounded-t-md">
+              <div class="flex items-center gap-2">
+                <h3 class="text-xs font-medium">{{ rarity }}</h3>
+
+                <!-- cards per pack -->
+                <div class="flex items-center gap-1">
+                  <input
+                    v-model.number="countsByRarity[rarity].count"
+                    type="number"
+                    :min="1"
+                    :max="ids.length"
+                    class="w-14 border rounded px-1 py-0.5 text-xs"
+                    :title="'How many ' + rarity + ' cards per pack (1–' + ids.length + ')'"
+                  />
+                  <span class="text-[10px] text-gray-500">cards</span>
+                </div>
+
+                <!-- probability percent -->
+                <div class="flex items-center gap-1 ml-2">
+                  <input
+                    v-model.number="countsByRarity[rarity].probabilityPercent"
+                    type="number"
+                    min="1"
+                    max="100"
+                    class="w-16 border rounded px-1 py-0.5 text-xs"
+                    :title="'Probability of receiving ' + rarity + ' (1%–100%)'"
+                  />
+                  <span class="text-[10px] text-gray-500">%</span>
+                </div>
+              </div>
+
+              <!-- total weight -->
+              <span
+                class="weight-badge"
+                :class="sumWeights(rarity) === 100 ? 'weight-ok' : 'weight-bad'"
+                :title="'Total weight = ' + sumWeights(rarity) + '%' "
+              >
+                {{ sumWeights(rarity) }} %
+              </span>
+            </div>
+
+            <!-- rows -->
+            <div>
+              <div
+                v-for="id in ids"
+                :key="id"
+                class="group-row flex items-center gap-2 px-2 py-1.5"
               >
                 <img
-                  v-if="s.assetPath"
-                  :src="s.assetPath"
-                  class="w-8 h-8 object-cover rounded border border-gray-300"
+                  v-if="lookup[id]?.assetPath"
+                  :src="lookup[id].assetPath"
+                  class="w-8 h-8 object-cover rounded border"
                 />
                 <div class="flex-1 truncate">
-                  <p class="truncate font-medium flex items-center gap-2">
-                    <span class="truncate">{{ s.name }}</span>
-                    <span :class="s.isSecondEdition ? 'edition-badge edition-badge-2nd' : 'edition-badge edition-badge-1st'">
-                      {{ s.isSecondEdition ? '2nd Edition' : '1st Edition' }}
-                    </span>
+                  <p class="truncate font-medium flex items-center gap-1 text-xs">
+                    <span class="truncate">{{ lookup[id]?.name }}</span>
+                    <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
                   </p>
-                  <p class="text-xs text-gray-500">{{ s.rarity }}</p>
                 </div>
-              </li>
-            </ul>
-          </div>
-          <span class="text-sm text-gray-600">Selected: {{ selectedCount }}</span>
-        </div>
-      </section>
 
-      <!-- 3️⃣  SELECTED CTOONS GROUPED BY RARITY --------------------------- -->
-      <section class="space-y-10">
-        <div
-          v-for="(ids, rarity) in grouped"
-          :key="rarity"
-          class="border border-gray-300 rounded-md"
-        >
-          <!-- header -->
-          <div class="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-t-md">
-            <div class="flex items-center gap-3">
-              <h3 class="font-medium">{{ rarity }}</h3>
+                <!-- weight -->
+                <div class="flex items-center gap-1">
+                  <input
+                    v-model.number="weights[id]"
+                    type="number"
+                    min="1"
+                    max="100"
+                    class="w-16 border rounded px-1 py-0.5 text-xs"
+                    @input="onManualWeight(rarity, id)"
+                    :title="'Drop chance for ' + lookup[id]?.name"
+                  />
+                  <span class="text-[10px] text-gray-500">%</span>
+                </div>
 
-              <!-- cards per pack -->
-              <div class="flex items-center gap-1">
-                <input
-                  v-model.number="countsByRarity[rarity].count"
-                  type="number"
-                  :min="1"
-                  :max="ids.length"
-                  class="w-16 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"
-                  :title="'How many ' + rarity + ' cards per pack (1–' + ids.length + ')'"
-                />
-                <span class="text-xs text-gray-500">cards</span>
-              </div>
-
-              <!-- probability percent -->
-              <div class="flex items-center gap-1 ml-3">
-                <input
-                  v-model.number="countsByRarity[rarity].probabilityPercent"
-                  type="number"
-                  min="1"
-                  max="100"
-                  class="w-20 rounded-md border border-gray-400 px-2 py-1 text-sm focus:ring-1 focus:ring-blue-600 focus:border-blue-600"
-                  :title="'Probability of receiving ' + rarity + ' (1%–100%)'"
-                />
-                <span class="text-xs text-gray-500">%</span>
+                <!-- remove -->
+                <button
+                  type="button"
+                  @click="toggleSelect(lookup[id])"
+                  class="text-red-700 hover:underline text-[11px]"
+                >
+                  Remove
+                </button>
               </div>
             </div>
-
-            <!-- total weight -->
-            <span
-              class="weight-badge"
-              :class="sumWeights(rarity) === 100 ? 'weight-ok' : 'weight-bad'"
-              :title="'Total weight = ' + sumWeights(rarity) + '%' "
-            >
-              {{ sumWeights(rarity) }} %
-            </span>
           </div>
+        </section>
 
-          <!-- rows -->
-          <div>
-            <div
-              v-for="id in ids"
-              :key="id"
-              class="group-row flex items-center gap-3 px-4 py-2"
-            >
-              <img
-                v-if="lookup[id]?.assetPath"
-                :src="lookup[id].assetPath"
-                class="w-10 h-10 object-cover rounded border border-gray-300"
-              />
-              <div class="flex-1 truncate">
-                <p class="truncate font-medium flex items-center gap-2">
-                  <span class="truncate">{{ lookup[id]?.name }}</span>
-                  <span v-if="lookup[id]?.isSecondEdition" class="edition-badge edition-badge-2nd">2nd Edition</span>
-                </p>
-              </div>
-
-              <!-- weight -->
-              <div class="flex items-center gap-1">
-                <input
-                  v-model.number="weights[id]"
-                  type="number"
-                  min="1"
-                  max="100"
-                  class="w-20 rounded-md border border-gray-400 px-2 py-1 focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-                  @input="onManualWeight(rarity, id)"
-                  :title="'Drop chance for ' + lookup[id]?.name"
-                />
-                <span class="text-xs text-gray-500">%</span>
-              </div>
-
-              <!-- remove -->
-              <button
-                type="button"
-                @click="toggleSelect(lookup[id])"
-                class="text-red-700 hover:underline text-sm focus-visible:outline-red-700"
-              >
-                Remove
-              </button>
-            </div>
-          </div>
+        <!-- 4️⃣  SUBMIT ------------------------------------------------------ -->
+        <div>
+          <button
+            type="submit"
+            :disabled="!allValid || !imageFile"
+            :title="submitTooltip"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            Create Pack
+          </button>
         </div>
-      </section>
-
-      <!-- 4️⃣  SUBMIT ------------------------------------------------------ -->
-      <div>
-        <button
-          type="submit"
-          :disabled="!allValid || !imageFile"
-          :title="submitTooltip"
-          class="inline-flex items-center gap-2 rounded-md px-6 py-2.5 font-semibold transition
-                 text-white
-                 disabled:cursor-not-allowed
-                 disabled:bg-gray-400
-                 bg-blue-700 hover:bg-blue-800
-                 focus-visible:outline-2 focus-visible:outline-blue-700"
-        >
-          Create Pack
-        </button>
-      </div>
-    </form>
-    <!-- ╰──────────────────────────────────────────────────────────────────╯ -->
+      </form>
+      <!-- ╰──────────────────────────────────────────────────────────────────╯ -->
+    </div>
   </div>
 </template>
 
@@ -784,18 +778,18 @@ async function submit() {
   z-index: 60;
 }
 .weight-badge {
-  @apply inline-block rounded-full px-2 py-0.5 text-xs font-semibold;
+  @apply inline-block rounded px-1.5 py-0 text-[10px] font-medium;
 }
 .weight-ok  { @apply bg-green-100 text-green-700; }
 .weight-bad { @apply bg-red-100   text-red-700;   }
 .edition-badge {
   display: inline-block;
   flex-shrink: 0;
-  font-size: 0.6rem;
+  font-size: 0.55rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  padding: 1px 6px;
+  padding: 1px 5px;
   border-radius: 10px;
 }
 .edition-badge-2nd { background: #7c3aed; color: #fff; }

--- a/components/newsite/admin/legacy/AdminLegacyProduction.vue
+++ b/components/newsite/admin/legacy/AdminLegacyProduction.vue
@@ -1,17 +1,18 @@
 <template>
-  <div class="bg-gray-50 p-6">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-xl mx-auto bg-white rounded-lg shadow p-6 ">
-      <h1 class="text-2xl font-semibold mb-4">Manage Production Instance</h1>
+    <div class="px-2 py-2">
+    <div class="bg-white rounded-lg shadow p-3">
+      <h1 class="text-base font-semibold mb-3">Manage Production Instance</h1>
 
-      <div class="flex items-center justify-between mb-4">
-        <div class="text-sm">
+      <div class="flex items-center justify-between mb-3">
+        <div class="text-xs">
           <div class="text-gray-600">Status</div>
           <div class="font-medium flex items-center gap-2">
             <span v-if="status==='active'">On</span>
             <span v-else-if="status==='off'">Off</span>
             <span v-else>{{ status }}</span>
-            <span v-if="vcpus && memoryMb" class="text-xs text-gray-500">
+            <span v-if="vcpus && memoryMb" class="text-[10px] text-gray-500">
               ({{ vcpus }} vCPU / {{ formatMemory(memoryMb) }})
             </span>
           </div>
@@ -19,7 +20,7 @@
         <button
           :disabled="working || scaleWorking || status==='unknown' || status==='missing'"
           @click="togglePower"
-          class="px-4 py-2 rounded text-white disabled:opacity-50"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md text-white disabled:opacity-50"
           :class="status==='active' ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700'"
         >
           <span v-if="working && status!=='active'">Turning On Production...</span>
@@ -28,21 +29,21 @@
         </button>
       </div>
 
-      <div class="flex items-center justify-between mb-4">
-        <div class="text-sm">
+      <div class="flex items-center justify-between mb-3">
+        <div class="text-xs">
           <div class="text-gray-600">Scale</div>
           <div class="font-medium">
             <span v-if="scaleUpUntil">Upsized</span>
             <span v-else>Normal</span>
           </div>
-          <div v-if="scaleUpUntil" class="text-xs text-gray-500">
+          <div v-if="scaleUpUntil" class="text-[10px] text-gray-500">
             Downsizes at {{ formatTimestamp(scaleUpUntil) }}
           </div>
         </div>
         <button
           :disabled="working || scaleWorking || status==='unknown' || status==='missing'"
           @click="handleScaleAction"
-          class="px-4 py-2 rounded text-white disabled:opacity-50 bg-blue-600 hover:bg-blue-700"
+          class="px-3 py-1.5 text-xs font-semibold rounded-md text-white disabled:opacity-50 bg-blue-600 hover:bg-blue-700"
         >
           <span v-if="scaleWorking && scaleUpUntil">Downsizing...</span>
           <span v-else-if="scaleWorking">Scaling Up...</span>
@@ -50,17 +51,18 @@
         </button>
       </div>
 
-      <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
+      <p v-if="error" class="text-xs text-red-600">{{ error }}</p>
 
-      <div class="mt-4">
+      <div class="mt-3">
         <button
           @click="refresh"
           :disabled="working || scaleWorking"
-          class="px-3 py-1 border rounded text-sm disabled:opacity-50"
+          class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50 disabled:opacity-50"
         >
           Refresh status
         </button>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacyScavenger.vue
+++ b/components/newsite/admin/legacy/AdminLegacyScavenger.vue
@@ -1,50 +1,53 @@
 <template>
-  <div class="bg-gray-100 p-6 ">
-    <h1 class="text-3xl font-bold mb-6">Admin: Scavenger Hunt</h1>
+  <div class="admin-legacy-scavenger bg-gray-50 text-xs">
+    <div class="px-2 py-2">
+    <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+      <h1 class="text-base font-semibold">Admin: Scavenger Hunt</h1>
+    </div>
 
-    <div class="bg-white rounded-lg shadow-md max-w-5xl mx-auto p-6 space-y-10">
+    <div class="bg-white rounded border shadow max-w-5xl mx-auto p-3 space-y-6">
       <!-- Global Settings -->
       <section>
-        <h2 class="text-2xl font-semibold mb-4">Global Settings</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-xl">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Chance Percent (0–100)</label>
-            <input type="number" v-model.number="chance" class="input" min="0" max="100" />
+        <h2 class="text-xs font-semibold mb-2">Global Settings</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-xl">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Chance Percent (0–100)</label>
+            <input type="number" v-model.number="chance" class="border rounded-md px-2 py-1.5 text-sm" min="0" max="100" />
           </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Cooldown (hours)</label>
-            <input type="number" v-model.number="cooldown" class="input" min="0" />
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Cooldown (hours)</label>
+            <input type="number" v-model.number="cooldown" class="border rounded-md px-2 py-1.5 text-sm" min="0" />
           </div>
         </div>
-        <div class="mt-4">
-          <button class="btn-primary" @click="saveConfig" :disabled="savingCfg">{{ savingCfg ? 'Saving…' : 'Save Settings' }}</button>
+        <div class="mt-3">
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700" @click="saveConfig" :disabled="savingCfg">{{ savingCfg ? 'Saving…' : 'Save Settings' }}</button>
         </div>
       </section>
 
       <!-- Exclusive cToon Pool -->
       <section>
-        <h2 class="text-2xl font-semibold mb-4">Exclusive cToon Pool</h2>
+        <h2 class="text-xs font-semibold mb-2">Exclusive cToon Pool</h2>
         <div class="mb-3 relative max-w-xl">
-          <label class="block text-sm font-medium text-gray-700 mb-1">Add cToon</label>
+          <label class="block text-xs font-medium mb-1">Add cToon</label>
           <input
             type="text"
             v-model="search"
             @focus="showDropdown = true"
             @input="onSearchInput"
             placeholder="Type to search…"
-            class="input"
+            class="border rounded-md px-2 py-1.5 text-sm w-full"
           />
           <ul v-if="showDropdown && matches.length" class="absolute z-10 mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
             <li
               v-for="c in matches"
               :key="c.id"
               @mousedown.prevent="addPool(c)"
-              class="flex items-center px-3 py-2 cursor-pointer hover:bg-indigo-50"
+              class="flex items-center px-2 py-1.5 cursor-pointer hover:bg-indigo-50"
             >
-              <img :src="c.assetPath" alt="" class="w-6 h-6 rounded mr-2 object-cover border" />
-              <div>
-                <p class="text-sm">{{ c.name }}</p>
-                <p class="text-xs text-gray-500">{{ c.rarity }}</p>
+              <img :src="c.assetPath" alt="" class="w-6 h-6 rounded mr-2 object-cover border flex-shrink-0" />
+              <div class="min-w-0">
+                <p class="text-xs truncate">{{ c.name }}</p>
+                <p class="text-[10px] text-gray-500">{{ c.rarity }}</p>
               </div>
             </li>
           </ul>
@@ -54,7 +57,7 @@
           <span
             v-for="row in pool"
             :key="row.id"
-            class="inline-flex items-center bg-indigo-100 text-indigo-800 px-2 py-1 rounded-full text-sm"
+            class="inline-flex items-center bg-indigo-100 text-indigo-800 px-2 py-1 rounded-full text-xs"
           >
             <img :src="row.ctoon.assetPath" alt="" class="w-5 h-5 rounded mr-2 object-cover border" />
             {{ row.ctoon.name }}
@@ -65,115 +68,116 @@
 
       <!-- Stories (basic create + list) -->
       <section>
-        <h2 class="text-2xl font-semibold mb-4">Stories</h2>
+        <h2 class="text-xs font-semibold mb-2">Stories</h2>
 
-        <details class="mb-4">
-          <summary class="cursor-pointer font-semibold">Add Story</summary>
-          <div class="mt-3 space-y-4">
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Title</label>
-                <input v-model="form.title" class="input" />
+        <details class="mb-3">
+          <summary class="cursor-pointer text-xs font-semibold">Add Story</summary>
+          <div class="mt-3 space-y-3">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Title</label>
+                <input v-model="form.title" class="border rounded-md px-2 py-1.5 text-sm" />
               </div>
               <div class="flex items-end">
-                <label class="inline-flex items-center gap-2 text-sm ml-1">
+                <label class="inline-flex items-center gap-2 text-xs ml-1">
                   <input type="checkbox" v-model="form.isActive" /> Active
                 </label>
               </div>
             </div>
 
             <!-- Fixed branching: '', A, B, AA, AB, BA, BB -->
-            <div class="p-3 border rounded">
-              <h3 class="font-semibold mb-3">Steps</h3>
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div v-for="p in requiredPaths" :key="p" class="border rounded p-3">
-                  <div class="text-sm font-semibold mb-1">Path: <span class="font-mono">{{ p || '(root)' }}</span></div>
-                  <div v-if="trailFor(p).length" class="mb-2 text-xs text-gray-600 flex flex-wrap gap-1">
+            <div class="p-2 border rounded-md">
+              <h3 class="text-xs font-semibold mb-2">Steps</h3>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div v-for="p in requiredPaths" :key="p" class="border rounded-md p-2">
+                  <div class="text-xs font-semibold mb-1">Path: <span class="font-mono">{{ p || '(root)' }}</span></div>
+                  <div v-if="trailFor(p).length" class="mb-2 text-[10px] text-gray-600 flex flex-wrap gap-1">
                     <span v-for="(t,i) in trailFor(p)" :key="i" class="inline-flex items-center gap-1 bg-gray-100 rounded-full px-2 py-0.5">
                       <span class="font-mono">{{ t.choice }}</span>
                       <span>— {{ t.label || '(label?)' }}</span>
                     </span>
                   </div>
-                  <label class="block text-sm">Description</label>
-                  <textarea v-model="formSteps[p].description" class="input" rows="2"></textarea>
+                  <label class="block text-xs font-medium">Description</label>
+                  <textarea v-model="formSteps[p].description" class="border rounded-md px-2 py-1.5 text-sm w-full" rows="2"></textarea>
                   <!-- Step image above options -->
                   <div class="mt-2">
-                    <label class="block text-sm">Step Image</label>
+                    <label class="block text-xs font-medium">Step Image</label>
                     <div class="mt-1 flex items-center gap-2">
                       <input type="file" accept="image/*" @change="e => onFormFileChange(p, e)" class="text-xs" />
-                      <button class="px-2 py-1 text-xs rounded border" @click="uploadFormStepImage(p)" :disabled="!formFiles[p] || uploading[p]">{{ uploading[p] ? 'Uploading…' : 'Upload' }}</button>
+                      <button class="px-2 py-1 text-xs border rounded-md hover:bg-gray-50" @click="uploadFormStepImage(p)" :disabled="!formFiles[p] || uploading[p]">{{ uploading[p] ? 'Uploading…' : 'Upload' }}</button>
                     </div>
                     <div v-if="formSteps[p].imagePath" class="mt-2 flex items-center gap-3">
                       <img :src="formSteps[p].imagePath" alt="" class="w-24 h-24 object-cover rounded border" />
-                      <button class="px-2 py-1 text-xs rounded border" @click="removeFormStepImage(p)">Remove</button>
+                      <button class="px-2 py-1 text-xs border rounded-md hover:bg-gray-50" @click="removeFormStepImage(p)">Remove</button>
                     </div>
                   </div>
 
-                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
-                    <div>
-                      <label class="block text-sm">Option A</label>
-                      <input v-model="formSteps[p].optionA" class="input" />
+                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-3">
+                    <div class="flex flex-col gap-1">
+                      <label class="text-xs font-medium">Option A</label>
+                      <input v-model="formSteps[p].optionA" class="border rounded-md px-2 py-1.5 text-sm" />
                     </div>
-                    <div>
-                      <label class="block text-sm">Option B</label>
-                      <input v-model="formSteps[p].optionB" class="input" />
+                    <div class="flex flex-col gap-1">
+                      <label class="text-xs font-medium">Option B</label>
+                      <input v-model="formSteps[p].optionB" class="border rounded-md px-2 py-1.5 text-sm" />
                     </div>
                   </div>
                 </div>
               </div>
             </div>
 
-            <div class="p-3 border rounded">
-              <h3 class="font-semibold mb-2">Outcomes</h3>
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div v-for="p in terminalPaths" :key="p" class="border rounded p-3 space-y-2">
+            <div class="p-2 border rounded-md">
+              <h3 class="text-xs font-semibold mb-2">Outcomes</h3>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <div v-for="p in terminalPaths" :key="p" class="border rounded-md p-2 space-y-2">
                   <!-- breadcrumb of choices leading to this outcome -->
-                  <div class="text-xs text-gray-600 flex flex-wrap gap-1">
+                  <div class="text-[10px] text-gray-600 flex flex-wrap gap-1">
                     <span v-for="(t,i) in outcomeTrailFor(p)" :key="i" class="inline-flex items-center gap-1 bg-gray-100 rounded-full px-2 py-0.5">
                       <span class="font-mono">{{ t.choice }}</span>
                       <span>— {{ t.label || '(label?)' }}</span>
                     </span>
                   </div>
                   <div class="flex items-center gap-2">
-                    <span class="w-14 font-mono">{{ p }}</span>
-                    <select v-model="formOutcome[p].type" class="border rounded px-2 py-1">
+                    <span class="w-14 font-mono text-xs">{{ p }}</span>
+                    <select v-model="formOutcome[p].type" class="border rounded-md px-2 py-1 text-xs">
                       <option value="NOTHING">Nothing</option>
                       <option value="POINTS">Points</option>
                       <option value="EXCLUSIVE_CTOON">Exclusive cToon</option>
                     </select>
-                    <input v-if="formOutcome[p].type==='POINTS'" type="number" class="border rounded px-2 py-1 w-24" v-model.number="formOutcome[p].points" placeholder="pts" />
+                    <input v-if="formOutcome[p].type==='POINTS'" type="number" class="border rounded-md px-2 py-1 text-xs w-24" v-model.number="formOutcome[p].points" placeholder="pts" />
                   </div>
-                  <div>
-                    <label class="block text-xs text-gray-600">Outcome text (optional)</label>
-                    <input class="input" v-model="formOutcome[p].text" placeholder="Shown with the final result" />
+                  <div class="flex flex-col gap-1">
+                    <label class="text-[10px] text-gray-600">Outcome text (optional)</label>
+                    <input class="border rounded-md px-2 py-1.5 text-sm" v-model="formOutcome[p].text" placeholder="Shown with the final result" />
                   </div>
                 </div>
               </div>
             </div>
 
             <div>
-              <button class="btn-primary" @click="createStory" :disabled="savingStory">{{ savingStory ? 'Saving…' : 'Create Story' }}</button>
+              <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700" @click="createStory" :disabled="savingStory">{{ savingStory ? 'Saving…' : 'Create Story' }}</button>
             </div>
           </div>
         </details>
 
         <div>
-          <h3 class="text-lg font-semibold mb-2">Existing Stories</h3>
-          <div v-if="!stories.length" class="text-sm text-gray-500">No stories yet.</div>
-          <ul v-else class="divide-y border rounded">
-            <li v-for="s in stories" :key="s.id" class="p-3 flex items-center justify-between">
+          <h3 class="text-xs font-semibold mb-2">Existing Stories</h3>
+          <div v-if="!stories.length" class="text-xs text-gray-500">No stories yet.</div>
+          <ul v-else class="divide-y border rounded-md">
+            <li v-for="s in stories" :key="s.id" class="p-2 flex items-center justify-between">
               <div>
-                <div class="font-medium">{{ s.title }}</div>
-                <div class="text-xs text-gray-500">{{ s.isActive ? 'Active' : 'Inactive' }}</div>
+                <div class="font-medium text-xs">{{ s.title }}</div>
+                <div class="text-[10px] text-gray-500">{{ s.isActive ? 'Active' : 'Inactive' }}</div>
               </div>
               <div class="flex items-center gap-2">
-                <button class="px-3 py-1 rounded border" @click="openEdit(s)">Edit</button>
-                <button class="px-3 py-1 rounded border" @click="removeStory(s)">Delete</button>
+                <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="openEdit(s)">Edit</button>
+                <button class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="removeStory(s)">Delete</button>
               </div>
             </li>
           </ul>
         </div>
       </section>
+    </div>
     </div>
 
     <!-- Toast -->
@@ -185,95 +189,98 @@
     </div>
 
     <!-- Edit Story Modal -->
-    <div v-if="showEditModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" @click.self="closeEdit">
-      <div class="bg-white rounded-lg shadow-lg w-full max-w-5xl p-5 overflow-y-auto max-h-[90svh]">
-        <div class="flex items-center justify-between mb-3">
-          <h3 class="text-xl font-semibold">Edit Story</h3>
-          <button class="text-gray-600 hover:text-gray-900" @click="closeEdit">✕</button>
+    <div v-if="showEditModal" class="fixed inset-0 z-50 flex items-center justify-center p-2">
+      <div class="absolute inset-0 bg-black/50" @click="closeEdit"></div>
+      <div class="relative bg-white w-full max-w-5xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="flex items-center justify-between px-4 py-3 border-b flex-shrink-0">
+          <h3 class="text-sm font-semibold">Edit Story</h3>
+          <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeEdit">✕</button>
         </div>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Title</label>
-            <input v-model="editForm.title" class="input" />
+        <div class="overflow-y-auto flex-1 px-4 py-3 space-y-4">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Title</label>
+            <input v-model="editForm.title" class="border rounded-md px-2 py-1.5 text-sm" />
           </div>
           <div class="flex items-end">
-            <label class="inline-flex items-center gap-2 text-sm ml-1">
+            <label class="inline-flex items-center gap-2 text-xs ml-1">
               <input type="checkbox" v-model="editForm.isActive" /> Active
             </label>
           </div>
         </div>
 
-        <div class="p-3 border rounded mb-4">
-          <h4 class="font-semibold mb-3">Steps</h4>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div v-for="p in requiredPaths" :key="p" class="border rounded p-3">
-              <div class="text-sm font-semibold mb-1">Path: <span class="font-mono">{{ p || '(root)' }}</span></div>
-              <div v-if="editTrailFor(p).length" class="mb-2 text-xs text-gray-600 flex flex-wrap gap-1">
+        <div class="p-2 border rounded-md">
+          <h4 class="text-xs font-semibold mb-2">Steps</h4>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div v-for="p in requiredPaths" :key="p" class="border rounded-md p-2">
+              <div class="text-xs font-semibold mb-1">Path: <span class="font-mono">{{ p || '(root)' }}</span></div>
+              <div v-if="editTrailFor(p).length" class="mb-2 text-[10px] text-gray-600 flex flex-wrap gap-1">
                 <span v-for="(t,i) in editTrailFor(p)" :key="i" class="inline-flex items-center gap-1 bg-gray-100 rounded-full px-2 py-0.5">
                   <span class="font-mono">{{ t.choice }}</span>
                   <span>— {{ t.label || '(label?)' }}</span>
                 </span>
               </div>
-              <label class="block text-sm">Description</label>
-              <textarea v-model="editSteps[p].description" class="input" rows="2"></textarea>
+              <label class="block text-xs font-medium">Description</label>
+              <textarea v-model="editSteps[p].description" class="border rounded-md px-2 py-1.5 text-sm w-full" rows="2"></textarea>
               <!-- Step image above options (edit) -->
               <div class="mt-2">
-                <label class="block text-sm">Step Image</label>
+                <label class="block text-xs font-medium">Step Image</label>
                 <div class="mt-1 flex items-center gap-2">
                   <input type="file" accept="image/*" @change="e => onEditFileChange(p, e)" class="text-xs" />
-                  <button class="px-2 py-1 text-xs rounded border" @click="uploadEditStepImage(p)" :disabled="!editFiles[p] || uploading[p]">{{ uploading[p] ? 'Uploading…' : 'Upload' }}</button>
+                  <button class="px-2 py-1 text-xs border rounded-md hover:bg-gray-50" @click="uploadEditStepImage(p)" :disabled="!editFiles[p] || uploading[p]">{{ uploading[p] ? 'Uploading…' : 'Upload' }}</button>
                 </div>
                 <div v-if="editSteps[p].imagePath" class="mt-2 flex items-center gap-3">
                   <img :src="editSteps[p].imagePath" alt="" class="w-24 h-24 object-cover rounded border" />
-                  <button class="px-2 py-1 text-xs rounded border" @click="removeEditStepImage(p)" :disabled="uploading[p]">Remove</button>
+                  <button class="px-2 py-1 text-xs border rounded-md hover:bg-gray-50" @click="removeEditStepImage(p)" :disabled="uploading[p]">Remove</button>
                 </div>
               </div>
 
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
-                <div>
-                  <label class="block text-sm">Option A</label>
-                  <input v-model="editSteps[p].optionA" class="input" />
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-3">
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Option A</label>
+                  <input v-model="editSteps[p].optionA" class="border rounded-md px-2 py-1.5 text-sm" />
                 </div>
-                <div>
-                  <label class="block text-sm">Option B</label>
-                  <input v-model="editSteps[p].optionB" class="input" />
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-medium">Option B</label>
+                  <input v-model="editSteps[p].optionB" class="border rounded-md px-2 py-1.5 text-sm" />
                 </div>
               </div>
             </div>
           </div>
         </div>
 
-        <div class="p-3 border rounded mb-4">
-          <h4 class="font-semibold mb-2">Outcomes</h4>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div v-for="p in terminalPaths" :key="p" class="border rounded p-3 space-y-2">
-              <div class="text-xs text-gray-600 flex flex-wrap gap-1">
+        <div class="p-2 border rounded-md">
+          <h4 class="text-xs font-semibold mb-2">Outcomes</h4>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div v-for="p in terminalPaths" :key="p" class="border rounded-md p-2 space-y-2">
+              <div class="text-[10px] text-gray-600 flex flex-wrap gap-1">
                 <span v-for="(t,i) in editOutcomeTrailFor(p)" :key="i" class="inline-flex items-center gap-1 bg-gray-100 rounded-full px-2 py-0.5">
                   <span class="font-mono">{{ t.choice }}</span>
                   <span>— {{ t.label || '(label?)' }}</span>
                 </span>
               </div>
               <div class="flex items-center gap-2">
-                <span class="w-14 font-mono">{{ p }}</span>
-                <select v-model="editOutcome[p].type" class="border rounded px-2 py-1">
+                <span class="w-14 font-mono text-xs">{{ p }}</span>
+                <select v-model="editOutcome[p].type" class="border rounded-md px-2 py-1 text-xs">
                   <option value="NOTHING">Nothing</option>
                   <option value="POINTS">Points</option>
                   <option value="EXCLUSIVE_CTOON">Exclusive cToon</option>
                 </select>
-                <input v-if="editOutcome[p].type==='POINTS'" type="number" class="border rounded px-2 py-1 w-24" v-model.number="editOutcome[p].points" placeholder="pts" />
+                <input v-if="editOutcome[p].type==='POINTS'" type="number" class="border rounded-md px-2 py-1 text-xs w-24" v-model.number="editOutcome[p].points" placeholder="pts" />
               </div>
-              <div>
-                <label class="block text-xs text-gray-600">Outcome text (optional)</label>
-                <input class="input" v-model="editOutcome[p].text" placeholder="Shown with the final result" />
+              <div class="flex flex-col gap-1">
+                <label class="text-[10px] text-gray-600">Outcome text (optional)</label>
+                <input class="border rounded-md px-2 py-1.5 text-sm" v-model="editOutcome[p].text" placeholder="Shown with the final result" />
               </div>
             </div>
           </div>
         </div>
+        </div>
 
-        <div class="flex justify-end gap-2">
-          <button class="px-3 py-2 rounded border" @click="closeEdit">Cancel</button>
-          <button class="btn-primary" :disabled="savingEdit" @click="saveEdit">{{ savingEdit ? 'Saving…' : 'Save Changes' }}</button>
+        <div class="flex justify-end gap-2 px-4 py-3 border-t flex-shrink-0">
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeEdit">Cancel</button>
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700" :disabled="savingEdit" @click="saveEdit">{{ savingEdit ? 'Saving…' : 'Save Changes' }}</button>
         </div>
       </div>
     </div>

--- a/components/newsite/admin/legacy/AdminLegacyStarterSets.vue
+++ b/components/newsite/admin/legacy/AdminLegacyStarterSets.vue
@@ -2,82 +2,84 @@
    pages/admin/starter-sets.vue (JS)
    ======================================= */
 <template>
-  <div class="bg-gray-50 p-6">
+  <div class="bg-gray-50 text-xs">
+    <div class="px-2 py-2">
 
-    <div class="max-w-6xl mx-auto bg-white p-6 rounded-lg shadow ">
-      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-3">
-        <h1 class="text-2xl font-semibold">Starter Sets</h1>
+    <div class="bg-white rounded border p-3">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2">
+        <h1 class="text-base font-semibold">Starter Sets</h1>
         <!-- Create new set -->
-        <form class="flex gap-2" @submit.prevent="createSet">
+        <form class="flex flex-wrap gap-2" @submit.prevent="createSet">
           <input v-model="createForm.name" type="text" required placeholder="New set name"
-                 class="border rounded p-2 w-56" />
+                 class="border rounded-md px-2 py-1.5 text-sm w-48" />
           <input v-model="createForm.key" type="text" placeholder="Key / slug (optional)"
-                 class="border rounded p-2 w-56" />
-          <button class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Create</button>
+                 class="border rounded-md px-2 py-1.5 text-sm w-48" />
+          <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700">Create</button>
         </form>
       </div>
 
-      <div class="grid md:grid-cols-3 gap-6">
-        <section v-for="set in sets" :key="set.id" class="border rounded-lg p-4">
-          <header class="flex items-center gap-2 mb-3">
+      <div class="grid md:grid-cols-3 gap-2">
+        <section v-for="set in sets" :key="set.id" class="bg-white border rounded-lg shadow p-2">
+          <header class="flex items-center gap-2 mb-2">
             <input v-model="set.name" @change="saveSetBasics(set)"
-                   class="font-medium text-lg border rounded px-2 py-1 flex-1" />
-            <label class="text-sm flex items-center gap-2">
+                   class="font-medium border rounded-md px-2 py-1 text-sm flex-1" />
+            <label class="text-[11px] flex items-center gap-1">
               <input type="checkbox" v-model="set.isActive" @change="saveSetBasics(set)" /> Active
             </label>
           </header>
 
-          <div class="flex items-center gap-3 text-sm mb-3">
-            <span class="text-gray-600">Order</span>
+          <div class="flex items-center gap-2 text-[11px] mb-2">
+            <span class="text-gray-500">Order</span>
             <input type="number" v-model.number="set.sortOrder" @change="saveSetBasics(set)"
-                   class="w-20 border rounded px-2 py-1" />
+                   class="w-16 border rounded px-1 py-0.5 text-xs" />
           </div>
 
           <textarea v-model="set.description" @change="saveSetBasics(set)" rows="2"
-                    class="w-full border rounded px-2 py-1 mb-3" placeholder="Optional description"></textarea>
+                    class="w-full border rounded-md px-2 py-1.5 text-sm mb-2" placeholder="Optional description"></textarea>
 
           <!-- Items -->
-          <ul class="border rounded divide-y mb-3">
-            <li v-for="(it, idx) in set.itemsSorted" :key="it.id" class="flex items-center gap-3 p-2">
-              <img v-if="it.ctoon.assetPath" :src="it.ctoon.assetPath" class="w-10 h-10 object-contain" />
+          <ul class="border rounded-md divide-y mb-2">
+            <li v-for="(it, idx) in set.itemsSorted" :key="it.id" class="flex items-center gap-2 px-2 py-1.5">
+              <img v-if="it.ctoon.assetPath" :src="it.ctoon.assetPath" class="w-8 h-8 object-contain flex-shrink-0" />
               <div class="min-w-0">
-                <div class="truncate font-medium">{{ it.ctoon.name }}</div>
-                <div class="text-xs text-gray-500">Rarity: {{ it.ctoon.rarity }}</div>
+                <div class="truncate font-medium text-xs">{{ it.ctoon.name }}</div>
+                <div class="text-[10px] text-gray-500">Rarity: {{ it.ctoon.rarity }}</div>
               </div>
-              <div class="ml-auto flex items-center gap-2">
-                <button class="px-2 py-1 border rounded" :disabled="idx===0" @click="moveItem(set, it, idx-1)">↑</button>
-                <button class="px-2 py-1 border rounded" :disabled="idx===set.itemsSorted.length-1" @click="moveItem(set, it, idx+1)">↓</button>
-                <button class="px-2 py-1 border rounded text-red-600" @click="removeItem(set, it)">Remove</button>
+              <div class="ml-auto flex items-center gap-1">
+                <button class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50" :disabled="idx===0" @click="moveItem(set, it, idx-1)">↑</button>
+                <button class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50" :disabled="idx===set.itemsSorted.length-1" @click="moveItem(set, it, idx+1)">↓</button>
+                <button class="px-2 py-1 text-[11px] border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="removeItem(set, it)">Remove</button>
               </div>
             </li>
-            <li v-if="!set.itemsSorted.length" class="p-3 text-sm text-gray-500">No items yet.</li>
+            <li v-if="!set.itemsSorted.length" class="p-2 text-[11px] text-gray-500">No items yet.</li>
           </ul>
 
           <!-- Add item -->
           <div>
-            <label class="block mb-1 font-medium">Add cToons to this set</label>
+            <label class="text-xs font-medium block mb-1">Add cToons to this set</label>
             <input v-model="set.search" @input="onSearch(set)" type="text"
                    placeholder="Type 3+ characters to search by name"
-                   class="w-full border rounded px-3 py-2" />
-            <div v-if="set.searching" class="text-xs text-gray-500 mt-1">Searching…</div>
-            <ul v-if="set.results.length" class="mt-2 border rounded divide-y max-h-48 overflow-auto">
+                   class="w-full border rounded-md px-2 py-1.5 text-sm" />
+            <div v-if="set.searching" class="text-[10px] text-gray-500 mt-1">Searching…</div>
+            <ul v-if="set.results.length" class="mt-2 border rounded-md divide-y max-h-48 overflow-auto">
               <li v-for="r in set.results" :key="r.id" class="p-2 flex items-center gap-2 hover:bg-gray-50">
-                <img v-if="r.assetPath" :src="r.assetPath" class="w-8 h-8 object-contain" />
+                <img v-if="r.assetPath" :src="r.assetPath" class="w-7 h-7 object-contain flex-shrink-0" />
                 <div class="min-w-0">
-                  <div class="text-sm font-medium truncate">{{ r.name }}</div>
-                  <div class="text-xs text-gray-500">{{ r.rarity }}</div>
+                  <div class="text-xs font-medium truncate">{{ r.name }}</div>
+                  <div class="text-[10px] text-gray-500">{{ r.rarity }}</div>
                 </div>
-                <button class="ml-auto px-2 py-1 bg-indigo-600 text-white rounded" @click="addItem(set, r)">Add</button>
+                <button class="ml-auto px-3 py-1 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700" @click="addItem(set, r)">Add</button>
               </li>
             </ul>
           </div>
 
-          <footer class="mt-4 flex items-center justify-between text-sm">
+          <footer class="mt-2 flex items-center justify-between text-[11px]">
             <span class="text-gray-500">{{ set.itemsSorted.length }} cToons</span>
-            <button class="text-red-600" @click="deleteSet(set)">Delete Set</button>
+            <button class="px-3 py-1 text-xs border rounded-md text-red-700 border-red-200 hover:bg-red-50" @click="deleteSet(set)">Delete Set</button>
           </footer>
         </section>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/components/newsite/admin/legacy/AdminLegacySubmittedCtoons.vue
+++ b/components/newsite/admin/legacy/AdminLegacySubmittedCtoons.vue
@@ -1,18 +1,18 @@
 <template>
-  <div class="bg-gray-50 p-4 md:p-6">
+  <div class="bg-gray-50 text-xs">
 
     <!-- Toast notifications -->
     <Toast v-for="t in toasts" :key="t.id" :message="t.message" :type="t.type" />
 
-    <div class="max-w-7xl mx-auto md:mt-24">
-      <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <h1 class="text-2xl font-semibold">Review Submitted cToons</h1>
+    <div class="px-2 py-2">
+      <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+        <h1 class="text-base font-semibold">Review Submitted cToons</h1>
         <div class="flex gap-2">
           <button
             v-if="selectedIds.size > 0"
             @click="approveSelected"
             :disabled="processing"
-            class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50 text-sm"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
           >
             ✓ Approve ({{ selectedIds.size }})
           </button>
@@ -20,7 +20,7 @@
             v-if="selectedIds.size > 0"
             @click="declineSelected"
             :disabled="processing"
-            class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 disabled:opacity-50 text-sm"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
           >
             ✕ Decline ({{ selectedIds.size }})
           </button>
@@ -28,24 +28,24 @@
       </div>
 
       <!-- Loading -->
-      <div v-if="loading" class="text-center py-12 text-gray-500">Loading submissions…</div>
+      <div v-if="loading" class="text-gray-500 py-6 text-center">Loading submissions…</div>
 
       <!-- Empty -->
-      <div v-else-if="!submissions.length" class="text-center py-12 text-gray-400">
-        <div class="text-4xl mb-3">🎉</div>
+      <div v-else-if="!submissions.length" class="text-gray-400 py-6 text-center">
+        <div class="text-2xl mb-2">🎉</div>
         <p class="font-medium">No pending submissions!</p>
       </div>
 
       <!-- Cards Grid -->
-      <div v-else class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+      <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
         <div
           v-for="sub in submissions"
           :key="sub.id"
-          class="bg-white rounded-lg shadow border"
+          class="bg-white border rounded-lg shadow"
           :class="selectedIds.has(sub.id) ? 'ring-2 ring-blue-500' : ''"
         >
           <!-- Card header with checkbox and meta -->
-          <div class="flex items-start gap-3 p-4 border-b">
+          <div class="flex items-start gap-2 p-2 border-b">
             <input
               type="checkbox"
               :checked="selectedIds.has(sub.id)"
@@ -53,14 +53,14 @@
               class="mt-1 h-4 w-4 shrink-0"
             />
             <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 flex-wrap">
-                <span class="font-semibold truncate">{{ sub.name }}</span>
+              <div class="flex items-center gap-1.5 flex-wrap">
+                <span class="font-semibold text-xs truncate">{{ sub.name }}</span>
                 <span
-                  class="text-xs px-2 py-0.5 rounded-full"
+                  class="text-[10px] px-1.5 py-0 rounded font-medium"
                   :class="rarityClass(sub.rarity)"
                 >{{ sub.rarity }}</span>
               </div>
-              <div class="text-xs text-gray-500 mt-0.5">
+              <div class="text-[10px] text-gray-500 mt-0.5">
                 Submitted by
                 <span class="font-medium text-gray-700">{{ sub.user?.username || sub.user?.discordTag || 'Unknown' }}</span>
                 · {{ formatDate(sub.submittedAt) }}
@@ -69,7 +69,7 @@
           </div>
 
           <!-- Image + duplicate check -->
-          <div class="p-4 flex gap-4">
+          <div class="p-2 flex gap-2">
             <div class="shrink-0">
               <img
                 :src="sub.assetPath"
@@ -79,69 +79,69 @@
               <div class="mt-2 text-center">
                 <button
                   @click="checkDuplicateForSub(sub)"
-                  class="text-xs text-blue-600 hover:underline"
+                  class="text-[11px] text-blue-600 hover:underline"
                 >Check dupe</button>
-                <div v-if="sub._dupStatus === 'checking'" class="text-xs text-gray-500">Checking…</div>
-                <div v-else-if="sub._dupMatch" class="text-xs mt-1">
+                <div v-if="sub._dupStatus === 'checking'" class="text-[10px] text-gray-500">Checking…</div>
+                <div v-else-if="sub._dupMatch" class="text-[10px] mt-1">
                   <div class="text-amber-700 font-medium">Possible dup!</div>
                   <img v-if="sub._dupMatch.ctoon?.assetPath" :src="sub._dupMatch.ctoon.assetPath" class="w-10 h-10 object-contain border rounded mx-auto my-1" />
                   <div class="text-[10px] text-gray-600">{{ sub._dupMatch.ctoon?.name }}</div>
                   <div class="text-[10px] text-gray-500">p:{{ sub._dupMatch.phashDist }} d:{{ sub._dupMatch.dhashDist }}</div>
                 </div>
-                <div v-else-if="sub._dupStatus === 'done'" class="text-xs text-green-600 mt-1">✓ No dupe</div>
+                <div v-else-if="sub._dupStatus === 'done'" class="text-[10px] text-green-600 mt-1">✓ No dupe</div>
               </div>
             </div>
             <!-- Editable fields -->
-            <div class="flex-1 space-y-2 min-w-0">
+            <div class="flex-1 space-y-1.5 min-w-0">
               <!-- Name -->
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Name</label>
-                <input v-model="sub.name" @blur="saveField(sub, 'name', sub.name)" class="w-full border rounded p-1 text-sm" />
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Name</label>
+                <input v-model="sub.name" @blur="saveField(sub, 'name', sub.name)" class="w-full border rounded-md px-2 py-1.5 text-sm" />
               </div>
               <!-- Rarity -->
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Rarity</label>
-                <select v-model="sub.rarity" @change="saveField(sub, 'rarity', sub.rarity)" class="w-full border rounded p-1 text-sm bg-white">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Rarity</label>
+                <select v-model="sub.rarity" @change="saveField(sub, 'rarity', sub.rarity)" class="w-full border rounded-md px-2 py-1.5 text-sm bg-white">
                   <option v-for="opt in rarityOptions" :key="opt" :value="opt">{{ opt }}</option>
                 </select>
               </div>
               <!-- Characters -->
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Characters</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Characters</label>
                 <input
                   :value="sub.characters.join(', ')"
                   @blur="e => saveChars(sub, e.target.value)"
-                  class="w-full border rounded p-1 text-sm"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
                 />
               </div>
             </div>
           </div>
 
           <!-- More fields -->
-          <div class="px-4 pb-4 space-y-2">
+          <div class="px-2 pb-2 space-y-1.5">
             <!-- Series -->
             <div class="grid grid-cols-2 gap-2">
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Series</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Series</label>
                 <input
                   v-model="sub.series"
                   :list="`series-list-${sub.id}`"
                   @input="onSeriesInput(sub)"
                   @blur="saveField(sub, 'series', sub.series)"
-                  class="w-full border rounded p-1 text-sm"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
                 />
                 <datalist v-if="sub.series.length >= 3" :id="`series-list-${sub.id}`">
                   <option v-for="opt in seriesCacheAdmin" :key="opt" :value="opt" />
                 </datalist>
               </div>
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Set</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Set</label>
                 <input
                   v-model="sub.set"
                   :list="`set-list-${sub.id}`"
                   @input="onSetInput(sub)"
                   @blur="saveField(sub, 'set', sub.set)"
-                  class="w-full border rounded p-1 text-sm"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
                 />
                 <datalist v-if="sub.set.length >= 3" :id="`set-list-${sub.id}`">
                   <option v-for="opt in setsCacheAdmin" :key="opt" :value="opt" />
@@ -150,69 +150,69 @@
             </div>
 
             <!-- Description -->
-            <div>
-              <label class="block text-xs font-medium text-gray-600 mb-0.5">Description</label>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Description</label>
               <textarea
                 v-model="sub.description"
                 @blur="saveField(sub, 'description', sub.description)"
                 rows="2"
-                class="w-full border rounded p-1 text-sm resize-none"
+                class="w-full border rounded-md px-2 py-1.5 text-sm resize-none"
                 placeholder="No description provided."
               />
             </div>
 
             <!-- Release Date + Quantities row -->
             <div class="grid grid-cols-2 gap-2">
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Release Date</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Release Date</label>
                 <input
                   type="datetime-local"
                   :value="toLocalDatetime(sub.releaseDate)"
                   @blur="e => saveField(sub, 'releaseDate', new Date(e.target.value).toISOString())"
-                  class="w-full border rounded p-1 text-xs"
+                  class="w-full border rounded-md px-2 py-1.5 text-xs"
                 />
               </div>
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Per-User Limit</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Per-User Limit</label>
                 <input
                   type="number"
                   v-model.number="sub.perUserLimit"
                   @blur="saveField(sub, 'perUserLimit', sub.perUserLimit)"
                   min="0"
-                  class="w-full border rounded p-1 text-sm"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
                 />
               </div>
             </div>
 
             <div class="grid grid-cols-3 gap-2">
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Total Qty</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Total Qty</label>
                 <input
                   type="number"
                   v-model.number="sub.totalQuantity"
                   @blur="saveField(sub, 'totalQuantity', sub.totalQuantity)"
                   min="1"
-                  class="w-full border rounded p-1 text-sm"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
                 />
               </div>
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Initial Qty</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Initial Qty</label>
                 <input
                   type="number"
                   v-model.number="sub.initialQuantity"
                   @blur="saveField(sub, 'initialQuantity', sub.initialQuantity)"
                   min="0"
-                  class="w-full border rounded p-1 text-sm"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
                 />
               </div>
-              <div>
-                <label class="block text-xs font-medium text-gray-600 mb-0.5">Price</label>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-medium">Price</label>
                 <input
                   type="number"
                   v-model.number="sub.price"
                   @blur="saveField(sub, 'price', sub.price)"
                   min="0"
-                  class="w-full border rounded p-1 text-sm"
+                  class="w-full border rounded-md px-2 py-1.5 text-sm"
                 />
               </div>
             </div>
@@ -226,7 +226,7 @@
                 @change="saveField(sub, 'inCmart', sub.inCmart)"
                 class="h-4 w-4"
               />
-              <label :for="`cmart-${sub.id}`" class="text-sm">In cMart</label>
+              <label :for="`cmart-${sub.id}`" class="text-xs">In cMart</label>
             </div>
 
             <!-- Per-card actions -->
@@ -234,18 +234,18 @@
               <button
                 @click="approveSingle(sub)"
                 :disabled="processing"
-                class="flex-1 bg-green-600 text-white py-1.5 rounded text-sm hover:bg-green-700 disabled:opacity-50"
+                class="flex-1 px-2 py-1 text-[11px] font-semibold rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
               >✓ Approve</button>
               <button
                 @click="declineSingle(sub)"
                 :disabled="processing"
-                class="flex-1 bg-red-600 text-white py-1.5 rounded text-sm hover:bg-red-700 disabled:opacity-50"
+                class="flex-1 px-2 py-1 text-[11px] font-semibold rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
               >✕ Decline</button>
             </div>
 
             <!-- Save indicator -->
-            <div v-if="sub._saving" class="text-xs text-blue-500 text-right">Saving…</div>
-            <div v-if="sub._saveError" class="text-xs text-red-500 text-right">{{ sub._saveError }}</div>
+            <div v-if="sub._saving" class="text-[10px] text-blue-500 text-right">Saving…</div>
+            <div v-if="sub._saveError" class="text-[10px] text-red-500 text-right">{{ sub._saveError }}</div>
           </div>
         </div>
       </div>

--- a/components/newsite/admin/legacy/AdminLegacySuspiciousActivity.vue
+++ b/components/newsite/admin/legacy/AdminLegacySuspiciousActivity.vue
@@ -1,32 +1,32 @@
 <template>
-  <div class="p-6 space-y-6 ">
+  <div class="bg-gray-50 text-xs">
 
-    <div class="max-w-6xl mx-auto" style="margin-top: 50px;">
-      <div class="flex items-start justify-between mb-6">
+    <div class="px-2 py-2 max-w-6xl mx-auto">
+      <div class="flex items-start justify-between flex-wrap gap-2 mb-3">
         <div>
-          <h1 class="text-2xl font-bold">Suspicious Activity Monitor</h1>
-          <p class="text-sm text-gray-500 mt-1">Define rules to flag users exhibiting suspicious patterns. Run analysis on demand to see current results.</p>
+          <h1 class="text-base font-semibold">Suspicious Activity Monitor</h1>
+          <p class="text-[11px] text-gray-500 mt-0.5">Define rules to flag users exhibiting suspicious patterns. Run analysis on demand to see current results.</p>
         </div>
       </div>
 
       <!-- ── Rules section ────────────────────────────────────────────────── -->
-      <section class="bg-white border rounded p-4 mb-6">
-        <div class="flex items-center justify-between mb-3">
-          <h2 class="font-semibold text-lg">Rules</h2>
+      <section class="bg-white rounded border p-3 mb-3">
+        <div class="flex items-center justify-between mb-2">
+          <h2 class="text-sm font-semibold">Rules</h2>
           <button
-            class="bg-indigo-600 text-white text-sm px-3 py-1.5 rounded hover:bg-indigo-700"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
             @click="openCreateRuleModal"
           >+ New Rule</button>
         </div>
 
-        <div v-if="rulesLoading" class="text-sm text-gray-500 py-4 text-center">Loading rules…</div>
+        <div v-if="rulesLoading" class="text-gray-500 py-4 text-center">Loading rules…</div>
 
-        <div v-else-if="rules.length === 0" class="text-sm text-gray-400 py-4 text-center">
+        <div v-else-if="rules.length === 0" class="text-gray-400 py-4 text-center">
           No rules yet. Create one to start monitoring.
         </div>
 
         <div v-else class="divide-y">
-          <div v-for="rule in rules" :key="rule.id" class="py-3 flex items-start gap-3">
+          <div v-for="rule in rules" :key="rule.id" class="py-2 flex items-start gap-2">
             <!-- Active indicator -->
             <button
               :title="rule.isActive ? 'Click to deactivate' : 'Click to activate'"
@@ -40,12 +40,12 @@
             </button>
 
             <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 flex-wrap">
+              <div class="flex items-center gap-1.5 flex-wrap">
                 <span class="font-medium">{{ rule.name }}</span>
-                <span v-if="!rule.isActive" class="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">inactive</span>
+                <span v-if="!rule.isActive" class="px-1.5 py-0 rounded text-[10px] font-medium border bg-gray-100 text-gray-600 border-gray-300">inactive</span>
               </div>
-              <p v-if="rule.description" class="text-sm text-gray-500 mt-0.5">{{ rule.description }}</p>
-              <div class="text-xs text-gray-400 mt-1 space-x-2">
+              <p v-if="rule.description" class="text-[11px] text-gray-500 mt-0.5">{{ rule.description }}</p>
+              <div class="text-[10px] text-gray-400 mt-1 space-x-2">
                 <span>{{ rule.timeWindowDays ? `Last ${rule.timeWindowDays} days` : 'All time' }}</span>
                 <span>·</span>
                 <span>{{ rule.conditionLogic }} logic</span>
@@ -57,7 +57,7 @@
                 <span
                   v-for="c in rule.conditions"
                   :key="c.id"
-                  class="inline-block text-xs bg-indigo-50 text-indigo-700 border border-indigo-200 rounded px-1.5 py-0.5"
+                  class="inline-block text-[10px] bg-indigo-50 text-indigo-700 border border-indigo-200 rounded px-1.5 py-0"
                 >
                   {{ metricLabel(c.metric) }} {{ operatorLabel(c.operator) }} {{ c.threshold }}
                 </span>
@@ -66,11 +66,11 @@
 
             <div class="flex gap-2 flex-shrink-0">
               <button
-                class="text-sm text-blue-600 hover:underline"
+                class="text-blue-600 hover:underline"
                 @click="openEditRuleModal(rule)"
               >Edit</button>
               <button
-                class="text-sm text-red-600 hover:underline"
+                class="text-red-600 hover:underline"
                 @click="deleteRule(rule)"
               >Delete</button>
             </div>
@@ -79,10 +79,10 @@
       </section>
 
       <!-- ── Analysis section ─────────────────────────────────────────────── -->
-      <section class="bg-white border rounded p-4">
-        <div class="flex items-center gap-4 flex-wrap mb-4">
+      <section class="bg-white rounded border p-3">
+        <div class="flex items-center gap-3 flex-wrap mb-3">
           <button
-            class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50 font-medium"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
             :disabled="analyzing || rules.filter(r => r.isActive).length === 0"
             @click="runAnalysis"
           >
@@ -90,62 +90,62 @@
             <span v-else>▶ Run Analysis</span>
           </button>
 
-          <label class="flex items-center gap-2 text-sm cursor-pointer select-none">
+          <label class="flex items-center gap-2 cursor-pointer select-none">
             <input v-model="showMuted" type="checkbox" class="rounded" />
             Show muted users
           </label>
 
-          <span v-if="analysisResult" class="text-sm text-gray-400 ml-auto">
+          <span v-if="analysisResult" class="text-gray-400 ml-auto">
             {{ rulesEvaluatedLabel }} · {{ analysisResult.flaggedUsers.length }} flagged ·
             Last run {{ lastRunLabel }}
           </span>
         </div>
 
-        <div v-if="analyzeError" class="text-sm text-red-600 mb-3 bg-red-50 border border-red-200 rounded p-2">
+        <div v-if="analyzeError" class="text-red-600 mb-2 bg-red-50 border border-red-200 rounded-md p-2">
           {{ analyzeError }}
         </div>
 
-        <div v-if="!analysisResult && !analyzing" class="text-sm text-gray-400 text-center py-8">
+        <div v-if="!analysisResult && !analyzing" class="text-gray-400 text-center py-8">
           Click "Run Analysis" to evaluate all active rules against current user data.
         </div>
 
-        <div v-else-if="displayedUsers.length === 0 && analysisResult" class="text-sm text-gray-400 text-center py-8">
+        <div v-else-if="displayedUsers.length === 0 && analysisResult" class="text-gray-400 text-center py-8">
           <span v-if="analysisResult.flaggedUsers.length === 0">No users flagged by the current active rules.</span>
           <span v-else>All flagged users are muted. Enable "Show muted users" to see them.</span>
         </div>
 
         <!-- Flagged user cards -->
-        <div v-else class="space-y-3">
+        <div v-else class="space-y-2">
           <div
             v-for="user in displayedUsers"
             :key="user.userId"
-            class="border rounded"
+            class="border rounded-lg"
             :class="user.isMuted ? 'border-gray-200 opacity-60' : 'border-red-200'"
           >
             <!-- User header row -->
-            <div class="flex items-start gap-3 p-3">
+            <div class="flex items-start gap-2 p-2">
               <!-- Avatar -->
               <img
                 v-if="user.avatar"
                 :src="user.avatar"
-                class="w-10 h-10 rounded-full flex-shrink-0 object-cover"
+                class="w-8 h-8 rounded-full flex-shrink-0 object-cover"
                 alt=""
               />
-              <div v-else class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0 text-gray-500 text-sm font-bold">
+              <div v-else class="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0 text-gray-500 text-xs font-bold">
                 {{ (user.username || '?')[0].toUpperCase() }}
               </div>
 
               <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 flex-wrap">
+                <div class="flex items-center gap-1.5 flex-wrap">
                   <a
                     :href="`/newsite/admin/manageUsers?q=${user.username}`"
                     target="_blank"
                     class="font-semibold text-indigo-700 hover:underline"
                   >{{ user.username || '(no username)' }}</a>
-                  <span v-if="user.discordTag" class="text-xs text-gray-400">{{ user.discordTag }}</span>
+                  <span v-if="user.discordTag" class="text-[10px] text-gray-400">{{ user.discordTag }}</span>
                   <span
                     v-if="user.isMuted"
-                    class="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded border"
+                    class="px-1.5 py-0 rounded text-[10px] font-medium border bg-gray-100 text-gray-600 border-gray-300"
                     :title="user.muteInfo?.reason ? `Reason: ${user.muteInfo.reason}` : 'No reason given'"
                   >muted{{ user.muteInfo?.mutedBy ? ` by ${user.muteInfo.mutedBy}` : '' }}</span>
                 </div>
@@ -155,12 +155,12 @@
                   <span
                     v-for="rule in user.triggeredRules"
                     :key="rule.ruleId"
-                    class="inline-block text-xs bg-red-50 text-red-700 border border-red-200 rounded px-1.5 py-0.5"
+                    class="inline-block text-[10px] bg-red-50 text-red-700 border border-red-200 rounded px-1.5 py-0"
                   >{{ rule.ruleName }}</span>
                 </div>
 
                 <!-- Quick metric summary -->
-                <div class="text-xs text-gray-500 mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5">
+                <div class="text-[10px] text-gray-500 mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5">
                   <span v-if="user.metrics.tradeOfferCount != null">
                     {{ user.metrics.tradeOfferCount }} trade{{ user.metrics.tradeOfferCount !== 1 ? 's' : '' }}
                   </span>
@@ -198,38 +198,38 @@
               </div>
 
               <!-- Action buttons -->
-              <div class="flex gap-2 flex-shrink-0">
+              <div class="flex gap-1.5 flex-shrink-0">
                 <button
-                  class="text-xs border rounded px-2 py-1 hover:bg-gray-50"
+                  class="px-2 py-1 text-[11px] border rounded-md hover:bg-gray-50"
                   @click="toggleExpand(user.userId)"
                 >{{ expandedUsers.has(user.userId) ? '▲ Hide' : '▼ Details' }}</button>
                 <button
                   v-if="!user.isMuted"
-                  class="text-xs bg-orange-100 text-orange-700 border border-orange-200 rounded px-2 py-1 hover:bg-orange-200"
+                  class="px-2 py-1 text-[11px] bg-orange-100 text-orange-700 border border-orange-200 rounded-md hover:bg-orange-200"
                   @click="openMuteModal(user)"
                 >Mute</button>
                 <button
                   v-else
-                  class="text-xs bg-blue-50 text-blue-700 border border-blue-200 rounded px-2 py-1 hover:bg-blue-100"
+                  class="px-2 py-1 text-[11px] bg-blue-50 text-blue-700 border border-blue-200 rounded-md hover:bg-blue-100"
                   @click="unmuteUser(user)"
                 >Unmute</button>
               </div>
             </div>
 
             <!-- Expanded detail panel -->
-            <div v-if="expandedUsers.has(user.userId)" class="border-t bg-gray-50 p-3 space-y-4">
+            <div v-if="expandedUsers.has(user.userId)" class="border-t bg-gray-50 p-2 space-y-3">
 
               <!-- Matched conditions detail -->
               <div>
-                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Why flagged</h4>
+                <h4 class="text-[10px] font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Why flagged</h4>
                 <div class="space-y-1">
                   <div v-for="rule in user.triggeredRules" :key="rule.ruleId">
-                    <div class="text-xs font-medium text-gray-700">{{ rule.ruleName }}</div>
+                    <div class="text-[11px] font-medium text-gray-700">{{ rule.ruleName }}</div>
                     <ul class="mt-0.5 space-y-0.5">
                       <li
                         v-for="(cond, i) in rule.matchedConditions"
                         :key="i"
-                        class="text-xs text-gray-600 pl-3 before:content-['•'] before:mr-1"
+                        class="text-[10px] text-gray-600 pl-3 before:content-['•'] before:mr-1"
                       >{{ cond }}</li>
                     </ul>
                   </div>
@@ -238,12 +238,12 @@
 
               <!-- All computed metrics -->
               <div>
-                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">All metrics computed</h4>
+                <h4 class="text-[10px] font-semibold text-gray-600 uppercase tracking-wide mb-1.5">All metrics computed</h4>
                 <div class="grid grid-cols-2 md:grid-cols-3 gap-1.5">
                   <div
                     v-for="[key, val] in Object.entries(user.metrics)"
                     :key="key"
-                    class="bg-white border rounded px-2 py-1.5 text-xs"
+                    class="bg-white border rounded-md px-2 py-1.5 text-[11px]"
                   >
                     <div class="text-gray-500">{{ metricLabel(key) }}</div>
                     <div class="font-semibold text-gray-800">{{ val }}{{ metricUnit(key) }}</div>
@@ -253,14 +253,14 @@
 
               <!-- Trade partners -->
               <div v-if="user.context.topTradePartners.length > 0">
-                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Top trade partners</h4>
+                <h4 class="text-[10px] font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Top trade partners</h4>
                 <div class="flex flex-wrap gap-2">
                   <a
                     v-for="p in user.context.topTradePartners"
                     :key="p.userId"
                     :href="`/newsite/admin/manageUsers?q=${p.username}`"
                     target="_blank"
-                    class="inline-flex items-center gap-1 text-xs bg-white border rounded px-2 py-1 hover:bg-indigo-50 text-indigo-700"
+                    class="inline-flex items-center gap-1 text-[11px] bg-white border rounded-md px-2 py-1 hover:bg-indigo-50 text-indigo-700"
                   >
                     {{ p.username || '(unknown)' }}
                     <span class="text-gray-400 font-normal">× {{ p.tradeCount }}</span>
@@ -270,14 +270,14 @@
 
               <!-- Auction sellers -->
               <div v-if="user.context.topAuctionSellers.length > 0">
-                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Auction wins by seller</h4>
+                <h4 class="text-[10px] font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Auction wins by seller</h4>
                 <div class="flex flex-wrap gap-2">
                   <a
                     v-for="s in user.context.topAuctionSellers"
                     :key="s.userId"
                     :href="`/newsite/admin/manageUsers?q=${s.username}`"
                     target="_blank"
-                    class="inline-flex items-center gap-1 text-xs bg-white border rounded px-2 py-1 hover:bg-indigo-50 text-indigo-700"
+                    class="inline-flex items-center gap-1 text-[11px] bg-white border rounded-md px-2 py-1 hover:bg-indigo-50 text-indigo-700"
                   >
                     {{ s.username || '(unknown)' }}
                     <span class="text-gray-400 font-normal">{{ s.wins }} win{{ s.wins !== 1 ? 's' : '' }}</span>
@@ -287,12 +287,12 @@
 
               <!-- Shared IP users -->
               <div v-if="user.context.sharedIPUsers.length > 0">
-                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Accounts sharing an IP</h4>
+                <h4 class="text-[10px] font-semibold text-gray-600 uppercase tracking-wide mb-1.5">Accounts sharing an IP</h4>
                 <div class="space-y-1">
                   <div
                     v-for="s in user.context.sharedIPUsers"
                     :key="s.userId"
-                    class="flex items-center gap-2 text-xs"
+                    class="flex items-center gap-2 text-[11px]"
                   >
                     <a
                       :href="`/newsite/admin/manageUsers?q=${s.username}`"
@@ -306,12 +306,12 @@
 
               <!-- cMart top cToons -->
               <div v-if="user.context.cmartTopCtoons && user.context.cmartTopCtoons.length > 0">
-                <h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1.5">cMart purchases by cToon</h4>
+                <h4 class="text-[10px] font-semibold text-gray-600 uppercase tracking-wide mb-1.5">cMart purchases by cToon</h4>
                 <div class="flex flex-wrap gap-2">
                   <span
                     v-for="c in user.context.cmartTopCtoons"
                     :key="c.ctoonName"
-                    class="inline-flex items-center gap-1 text-xs bg-orange-50 border border-orange-200 rounded px-2 py-1 text-orange-800"
+                    class="inline-flex items-center gap-1 text-[11px] bg-orange-50 border border-orange-200 rounded-md px-2 py-1 text-orange-800"
                   >
                     {{ c.ctoonName }}
                     <span class="text-gray-400 font-normal">× {{ c.purchaseCount }}</span>
@@ -321,7 +321,7 @@
 
               <div
                 v-if="user.context.topTradePartners.length === 0 && user.context.topAuctionSellers.length === 0 && user.context.sharedIPUsers.length === 0 && (!user.context.cmartTopCtoons || user.context.cmartTopCtoons.length === 0)"
-                class="text-xs text-gray-400"
+                class="text-[11px] text-gray-400"
               >No contextual data available for this user.</div>
             </div>
           </div>
@@ -330,31 +330,31 @@
     </div>
 
     <!-- ── Rule Create / Edit Modal ─────────────────────────────────────── -->
-    <div v-if="ruleModal.open" class="fixed inset-0 bg-black/40 z-50 flex items-start justify-center p-4 overflow-y-auto">
-      <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl my-8">
-        <div class="flex items-center justify-between p-4 border-b">
-          <h2 class="font-semibold text-lg">{{ ruleModal.mode === 'create' ? 'New Rule' : 'Edit Rule' }}</h2>
+    <div v-if="ruleModal.open" class="fixed inset-0 z-50 flex items-start justify-center p-2 overflow-y-auto bg-black/50">
+      <div class="relative bg-white w-full max-w-2xl rounded-lg shadow-lg my-8">
+        <div class="flex items-center justify-between px-4 py-3 border-b">
+          <h2 class="text-sm font-semibold">{{ ruleModal.mode === 'create' ? 'New Rule' : 'Edit Rule' }}</h2>
           <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="closeRuleModal">×</button>
         </div>
 
-        <div class="p-4 space-y-4">
+        <div class="px-4 py-3 space-y-3">
           <!-- Name -->
-          <div>
-            <label class="block text-sm font-medium mb-1">Rule name <span class="text-red-500">*</span></label>
-            <input v-model.trim="ruleForm.name" class="w-full border rounded px-3 py-2" placeholder="e.g. Alt Account Trade Funnel" />
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Rule name <span class="text-red-500">*</span></label>
+            <input v-model.trim="ruleForm.name" class="border rounded-md px-2 py-1.5 text-sm" placeholder="e.g. Alt Account Trade Funnel" />
           </div>
 
           <!-- Description -->
-          <div>
-            <label class="block text-sm font-medium mb-1">Description</label>
-            <textarea v-model.trim="ruleForm.description" class="w-full border rounded px-3 py-2 text-sm" rows="2" placeholder="Explain what this rule is looking for…"></textarea>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Description</label>
+            <textarea v-model.trim="ruleForm.description" class="border rounded-md px-2 py-1.5 text-sm" rows="2" placeholder="Explain what this rule is looking for…"></textarea>
           </div>
 
           <!-- Row: time window + condition logic + active toggle -->
-          <div class="grid grid-cols-3 gap-3">
-            <div>
-              <label class="block text-sm font-medium mb-1">Time window</label>
-              <select v-model="ruleForm.timeWindowDays" class="w-full border rounded px-3 py-2 text-sm">
+          <div class="grid grid-cols-3 gap-2">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Time window</label>
+              <select v-model="ruleForm.timeWindowDays" class="border rounded-md px-2 py-1.5 text-sm">
                 <option :value="null">All time</option>
                 <option :value="7">Last 7 days</option>
                 <option :value="14">Last 14 days</option>
@@ -365,18 +365,18 @@
                 <option :value="365">Last 365 days</option>
               </select>
             </div>
-            <div>
-              <label class="block text-sm font-medium mb-1">Condition logic</label>
-              <select v-model="ruleForm.conditionLogic" class="w-full border rounded px-3 py-2 text-sm">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Condition logic</label>
+              <select v-model="ruleForm.conditionLogic" class="border rounded-md px-2 py-1.5 text-sm">
                 <option value="AND">AND — all conditions must match</option>
                 <option value="OR">OR — any condition matches</option>
               </select>
             </div>
-            <div>
-              <label class="block text-sm font-medium mb-1">Active</label>
-              <label class="flex items-center gap-2 mt-2.5 cursor-pointer">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">Active</label>
+              <label class="flex items-center gap-2 mt-1.5 cursor-pointer">
                 <input v-model="ruleForm.isActive" type="checkbox" class="rounded" />
-                <span class="text-sm">{{ ruleForm.isActive ? 'Yes — included in analysis' : 'No — skipped' }}</span>
+                <span class="text-xs">{{ ruleForm.isActive ? 'Yes — included in analysis' : 'No — skipped' }}</span>
               </label>
             </div>
           </div>
@@ -384,7 +384,7 @@
           <!-- Conditions -->
           <div>
             <div class="flex items-center justify-between mb-2">
-              <label class="block text-sm font-medium">Conditions <span class="text-red-500">*</span></label>
+              <label class="text-xs font-medium">Conditions <span class="text-red-500">*</span></label>
               <button
                 type="button"
                 class="text-xs text-indigo-600 hover:underline"
@@ -392,7 +392,7 @@
               >+ Add condition</button>
             </div>
 
-            <div v-if="ruleForm.conditions.length === 0" class="text-sm text-gray-400 border border-dashed rounded p-3 text-center">
+            <div v-if="ruleForm.conditions.length === 0" class="text-xs text-gray-400 border border-dashed rounded-md p-2 text-center">
               No conditions yet. Add at least one.
             </div>
 
@@ -400,11 +400,11 @@
               <div
                 v-for="(cond, i) in ruleForm.conditions"
                 :key="i"
-                class="flex items-center gap-2 flex-wrap bg-gray-50 border rounded p-2"
+                class="flex items-center gap-2 flex-wrap bg-gray-50 border rounded-md p-2"
               >
                 <!-- Metric selector -->
                 <div class="flex-1 min-w-[180px]">
-                  <select v-model="cond.metric" class="w-full border rounded px-2 py-1.5 text-sm">
+                  <select v-model="cond.metric" class="w-full border rounded-md px-2 py-1.5 text-sm">
                     <option value="" disabled>Select metric…</option>
                     <optgroup v-for="cat in metricCategories" :key="cat.name" :label="cat.name">
                       <option v-for="m in cat.metrics" :key="m.key" :value="m.key">{{ m.label }}</option>
@@ -414,7 +414,7 @@
 
                 <!-- Operator selector -->
                 <div>
-                  <select v-model="cond.operator" class="border rounded px-2 py-1.5 text-sm">
+                  <select v-model="cond.operator" class="border rounded-md px-2 py-1.5 text-sm">
                     <option value="gt">is greater than</option>
                     <option value="gte">is ≥</option>
                     <option value="lt">is less than</option>
@@ -430,13 +430,13 @@
                     type="number"
                     min="0"
                     step="any"
-                    class="w-full border rounded px-2 py-1.5 text-sm"
+                    class="w-full border rounded-md px-2 py-1.5 text-sm"
                     placeholder="0"
                   />
                 </div>
 
                 <!-- Unit hint -->
-                <span v-if="cond.metric" class="text-xs text-gray-400">{{ metricUnit(cond.metric) }}</span>
+                <span v-if="cond.metric" class="text-[10px] text-gray-400">{{ metricUnit(cond.metric) }}</span>
 
                 <button
                   type="button"
@@ -447,7 +447,7 @@
             </div>
 
             <!-- Human readable preview -->
-            <div v-if="ruleForm.conditions.filter(c => c.metric).length > 0" class="mt-2 text-xs text-gray-500 bg-indigo-50 border border-indigo-100 rounded p-2">
+            <div v-if="ruleForm.conditions.filter(c => c.metric).length > 0" class="mt-2 text-[11px] text-gray-500 bg-indigo-50 border border-indigo-100 rounded-md p-2">
               <span class="font-medium text-indigo-700">Preview: </span>
               Flag user if
               <span
@@ -458,7 +458,7 @@
           </div>
 
           <!-- Metric reference -->
-          <details class="text-xs">
+          <details class="text-[11px]">
             <summary class="cursor-pointer text-gray-500 hover:text-gray-700">Metric reference ▾</summary>
             <div class="mt-2 space-y-1">
               <div v-for="[key, def] in Object.entries(METRIC_DEFINITIONS)" :key="key" class="flex gap-2">
@@ -468,13 +468,13 @@
             </div>
           </details>
 
-          <p v-if="ruleFormError" class="text-sm text-red-600">{{ ruleFormError }}</p>
+          <p v-if="ruleFormError" class="text-xs text-red-600">{{ ruleFormError }}</p>
         </div>
 
-        <div class="flex justify-end gap-2 p-4 border-t">
-          <button class="border rounded px-4 py-2 text-sm hover:bg-gray-50" @click="closeRuleModal">Cancel</button>
+        <div class="flex justify-end gap-2 px-4 py-3 border-t">
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="closeRuleModal">Cancel</button>
           <button
-            class="bg-indigo-600 text-white px-4 py-2 rounded text-sm hover:bg-indigo-700 disabled:opacity-50"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
             :disabled="ruleSaving"
             @click="saveRule"
           >{{ ruleSaving ? 'Saving…' : ruleModal.mode === 'create' ? 'Create Rule' : 'Save Changes' }}</button>
@@ -483,32 +483,32 @@
     </div>
 
     <!-- ── Mute Modal ──────────────────────────────────────────────────────── -->
-    <div v-if="muteModal.open" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-lg shadow-xl w-full max-w-md">
-        <div class="p-4 border-b flex items-center justify-between">
-          <h2 class="font-semibold">Mute user from monitor</h2>
+    <div v-if="muteModal.open" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50">
+      <div class="relative bg-white w-full max-w-md rounded-lg shadow-lg">
+        <div class="px-4 py-3 border-b flex items-center justify-between">
+          <h2 class="text-sm font-semibold">Mute user from monitor</h2>
           <button class="text-gray-400 hover:text-gray-600 text-xl leading-none" @click="muteModal.open = false">×</button>
         </div>
-        <div class="p-4 space-y-3">
-          <p class="text-sm">
+        <div class="px-4 py-3 space-y-2">
+          <p class="text-xs">
             Muting <strong>{{ muteModal.user?.username }}</strong> will hide them from the suspicious activity list
             (unless "Show muted users" is toggled on). They will still appear in all other admin tools.
           </p>
-          <div>
-            <label class="block text-sm font-medium mb-1">Reason (optional)</label>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-medium">Reason (optional)</label>
             <textarea
               v-model.trim="muteReason"
-              class="w-full border rounded px-3 py-2 text-sm"
+              class="border rounded-md px-2 py-1.5 text-sm"
               rows="2"
               placeholder="e.g. Investigated and confirmed legitimate activity"
             ></textarea>
           </div>
-          <p v-if="muteError" class="text-sm text-red-600">{{ muteError }}</p>
+          <p v-if="muteError" class="text-xs text-red-600">{{ muteError }}</p>
         </div>
-        <div class="flex justify-end gap-2 p-4 border-t">
-          <button class="border rounded px-4 py-2 text-sm hover:bg-gray-50" @click="muteModal.open = false">Cancel</button>
+        <div class="flex justify-end gap-2 px-4 py-3 border-t">
+          <button class="px-3 py-1 text-xs border rounded-md hover:bg-gray-50" @click="muteModal.open = false">Cancel</button>
           <button
-            class="bg-orange-600 text-white px-4 py-2 rounded text-sm hover:bg-orange-700 disabled:opacity-50"
+            class="px-3 py-1.5 text-xs font-semibold rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50"
             :disabled="muteSaving"
             @click="confirmMute"
           >{{ muteSaving ? 'Muting…' : 'Mute User' }}</button>

--- a/prisma/migrations/20260813000000_add_auctiononly_userctoonid_isstarted_index/migration.sql
+++ b/prisma/migrations/20260813000000_add_auctiononly_userctoonid_isstarted_index/migration.sql
@@ -1,0 +1,3 @@
+-- Backs the pending-listing check in createDailyFeaturedAuction (excludes
+-- userCtoons with a pending AuctionOnly listing via a relation filter).
+CREATE INDEX "AuctionOnly_userCtoonId_isStarted_idx" ON "AuctionOnly"("userCtoonId", "isStarted");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2100,6 +2100,7 @@ model AuctionOnly {
 
   @@index([startsAt])
   @@index([endsAt])
+  @@index([userCtoonId, isStarted])
 }
 
 model AuctionOnlyErrorLog {

--- a/server/api/admin/auction-only/[id]/start.post.js
+++ b/server/api/admin/auction-only/[id]/start.post.js
@@ -45,6 +45,10 @@ async function handleStart(event) {
     throw createError({ statusCode: 500, statusMessage: `Failed to start auction: ${err?.message || String(err)}` })
   }
 
+  if (result?.refused) {
+    throw createError({ statusCode: 409, statusMessage: result.reason })
+  }
+
   if (!result) {
     throw createError({
       statusCode: 409,

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -16,6 +16,8 @@ import { getFeaturedDissolveConfig, isCtoonFeatured } from '../utils/featuredDis
 import { applyDissolveSchedule, getDissolveScheduleConfig } from '../utils/dissolveSchedule.js'
 import { logAuctionOnlyError } from '../utils/auctionOnlyErrorLog.js'
 import { activateAuctionOnlyRow, AUCTION_ONLY_ROW_INCLUDE } from '../utils/auctionOnlyActivate.js'
+import { rarityFloor } from '../utils/auctionPriceSuggestion.js'
+import { isAutoAuctionEligibleRarity } from '../utils/autoAuctionEligibility.js'
 import { logCronError } from '../utils/cronErrorLog.js'
 import { autoAssignExpiredCMoonUsers } from '../utils/cmoon.js'
 
@@ -1047,13 +1049,15 @@ async function createDailyFeaturedAuction() {
   })
   if (!officialUser) return
 
-  const candidates = await prisma.userCtoon.findMany({
+  const rawCandidates = await prisma.userCtoon.findMany({
     where: {
       userId: officialUser.id,
       burnedAt: null,
-      ctoon: {
-        rarity: { not: "Crazy Rare" }
-      }
+      // Excludes any pending (unstarted) AuctionOnly listing via the relation
+      // itself, rather than loading every pending userCtoonId into a notIn
+      // array — stays bounded as the AuctionOnly table grows. Backed by the
+      // AuctionOnly(userCtoonId, isStarted) index.
+      auctionOnlyListings: { none: { isStarted: false } }
     },
     include: {
       ctoon: {
@@ -1062,17 +1066,9 @@ async function createDailyFeaturedAuction() {
     }
   })
 
-  if (!candidates.length) return
+  const candidates = rawCandidates.filter(c => isAutoAuctionEligibleRarity(c.ctoon?.rarity))
 
-  const rarityFloor = (r) => {
-    const s = (r || "").trim().toLowerCase()
-    if (s === "common") return 25
-    if (s === "uncommon") return 50
-    if (s === "rare") return 100
-    if (s === "very rare") return 187
-    if (s === "crazy rare") return 312
-    return 50
-  }
+  if (!candidates.length) return
 
   const shuffled = candidates.slice()
   for (let i = shuffled.length - 1; i > 0; i--) {

--- a/server/utils/auctionOnlyActivate.js
+++ b/server/utils/auctionOnlyActivate.js
@@ -7,18 +7,11 @@
 import fetch from 'node-fetch'
 import { prisma } from '../prisma.js'
 import { scheduleAuctionClose } from './queues.js'
+import { rarityFloor } from './auctionPriceSuggestion.js'
+import { logAuctionOnlyError } from './auctionOnlyErrorLog.js'
 
 const DISCORD_API = 'https://discord.com/api/v10'
-
-export function auctionOnlyRarityFloor(r) {
-  const s = (r || '').trim().toLowerCase()
-  if (s === 'common') return 25
-  if (s === 'uncommon') return 50
-  if (s === 'rare') return 100
-  if (s === 'very rare') return 187
-  if (s === 'crazy rare') return 312
-  return 50
-}
+const OFFICIAL_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
 
 export async function sendAuctionOnlyDiscordAnnouncement(result, isHolidayItem = false) {
   try {
@@ -99,8 +92,15 @@ export const AUCTION_ONLY_ROW_INCLUDE = {
 }
 
 // Activates a single AuctionOnly row (id + userCtoon include as above) into a
-// live Auction. Returns the created-auction summary, or null if the row was
-// already started / already has a live Auction by the time the transaction runs.
+// live Auction. Returns:
+//   - the created-auction summary on success
+//   - null if the row was already started / already has a live Auction by the
+//     time the transaction runs (not an error — just lost a race)
+//   - { refused: true, reason } if the official account no longer holds the
+//     copy that was scheduled to be auctioned. The listing is left pending
+//     (not marked isStarted) rather than silently activated against whoever
+//     holds the copy now, and the refusal is logged to AuctionOnlyErrorLog
+//     for the Manage Auction Only page.
 export async function activateAuctionOnlyRow(row) {
   const result = await prisma.$transaction(async (tx) => {
     const fresh = await tx.auctionOnly.findUnique({
@@ -117,6 +117,20 @@ export async function activateAuctionOnlyRow(row) {
     })
     if (!fresh || fresh.isStarted) return null
 
+    const official = await tx.user.findUnique({
+      where: { username: OFFICIAL_USERNAME },
+      select: { id: true }
+    })
+    if (!official) return { refused: true, reason: 'Official account not found' }
+
+    const userCtoon = await tx.userCtoon.findUnique({
+      where: { id: fresh.userCtoonId },
+      select: { userId: true, mintNumber: true }
+    })
+    if (!userCtoon || userCtoon.userId !== official.id) {
+      return { refused: true, reason: 'The official account no longer holds this copy — listing left pending.' }
+    }
+
     const active = await tx.auction.findFirst({
       where: { userCtoonId: fresh.userCtoonId, status: 'ACTIVE' },
       select: { id: true }
@@ -126,7 +140,7 @@ export async function activateAuctionOnlyRow(row) {
       return null
     }
 
-    const floor = auctionOnlyRarityFloor(row.userCtoon?.ctoon?.rarity)
+    const floor = rarityFloor(row.userCtoon?.ctoon?.rarity)
     const initialBet = Math.max(Number(fresh.pricePoints || 0), floor)
 
     const ms = new Date(fresh.endsAt).getTime() - new Date(fresh.startsAt).getTime()
@@ -138,7 +152,7 @@ export async function activateAuctionOnlyRow(row) {
         initialBet,
         duration: durationDays,
         endAt: new Date(fresh.endsAt),
-        creatorId: row.userCtoon?.userId,
+        creatorId: userCtoon.userId,
         isFeatured: fresh.isFeatured,
         auctionOnlyId: fresh.id
       },
@@ -161,13 +175,18 @@ export async function activateAuctionOnlyRow(row) {
       initialBet,
       durationDays,
       ctoon: row.userCtoon.ctoon,
-      mintNumber: row.userCtoon.mintNumber,
+      mintNumber: userCtoon.mintNumber,
       ctoonId: row.userCtoon.ctoon.id,
       isFeatured: fresh.isFeatured
     }
   })
 
   if (!result) return null
+
+  if (result.refused) {
+    await logAuctionOnlyError('activation', new Error(result.reason), row.id)
+    return result
+  }
 
   await scheduleAuctionClose(result.auctionId, result.endAt)
 

--- a/server/utils/autoAuctionEligibility.js
+++ b/server/utils/autoAuctionEligibility.js
@@ -1,0 +1,29 @@
+// server/utils/autoAuctionEligibility.js
+//
+// Rarity gate for the auto-listing systems (daily featured auction,
+// dissolve-queue launch): the only paths that pick a cToon to auction off
+// with nobody reviewing the choice first.
+//
+// Auction Only / Prize Only / Code Only cToons are never meant to be sold at
+// a plain rarity-floor price — Auction Only items already have their own
+// admin-curated listing flow, and Prize/Code Only items have no market price
+// to floor against. Crazy Rare is excluded because those are one-of-a-kind
+// and too valuable to auto-list. Anything else must have an explicit entry
+// in RARITY_FLOORS: silently falling back to DEFAULT_RARITY_FLOOR for an
+// unrecognized rarity is exactly what let unpriced items get auto-listed at
+// 50pts.
+import { RARITY_FLOORS } from './auctionPriceSuggestion.js'
+
+const AUTO_AUCTION_EXCLUDED_RARITIES = new Set([
+  'auction only',
+  'prize only',
+  'code only',
+  'crazy rare'
+])
+
+export function isAutoAuctionEligibleRarity(rarity) {
+  const key = String(rarity ?? '').trim().toLowerCase()
+  if (!key) return false
+  if (AUTO_AUCTION_EXCLUDED_RARITIES.has(key)) return false
+  return Object.prototype.hasOwnProperty.call(RARITY_FLOORS, key)
+}

--- a/server/workers/dissolve-auction-launch.worker.js
+++ b/server/workers/dissolve-auction-launch.worker.js
@@ -1,6 +1,8 @@
 import { Worker } from 'bullmq'
 import { prisma } from '../prisma.js'
 import { scheduleAuctionClose } from '../utils/queues.js'
+import { rarityFloor } from '../utils/auctionPriceSuggestion.js'
+import { isAutoAuctionEligibleRarity } from '../utils/autoAuctionEligibility.js'
 
 const QUEUE_NAME = process.env.DISSOLVE_AUCTION_LAUNCH_QUEUE_KEY || 'dissolveAuctionLaunch'
 const OFFICIAL_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
@@ -9,16 +11,6 @@ const connection = {
   host: process.env.REDIS_HOST,
   port: Number(process.env.REDIS_PORT),
   password: process.env.REDIS_PASSWORD?.trim() || undefined,
-}
-
-function rarityFloor(r) {
-  const s = (r || '').trim().toLowerCase()
-  if (s === 'common')     return 25
-  if (s === 'uncommon')   return 50
-  if (s === 'rare')       return 100
-  if (s === 'very rare')  return 187
-  if (s === 'crazy rare') return 312
-  return 50
 }
 
 new Worker(QUEUE_NAME, async (job) => {
@@ -37,6 +29,18 @@ new Worker(QUEUE_NAME, async (job) => {
     }
   })
   if (!entry) return  // already processed or deleted
+
+  // Not auto-listable (Auction/Prize/Code Only, Crazy Rare, or an
+  // unrecognized rarity with no explicit floor). Clear scheduledFor instead
+  // of leaving the entry stranded with no job: the next applyDissolveSchedule
+  // run picks up any entry with scheduledFor: null and re-queues it.
+  if (!isAutoAuctionEligibleRarity(entry.userCtoon?.ctoon?.rarity)) {
+    await prisma.dissolveAuctionQueue.update({
+      where: { id: entry.id },
+      data: { scheduledFor: null }
+    })
+    return
+  }
 
   const endAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
 

--- a/tests/autoAuctionEligibility.test.js
+++ b/tests/autoAuctionEligibility.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isAutoAuctionEligibleRarity } from '../server/utils/autoAuctionEligibility.js'
+
+test('isAutoAuctionEligibleRarity allows priced, non-excluded rarities', () => {
+  assert.equal(isAutoAuctionEligibleRarity('Common'), true)
+  assert.equal(isAutoAuctionEligibleRarity('uncommon'), true)
+  assert.equal(isAutoAuctionEligibleRarity('  Rare  '), true)
+  assert.equal(isAutoAuctionEligibleRarity('Very Rare'), true)
+})
+
+test('isAutoAuctionEligibleRarity excludes Auction/Prize/Code Only and Crazy Rare', () => {
+  assert.equal(isAutoAuctionEligibleRarity('Auction Only'), false)
+  assert.equal(isAutoAuctionEligibleRarity('Prize Only'), false)
+  assert.equal(isAutoAuctionEligibleRarity('Code Only'), false)
+  assert.equal(isAutoAuctionEligibleRarity('Crazy Rare'), false)
+  assert.equal(isAutoAuctionEligibleRarity('crazy rare'), false)
+})
+
+test('isAutoAuctionEligibleRarity refuses to guess a floor for unknown/missing rarities', () => {
+  assert.equal(isAutoAuctionEligibleRarity('Some New Rarity'), false)
+  assert.equal(isAutoAuctionEligibleRarity(''), false)
+  assert.equal(isAutoAuctionEligibleRarity(null), false)
+  assert.equal(isAutoAuctionEligibleRarity(undefined), false)
+})


### PR DESCRIPTION
Auto-listing paths (daily featured auction, dissolve-queue launch) were
falling back to a guessed 50pt floor for any rarity they didn't
recognize, including Auction Only / Prize Only / Code Only items with
no organic market price and one-of-a-kind Crazy Rares. Added
isAutoAuctionEligibleRarity() to gate both paths on the authoritative
RARITY_FLOORS list, excluding those rarities outright and refusing
unrecognized ones instead of guessing.

Also:
- createDailyFeaturedAuction now excludes userCtoons with a pending
  AuctionOnly listing via a bounded relation filter, backed by a new
  AuctionOnly(userCtoonId, isStarted) index.
- activateAuctionOnlyRow re-verifies the official account still holds
  the copy inside the transaction before activating, leaving the
  listing pending and logging to AuctionOnlyErrorLog otherwise;
  creatorId/mintNumber now come from that fresh read.
- The manual "Start Now" endpoint surfaces the real refusal reason
  instead of a generic "changed concurrently" message.
- dissolve-auction-launch.worker skips ineligible rarities and clears
  scheduledFor so applyDissolveSchedule re-queues the entry.
- Consolidated the duplicated rarityFloor implementations onto the
  authoritative copy in auctionPriceSuggestion.js.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017qRdEh35aotQ4VNJF1Gw2i