### PR TITLE
Add notification hub and locked-points display

### DIFF
--- a/components/Onboarding.vue
+++ b/components/Onboarding.vue
@@ -1,23 +1,22 @@
 <template>
-  <div ref="onboardingRef" class="fixed bottom-3 right-3 z-50 flex flex-col items-end gap-2">
+  <div ref="onboardingRef" class="ob-root fixed right-3 z-50 flex flex-col items-end gap-2">
     <transition name="daily-drawer">
       <div
         v-show="isOpen"
-        class="ob-panel w-72 sm:w-80 rounded-2xl border border-white/15 shadow-xl backdrop-blur overflow-hidden"
-        style="--panel-max: 300px;"
+        class="ob-panel w-72 sm:w-80 rounded-2xl border border-white/15 shadow-xl backdrop-blur overflow-hidden flex flex-col"
       >
-        <div class="h-1 w-full bg-gradient-to-r from-[var(--OrbitDarkBlue)] via-[var(--OrbitLightBlue)] to-[#66CC00]"></div>
-        <div class="px-4 py-3">
+        <div class="h-1 w-full bg-gradient-to-r from-[var(--OrbitDarkBlue)] via-[var(--OrbitLightBlue)] to-[#66CC00] flex-none"></div>
+        <div class="px-4 py-3 flex-none">
           <div class="flex items-center justify-between">
             <div>
               <p class="text-[11px] uppercase tracking-widest text-white/50">Onboarding</p>
               <h3 class="text-sm font-semibold text-white">
-                {{ activeTab === 'daily' ? 'Daily Checklist' : 'Events' }}
+                {{ panelHeading }}
               </h3>
             </div>
             <button
               type="button"
-              class="text-xs font-semibold text-white/60 hover:text-white transition"
+              class="ob-hide text-xs font-semibold text-white/60 hover:text-white transition"
               @click="isOpen = false"
             >
               Hide
@@ -38,10 +37,21 @@
             >
               Events
             </button>
+            <!-- "Alerts", not "Notifications". At 360px the panel is 288px wide,
+                 which leaves each of three tabs ~58px of text room at 12px —
+                 "Notifications" wraps to two lines, "Alerts" does not. -->
+            <button
+              type="button"
+              :class="tabButtonClass('alerts')"
+              @click="activeTab = 'alerts'"
+            >
+              Alerts
+              <span v-if="unreadCount > 0" class="ob-tab-count">{{ badgeLabel }}</span>
+            </button>
           </div>
         </div>
-        <div class="px-4 pb-4">
-          <div v-if="activeTab === 'daily'">
+        <div class="px-4 pb-4 flex-1 min-h-0 flex flex-col">
+          <div v-if="activeTab === 'daily'" class="flex-1 min-h-0 flex flex-col">
             <div v-if="dailyPending || (!dailyData && !dailyError)" class="space-y-3 animate-pulse">
               <div class="h-4 bg-white/10 rounded w-5/6"></div>
               <div class="h-4 bg-white/10 rounded w-4/6"></div>
@@ -50,7 +60,7 @@
             <div v-else-if="dailyError" class="text-sm text-white/55">
               Sign in to view your daily activities.
             </div>
-            <ul v-else class="space-y-3 max-h-[220px] overflow-y-auto pr-1">
+            <ul v-else class="space-y-3 flex-1 min-h-0 overflow-y-auto overscroll-contain pr-1">
               <li v-for="item in items" :key="item.id" class="flex items-start gap-3">
                 <span
                   :class="[
@@ -93,7 +103,52 @@
               </li>
             </ul>
           </div>
-          <div v-else>
+          <div v-else-if="activeTab === 'alerts'" class="flex-1 min-h-0 flex flex-col">
+            <div v-if="alertsPending && !alertsLoaded" class="space-y-3 animate-pulse">
+              <div class="h-4 bg-white/10 rounded w-5/6"></div>
+              <div class="h-4 bg-white/10 rounded w-4/6"></div>
+              <div class="h-4 bg-white/10 rounded w-3/6"></div>
+            </div>
+            <div v-else-if="alertsError" class="text-sm text-white/55">
+              Sign in to view your notifications.
+            </div>
+            <template v-else>
+              <button
+                v-if="unreadCount > 0"
+                type="button"
+                class="ob-mark-all mb-2 w-full rounded-lg border border-white/15 bg-white/5 text-[11px] font-semibold text-white/70 hover:text-white hover:bg-white/10 transition"
+                @click="markAllRead"
+              >
+                Mark all read
+              </button>
+              <p v-if="!notifications.length" class="text-sm text-white/45">
+                No notifications yet.
+              </p>
+              <ul v-else class="space-y-2 flex-1 min-h-0 overflow-y-auto overscroll-contain pr-1">
+                <li v-for="n in notifications" :key="n.id">
+                  <component
+                    :is="notificationRoute(n) ? 'NuxtLink' : 'div'"
+                    v-bind="notificationRoute(n) ? { to: notificationRoute(n) } : {}"
+                    class="ob-alert block rounded-lg border px-3 py-2 transition"
+                    :class="n.readAt ? 'ob-alert-read border-white/10' : 'ob-alert-unread border-white/20'"
+                    @click="onNotificationClick(n)"
+                  >
+                    <div class="flex items-start gap-2">
+                      <span v-if="!n.readAt" class="ob-alert-dot mt-1.5 flex-none"></span>
+                      <div class="min-w-0 flex-1">
+                        <p class="ob-clamp-2 break-words text-sm text-white/90">
+                          {{ n.title }}<span v-if="n.count > 1" class="text-white/50"> ×{{ n.count }}</span>
+                        </p>
+                        <p v-if="n.body" class="ob-clamp-1 break-words text-xs text-white/50">{{ n.body }}</p>
+                        <p class="text-[10px] text-white/35">{{ formatRelative(n.createdAt) }}</p>
+                      </div>
+                    </div>
+                  </component>
+                </li>
+              </ul>
+            </template>
+          </div>
+          <div v-else class="flex-1 min-h-0 flex flex-col">
             <div v-if="eventsPending || (!eventsData && !eventsError)" class="space-y-3 animate-pulse">
               <div class="h-4 bg-white/10 rounded w-5/6"></div>
               <div class="h-4 bg-white/10 rounded w-4/6"></div>
@@ -102,7 +157,7 @@
             <div v-else-if="eventsError" class="text-sm text-white/55">
               Sign in to view active events.
             </div>
-            <div v-else class="space-y-4 max-h-[220px] overflow-y-auto pr-1">
+            <div v-else class="space-y-4 flex-1 min-h-0 overflow-y-auto overscroll-contain pr-1">
               <div>
                 <p class="text-[11px] uppercase tracking-widest text-white/50">Holiday Events</p>
                 <div class="mt-1 text-[11px] text-white/40 leading-snug">Check the cMart Holiday tab to purchase Holiday cToons.</div>
@@ -189,10 +244,21 @@
 
     <button
       type="button"
-      class="ob-toggle group inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white shadow-lg backdrop-blur transition hover:shadow-xl hover:border-white/35"
+      class="ob-toggle group relative inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white shadow-lg backdrop-blur transition hover:shadow-xl hover:border-white/35"
+      :aria-label="unreadCount > 0 ? `Daily — ${unreadCount} unread notifications` : 'Daily'"
       @click="toggleOpen"
     >
-      <span class="h-2 w-2 rounded-full bg-[#66CC00] shadow-[0_0_10px_#66CC00]"></span>
+      <!-- The status dot turns red when there is something unread. The button
+           says "Daily", so a bare badge would read as "you have daily tasks
+           left" — which is what the green dot already implies. -->
+      <span
+        class="h-2 w-2 rounded-full"
+        :class="unreadCount > 0
+          ? 'bg-[#ef4444] shadow-[0_0_10px_#ef4444]'
+          : 'bg-[#66CC00] shadow-[0_0_10px_#66CC00]'"
+      ></span>
+      <!-- Nothing renders at all when the count is zero. -->
+      <span v-if="unreadCount > 0" class="ob-badge">{{ badgeLabel }}</span>
       Daily
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -227,7 +293,15 @@ const czoneContestPath = (id) =>
 const isOpen = ref(false)
 const onboardingRef = ref(null)
 
+const { user } = useAuth()
+
 const activeTab = ref('daily')
+const notifications = ref([])
+const unreadCount = ref(0)
+const alertsPending = ref(false)
+const alertsLoaded = ref(false)
+const alertsError = ref(null)
+
 const dailyData = ref(null)
 const dailyPending = ref(false)
 const dailyError = ref(null)
@@ -259,14 +333,120 @@ const fetchEvents = async () => {
   }
 }
 
+const fetchAlerts = async () => {
+  alertsPending.value = true
+  alertsError.value = null
+  try {
+    const res = await $fetch('/api/notifications', { credentials: 'include' })
+    notifications.value = res?.items || []
+    unreadCount.value = Number(res?.unreadCount || 0)
+    alertsLoaded.value = true
+  } catch (err) {
+    alertsError.value = err
+  } finally {
+    alertsPending.value = false
+  }
+}
+
+// Just the badge number. Separate from fetchAlerts because this is the one that
+// runs on a timer: it hits /api/notifications/count, which authenticates off the
+// JWT already parsed by middleware and is listed in HOT_PATHS, so a tick is a
+// single indexed COUNT rather than the ~20 round trips the usual
+// $fetch('/api/auth/me') auth pattern would cost.
+const fetchUnreadCount = async () => {
+  if (!user.value) return
+  try {
+    const res = await $fetch('/api/notifications/count', { credentials: 'include' })
+    unreadCount.value = Number(res?.unreadCount || 0)
+  } catch {
+    // Silent: a failed poll must not surface an error on every page.
+  }
+}
+
 watch([isOpen, activeTab], ([nextOpen, nextTab]) => {
   if (!nextOpen) return
   if (nextTab === 'daily') {
     fetchDaily()
     return
   }
+  if (nextTab === 'alerts') {
+    // Opening the tab deliberately does NOT mark anything read — a stray tap on
+    // a phone would otherwise wipe the only signal that something happened.
+    fetchAlerts()
+    return
+  }
   fetchEvents()
 })
+
+const notificationRoute = (n) => {
+  // Built here from `type`, never from a stored string. A route persisted in the
+  // database by five call sites and rendered into a NuxtLink `:to` would be an
+  // open-redirect / `javascript:` sink; there is no such column, by design.
+  if (!n) return null
+  if (n.type === 'TRADE_OFFER_RECEIVED' || n.type === 'TRADE_OFFER_ACCEPTED') {
+    return '/newsite/trade'
+  }
+  if (!n.contextId) return null
+  return `/newsite/AuctionHouse/${encodeURIComponent(n.contextId)}`
+}
+
+const markRead = async (ids) => {
+  if (!ids.length) return
+  try {
+    await $fetch('/api/notifications/read', {
+      method: 'POST',
+      credentials: 'include',
+      body: { ids }
+    })
+  } catch {}
+}
+
+const onNotificationClick = async (n) => {
+  if (!n || n.readAt) return
+  // Optimistic: the drawer closes on navigation, so waiting for the round trip
+  // would show a stale unread dot for the frame before it does.
+  n.readAt = new Date().toISOString()
+  unreadCount.value = Math.max(0, unreadCount.value - 1)
+  await markRead([n.id])
+}
+
+const markAllRead = async () => {
+  const now = new Date().toISOString()
+  notifications.value.forEach(n => { if (!n.readAt) n.readAt = now })
+  unreadCount.value = 0
+  try {
+    await $fetch('/api/notifications/read', {
+      method: 'POST',
+      credentials: 'include',
+      body: { all: true }
+    })
+  } catch {
+    // Put the truth back if the server disagreed.
+    fetchAlerts()
+  }
+}
+
+const badgeLabel = computed(() => (unreadCount.value > 99 ? '99+' : String(unreadCount.value)))
+
+const panelHeading = computed(() => {
+  if (activeTab.value === 'daily') return 'Daily Checklist'
+  if (activeTab.value === 'alerts') return 'Notifications'
+  return 'Events'
+})
+
+const formatRelative = (date) => {
+  const d = date ? new Date(date) : null
+  if (!d || Number.isNaN(d.getTime())) return ''
+  const secs = Math.max(0, Math.floor((Date.now() - d.getTime()) / 1000))
+  if (secs < 60) return 'just now'
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return formatDate(d)
+}
 
 const formatNumber = (value) => {
   const num = Number(value)
@@ -340,7 +520,7 @@ const toggleOpen = () => {
 }
 
 const tabButtonClass = (tab) => ([
-  'flex-1 rounded-full px-3 py-1.5 transition',
+  'ob-tab flex-1 rounded-full px-3 py-1.5 transition',
   activeTab.value === tab
     ? 'bg-[var(--OrbitDarkBlue)] text-white shadow-sm'
     : 'text-white/50 hover:text-white'
@@ -380,18 +560,144 @@ const handleOutsideClick = (event) => {
   }
 }
 
+// 120s, and only while the tab is actually being looked at. The badge is not
+// time-critical, this runs on every page for every logged-in user, and an
+// unguarded interval means abandoned background tabs polling forever.
+const POLL_MS = 120_000
+let pollTimer = null
+
+const startPolling = () => {
+  if (pollTimer || !user.value) return
+  // Jitter, so clients that all loaded after the same deploy do not converge
+  // into one synchronised burst every two minutes.
+  const jitter = 1 + (Math.random() * 0.4 - 0.2)
+  pollTimer = setInterval(fetchUnreadCount, Math.round(POLL_MS * jitter))
+}
+
+const stopPolling = () => {
+  if (!pollTimer) return
+  clearInterval(pollTimer)
+  pollTimer = null
+}
+
+const handleVisibility = () => {
+  if (document.visibilityState === 'visible') {
+    fetchUnreadCount()
+    startPolling()
+  } else {
+    stopPolling()
+  }
+}
+
 onMounted(() => {
-  document.addEventListener('click', handleOutsideClick)
+  // pointerdown, not click: on iOS Safari a `click` on a non-interactive element
+  // does not reach `document`, so tap-outside-to-dismiss silently did nothing on
+  // iPhone — which matters more now that the panel is a notification surface.
+  document.addEventListener('pointerdown', handleOutsideClick)
+  document.addEventListener('visibilitychange', handleVisibility)
+
+  // The count arrives free on the /api/auth/me payload the app already loads, so
+  // the badge is correct on first paint without waiting for a poll.
+  if (user.value) {
+    unreadCount.value = Number(user.value.unreadNotifications || 0)
+    startPolling()
+  }
+})
+
+// Logged-out visitors see this component too (it is rendered unconditionally by
+// the newsite layout), so polling must start only once there is a session —
+// otherwise every public page 401s on a timer forever.
+watch(user, (next) => {
+  if (next) {
+    unreadCount.value = Number(next.unreadNotifications || 0)
+    startPolling()
+  } else {
+    unreadCount.value = 0
+    stopPolling()
+  }
 })
 
 onBeforeUnmount(() => {
-  document.removeEventListener('click', handleOutsideClick)
+  document.removeEventListener('pointerdown', handleOutsideClick)
+  document.removeEventListener('visibilitychange', handleVisibility)
+  stopPolling()
 })
 </script>
 
 <style scoped>
+.ob-root {
+  /* 12px put the toggle under the iPhone home indicator / Safari bottom bar. */
+  bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+}
+
 .ob-panel {
   background: rgba(10, 25, 55, 0.96);
+  /* Bounds the panel against the viewport. Without this it grows upward with no
+     limit: in landscape (~375px of visual viewport) the header — the only way to
+     switch tabs — ran off the top of the screen with no way to scroll to it. The
+     inner lists are flex-1/min-h-0, so they absorb whatever is left. */
+  max-height: min(70dvh, 420px);
+}
+
+.ob-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 9999px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.ob-tab-count {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 0 4px;
+  border-radius: 9999px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.ob-alert { text-decoration: none; }
+.ob-alert-unread { background: rgba(255, 255, 255, 0.08); }
+.ob-alert-read   { background: rgba(255, 255, 255, 0.03); }
+.ob-alert:hover  { background: rgba(255, 255, 255, 0.13); }
+
+.ob-alert-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 9999px;
+  background: #ef4444;
+}
+
+.ob-mark-all { padding: 6px 8px; }
+
+/* Titles and bodies carry usernames and cToon names, which have no spaces to
+   break at. Unclamped, one long title eats the whole scroller on a phone. */
+.ob-clamp-2,
+.ob-clamp-1 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.ob-clamp-2 { -webkit-line-clamp: 2; }
+.ob-clamp-1 { -webkit-line-clamp: 1; }
+
+@media (max-width: 768px) {
+  /* Real tap targets. These were ~28px (tabs) and a padding-less ~16px text run
+     (Hide) — under the 44px iOS / 48dp Android floor, on what is now the primary
+     notification surface on mobile. */
+  .ob-toggle { min-height: 44px; }
+  .ob-hide { min-height: 40px; padding: 0 8px; }
+  .ob-mark-all { min-height: 40px; }
+  .ob-tab { min-height: 40px; }
 }
 
 .ob-toggle {
@@ -402,22 +708,27 @@ onBeforeUnmount(() => {
   background: rgba(255, 255, 255, 0.06);
 }
 
+/* Animates opacity and transform rather than max-height.
+   The old version transitioned max-height to a hardcoded 300px while the panel's
+   natural height was already ~344px, so opening snapped the last ~44px in a
+   single frame and closing jumped down before collapsing. A third tab and
+   multi-line notification titles would only widen that gap — and any fixed
+   number here drifts again the next time the contents change. */
 .daily-drawer-enter-active,
 .daily-drawer-leave-active {
-  transition: max-height 0.25s ease, opacity 0.25s ease, transform 0.25s ease;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  transform-origin: bottom right;
 }
 
 .daily-drawer-enter-from,
 .daily-drawer-leave-to {
-  max-height: 0;
   opacity: 0;
-  transform: translateY(10px);
+  transform: translateY(8px) scale(0.97);
 }
 
 .daily-drawer-enter-to,
 .daily-drawer-leave-from {
-  max-height: var(--panel-max, 300px);
   opacity: 1;
-  transform: translateY(0);
+  transform: translateY(0) scale(1);
 }
 </style>

--- a/components/newsite/AuctionDetails.vue
+++ b/components/newsite/AuctionDetails.vue
@@ -232,7 +232,12 @@ async function loadAuction() {
   auction.value = data
   auction.value.highestBid = data.highestBid ?? data.currentBid ?? 0
   bids.value       = data.bids || []
-  userPoints.value = pts.points
+  // Available, not gross. The server rejects a bid it cannot fund from
+  // points-minus-active-locks (see bid.post.js), so gating the button and the
+  // "Need N more pts (have X)" hint on the gross balance told users they could
+  // afford bids that were then refused. `?? pts.points` keeps this working if
+  // the endpoint is ever rolled back.
+  userPoints.value = pts.available ?? pts.points
   blockedByFeaturedLead.value = !!data.blockedByFeaturedLead
   currentTopBidder.value = topBidderFromHistory.value ?? data.highestBidderUsername ?? null
   recentSales.value = await $fetch(`/api/auction/${props.auctionId}/getRecentAuctions`)
@@ -559,12 +564,15 @@ onUnmounted(() => {
 
 .adet-timer { font-size: 0.7rem; font-weight: bold; color: #fca5a5; }
 .adet-winner { font-size: 0.72rem; font-weight: bold; color: var(--OrbitGreen); }
-.adet-winner-name { color: #fff; }
+/* min-width/ellipsis: these are nowrap text runs inside a space-between flex row
+   with no shrink floor, so a long username would otherwise punch out of
+   .adet-info and give the whole body a horizontal scrollbar. */
+.adet-winner-name { color: #fff; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .adet-bid-info { display: flex; flex-direction: column; gap: 2px; }
 .adet-bid-row  { display: flex; justify-content: space-between; align-items: center; }
-.adet-bid-lbl  { font-size: 0.6rem; color: rgba(255,255,255,0.45); text-transform: uppercase; letter-spacing: 0.05em; }
-.adet-bid-amt  { font-size: 0.72rem; font-weight: bold; color: #fff; }
+.adet-bid-lbl  { font-size: 0.6rem; color: rgba(255,255,255,0.45); text-transform: uppercase; letter-spacing: 0.05em; flex-shrink: 0; }
+.adet-bid-amt  { font-size: 0.72rem; font-weight: bold; color: #fff; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .adet-featured-notice {
   font-size: 0.6rem;
@@ -693,7 +701,7 @@ onUnmounted(() => {
   font-size: 0.65rem;
 }
 
-.adet-history-user { color: rgba(255,255,255,0.8); }
+.adet-history-user { color: rgba(255,255,255,0.8); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .adet-history-amt  { font-weight: bold; color: #fff; }
 
 .adet-empty {

--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -9,7 +9,12 @@
         <button class="tr-tab" :class="{ active: tradeActiveTab === 'create' }" @click="switchTab('create')">Create Trade</button>
       </div>
       <div v-if="tradeActiveTab !== 'create'" class="tr-topbar-right">
-        <span class="tr-pts-label">{{ (user?.points ?? 0).toLocaleString() }} pts</span>
+        <span class="tr-pts-label">
+          {{ (user?.points ?? 0).toLocaleString() }} pts<span
+            v-if="(user?.lockedPoints ?? 0) > 0"
+            class="tr-pts-locked"
+          > · {{ (user.lockedPoints).toLocaleString() }} locked</span>
+        </span>
       </div>
       <div v-else-if="tradeTargetUser" class="tr-topbar-right">
         <span class="tr-step-indicator">Step {{ tradeCurrentStep }} of 3</span>
@@ -321,7 +326,7 @@
                 <input
                   type="number"
                   v-model.number="pointsToOffer"
-                  :max="user?.points || 0"
+                  :max="user?.availablePoints ?? user?.points ?? 0"
                   min="0"
                   @input="pointsToOffer = Math.max(0, pointsToOffer)"
                   class="tr-points-input"
@@ -1850,6 +1855,9 @@ onBeforeUnmount(() => {
 .tr-tab:not(.active):hover { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.75); }
 .tr-topbar-right { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .tr-pts-label { font-size: 0.65rem; color: var(--OrbitGreen); font-weight: bold; }
+/* The points chip sits right above the offer builder, so the locked figure has
+   to be visible here too — otherwise the max on the points input looks arbitrary. */
+.tr-pts-locked { color: #ffd166; }
 .tr-step-indicator { font-size: 0.62rem; color: rgba(255,255,255,0.6); }
 
 /* ── Content ── */

--- a/components/newsite/UserInfo.vue
+++ b/components/newsite/UserInfo.vue
@@ -17,7 +17,19 @@
         </template>
         <template v-else>
           <NuxtLink :to="`/newsite/czone/${user.username}`" class="user-info-username" ref="usernameEl">{{ user.username }}</NuxtLink>
-          <span class="user-info-stat">{{ (user.points ?? 0).toLocaleString() }} Points</span>
+          <!-- Locked rides the existing points line rather than getting a line of
+               its own. This box is a fixed 85px with overflow:hidden, and its
+               current five rows already measure ~90px — the daily-reset row is
+               being shaved today. A sixth row would clip the divider and the
+               countdown outright, and growing --sidebar-top-height means
+               shrinking --sidebar-middle-height in :root plus the five pages
+               that override it, or WinballPromo gets clipped instead. -->
+          <span class="user-info-stat" :title="lockedTitle">
+            {{ (user.points ?? 0).toLocaleString() }} Points<span
+              v-if="lockedPoints > 0"
+              class="user-info-locked"
+            > · {{ lockedPoints.toLocaleString() }} locked</span>
+          </span>
           <span class="user-info-stat">{{ (collectionSummary.uniqueCount ?? 0).toLocaleString() }} Unique cToons</span>
           <span class="user-info-stat">{{ (collectionSummary.totalCount ?? 0).toLocaleString() }} Total cToons</span>
         </template>
@@ -39,6 +51,18 @@
 import { DateTime } from 'luxon'
 
 const { user, fetchSelf } = useAuth()
+
+// Points committed to live auction bids and pending trade offers. Comes back on
+// the /api/auth/me payload that fetchSelf() below already loads, so this costs
+// no extra request.
+const lockedPoints = computed(() => Number(user.value?.lockedPoints ?? 0))
+const lockedTitle = computed(() => {
+  if (lockedPoints.value <= 0) return ''
+  const available = Number(user.value?.availablePoints ?? 0)
+  return `${lockedPoints.value.toLocaleString()} points are locked in auction bids and pending trade offers. `
+    + `You can spend ${available.toLocaleString()}.`
+})
+
 const collectionSummary = ref({ totalCount: 0, uniqueCount: 0 })
 const resetCountdown = ref('--:--:--')
 const ready = ref(false)
@@ -141,6 +165,15 @@ onUnmounted(() => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Brighter than the stat text it sits in, so the locked figure reads as a
+   distinct number rather than as part of the points total. .user-info-stat
+   already clips with an ellipsis, so on a narrow sidebar this degrades to
+   "12,340 Points · 2,5…" rather than breaking the fixed-height box. */
+.user-info-locked {
+  color: #ffd166;
+  font-weight: bold;
 }
 
 .user-info-divider {

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -290,7 +290,15 @@ html.newsite-active body {
       @created="onAuctionCreated"
     />
   </div>
-  <Onboarding />
+  <!-- Hidden while a modal is up. `.site-container` gets `transform: scale()` on
+       desktop, which makes it a stacking context at z-index auto, so the modals
+       inside it (CtoonInfoCard at 10000, AuctionModal at 1000) are trapped below
+       this sibling's z-50 and the floating pill paints over them. On mobile the
+       transform is dropped, the container stops being a stacking context, and
+       the modals cover the pill correctly — so without this the behaviour flips
+       at 768px, which is exactly the class of bug the note above warns about.
+       A permanently-visible unread badge would make it obvious. -->
+  <Onboarding v-if="!ctoonModalIsOpen && !auctionModalIsOpen" />
   <CMoonSelectModal />
 </template>
 

--- a/pages/newsite/settings.vue
+++ b/pages/newsite/settings.vue
@@ -19,7 +19,11 @@
           <div class="settings-body">
             <div class="settings-row">
               <div>
-                <h2 class="settings-row-title">Auction Notifications</h2>
+                <!-- Named for the channel it actually controls. In-app
+                     notifications are a separate channel and deliberately ignore
+                     this flag: turning it off means "stop DMing me", not "hide
+                     alerts inside the site I am looking at". -->
+                <h2 class="settings-row-title">Auction Discord DMs</h2>
                 <p class="settings-row-desc">Receive Discord DMs when you're outbid on an auction.</p>
               </div>
 

--- a/prisma/migrations/20260814000000_add_notifications/migration.sql
+++ b/prisma/migrations/20260814000000_add_notifications/migration.sql
@@ -1,0 +1,84 @@
+-- In-app notification hub.
+--
+-- Five events write here: outbid on an auction, a new bid on your auction, an
+-- auction you won, an incoming trade offer, and an offer of yours being accepted.
+-- Two of those fire on the hottest path in the app (every bid), so the indexes
+-- below are chosen for the two queries that actually run, not for the shape of
+-- the model.
+
+CREATE TYPE "NotificationType" AS ENUM (
+  'AUCTION_OUTBID',
+  'AUCTION_NEW_BID',
+  'AUCTION_WON',
+  'TRADE_OFFER_RECEIVED',
+  'TRADE_OFFER_ACCEPTED'
+);
+
+CREATE TABLE "Notification" (
+  "id"          TEXT NOT NULL,
+  "userId"      TEXT NOT NULL,
+  "type"        "NotificationType" NOT NULL,
+  "title"       TEXT NOT NULL,
+  "body"        TEXT,
+  "contextType" "LockedContextType",
+  "contextId"   TEXT,
+  "count"       INTEGER NOT NULL DEFAULT 1,
+  "readAt"      TIMESTAMP(3),
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "Notification"
+  ADD CONSTRAINT "Notification_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- The drawer: newest N for one user.
+--
+-- Note the column order. An index of (userId, readAt, createdAt) — the obvious
+-- one to reach for — cannot serve this at all: readAt sits between the equality
+-- column and the sort column, so Postgres can only use the leading userId and
+-- then has to sort the user's entire notification history to return 30 rows.
+CREATE INDEX "Notification_userId_createdAt_idx"
+    ON "Notification"("userId", "createdAt" DESC);
+
+-- The badge: count unread for one user, on an interval, for every logged-in
+-- user. Partial, so the index contains only unread rows and stays a few hundred
+-- entries forever regardless of how deep the read history gets. This is the one
+-- index that has to stay small, because it is the one that is hit constantly.
+--
+-- Not expressible in the Prisma schema language; `prisma migrate dev` will
+-- report it as drift and offer to drop it — keep it.
+CREATE INDEX "Notification_unread_idx"
+    ON "Notification"("userId")
+ WHERE "readAt" IS NULL;
+
+-- Collapse key. Without this, one manual bid into a proxy auto-bid war writes a
+-- notification per Bid row (server/utils/autoBid.js loops until the ladder
+-- settles), so a seller gets ten cards for one human action and a badge of ten.
+-- With it, the writer upserts: twelve bids on one auction become one row with
+-- count = 12.
+--
+-- It also blunts notification spam. Nothing rate-limits trade offers, and an
+-- offer of 1 point is free to send, so an attacker could otherwise mint
+-- unbounded permanent rows in a victim's hub. Collapsing TRADE_OFFER_RECEIVED on
+-- the sender's id caps that at one row per hostile account.
+--
+-- Scoped to unread rows so that clearing the badge starts a fresh row rather
+-- than resurrecting an old one the user has already dealt with. Also partial,
+-- also invisible to Prisma — keep it.
+CREATE UNIQUE INDEX "Notification_collapse_key"
+    ON "Notification"("userId", "type", "contextId")
+ WHERE "readAt" IS NULL;
+
+-- Locked points are now read on /api/auth/me, i.e. on every page load, to show
+-- the "N locked" figure in the sidebar. That query sums `amount` over a user's
+-- ACTIVE locks; the existing (userId, status) index finds the rows but does not
+-- carry `amount`, so every matching row cost a heap fetch. INCLUDE makes the
+-- aggregate index-only.
+--
+-- The table really is named "loackedPoints" — see the @@map in schema.prisma.
+-- The typo is load-bearing in raw SQL.
+CREATE INDEX "loackedPoints_userId_status_amount_idx"
+    ON "loackedPoints"("userId", "status") INCLUDE ("amount");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,18 @@ enum LockedPointsReason {
   TRADE_OFFER
 }
 
+/// In-app notification kinds. Deliberately a closed set: server/utils/notifications.js
+/// builds every title and body from a fixed whitelist of fields per type, so no
+/// caller can smuggle another user's private data (an auto-bid maximum, say) into
+/// text that gets shown to someone else.
+enum NotificationType {
+  AUCTION_OUTBID
+  AUCTION_NEW_BID
+  AUCTION_WON
+  TRADE_OFFER_RECEIVED
+  TRADE_OFFER_ACCEPTED
+}
+
 /// Current state of a lock
 enum LockedPointsStatus {
   ACTIVE
@@ -96,6 +108,40 @@ model LockedPoints {
   @@index([userId, status])
   @@index([contextType, contextId, status])
   @@map("loackedPoints")
+}
+
+/// One in-app notification. Rows are collapsed rather than accumulated: repeated
+/// events of the same kind about the same thing (twelve bids on one auction, three
+/// trade offers from one user) bump `count` on the existing unread row instead of
+/// inserting twelve. That is enforced by a partial unique index on
+/// (userId, type, contextId) WHERE "readAt" IS NULL, which lives in the migration
+/// because partial indexes are not expressible in the Prisma schema language.
+///
+/// There is deliberately no `link` column. A free-text route written by five call
+/// sites — one of them in a separate process — and rendered into a NuxtLink `:to`
+/// is an open-redirect and `javascript:` sink that would persist in the database.
+/// The route is derived on the client from `type` alone; `contextId` is only ever
+/// a collapse key and, for auctions, the id used to build the path.
+model Notification {
+  id          String           @id @default(uuid())
+  userId      String
+  type        NotificationType
+  title       String
+  body        String?
+  contextType LockedContextType?
+  contextId   String?
+  /// How many times this event has recurred while still unread. 1 for a fresh row.
+  count       Int              @default(1)
+  readAt      DateTime?
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
+
+  // Serves the drawer's "newest N for this user". The badge's "count unread"
+  // rides a partial index created in the migration, so the hot query touches an
+  // index sized by unread volume rather than by total history.
+  @@index([userId, createdAt])
 }
 
 model CZone {
@@ -429,6 +475,7 @@ model User {
   gamePointLogs             GamePointLog[]
   pointsLogs                PointsLog[]
   lockedPoints              LockedPoints[]
+  notifications             Notification[]
   claims                    Claim[]
   visits                    Visit[]
   points                    UserPoints?

--- a/server/api/auction/[id]/bid.post.js
+++ b/server/api/auction/[id]/bid.post.js
@@ -6,6 +6,7 @@ import { prisma as db } from '@/server/prisma'
 import { applyProxyAutoBids, incrementFor } from '@/server/utils/autoBid'
 import { scheduleAuctionClose } from '@/server/utils/queues'
 import { assertFeaturedEligibility, assertNoConcurrentFeaturedLead } from '@/server/utils/featuredEligibility'
+import { notifyOutbid, notifyAuctionBid } from '@/server/utils/notifications'
 
 const ANTI_SNIPE_MS = 60_000
 
@@ -130,7 +131,11 @@ export default defineEventHandler(async (event) => {
 
     // Compute available points = total points - active locked points
     const up = await tx.userPoints.findUnique({ where: { userId } })
-    const activeLocks = await tx.lockedPoints.findMany({
+    // Summed in Postgres rather than shipping every lock row over the wire to
+    // reduce in JS. This runs inside the auction's hot transaction, and the new
+    // (userId, status) INCLUDE (amount) index makes it index-only.
+    const lockAgg = await tx.lockedPoints.aggregate({
+      _sum: { amount: true },
       where: {
         userId,
         status: 'ACTIVE',
@@ -141,9 +146,8 @@ export default defineEventHandler(async (event) => {
           ],
         },
       },
-      select: { amount: true },
     })
-    const lockedSum = activeLocks.reduce((acc, r) => acc + (r.amount || 0), 0)
+    const lockedSum = lockAgg._sum.amount || 0
     const totalPts  = up?.points || 0
     const available = totalPts - lockedSum
     if (available < manualAmount) {
@@ -222,6 +226,49 @@ export default defineEventHandler(async (event) => {
       console.error('[AuctionClose] Failed to reschedule after bid:', err)
     )
   }
+
+  // 5b) In-app notifications.
+  //
+  // Placement matters here. Not inside the transaction above: that block already
+  // runs ~10 queries plus the unbounded proxy auto-bid loop while holding row
+  // locks on this auction, and every concurrent bidder serialises behind it.
+  // Not down with the Discord DM either: that sits behind a fresh socket.io
+  // handshake with a 1500ms worst case, and the bidder's response already waits
+  // on it. After the commit, not awaited, is the only place that costs the
+  // bidder nothing.
+  //
+  // The recipients come from `outbidUserIds`, which the transaction already
+  // accumulates from both the manual displacement and the proxy cascade. Note
+  // the DM path below deliberately uses a lossier reconstruction that picks only
+  // the LAST leader to lose the lead, because DMs are expensive; the hub is
+  // cheap, so it can notify everyone who was actually outbid. In a cascade
+  // A → B → A → C, the DM path tells only A, while this tells both A and B.
+  ;(async () => {
+    const finalLeaderId = finalAuction?.highestBidderId ?? null
+    const finalAmount   = finalAuction?.highestBid ?? manualAmount
+
+    const ctoon = await db.auction.findUnique({
+      where: { id: auctionId },
+      select: { userCtoon: { select: { ctoon: { select: { name: true } } } } }
+    })
+    const ctoonName = ctoon?.userCtoon?.ctoon?.name || null
+
+    const outbid = Array.from(new Set(outbidUserIds))
+      .filter(uid => uid && uid !== finalLeaderId)
+    for (const uid of outbid) {
+      await notifyOutbid(db, { userId: uid, auctionId, ctoonName, amount: finalAmount })
+    }
+
+    // One notification per request, not per Bid row. A single manual bid into a
+    // proxy war writes many Bid rows, and the seller does not want a card for
+    // each rung of the ladder. The collapse index makes repeat bids over time
+    // bump a count rather than stack up, too.
+    if (pre.creatorId && pre.creatorId !== userId) {
+      await notifyAuctionBid(db, {
+        userId: pre.creatorId, auctionId, ctoonName, amount: finalAmount
+      })
+    }
+  })().catch(err => console.error('[notifications] bid path:', err?.message || err))
 
   // 6) Emit socket events
   const url = useRuntimeConfig().socketOrigin

--- a/server/api/auth/me.get.js
+++ b/server/api/auth/me.get.js
@@ -60,7 +60,7 @@ export default defineEventHandler(async (event) => {
   // Ensure fresh tokens and up-to-date roles
   await refreshDiscordTokenAndRoles(prisma, user, config)
 
-  const [ctoonCount, uniqueCtoonRows] = await Promise.all([
+  const [ctoonCount, uniqueCtoonRows, lockAgg, unreadNotifications] = await Promise.all([
     prisma.userCtoon.count({
       where: {
         userId: user.id,
@@ -73,8 +73,27 @@ export default defineEventHandler(async (event) => {
         userId: user.id,
         burnedAt: null
       }
-    })
+    }),
+    // Points committed to live auction bids and pending trade offers. UserPoints
+    // .points is the GROSS balance — locks are an overlay that every spend path
+    // subtracts at spend time — so without this the sidebar shows a number the
+    // user cannot actually spend.
+    //
+    // Both of these ride the /api/auth/me request rather than getting endpoints
+    // of their own. Every handler here authenticates by internally re-fetching
+    // this route, so a separate endpoint for either figure would re-derive this
+    // entire payload (including the two collection aggregates above) to return
+    // one integer. Added to the existing Promise.all, they cost one extra
+    // round trip each on a request that was happening anyway.
+    prisma.lockedPoints.aggregate({
+      _sum: { amount: true },
+      where: { userId: user.id, status: 'ACTIVE' }
+    }),
+    prisma.notification.count({ where: { userId: user.id, readAt: null } })
   ])
+
+  const lockedPoints = lockAgg._sum.amount || 0
+  const grossPoints  = user.points?.points || 0
 
   // Return full session data
   return {
@@ -85,7 +104,12 @@ export default defineEventHandler(async (event) => {
     avatar: user.avatar,
     username: user.username || null,
     roles: user.roles,
-    points: user.points?.points || 0,
+    points: grossPoints,
+    lockedPoints,
+    // What the user can actually commit right now. Clamped for display only; the
+    // spend paths do their own arithmetic and must not be fed a clamped figure.
+    availablePoints: Math.max(0, grossPoints - lockedPoints),
+    unreadNotifications,
     needsSetup: !(user.username && user.avatar && ctoonCount > 0),
     inGuild: user.inGuild,
     isAdmin: user.isAdmin,

--- a/server/api/notifications/count.get.js
+++ b/server/api/notifications/count.get.js
@@ -1,0 +1,41 @@
+// The badge's unread count. This is the only endpoint in the notification
+// feature that gets polled, so it is the only one whose cost is multiplied by
+// every logged-in user and every open tab.
+//
+// ── Why this one does not call /api/auth/me ──────────────────────────────────
+// Every other handler in this codebase authenticates with
+// `$fetch('/api/auth/me', { headers: { cookie } })`. That is an internal HTTP
+// round trip which re-runs the whole middleware stack (guild-check's user
+// lookup, daily-points' upsert AND interactive transaction, login-log's two
+// queries) and then, inside me.get.js, does a user lookup plus two
+// collection-wide userCtoon aggregates. Roughly twenty Postgres round trips and
+// two interactive transactions, to return one integer that is 0 for most users
+// most of the time. server/middleware/daily-points.js and
+// server/utils/hotPaths.js both document that this pattern has already
+// exhausted the connection pool once.
+//
+// So this handler reads `event.context.userId`, which server/middleware/auth.js
+// has already established from the signed JWT at no DB cost, and is listed in
+// HOT_PATHS so the per-request bookkeeping middleware skips it. That is safe for
+// the reason hotPaths.js already gives: every page load still hits
+// /api/auth/me, so the daily award, guild sync and login log still fire on the
+// surrounding navigation.
+//
+// ── The catch that the cheap path would otherwise drop ───────────────────────
+// Ban enforcement lives in /api/auth/me (it throws 403 for a banned user), so
+// skipping it would leave banned accounts served by this route. Rather than pay
+// for a second query to check, the ban is folded into the count itself as a
+// relation filter — same single index-backed statement, no extra round trip.
+import { defineEventHandler, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.userId
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+
+  const unreadCount = await db.notification.count({
+    where: { userId, readAt: null, user: { banned: false } }
+  })
+
+  return { unreadCount }
+})

--- a/server/api/notifications/index.get.js
+++ b/server/api/notifications/index.get.js
@@ -1,0 +1,44 @@
+// The notification drawer's payload: newest N for the caller, plus the unread
+// count so the badge and the list can never disagree with each other.
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+// Deliberately fixed, and deliberately not read from the query string. An
+// attacker-supplied `?limit=` is the read-side version of an unbounded write.
+const PAGE_SIZE = 30
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  const userId = me?.id
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+
+  const [items, unreadCount] = await Promise.all([
+    db.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      take: PAGE_SIZE,
+      // No userId, and no route: the client builds the path from `type` and
+      // `contextId`. See the Notification model note in prisma/schema.prisma.
+      select: {
+        id: true,
+        type: true,
+        title: true,
+        body: true,
+        contextType: true,
+        contextId: true,
+        count: true,
+        readAt: true,
+        createdAt: true
+      }
+    }),
+    db.notification.count({ where: { userId, readAt: null } })
+  ])
+
+  return { items, unreadCount }
+})

--- a/server/api/notifications/read.post.js
+++ b/server/api/notifications/read.post.js
@@ -1,0 +1,78 @@
+// Mark notifications read.
+//
+// POST, not GET. The session cookie is sameSite:'lax' (see
+// server/api/auth/discord/callback.get.js), which does not travel on a
+// cross-site POST but DOES travel on a top-level GET navigation — so exposing
+// this as a GET would make `<img src=".../read?all=true">` a working CSRF that
+// silently clears someone's hub.
+import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+import { isUuid } from '@/server/utils/tradeOfferRules'
+
+// The drawer only ever shows PAGE_SIZE (30) rows, so 100 is already generous.
+// The cap is what stops `{ ids: [...200_000] }` from being turned into a
+// Postgres IN-list past the bind-parameter ceiling by any logged-in account.
+const MAX_IDS = 100
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  const userId = me?.id
+  if (!userId) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+
+  const body = await readBody(event)
+  const hasIds = body?.ids !== undefined
+  const hasAll = body?.all !== undefined
+
+  if (hasIds === hasAll) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Provide exactly one of `ids` or `all`'
+    })
+  }
+
+  if (hasAll) {
+    // Strict equality, not truthiness: `all: "false"` and `all: 0` must not
+    // clear the hub, and neither must a body that forgot to say what it meant.
+    if (body.all !== true) {
+      throw createError({ statusCode: 400, statusMessage: '`all` must be true' })
+    }
+    const { count } = await db.notification.updateMany({
+      // userId is in the WHERE clause, never a post-hoc check. Without it this
+      // statement marks the entire table read for every user on the site.
+      where: { userId, readAt: null },
+      data: { readAt: new Date() }
+    })
+    return { updated: count }
+  }
+
+  const ids = body.ids
+  if (!Array.isArray(ids)) {
+    throw createError({ statusCode: 400, statusMessage: '`ids` must be an array' })
+  }
+  if (ids.length === 0 || ids.length > MAX_IDS) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `\`ids\` must contain between 1 and ${MAX_IDS} entries`
+    })
+  }
+  for (const id of ids) {
+    if (!isUuid(id)) {
+      throw createError({ statusCode: 400, statusMessage: '`ids` contains an invalid id' })
+    }
+  }
+
+  const { count } = await db.notification.updateMany({
+    where: { id: { in: [...new Set(ids)] }, userId, readAt: null },
+    data: { readAt: new Date() }
+  })
+
+  // Only a total. Reporting which ids failed to match would confirm whether a
+  // given id exists on another account.
+  return { updated: count }
+})

--- a/server/api/trade/offers.post.js
+++ b/server/api/trade/offers.post.js
@@ -17,6 +17,7 @@ import {
   assertOfferHasContent,
   sendTradeOfferDM
 } from '@/server/utils/tradeOffer'
+import { notifyTradeOfferReceived } from '@/server/utils/notifications'
 
 export default defineEventHandler(async (event) => {
   // 1) Authenticate user
@@ -85,6 +86,15 @@ export default defineEventHandler(async (event) => {
     pointsOffered,
     offeredCount: resolvedOffered.length,
     requestedCount: resolvedRequested.length,
+    isCounter: false
+  }).catch(() => {})
+
+  // In-app notification, same placement and same reasoning as the DM above:
+  // after the commit, not awaited.
+  notifyTradeOfferReceived(prisma, {
+    userId: recipient.id,
+    fromUserId: initiatorId,
+    fromUsername: me.username,
     isCounter: false
   }).catch(() => {})
 

--- a/server/api/trade/offers/[id]/accept.post.js
+++ b/server/api/trade/offers/[id]/accept.post.js
@@ -4,6 +4,7 @@ import {
   createError
 } from 'h3'
 import { prisma } from '@/server/prisma'
+import { notifyTradeOfferAccepted } from '@/server/utils/notifications'
 
 export default defineEventHandler(async (event) => {
   // 1) Authenticate
@@ -226,8 +227,18 @@ export default defineEventHandler(async (event) => {
     maxWait: 10000
   })
 
+  // 7a) In-app notification to the initiator — their sent offer was accepted.
+  // Ahead of the DM block below because that block awaits two Discord API calls;
+  // this one must not be stuck behind them, and must not be skipped when the
+  // user has no Discord id or the bot token is unset.
+  notifyTradeOfferAccepted(prisma, {
+    userId: offer.initiatorId,
+    offerId,
+    byUsername: me.username
+  }).catch(() => {})
+
   try {
-    // 7) Notify initiator via Discord DM
+    // 7b) Notify initiator via Discord DM
     if (initiator?.discordId && process.env.BOT_TOKEN) {
       const BOT_TOKEN = process.env.BOT_TOKEN
       const isProd = process.env.NODE_ENV === 'production'

--- a/server/api/trade/offers/[id]/counter.post.js
+++ b/server/api/trade/offers/[id]/counter.post.js
@@ -26,6 +26,7 @@ import {
   isUuid,
   MAX_COUNTER_CHAIN_DEPTH
 } from '@/server/utils/tradeOffer'
+import { notifyTradeOfferReceived } from '@/server/utils/notifications'
 
 /// One response for every "you may not counter this" case. Distinguishing
 /// "no such offer" from "not yours" from "already settled" would make this
@@ -159,6 +160,17 @@ export default defineEventHandler(async (event) => {
     pointsOffered,
     offeredCount: resolvedOffered.length,
     requestedCount: resolvedRequested.length,
+    isCounter: true
+  }).catch(() => {})
+
+  // Exactly one in-app notification too, mirroring the DM rule above. The
+  // countered party IS this recipient — emitting a separate "your offer was
+  // countered" alongside this would re-introduce the double-notification the
+  // comment above exists to prevent.
+  notifyTradeOfferReceived(prisma, {
+    userId: recipient.id,
+    fromUserId: callerId,
+    fromUsername: me.username,
     isCounter: true
   }).catch(() => {})
 

--- a/server/api/user/points.get.js
+++ b/server/api/user/points.get.js
@@ -24,6 +24,25 @@ export default defineEventHandler(async (event) => {
     record = await prisma.userPoints.create({ data: { userId, points: 0 } })
   }
 
-  // 3. Return only the points count
-  return { points: record.points }
+  // 3. Sum this caller's ACTIVE locks. Never any other user's — the only route
+  //    that may read someone else's locks is admin-gated
+  //    (server/api/admin/users/[id]/locked-points.get.js), and it returns the
+  //    individual rows because an admin is investigating. Callers here get one
+  //    number: shipping contextIds would leak the user's own live bid positions
+  //    into every surface that touches this response, for no benefit.
+  const lockAgg = await prisma.lockedPoints.aggregate({
+    _sum: { amount: true },
+    where: { userId, status: 'ACTIVE' }
+  })
+  const locked = lockAgg._sum.amount || 0
+
+  // `points` stays the gross balance so existing callers are unaffected.
+  // `available` is what the server will actually let this user commit — see the
+  // insufficient-points check in server/api/auction/[id]/bid.post.js, which
+  // computes exactly this.
+  return {
+    points: record.points,
+    locked,
+    available: Math.max(0, record.points - locked)
+  }
 })

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -11,6 +11,9 @@ import { startDiagnostics } from './diagnostics/telemetry.mjs'
 import { Worker } from 'bullmq'
 import { redisConnection, scheduleAuctionClose, scheduleMintEnd } from './utils/queues.js'
 import { resolveAuctionCloseOutcome, AUCTION_CLOSE_DOUBLE_SALE } from './utils/auctionClose.js'
+// Relative, like everything else here: this is a plain Node process, so the `@/`
+// alias Nuxt handlers use does not resolve. See the header of that file.
+import { notifyAuctionWon } from './utils/notifications.js'
 import { getRedis } from './utils/redis.js'
 import * as redisState from './utils/redisState.js'
 
@@ -2989,7 +2992,11 @@ startEdRpsSweep(io)
 async function performAuctionClose(auctionId) {
   const auc = await db.auction.findUnique({
     where: { id: auctionId },
-    select: { id: true, status: true, endAt: true, creatorId: true, userCtoonId: true, createdAt: true }
+    select: {
+      id: true, status: true, endAt: true, creatorId: true, userCtoonId: true, createdAt: true,
+      // Only for the "you won" notification's text.
+      userCtoon: { select: { ctoon: { select: { name: true } } } }
+    }
   })
 
   // Guard: already closed or cancelled (e.g. duplicate job fire)
@@ -3137,6 +3144,21 @@ async function performAuctionClose(auctionId) {
           method:    'Auction',
           direction: 'decrease'
         }
+      })
+
+      // "You won" goes here, inside the settle branch, rather than after the
+      // transaction. Two reasons. It is then atomic with the payout, so a
+      // notification can never exist for a sale that rolled back. And it is
+      // unreachable from the two terminal paths above that must NOT produce one:
+      // the early return when a concurrent anti-snipe bid extended endAt (no
+      // sale happened yet), and the DOUBLE_SALE branch, where the bidder did not
+      // get the cToon and is owed a manual refund decision — telling them they
+      // won would be worse than telling them nothing.
+      await notifyAuctionWon(tx, {
+        userId: winningBid.userId,
+        auctionId: id,
+        ctoonName: auc.userCtoon?.ctoon?.name || null,
+        amount: winningBid.amount
       })
 
       await tx.lockedPoints.updateMany({

--- a/server/utils/hotPaths.js
+++ b/server/utils/hotPaths.js
@@ -14,11 +14,18 @@
 // is many hands, so these two routes are the highest-frequency authenticated endpoints in the
 // app. They read only the session row and Redis. Handlers that move points call
 // assertPlayable() themselves, since skipping guild-check means event.context.user is unset.
+// The notification badge is in the same position for a different reason: it is
+// not many calls per user action, it is one call per user per poll interval, on
+// every page, forever. It reads a single count and nothing else. It authenticates
+// off event.context.userId (set by the JWT middleware, which is not skipped here)
+// and folds the ban check into its own query — see the long note in
+// server/api/notifications/count.get.js.
 const HOT_PATHS = [
   '/api/game/guessctoon/answer',
   '/api/game/guessctoon/image/',
   '/api/game/blackjack/bet',
-  '/api/game/blackjack/action'
+  '/api/game/blackjack/action',
+  '/api/notifications/count'
 ]
 
 export function isHotPath (path) {

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -1,0 +1,208 @@
+// In-app notification writer.
+//
+// ── Import rules (please read before editing) ────────────────────────────────
+// This module is imported from BOTH runtimes:
+//   • Nuxt API handlers, as '@/server/utils/notifications'
+//   • server/socket-server.js, as './utils/notifications.js' — a plain
+//     `node server/socket-server.js` process (see package.json "socket")
+//
+// The `@/` alias and `#imports` are Nuxt/Vite-only. A plain Node process cannot
+// resolve them: `import('@/server/prisma')` fails with ERR_MODULE_NOT_FOUND.
+// That is why this file takes the Prisma client as a parameter instead of
+// importing it, and imports nothing else at all. Do not "tidy" these signatures
+// into an `import { prisma } from '@/server/prisma'` — it would break auction
+// close, in a process with no test coverage, at whatever hour the auction ends.
+//
+// The same rule rules out importing server/utils/autoBid.js (imports `#imports`)
+// and server/utils/systemAccounts.js (imports `@/server/prisma`) from here.
+//
+// ── Content rules ────────────────────────────────────────────────────────────
+// Every title and body is built here from a fixed set of fields per type.
+// Callers pass values, never prose. This is what keeps a private auto-bid
+// maximum — the one genuinely non-public number in the auction system, see
+// server/api/auction/[id]/autobid.get.js — out of text shown to someone else.
+// Only amounts that were written as real Bid rows (and are therefore already
+// public via /api/auction/[id]) may appear in an auction notification.
+//
+// There is no `link` field. Routes are derived on the client from `type`; see
+// the note on the Notification model in prisma/schema.prisma.
+
+// node:crypto, not the `uuid` package and not Postgres' gen_random_uuid(): a core
+// module is the only import that is guaranteed to resolve identically in both
+// runtimes described above, and it does not assume a Postgres version or an
+// installed extension.
+import { randomUUID } from 'node:crypto'
+
+export const NOTIFICATION_TYPES = Object.freeze({
+  AUCTION_OUTBID: 'AUCTION_OUTBID',
+  AUCTION_NEW_BID: 'AUCTION_NEW_BID',
+  AUCTION_WON: 'AUCTION_WON',
+  TRADE_OFFER_RECEIVED: 'TRADE_OFFER_RECEIVED',
+  TRADE_OFFER_ACCEPTED: 'TRADE_OFFER_ACCEPTED'
+})
+
+// Mirrors the guard in server/utils/discord.js — the official account is a
+// system actor that holds auction-only stock and dissolved users' listings. It
+// has no player behind it to read a notification.
+const OFFICIAL_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
+
+const fmt = (n) => Number(n || 0).toLocaleString('en-US')
+
+/**
+ * Upsert one notification, collapsing onto the recipient's existing unread row
+ * for the same (type, contextId) if there is one.
+ *
+ * Raw SQL because the collapse key is a partial unique index — Prisma's `upsert`
+ * can only infer conflicts from constraints it knows about, and partial indexes
+ * are not expressible in its schema language. `ON CONFLICT (cols) WHERE pred`
+ * lets Postgres infer the partial index directly.
+ *
+ * Never throws. Every caller is on a path where the real work (the bid, the
+ * trade, the payout) has already committed; failing to write a notification must
+ * not turn a successful action into an error response.
+ */
+export async function createNotification (db, {
+  userId,
+  type,
+  title,
+  body = null,
+  contextType = null,
+  contextId = null
+}) {
+  if (!db || !userId || !type || !title) return false
+  if (!NOTIFICATION_TYPES[type]) return false
+
+  try {
+    await db.$executeRaw`
+      INSERT INTO "Notification" (
+        "id", "userId", "type", "title", "body", "contextType", "contextId",
+        "count", "createdAt", "updatedAt"
+      )
+      VALUES (
+        ${randomUUID()},
+        ${userId},
+        ${type}::"NotificationType",
+        ${title},
+        ${body},
+        ${contextType}::"LockedContextType",
+        ${contextId},
+        1, NOW(), NOW()
+      )
+      ON CONFLICT ("userId", "type", "contextId") WHERE "readAt" IS NULL
+      DO UPDATE SET
+        "count"     = "Notification"."count" + 1,
+        "title"     = EXCLUDED."title",
+        "body"      = EXCLUDED."body",
+        "createdAt" = NOW(),
+        "updatedAt" = NOW()
+    `
+    return true
+  } catch (err) {
+    console.error('[notifications] write failed:', err?.message || err)
+    return false
+  }
+}
+
+/**
+ * Should this user get in-app notifications at all?
+ *
+ * Deliberately does NOT consult `allowAuctionNotifications`. That flag's only
+ * consumer is the Discord DM path (server/utils/discord.js), and the settings
+ * copy describes it as such — turning it off means "stop DMing me", not "blind
+ * me inside the site I am looking at". Reusing it here would silently break the
+ * hub for everyone who already opted out, with nothing to explain why.
+ *
+ * The official account is skipped: it is a system actor, not a player.
+ */
+async function isNotifiable (db, userId) {
+  if (!userId) return false
+  try {
+    const u = await db.user.findUnique({
+      where: { id: userId },
+      select: { username: true, banned: true }
+    })
+    if (!u) return false
+    if (u.banned) return false
+    if (u.username === OFFICIAL_USERNAME) return false
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** You were outbid on an auction you had the lead on. */
+export async function notifyOutbid (db, { userId, auctionId, ctoonName, amount }) {
+  if (!(await isNotifiable(db, userId))) return false
+  return createNotification(db, {
+    userId,
+    type: NOTIFICATION_TYPES.AUCTION_OUTBID,
+    title: `You were outbid on ${ctoonName || 'an auction'}`,
+    // `amount` is the winning Bid row's amount, already public in the auction's
+    // bid history. Never the outbidder's auto-bid maximum.
+    body: amount ? `The bid to beat is now ${fmt(amount)} pts.` : null,
+    contextType: 'AUCTION',
+    contextId: auctionId
+  })
+}
+
+/** Someone bid on an auction you listed. Collapses across a proxy-bid cascade. */
+export async function notifyAuctionBid (db, { userId, auctionId, ctoonName, amount }) {
+  if (!(await isNotifiable(db, userId))) return false
+  return createNotification(db, {
+    userId,
+    type: NOTIFICATION_TYPES.AUCTION_NEW_BID,
+    title: `New bid on your ${ctoonName || 'auction'}`,
+    body: amount ? `The bid is now ${fmt(amount)} pts.` : null,
+    contextType: 'AUCTION',
+    contextId: auctionId
+  })
+}
+
+/** You won an auction. Written in the same transaction as the payout. */
+export async function notifyAuctionWon (db, { userId, auctionId, ctoonName, amount }) {
+  return createNotification(db, {
+    userId,
+    type: NOTIFICATION_TYPES.AUCTION_WON,
+    title: `You won ${ctoonName || 'an auction'}!`,
+    body: amount ? `Winning bid: ${fmt(amount)} pts.` : null,
+    contextType: 'AUCTION',
+    contextId: auctionId
+  })
+}
+
+/**
+ * A trade offer landed in your incoming list.
+ *
+ * `contextId` is the SENDER's id, not the offer's. There is no per-offer page to
+ * deep-link to — every trade notification opens /newsite/trade — so using the
+ * sender collapses a flood of offers from one account into a single row instead
+ * of one row per offer. Nothing rate-limits offer creation and a 1-point offer
+ * is free to send, so without this the hub is an unbounded, attacker-writable
+ * store in a victim's account.
+ */
+export async function notifyTradeOfferReceived (db, { userId, fromUserId, fromUsername, isCounter = false }) {
+  if (!(await isNotifiable(db, userId))) return false
+  return createNotification(db, {
+    userId,
+    type: NOTIFICATION_TYPES.TRADE_OFFER_RECEIVED,
+    title: isCounter
+      ? `${fromUsername || 'Someone'} countered your trade offer`
+      : `New trade offer from ${fromUsername || 'someone'}`,
+    body: 'Open Trades to review it.',
+    contextType: 'TRADE',
+    contextId: fromUserId
+  })
+}
+
+/** A trade offer you sent was accepted. */
+export async function notifyTradeOfferAccepted (db, { userId, offerId, byUsername }) {
+  if (!(await isNotifiable(db, userId))) return false
+  return createNotification(db, {
+    userId,
+    type: NOTIFICATION_TYPES.TRADE_OFFER_ACCEPTED,
+    title: `${byUsername || 'Someone'} accepted your trade offer`,
+    body: 'The cToons and points have been transferred.',
+    contextType: 'TRADE',
+    contextId: offerId
+  })
+}

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -1,0 +1,196 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  NOTIFICATION_TYPES,
+  createNotification,
+  notifyOutbid,
+  notifyAuctionBid,
+  notifyAuctionWon,
+  notifyTradeOfferReceived,
+  notifyTradeOfferAccepted
+} from '../server/utils/notifications.js'
+
+// A stand-in for the Prisma client that records what it was asked to do. The
+// writer takes `db` as a parameter precisely so it can be driven like this from
+// both runtimes — see the import-rules header on the module under test.
+function fakeDb ({ user = { username: 'alice', banned: false }, throwOnWrite = false } = {}) {
+  const calls = { writes: [], userLookups: 0 }
+  return {
+    calls,
+    async $executeRaw (strings, ...values) {
+      if (throwOnWrite) throw new Error('db exploded')
+      calls.writes.push({ sql: strings.join('?'), values })
+      return 1
+    },
+    user: {
+      async findUnique () {
+        calls.userLookups++
+        return user
+      }
+    }
+  }
+}
+
+// ── The import contract ───────────────────────────────────────────
+// The socket server is a plain `node server/socket-server.js` process, so it
+// cannot resolve Nuxt's `@/` alias or `#imports`. That this test file imports
+// the module at all is the assertion: a bare `node --test` run would fail on any
+// aliased import added to it. Keep it that way.
+
+test('every helper is exported and callable', () => {
+  for (const fn of [createNotification, notifyOutbid, notifyAuctionBid,
+    notifyAuctionWon, notifyTradeOfferReceived, notifyTradeOfferAccepted]) {
+    assert.equal(typeof fn, 'function')
+  }
+})
+
+test('the type set is closed and frozen', () => {
+  assert.ok(Object.isFrozen(NOTIFICATION_TYPES))
+  assert.deepEqual(Object.keys(NOTIFICATION_TYPES).sort(), [
+    'AUCTION_NEW_BID',
+    'AUCTION_OUTBID',
+    'AUCTION_WON',
+    'TRADE_OFFER_ACCEPTED',
+    'TRADE_OFFER_RECEIVED'
+  ])
+})
+
+// ── createNotification ────────────────────────────────────────────
+
+test('createNotification rejects an unknown type rather than writing it', async () => {
+  const db = fakeDb()
+  const ok = await createNotification(db, {
+    userId: 'u1', type: 'TOTALLY_MADE_UP', title: 'hi'
+  })
+  assert.equal(ok, false)
+  assert.equal(db.calls.writes.length, 0)
+})
+
+test('createNotification requires a recipient and a title', async () => {
+  const db = fakeDb()
+  assert.equal(await createNotification(db, { type: 'AUCTION_WON', title: 't' }), false)
+  assert.equal(await createNotification(db, { userId: 'u1', type: 'AUCTION_WON' }), false)
+  assert.equal(db.calls.writes.length, 0)
+})
+
+test('createNotification upserts on the collapse key instead of inserting blindly', async () => {
+  const db = fakeDb()
+  await createNotification(db, {
+    userId: 'u1',
+    type: 'AUCTION_NEW_BID',
+    title: 'New bid',
+    contextType: 'AUCTION',
+    contextId: 'auction-1'
+  })
+  const { sql } = db.calls.writes[0]
+  // The collapse is what stops one proxy-bid cascade writing a notification per
+  // Bid row, and what caps trade-offer spam at one row per sender.
+  assert.match(sql, /ON CONFLICT/)
+  assert.match(sql, /"readAt" IS NULL/)
+  assert.match(sql, /"count"\s*=\s*"Notification"\."count"\s*\+\s*1/)
+})
+
+test('createNotification swallows database failures', async () => {
+  // Every call site sits after work that has already committed — a bid, a trade,
+  // a payout. A failed notification must never turn that into an error response.
+  const db = fakeDb({ throwOnWrite: true })
+  assert.equal(await createNotification(db, {
+    userId: 'u1', type: 'AUCTION_WON', title: 'You won'
+  }), false)
+})
+
+// ── Recipient eligibility ─────────────────────────────────────────
+
+test('banned users are not notified', async () => {
+  const db = fakeDb({ user: { username: 'alice', banned: true } })
+  await notifyOutbid(db, { userId: 'u1', auctionId: 'a1', ctoonName: 'Dexter', amount: 100 })
+  assert.equal(db.calls.writes.length, 0)
+})
+
+test('the official account is not notified', async () => {
+  // It is a system actor: it holds auction-only stock and dissolved users'
+  // listings, with no player behind it. Mirrors the guard in utils/discord.js.
+  const db = fakeDb({ user: { username: 'CartoonReOrbitOfficial', banned: false } })
+  await notifyAuctionBid(db, { userId: 'official', auctionId: 'a1', ctoonName: 'Dexter', amount: 100 })
+  assert.equal(db.calls.writes.length, 0)
+})
+
+test('a deleted recipient is not notified', async () => {
+  const db = fakeDb({ user: null })
+  await notifyTradeOfferReceived(db, { userId: 'gone', fromUserId: 'u2', fromUsername: 'bob' })
+  assert.equal(db.calls.writes.length, 0)
+})
+
+// ── Content ───────────────────────────────────────────────────────
+
+test('outbid text carries the public bid amount and nothing else', async () => {
+  const db = fakeDb()
+  await notifyOutbid(db, { userId: 'u1', auctionId: 'a1', ctoonName: 'Dexter', amount: 1500 })
+  const { values } = db.calls.writes[0]
+  const text = values.join(' | ')
+  assert.match(text, /Dexter/)
+  assert.match(text, /1,500/)
+  // The one genuinely private number in the auction system is another user's
+  // AuctionAutoBid.maxAmount. Callers pass values, never prose, so there is no
+  // path for it to reach this text — this asserts the shape that keeps it so.
+  assert.equal(values.filter(v => typeof v === 'number').length, 0)
+})
+
+test('auction notifications carry the auction id as their context', async () => {
+  const db = fakeDb()
+  await notifyAuctionWon(db, { userId: 'u1', auctionId: 'auction-7', ctoonName: 'Dee Dee', amount: 90 })
+  const { values } = db.calls.writes[0]
+  assert.ok(values.includes('AUCTION'))
+  assert.ok(values.includes('auction-7'))
+})
+
+test('auction-won skips the eligibility lookup', async () => {
+  // It is written inside the auction-close transaction, which already holds row
+  // locks that every concurrent bidder serialises behind. The winner is by
+  // definition a real actor who just paid, so the extra query is not worth
+  // widening that window.
+  const db = fakeDb()
+  await notifyAuctionWon(db, { userId: 'u1', auctionId: 'a1', ctoonName: 'X', amount: 1 })
+  assert.equal(db.calls.userLookups, 0)
+  assert.equal(db.calls.writes.length, 1)
+})
+
+test('received-offer notifications collapse on the sender, not the offer', async () => {
+  // Nothing rate-limits trade offers and a 1-point offer is free to send, so
+  // keying on the offer id would let one hostile account mint unbounded
+  // permanent rows in a victim's hub. There is no per-offer page to link to
+  // anyway — every trade notification opens /newsite/trade.
+  const db = fakeDb()
+  await notifyTradeOfferReceived(db, {
+    userId: 'victim', fromUserId: 'attacker-id', fromUsername: 'mallory'
+  })
+  const { values } = db.calls.writes[0]
+  assert.ok(values.includes('attacker-id'))
+  assert.ok(values.includes('TRADE'))
+})
+
+test('counter offers read as counters, not as fresh offers', async () => {
+  const db = fakeDb()
+  await notifyTradeOfferReceived(db, {
+    userId: 'u1', fromUserId: 'u2', fromUsername: 'bob', isCounter: true
+  })
+  assert.match(db.calls.writes[0].values.join(' | '), /countered/i)
+})
+
+test('accepted-offer notifications name the accepting user', async () => {
+  const db = fakeDb()
+  await notifyTradeOfferAccepted(db, { userId: 'u1', offerId: 'offer-3', byUsername: 'bob' })
+  const { values } = db.calls.writes[0]
+  assert.match(values.join(' | '), /bob/)
+  assert.ok(values.includes('offer-3'))
+})
+
+test('missing names degrade to neutral copy rather than "undefined"', async () => {
+  const db = fakeDb()
+  await notifyTradeOfferAccepted(db, { userId: 'u1', offerId: 'o1', byUsername: null })
+  await notifyOutbid(db, { userId: 'u1', auctionId: 'a1', ctoonName: null, amount: null })
+  for (const w of db.calls.writes) {
+    assert.doesNotMatch(w.values.join(' | '), /undefined|null/)
+  }
+})


### PR DESCRIPTION
Supersedes #907, with the auction lister username dropped. Everything else is unchanged. `server/api/auction/[id].get.js` is now byte-identical to `dev`.

## What's here

**Notification hub.** The Daily drawer gains an "Alerts" tab and an unread badge on the floating pill, covering the five events that previously only ever produced a Discord DM: being outbid, a new bid on your auction, winning an auction, an incoming trade offer, and a sent offer being accepted. Nothing renders when the count is zero. Clicking an item marks it read and deep-links; there's a "Mark all read" button. Opening the tab deliberately does *not* clear the badge, so a stray tap on a phone can't wipe the signal.

**Locked points.** `UserPoints.points` is the gross balance and `LockedPoints` is an overlay that every spend path subtracts at spend time, so the UI was showing a number users could not spend. The sidebar now shows the locked figure inline on the points line.

## Design notes worth review

**Notifications collapse rather than accumulate.** A single manual bid into a proxy auto-bid war writes many `Bid` rows, so notifying per row would give a seller ten cards for one human action. A partial unique index on `(userId, type, contextId) WHERE readAt IS NULL` turns those into one row with a `count`. The same index caps trade-offer spam at one row per sender, which matters because nothing rate-limits offer creation and a 1-point offer is free to send.

**There is deliberately no stored `link` column.** A free-text route written by five call sites and rendered into a `NuxtLink :to` would be a persistent open-redirect sink. Routes are derived on the client from the notification type.

**In-app notifications ignore `allowAuctionNotifications`.** That flag's only consumer is the Discord DM path and its description already says so, so reusing it would silently blind the hub for everyone who had opted out of DMs. The settings row is relabelled to name the channel it actually controls.

**`server/utils/notifications.js` is imported by both Nuxt and the standalone socket process**, so it takes the Prisma client as a parameter and imports nothing but `node:crypto` — the `@/` alias does not resolve under plain `node`. Verified it loads under bare Node; the test file's own import is the regression guard.

## Cost control

Two of these write on the hottest path in the app, so:

- The badge count and locked total ride the `/api/auth/me` payload every page already loads. Every handler here authenticates by internally re-fetching that route, so a dedicated endpoint for either figure would re-derive the whole payload — including two collection-wide aggregates — to return one integer.
- The polled count endpoint reads `event.context.userId` from the JWT the middleware already parsed, and is listed in `HOT_PATHS`, taking a tick from ~20 Postgres round trips to one. Ban enforcement normally lives in `/api/auth/me`, so it's folded into that same query as a relation filter rather than paid for separately.
- Polling is 120s, jittered, gated on an active session and a visible tab.
- Notification writes happen after the auction transaction commits and are not awaited, so they neither widen the row-lock window that concurrent bidders serialise behind nor sit behind the existing socket handshake and Discord call. "You won" is the exception: it belongs inside the settle branch, keeping it atomic with the payout and unreachable from the double-sale and anti-snipe-reschedule paths, where a win notification would be actively wrong.
- The locked-points sum in the bid transaction is now an aggregate instead of `findMany` plus a JS reduce, with a covering index.

## Mobile

The drawer had no viewport bound — in landscape its header ran off the top of the screen with no way to scroll back. It's now flex-bounded to `min(70dvh, 420px)` with the lists absorbing the remainder. Its open transition animated `max-height` to a hardcoded 300px against a natural ~344px, snapping the last 44px in one frame; a third tab would have widened that, so it animates opacity and transform instead. Also adds safe-area inset, 40–44px tap targets, overscroll containment, title clamping, and `pointerdown` for tap-outside-to-dismiss, which never fired on iOS Safari.

The locked figure is an inline suffix rather than a new row because the 85px sidebar box already overflows at ~90px, and growing it would mean shrinking the middle panel across five pages that override its height.

The floating pill is hidden while a modal is open: `.site-container` gets a transform on desktop only, making it a stacking context that traps the modals inside it below this sibling's `z-50`. A permanent badge would have painted over every modal on desktop and not on mobile.

## Fixes beyond the literal ask

Shipping the locked figure without these would have shipped a visible contradiction: the auction page gated its bid button and "have X" hint on the gross balance while the server rejects those bids, and the trade builder capped its points input the same way. Both now use available.

Auction detail also keeps three truncation fixes for the winner, top-bidder and bid-history rows. Those are nowrap text runs in a `space-between` flex row with no shrink floor, so a long username punched out of the container and gave the body a horizontal scrollbar. They're independent of the dropped lister feature.

## Testing

- 16 new tests in `tests/notifications.test.js`; 322/323 pass overall.
- One **pre-existing** failure, `monsterBattleEngine.test.js` ("attack-vs-attack KO prevents counterattack") — confirmed failing identically on the untouched tree, unrelated to this change.
- `npm run lint` is broken repo-wide (ESLint 10 wants `eslint.config.js`, repo has none), so it was not run. Modified SFCs were compile-checked via `vue/compiler-sfc` and server files via `node --check`.

## Deploy note

The migration is hand-written. `prisma migrate dev` will report the two partial indexes as drift and offer to drop them — **keep them**, same convention as the existing unique-active-auction migration.

## Not built

Two adjacent gaps, left out as outside the requested scope, both ~10 lines at already-instrumented sites:

- No notification when an offer is **rejected or withdrawn** — that already sends a DM, so the in-app hub will look asymmetric.
- The **seller isn't told when their auction sells**.

## Unrelated bug spotted, deliberately untouched

`refreshDiscordTokenAndRoles` is called with 3 args but declared with 2 (`me.get.js:61`, `guild-check.js:27`), so token/role refresh silently no-ops. Worth fixing separately — but not in the same change as anything that adds request volume, since it would put up to 3 Discord API calls back on the auth path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bTHex9DYnyG16fhadATjz

---
_Generated by [Claude Code](https://claude.ai/code/session_015bTHex9DYnyG16fhadATjz)_