### PR TITLE
Exclude dissolve-queue cToons from daily featured auction picker

### DIFF
--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -1057,7 +1057,11 @@ async function createDailyFeaturedAuction() {
       // itself, rather than loading every pending userCtoonId into a notIn
       // array — stays bounded as the AuctionOnly table grows. Backed by the
       // AuctionOnly(userCtoonId, isStarted) index.
-      auctionOnlyListings: { none: { isStarted: false } }
+      auctionOnlyListings: { none: { isStarted: false } },
+      // Excludes cToons sitting in the dissolve queue awaiting their own
+      // scheduled auto-listing (dissolve-auction-launch.worker.js), so this
+      // job never double-lists / preempts that separate launch.
+      dissolveAuctionQueue: null
     },
     include: {
       ctoon: {


### PR DESCRIPTION
The daily auto-auction candidate query already excluded pending
Auction Only listings, but had no exclusion for cToons sitting in the
dissolve queue awaiting their own scheduled auto-listing via
dissolve-auction-launch.worker.js. That gap meant a dissolved-account
cToon transferred to the official account could get randomly
auctioned early by this job before its own scheduled launch fired.