### PR TITLE
Show winning cZone image in Discord contest announcement

### DIFF
--- a/server/api/admin/czone-contest/[id]/distribute.post.js
+++ b/server/api/admin/czone-contest/[id]/distribute.post.js
@@ -23,7 +23,7 @@ export default defineEventHandler(async (event) => {
       winnerPrizes: true,
       participantPrizes: true,
       submissions: {
-        select: { id: true, userId: true }
+        select: { id: true, userId: true, imageUrl: true }
       }
     }
   })
@@ -119,7 +119,7 @@ export default defineEventHandler(async (event) => {
   // Fire the Discord announcement without blocking the admin's response — Discord being
   // slow/unreachable must never make a successful, already-committed distribution look failed.
   // announceCZoneContestWinner never throws; this catch is just a safety net.
-  announceContestDistribution(contest, winnerUserId, winnerPrizes, participantPrizes)
+  announceContestDistribution(contest, winnerUserId, winnerPrizes, participantPrizes, winnerSubmission.imageUrl)
     .catch(e => console.error('cZone contest Discord announcement failed:', e?.message || e))
 
   return {
@@ -130,7 +130,7 @@ export default defineEventHandler(async (event) => {
   }
 })
 
-async function announceContestDistribution(contest, winnerUserId, winnerPrizes, participantPrizes) {
+async function announceContestDistribution(contest, winnerUserId, winnerPrizes, participantPrizes, winnerImageUrl) {
   const ctoonIds = [
     ...(winnerPrizes.ctoons ?? []).map(c => c.ctoonId),
     ...(participantPrizes.ctoons ?? []).map(c => c.ctoonId)
@@ -151,6 +151,7 @@ async function announceContestDistribution(contest, winnerUserId, winnerPrizes, 
     winnerUserId,
     winnerPrizeSummary: withNames(winnerPrizes),
     participantPrizeSummary: withNames(participantPrizes),
-    participantCount: contest.submissions.length
+    participantCount: contest.submissions.length,
+    winnerImageUrl
   })
 }

--- a/server/api/czone-contest/[id]/submit.post.js
+++ b/server/api/czone-contest/[id]/submit.post.js
@@ -65,7 +65,9 @@ export default defineEventHandler(async (event) => {
   try {
     await mkdir(uploadDir, { recursive: true })
 
-    const safeExt = extname(filePart.filename || '').toLowerCase() || '.png'
+    const ALLOWED_EXTS = new Set(['.png', '.jpg', '.jpeg'])
+    const requestedExt = extname(filePart.filename || '').toLowerCase()
+    const safeExt = ALLOWED_EXTS.has(requestedExt) ? requestedExt : '.png'
     filename = `${me.id}-${id}-${Date.now()}${safeExt}`
     await writeFile(join(uploadDir, filename), filePart.data)
 

--- a/server/utils/discord.js
+++ b/server/utils/discord.js
@@ -301,7 +301,7 @@ export async function sendGuildChannelMessageByName(channelName, content) {
 // Everything else (content text, @everyone/@here, roles, other users) is blocked at the
 // API level via allowed_mentions, so message content built from user-controlled strings
 // (usernames, contest/item names, etc.) can never trigger an unintended mass-ping.
-export async function sendGuildChannelMessageById(channelId, content, tokenOverride = null, mentionUserIds = []) {
+export async function sendGuildChannelMessageById(channelId, content, tokenOverride = null, mentionUserIds = [], embeds = []) {
   const rawToken = tokenOverride || process.env.BOT_TOKEN
   if (!rawToken || !channelId) return false
   const authHeader = rawToken.startsWith('Bot ') ? rawToken : `Bot ${rawToken}`
@@ -314,7 +314,8 @@ export async function sendGuildChannelMessageById(channelId, content, tokenOverr
       },
       body: JSON.stringify({
         content,
-        allowed_mentions: { parse: [], users: mentionUserIds }
+        allowed_mentions: { parse: [], users: mentionUserIds },
+        ...(embeds.length ? { embeds } : {})
       }),
       signal: AbortSignal.timeout(5000)
     })
@@ -405,7 +406,8 @@ export async function announceCZoneContestWinner(prisma, {
   winnerUserId,
   winnerPrizeSummary,
   participantPrizeSummary,
-  participantCount = 0
+  participantCount = 0,
+  winnerImageUrl = null
 }) {
   try {
     const [config, winner] = await Promise.all([
@@ -434,7 +436,17 @@ export async function announceCZoneContestWinner(prisma, {
       msg += `\n🎁 All ${participantCount} participant${participantCount === 1 ? '' : 's'} received: ${participantParts}.`
     }
 
-    await sendGuildChannelMessageById(channelId, msg, botToken, canPing ? [winner.discordId] : [])
+    const embeds = []
+    if (winnerImageUrl) {
+      const isProd = process.env.NODE_ENV === 'production'
+      const baseUrl = isProd ? 'https://www.cartoonreorbit.com' : 'http://localhost:3000'
+      embeds.push({
+        title: String(contestName || 'cZone Contest').slice(0, 256),
+        image: { url: encodeURI(`${baseUrl}${winnerImageUrl}`) }
+      })
+    }
+
+    await sendGuildChannelMessageById(channelId, msg, botToken, canPing ? [winner.discordId] : [], embeds)
   } catch (e) {
     console.error('announceCZoneContestWinner failed:', e?.message || e)
   }


### PR DESCRIPTION
Attaches the winning submission's already-captured PNG (stored at
submission time) as a Discord embed image when contest prizes are
distributed, converting the plain-text-only announcement into an
embed with the contest name as title. Falls back to the existing
plain-text message when no image is available.

Also whitelists uploaded submission file extensions (.png/.jpg/.jpeg)
since the stored image URL is now fetched by an external client
(Discord) rather than only rendered in an <img> tag.