### PR TITLE
Add pinned dissolve-queue entries so manual reschedules survive bulk recomputes

### DIFF
--- a/pages/admin/dissolve-queue.vue
+++ b/pages/admin/dissolve-queue.vue
@@ -47,23 +47,32 @@
                   <span v-if="entry.series"> · {{ entry.series }}</span>
                   <span v-if="entry.set"> · {{ entry.set }}</span>
                   <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>
-                  <span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium"
+                </div>
+                <div class="flex flex-wrap items-center gap-1 mt-1">
+                  <span class="px-1.5 py-0.5 rounded text-xs font-medium"
                         :class="categoryChip(entry.category)">{{ entry.category }}</span>
-                  <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
-                  <span v-if="entry.fromInactive" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">From Inactive</span>
+                  <span v-if="entry.isFeatured" class="px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
+                  <span v-if="entry.fromInactive" class="px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">From Inactive</span>
+                  <span v-if="entry.pinned" class="px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">📌 Pinned</span>
                 </div>
                 <div v-if="entry.sourceUsername" class="text-xs text-gray-400 mt-0.5">From: {{ entry.sourceUsername }}</div>
                 <div class="text-xs text-gray-500 mt-1 sm:hidden">{{ fmtCST(entry.scheduledFor) }}</div>
               </div>
-              <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 shrink-0">
-                <div class="hidden sm:block text-xs text-gray-600">{{ fmtCST(entry.scheduledFor) }}</div>
+              <div class="flex flex-col sm:flex-row items-end sm:items-center gap-1 shrink-0">
+                <div class="hidden sm:block text-xs text-gray-600 mr-1">{{ fmtCST(entry.scheduledFor) }}</div>
                 <button
                   @click="openReschedule(entry)"
-                  class="text-xs text-blue-600 hover:text-blue-800"
+                  class="px-2 py-1.5 text-xs rounded text-blue-600 hover:bg-blue-50"
                 >Reschedule</button>
                 <button
+                  v-if="entry.pinned"
+                  @click="unpinEntry(entry.id)"
+                  class="px-2 py-1.5 text-xs rounded text-amber-600 hover:bg-amber-50 disabled:opacity-50"
+                  :disabled="unpinningId === entry.id"
+                >{{ unpinningId === entry.id ? '…' : 'Unpin' }}</button>
+                <button
                   @click="cancelEntry(entry.id)"
-                  class="text-xs text-red-500 hover:text-red-700"
+                  class="px-2 py-1.5 text-xs rounded text-red-500 hover:bg-red-50 disabled:opacity-50"
                   :disabled="cancellingId === entry.id"
                 >{{ cancellingId === entry.id ? '…' : 'Unschedule' }}</button>
               </div>
@@ -187,10 +196,13 @@
                   <span v-if="entry.series"> · {{ entry.series }}</span>
                   <span v-if="entry.set"> · {{ entry.set }}</span>
                   <span v-if="entry.mintNumber != null"> · Mint #{{ entry.mintNumber }}</span>
-                  <span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium"
+                </div>
+                <div class="flex flex-wrap items-center gap-1 mt-1">
+                  <span class="px-1.5 py-0.5 rounded text-xs font-medium"
                         :class="categoryChip(entry.category)">{{ entry.category }}</span>
-                  <span v-if="entry.isFeatured" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
-                  <span v-if="entry.fromInactive" class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">From Inactive</span>
+                  <span v-if="entry.isFeatured" class="px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Featured</span>
+                  <span v-if="entry.fromInactive" class="px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">From Inactive</span>
+                  <span v-if="entry.pinned" class="px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">📌 Pinned</span>
                 </div>
                 <div v-if="entry.sourceUsername" class="text-xs text-gray-400 mt-0.5">From: {{ entry.sourceUsername }}</div>
                 <div class="text-xs text-gray-500 mt-1">
@@ -200,11 +212,17 @@
               <div class="shrink-0 flex flex-col items-end gap-1">
                 <button
                   @click="openReschedule(entry)"
-                  class="text-xs text-blue-600 hover:text-blue-800"
+                  class="px-2 py-1.5 text-xs rounded text-blue-600 hover:bg-blue-50"
                 >Reschedule</button>
                 <button
+                  v-if="entry.pinned"
+                  @click="unpinEntry(entry.id)"
+                  class="px-2 py-1.5 text-xs rounded text-amber-600 hover:bg-amber-50 disabled:opacity-50"
+                  :disabled="unpinningId === entry.id"
+                >{{ unpinningId === entry.id ? '…' : 'Unpin' }}</button>
+                <button
                   @click="cancelEntry(entry.id)"
-                  class="text-xs text-red-500 hover:text-red-700"
+                  class="px-2 py-1.5 text-xs rounded text-red-500 hover:bg-red-50 disabled:opacity-50"
                   :disabled="cancellingId === entry.id"
                 >{{ cancellingId === entry.id ? '…' : (entry.scheduledFor ? 'Unschedule' : 'Remove') }}</button>
               </div>
@@ -291,6 +309,51 @@
             :disabled="scheduling"
             class="w-full sm:w-auto px-4 py-2 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
           >{{ scheduling ? 'Scheduling…' : 'Apply Schedule' }}</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Reschedule All: pinned-entry confirmation modal -->
+    <div v-if="showRescheduleConfirm" class="fixed inset-0 z-30 flex items-center justify-center p-3 sm:p-6 bg-black/40" @click.self="closeRescheduleConfirm">
+      <div class="bg-white rounded-lg shadow-xl w-full max-w-md max-h-[90vh] flex flex-col">
+        <div class="p-4 sm:p-5 border-b">
+          <h2 class="font-semibold text-lg">Some auctions were manually rescheduled</h2>
+        </div>
+
+        <div class="p-4 sm:p-5 overflow-y-auto space-y-3 flex-1 text-sm text-gray-700 leading-relaxed">
+          <p>
+            <span class="font-semibold">{{ pinnedCount }}</span>
+            {{ pinnedCount === 1 ? 'cToon currently has' : 'cToons currently have' }}
+            a date/time that a mod manually picked for it. That's called being
+            <span class="font-semibold">"pinned."</span>
+          </p>
+          <p>
+            Normally, "Reschedule All" recalculates the date/time for every entry using the cadence
+            settings above. Pinned entries are protected from that by default, so a mod's manual
+            choice doesn't get silently undone by this form.
+          </p>
+          <p>What should this run do with the pinned {{ pinnedCount === 1 ? 'entry' : 'entries' }}?</p>
+        </div>
+
+        <div class="p-4 sm:p-5 border-t space-y-2">
+          <button
+            @click="doApplySchedule(false)"
+            :disabled="scheduling"
+            class="w-full px-4 py-2.5 text-sm rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+          >Keep the {{ pinnedCount === 1 ? 'pinned entry' : `${pinnedCount} pinned entries` }} as-is (Recommended)</button>
+          <button
+            @click="doApplySchedule(true)"
+            :disabled="scheduling"
+            class="w-full px-4 py-2.5 text-sm rounded-md border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50"
+          >Reset the pinned {{ pinnedCount === 1 ? 'entry' : 'entries' }} too</button>
+          <p class="text-xs text-gray-400 text-center px-2">
+            Resetting will erase those manually-picked dates and reassign them like any other queue entry.
+          </p>
+          <button
+            @click="closeRescheduleConfirm"
+            :disabled="scheduling"
+            class="w-full px-4 py-2 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-50"
+          >Cancel</button>
         </div>
       </div>
     </div>
@@ -520,6 +583,10 @@ const scheduling      = ref(false)
 const scheduleError   = ref('')
 const scheduleSuccess = ref('')
 const cancellingId    = ref(null)
+const unpinningId     = ref(null)
+
+const showRescheduleConfirm = ref(false)
+const pinnedCount = computed(() => allEntries.value.filter(e => e.pinned).length)
 
 async function loadData() {
   try {
@@ -541,7 +608,22 @@ onBeforeUnmount(() => {
   document.removeEventListener('click', handleDocumentClick)
 })
 
-async function applySchedule() {
+function applySchedule() {
+  // Recompute-everything can silently overwrite dates mods hand-picked for
+  // specific entries — make that an explicit choice instead of a surprise.
+  if (form.value.reschedule && pinnedCount.value > 0) {
+    showRescheduleConfirm.value = true
+    return
+  }
+  doApplySchedule(false)
+}
+
+function closeRescheduleConfirm() {
+  showRescheduleConfirm.value = false
+}
+
+async function doApplySchedule(includePinned) {
+  showRescheduleConfirm.value = false
   scheduling.value    = true
   scheduleError.value = ''
   scheduleSuccess.value = ''
@@ -555,6 +637,7 @@ async function applySchedule() {
         featuredPerCadence: f.featuredPerCadence,
         otherPerCadence:    f.otherPerCadence,
         reschedule:         f.reschedule,
+        includePinned,
       }
     })
     scheduleSuccess.value = `Scheduled ${res.scheduled} entries.`
@@ -612,13 +695,28 @@ async function saveReschedule(id) {
       method: 'PATCH',
       body: { scheduledForUtc }
     })
-    updateEntryInLists(id, { scheduledFor: scheduledForUtc })
+    updateEntryInLists(id, { scheduledFor: scheduledForUtc, pinned: true })
     cancelReschedule()
     await loadData()
   } catch (e) {
     rescheduleError.value = e?.data?.statusMessage || 'Failed to reschedule entry.'
   } finally {
     reschedulingSaving.value = false
+  }
+}
+
+async function unpinEntry(id) {
+  unpinningId.value = id
+  try {
+    await $fetch(`/api/admin/dissolve-queue/${id}`, {
+      method: 'PATCH',
+      body: { unpin: true }
+    })
+    updateEntryInLists(id, { pinned: false })
+  } catch (e) {
+    console.error('Failed to unpin entry', e)
+  } finally {
+    unpinningId.value = null
   }
 }
 

--- a/prisma/migrations/20260815000000_add_dissolve_queue_pinned_at/migration.sql
+++ b/prisma/migrations/20260815000000_add_dissolve_queue_pinned_at/migration.sql
@@ -1,0 +1,8 @@
+-- Tracks when a mod manually rescheduled a DissolveAuctionQueue entry
+-- (set by [id].patch.js). Non-null rows are excluded from the bulk
+-- applyDissolveSchedule recompute unless the caller explicitly opts in
+-- with includePinned. No index: the table is small and the only query
+-- shape that filters on it (reschedule=true bulk recompute) already
+-- scans the whole table, so a standalone index would only add write
+-- overhead with no read benefit.
+ALTER TABLE "DissolveAuctionQueue" ADD COLUMN "pinnedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2138,6 +2138,7 @@ model DissolveAuctionQueue {
   fromInactive   Boolean   @default(false) // true = queued via the automatic 9-month inactivity dissolve
   sourceUsername String? // username of the dissolved account this cToon came from
   scheduledFor   DateTime? // UTC; null = not yet scheduled
+  pinnedAt       DateTime? // non-null = a mod manually rescheduled this entry (set by [id].patch.js); excluded from applyDissolveSchedule's bulk recompute unless includePinned is passed
   createdAt      DateTime  @default(now())
 
   userCtoon UserCtoon @relation(fields: [userCtoonId], references: [id])

--- a/server/api/admin/dissolve-queue/[id].patch.js
+++ b/server/api/admin/dissolve-queue/[id].patch.js
@@ -1,8 +1,10 @@
 // server/api/admin/dissolve-queue/[id].patch.js
-// Reschedule a single dissolve-queue entry to a new date/time.
+// Reschedule a single dissolve-queue entry to a new date/time, or unpin one
+// so it falls back under the automatic bulk scheduler.
 import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { scheduleDissolveAuctionLaunch } from '@/server/utils/queues'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -17,17 +19,48 @@ export default defineEventHandler(async (event) => {
   const { id } = event.context.params || {}
   if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing id' })
 
+  // Only these two shapes are ever read from the body — never spread it
+  // directly into a Prisma `data` object, since this row also carries
+  // fields (priority, fromInactive, category, …) a client must not set.
   const body = await readBody(event) || {}
-  const { scheduledForUtc } = body
-  if (!scheduledForUtc) throw createError({ statusCode: 400, statusMessage: 'scheduledForUtc required' })
-  const scheduledFor = new Date(scheduledForUtc)
-  if (isNaN(scheduledFor.getTime())) throw createError({ statusCode: 400, statusMessage: 'Invalid scheduledForUtc' })
+  const { scheduledForUtc, unpin } = body
 
   const entry = await prisma.dissolveAuctionQueue.findUnique({ where: { id } })
   if (!entry) throw createError({ statusCode: 404, statusMessage: 'Queue entry not found' })
 
-  await prisma.dissolveAuctionQueue.update({ where: { id }, data: { scheduledFor } })
+  if (unpin === true) {
+    if (!entry.pinnedAt) return { ok: true, scheduledFor: entry.scheduledFor, pinnedAt: null }
+
+    await prisma.dissolveAuctionQueue.update({ where: { id }, data: { pinnedAt: null } })
+
+    await logAdminChange(prisma, {
+      userId: me.id,
+      area: 'Admin:DissolveQueue',
+      key: 'unpinEntry',
+      targetUsername: entry.sourceUsername,
+      prevValue: { scheduledFor: entry.scheduledFor, pinnedAt: entry.pinnedAt },
+      newValue:  { scheduledFor: entry.scheduledFor, pinnedAt: null }
+    })
+
+    return { ok: true, scheduledFor: entry.scheduledFor, pinnedAt: null }
+  }
+
+  if (!scheduledForUtc) throw createError({ statusCode: 400, statusMessage: 'scheduledForUtc required' })
+  const scheduledFor = new Date(scheduledForUtc)
+  if (isNaN(scheduledFor.getTime())) throw createError({ statusCode: 400, statusMessage: 'Invalid scheduledForUtc' })
+
+  const pinnedAt = new Date()
+  await prisma.dissolveAuctionQueue.update({ where: { id }, data: { scheduledFor, pinnedAt } })
   await scheduleDissolveAuctionLaunch(id, scheduledFor)
 
-  return { ok: true, scheduledFor }
+  await logAdminChange(prisma, {
+    userId: me.id,
+    area: 'Admin:DissolveQueue',
+    key: 'rescheduleEntry',
+    targetUsername: entry.sourceUsername,
+    prevValue: { scheduledFor: entry.scheduledFor, pinnedAt: entry.pinnedAt },
+    newValue:  { scheduledFor, pinnedAt }
+  })
+
+  return { ok: true, scheduledFor, pinnedAt }
 })

--- a/server/api/admin/dissolve-queue/index.get.js
+++ b/server/api/admin/dissolve-queue/index.get.js
@@ -30,11 +30,13 @@ export default defineEventHandler(async (event) => {
     OTHER:    { total: 0, scheduled: 0, unscheduled: 0 },
   }
 
+  let pinnedCount = 0
   for (const e of allEntries) {
     const cat = byCategory[e.category] || byCategory.OTHER
     cat.total++
     if (e.scheduledFor) cat.scheduled++
     else cat.unscheduled++
+    if (e.pinnedAt) pinnedCount++
   }
 
   const mapEntry = (e) => ({
@@ -45,6 +47,7 @@ export default defineEventHandler(async (event) => {
     fromInactive:   e.fromInactive,
     sourceUsername: e.sourceUsername,
     scheduledFor:   e.scheduledFor,
+    pinned:         !!e.pinnedAt,
     createdAt:      e.createdAt,
     ctoonName:      e.userCtoon?.ctoon?.name ?? null,
     ctoonImage:     e.userCtoon?.ctoon?.assetPath ?? null,
@@ -66,6 +69,7 @@ export default defineEventHandler(async (event) => {
   return {
     total: allEntries.length,
     byCategory,
+    pinnedCount,
     upcoming,
     entries,
   }

--- a/server/api/admin/dissolve-queue/schedule.post.js
+++ b/server/api/admin/dissolve-queue/schedule.post.js
@@ -2,6 +2,8 @@
 // Reschedule all (or unscheduled) dissolve-queue entries from the management page.
 import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
 import { applyDissolveSchedule, saveDissolveScheduleConfig } from '@/server/utils/dissolveSchedule'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { prisma } from '@/server/prisma'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -20,6 +22,7 @@ export default defineEventHandler(async (event) => {
     featuredPerCadence,
     otherPerCadence,
     reschedule = false,
+    includePinned = false,
   } = body
 
   if (!startAtUtc) throw createError({ statusCode: 400, statusMessage: 'startAtUtc required' })
@@ -30,7 +33,23 @@ export default defineEventHandler(async (event) => {
   // cron can keep scheduling new entries the same way going forward.
   await saveDissolveScheduleConfig({ cadenceDays, featuredPerCadence, otherPerCadence })
 
-  const scheduled = await applyDissolveSchedule({ startAtUtc, cadenceDays, featuredPerCadence, otherPerCadence, reschedule })
+  // Only relevant when reschedule is also true — an admin explicitly choosing
+  // to reset entries other mods hand-scheduled is worth a distinct audit entry,
+  // since it silently discards their manual holds.
+  if (reschedule && includePinned) {
+    const pinnedCount = await prisma.dissolveAuctionQueue.count({ where: { pinnedAt: { not: null } } })
+    if (pinnedCount > 0) {
+      await logAdminChange(prisma, {
+        userId: me.id,
+        area: 'Admin:DissolveQueue',
+        key: 'bulkRescheduleOverridePinned',
+        prevValue: { pinnedCount },
+        newValue:  { startAtUtc, cadenceDays, featuredPerCadence, otherPerCadence }
+      })
+    }
+  }
+
+  const scheduled = await applyDissolveSchedule({ startAtUtc, cadenceDays, featuredPerCadence, otherPerCadence, reschedule, includePinned })
 
   return { scheduled }
 })

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -724,7 +724,10 @@ async function enforceDormantAccounts() {
         cadenceDays,
         featuredPerCadence,
         otherPerCadence,
-        reschedule: true
+        reschedule: true,
+        // Never let the automatic inactivity sweep touch entries a mod
+        // hand-scheduled — only an explicit admin "Reschedule All" override can.
+        includePinned: false
       })
     } catch (err) {
       console.error('[enforceDormantAccounts] Failed to auto-schedule dissolve queue:', err)

--- a/server/utils/dissolveSchedule.js
+++ b/server/utils/dissolveSchedule.js
@@ -54,9 +54,12 @@ export async function saveDissolveScheduleConfig({ cadenceDays, featuredPerCaden
  * @param {number} opts.featuredPerCadence
  * @param {number} opts.otherPerCadence
  * @param {boolean} [opts.reschedule] - if true, recompute every entry (not just unscheduled ones)
+ * @param {boolean} [opts.includePinned] - if true (and reschedule is true), also recompute
+ *   entries a mod manually rescheduled (pinnedAt set), clearing their pin in the process.
+ *   Ignored when reschedule is false, since unscheduled entries are never pinned.
  * @returns {Promise<number>} number of entries scheduled
  */
-export async function applyDissolveSchedule({ startAtUtc, cadenceDays, featuredPerCadence, otherPerCadence, reschedule = false }) {
+export async function applyDissolveSchedule({ startAtUtc, cadenceDays, featuredPerCadence, otherPerCadence, reschedule = false, includePinned = false }) {
   const startMs = new Date(startAtUtc).getTime()
   if (isNaN(startMs)) throw new Error('Invalid startAtUtc')
 
@@ -65,8 +68,12 @@ export async function applyDissolveSchedule({ startAtUtc, cadenceDays, featuredP
     OTHER:    Number(otherPerCadence)    || 0,
   }
 
+  const where = reschedule
+    ? (includePinned ? {} : { pinnedAt: null })
+    : { scheduledFor: null }
+
   const entries = await prisma.dissolveAuctionQueue.findMany({
-    where: reschedule ? {} : { scheduledFor: null },
+    where,
     orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
     select: { id: true, category: true, scheduledFor: true }
   })
@@ -91,7 +98,9 @@ export async function applyDissolveSchedule({ startAtUtc, cadenceDays, featuredP
       const scheduledFor = new Date(startMs + i * intervalMs)
       await prisma.dissolveAuctionQueue.update({
         where: { id: ids[i] },
-        data:  { scheduledFor }
+        // Any entry swept up by the auto-scheduler is auto-managed going
+        // forward, so clear its pin (a no-op for entries that weren't pinned).
+        data:  { scheduledFor, pinnedAt: null }
       })
       await scheduleDissolveAuctionLaunch(ids[i], scheduledFor)
       scheduled++


### PR DESCRIPTION
Mods rescheduling a single dissolve-queue entry had it silently reverted or
re-shuffled whenever the daily inactivity-dissolve cron (or an admin
"Reschedule All") ran, because applyDissolveSchedule recomputed every row
with no way to tell a hand-picked date from an auto-assigned one.

- Add DissolveAuctionQueue.pinnedAt, set whenever a mod reschedules an entry
  via PATCH /api/admin/dissolve-queue/[id]; excluded from bulk recomputes
  unless includePinned is explicitly passed.
- The inactivity cron always passes includePinned: false. The admin
  "Reschedule All" form surfaces a confirmation modal when pinned entries
  exist, letting the admin choose to keep or override them.
- Add an unpin action so an entry can return to auto-scheduling without
  deleting it, and audit-log pin/unpin/override actions.
- UI: badge pinned entries, bigger tap targets for row actions, mobile
  friendly confirmation modal.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015nNvVhFjg7KKwpGpV7LUWA