### PR TITLE
Add error visibility and future-date validation to dissolve queue reschedule

### DIFF
--- a/components/newsite/admin/legacy/AdminLegacyDissolveQueue.vue
+++ b/components/newsite/admin/legacy/AdminLegacyDissolveQueue.vue
@@ -5,6 +5,7 @@
       <div class="flex items-center justify-between flex-wrap gap-2">
         <h1 class="text-base font-semibold">Dissolve Queue</h1>
         <div class="flex items-center gap-3">
+          <button @click="openErrorsModal" class="text-xs text-red-600 hover:underline">Errors</button>
           <button @click="openFeaturedModal" class="text-xs text-blue-600 hover:underline">Edit Featured</button>
           <button @click="loadData" class="text-xs text-blue-600 hover:underline">Refresh</button>
         </div>
@@ -377,6 +378,72 @@
         </div>
       </div>
     </div>
+
+    <!-- Errors modal: failures launching a queue entry into a live auction -->
+    <div v-if="showErrorsModal" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50" @click.self="closeErrorsModal">
+      <div class="relative bg-white w-full max-w-2xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+          <h2 class="text-sm font-semibold">Errors</h2>
+          <div class="flex items-center gap-2">
+            <button
+              v-if="errorLog.length"
+              type="button"
+              class="px-2 py-1 text-xs border border-red-600 text-red-700 rounded-md hover:bg-red-50"
+              @click="clearErrorLog"
+            >Clear Log</button>
+            <button @click="closeErrorsModal" class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+          </div>
+        </div>
+        <div class="overflow-y-auto flex-1 px-4 py-3">
+          <div v-if="errorLogLoading" class="text-gray-500 py-6 text-center">Loading…</div>
+          <template v-else>
+            <div v-if="errorLog.length" class="bg-gray-50 rounded-md border divide-y">
+              <div v-for="e in errorLog" :key="e.id" class="p-2.5">
+                <div class="flex flex-wrap items-center gap-2 text-xs">
+                  <span class="font-medium">{{ e.ctoonName || 'Unknown cToon' }}</span>
+                  <span v-if="e.mintNumber != null" class="text-gray-500">Mint #{{ e.mintNumber }}</span>
+                  <span v-if="e.rarity" class="text-gray-500">· {{ e.rarity }}</span>
+                  <span v-if="e.series" class="text-gray-500">· {{ e.series }}</span>
+                  <span v-if="e.set" class="text-gray-500">· {{ e.set }}</span>
+                </div>
+                <div class="flex flex-wrap items-center gap-2 text-[10px] text-gray-500 mt-1">
+                  <span>{{ fmtCST(e.createdAt) }}</span>
+                  <span v-if="e.sourceUsername">· From: {{ e.sourceUsername }}</span>
+                  <span v-if="e.userCtoonId">· userCtoonId: {{ e.userCtoonId }}</span>
+                  <span v-if="e.queueEntryId">· queueEntryId: {{ e.queueEntryId }}</span>
+                </div>
+                <pre class="text-[11px] text-red-700 mt-1.5 whitespace-pre-wrap break-words">{{ e.message }}</pre>
+              </div>
+            </div>
+            <p v-else class="text-gray-500">No errors logged.</p>
+          </template>
+          <p v-if="errorLogError" class="text-red-600 mt-2 text-xs">{{ errorLogError }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Reschedule error modal: surfaces details when a reschedule save fails -->
+    <div v-if="showRescheduleErrorModal" class="fixed inset-0 z-50 flex items-center justify-center p-2 bg-black/50" @click.self="closeRescheduleErrorModal">
+      <div class="relative bg-white w-full max-w-xl rounded-lg shadow-lg flex flex-col max-h-[92vh]">
+        <div class="px-4 py-3 border-b flex-shrink-0 flex items-center justify-between">
+          <h2 class="text-sm font-semibold text-red-700">Reschedule Failed</h2>
+          <button @click="closeRescheduleErrorModal" class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+        </div>
+        <div v-if="rescheduleErrorDetails" class="overflow-y-auto flex-1 px-4 py-3 space-y-1.5 text-xs">
+          <div><span class="font-medium">cToon:</span> {{ rescheduleErrorDetails.ctoonName || '—' }}
+            <span v-if="rescheduleErrorDetails.mintNumber != null"> (Mint #{{ rescheduleErrorDetails.mintNumber }})</span>
+          </div>
+          <div><span class="font-medium">Queue entry ID:</span> {{ rescheduleErrorDetails.entryId }}</div>
+          <div><span class="font-medium">Attempted date/time:</span> {{ rescheduleErrorDetails.attemptedLocal }} ({{ rescheduleErrorDetails.attemptedUtc }})</div>
+          <div><span class="font-medium">HTTP status:</span> {{ rescheduleErrorDetails.statusCode ?? '—' }}</div>
+          <div><span class="font-medium">Time of failure:</span> {{ rescheduleErrorDetails.occurredAt }}</div>
+          <div>
+            <div class="font-medium mb-1">Error details:</div>
+            <pre class="text-[11px] text-red-700 bg-gray-50 border rounded p-2 whitespace-pre-wrap break-words">{{ rescheduleErrorDetails.message }}</pre>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -568,6 +635,15 @@ const rescheduleLocal     = ref('')
 const reschedulingSaving  = ref(false)
 const rescheduleError     = ref('')
 
+// Reschedule error modal
+const showRescheduleErrorModal = ref(false)
+const rescheduleErrorDetails   = ref(null)
+
+function closeRescheduleErrorModal() {
+  showRescheduleErrorModal.value = false
+  rescheduleErrorDetails.value = null
+}
+
 function toDatetimeLocal(iso) {
   const d = iso ? new Date(iso) : new Date()
   const pad = (n) => String(n).padStart(2, '0')
@@ -595,15 +671,30 @@ function updateEntryInLists(id, patch) {
   apply(allEntries.value)
 }
 
+// Matches the server-side floor in server/api/admin/dissolve-queue/[id].patch.js:
+// the launch job fires with delay = max(0, scheduledFor - now), so anything not
+// comfortably in the future would fire almost immediately instead of at the
+// intended time.
+const MIN_LEAD_MS = 60 * 1000
+
 async function saveReschedule(id) {
   rescheduleError.value = ''
   if (!rescheduleLocal.value) {
     rescheduleError.value = 'Please choose a date/time.'
     return
   }
+  const scheduledForDate = new Date(rescheduleLocal.value)
+  if (isNaN(scheduledForDate.getTime())) {
+    rescheduleError.value = 'Please choose a valid date/time.'
+    return
+  }
+  if (scheduledForDate.getTime() < Date.now() + MIN_LEAD_MS) {
+    rescheduleError.value = 'Please choose a date/time at least 1 minute in the future.'
+    return
+  }
   reschedulingSaving.value = true
   try {
-    const scheduledForUtc = new Date(rescheduleLocal.value).toISOString()
+    const scheduledForUtc = scheduledForDate.toISOString()
     await $fetch(`/api/admin/dissolve-queue/${id}`, {
       method: 'PATCH',
       body: { scheduledForUtc }
@@ -612,7 +703,19 @@ async function saveReschedule(id) {
     cancelReschedule()
     await loadData()
   } catch (e) {
+    const entry = [...upcoming.value, ...allEntries.value].find(x => x.id === id)
     rescheduleError.value = e?.data?.statusMessage || 'Failed to reschedule entry.'
+    rescheduleErrorDetails.value = {
+      entryId: id,
+      ctoonName: entry?.ctoonName || null,
+      mintNumber: entry?.mintNumber ?? null,
+      attemptedLocal: rescheduleLocal.value,
+      attemptedUtc: (() => { try { return scheduledForDate.toISOString() } catch { return '—' } })(),
+      statusCode: e?.statusCode ?? e?.data?.statusCode ?? e?.response?.status ?? null,
+      occurredAt: new Date().toISOString(),
+      message: e?.data?.statusMessage || e?.message || String(e),
+    }
+    showRescheduleErrorModal.value = true
   } finally {
     reschedulingSaving.value = false
   }
@@ -734,6 +837,38 @@ async function saveFeaturedConfig() {
     featuredError.value = e?.data?.statusMessage || 'Failed to save featured config.'
   } finally {
     savingFeatured.value = false
+  }
+}
+
+// ── Errors modal (dissolve-queue → live-auction launch failures) ──────────
+const showErrorsModal = ref(false)
+const errorLog        = ref([])
+const errorLogLoading = ref(false)
+const errorLogError   = ref('')
+
+async function openErrorsModal() {
+  showErrorsModal.value = true
+  errorLogError.value   = ''
+  errorLogLoading.value = true
+  try {
+    errorLog.value = await $fetch('/api/admin/dissolve-queue/errors', { headers })
+  } catch (e) {
+    errorLogError.value = e?.data?.statusMessage || 'Failed to load error log.'
+  } finally {
+    errorLogLoading.value = false
+  }
+}
+
+function closeErrorsModal() {
+  showErrorsModal.value = false
+}
+
+async function clearErrorLog() {
+  try {
+    await $fetch('/api/admin/dissolve-queue/errors', { method: 'DELETE' })
+    errorLog.value = []
+  } catch (e) {
+    errorLogError.value = e?.data?.statusMessage || 'Failed to clear error log.'
   }
 }
 </script>

--- a/pages/admin/dissolve-queue.vue
+++ b/pages/admin/dissolve-queue.vue
@@ -6,6 +6,7 @@
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Dissolve Queue</h1>
         <div class="flex items-center gap-4">
+          <button @click="openErrorsModal" class="text-sm text-red-600 underline">Errors</button>
           <button @click="openFeaturedModal" class="text-sm text-blue-600 underline">Edit Featured</button>
           <button @click="loadData" class="text-sm text-blue-600 underline">Refresh</button>
         </div>
@@ -441,6 +442,71 @@
         </div>
       </div>
     </div>
+
+    <!-- Errors modal: failures launching a queue entry into a live auction -->
+    <div v-if="showErrorsModal" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50" @click.self="closeErrorsModal">
+      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-2xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
+        <div class="flex items-center justify-between mb-4 gap-2">
+          <h2 class="text-xl font-semibold">Errors</h2>
+          <div class="flex items-center gap-2">
+            <button
+              v-if="errorLog.length"
+              type="button"
+              class="px-3 py-1.5 text-sm rounded border border-red-600 text-red-700 hover:bg-red-50"
+              @click="clearErrorLog"
+            >Clear Log</button>
+            <button class="text-gray-500 hover:text-gray-700 p-2 -m-2" @click="closeErrorsModal">X</button>
+          </div>
+        </div>
+
+        <div v-if="errorLogLoading" class="text-gray-500 py-6 text-center">Loading…</div>
+        <template v-else>
+          <div v-if="errorLog.length" class="bg-gray-50 rounded-lg border divide-y">
+            <div v-for="e in errorLog" :key="e.id" class="p-3 sm:p-4">
+              <div class="flex flex-wrap items-center gap-2 text-sm">
+                <span class="font-medium">{{ e.ctoonName || 'Unknown cToon' }}</span>
+                <span v-if="e.mintNumber != null" class="text-gray-500">Mint #{{ e.mintNumber }}</span>
+                <span v-if="e.rarity" class="text-gray-500">· {{ e.rarity }}</span>
+                <span v-if="e.series" class="text-gray-500">· {{ e.series }}</span>
+                <span v-if="e.set" class="text-gray-500">· {{ e.set }}</span>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-xs text-gray-500 mt-1">
+                <span>{{ fmtCST(e.createdAt) }}</span>
+                <span v-if="e.sourceUsername">· From: {{ e.sourceUsername }}</span>
+                <span v-if="e.userCtoonId">· userCtoonId: {{ e.userCtoonId }}</span>
+                <span v-if="e.queueEntryId">· queueEntryId: {{ e.queueEntryId }}</span>
+              </div>
+              <pre class="text-xs text-red-700 mt-2 whitespace-pre-wrap break-words">{{ e.message }}</pre>
+            </div>
+          </div>
+          <p v-else class="text-gray-500">No errors logged.</p>
+        </template>
+        <p v-if="errorLogError" class="text-red-600 mt-2 text-sm">{{ errorLogError }}</p>
+      </div>
+    </div>
+
+    <!-- Reschedule error modal: surfaces details when a reschedule save fails -->
+    <div v-if="showRescheduleErrorModal" class="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50" @click.self="closeRescheduleErrorModal">
+      <div class="bg-white rounded-lg shadow-lg w-[calc(100%-2rem)] max-w-xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
+        <div class="flex items-center justify-between mb-4 gap-2">
+          <h2 class="text-xl font-semibold text-red-700">Reschedule Failed</h2>
+          <button class="text-gray-500 hover:text-gray-700 p-2 -m-2" @click="closeRescheduleErrorModal">X</button>
+        </div>
+        <div v-if="rescheduleErrorDetails" class="space-y-2 text-sm">
+          <div><span class="font-medium">cToon:</span> {{ rescheduleErrorDetails.ctoonName || '—' }}
+            <span v-if="rescheduleErrorDetails.mintNumber != null"> (Mint #{{ rescheduleErrorDetails.mintNumber }})</span>
+          </div>
+          <div><span class="font-medium">Queue entry ID:</span> {{ rescheduleErrorDetails.entryId }}</div>
+          <div><span class="font-medium">Attempted date/time:</span> {{ rescheduleErrorDetails.attemptedLocal }} ({{ rescheduleErrorDetails.attemptedUtc }})</div>
+          <div><span class="font-medium">HTTP status:</span> {{ rescheduleErrorDetails.statusCode ?? '—' }}</div>
+          <div><span class="font-medium">Time of failure:</span> {{ rescheduleErrorDetails.occurredAt }}</div>
+          <div>
+            <div class="font-medium mb-1">Error details:</div>
+            <pre class="text-xs text-red-700 bg-gray-50 border rounded p-2 whitespace-pre-wrap break-words">{{ rescheduleErrorDetails.message }}</pre>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -655,6 +721,15 @@ const rescheduleLocal     = ref('')
 const reschedulingSaving  = ref(false)
 const rescheduleError     = ref('')
 
+// Reschedule error modal
+const showRescheduleErrorModal = ref(false)
+const rescheduleErrorDetails   = ref(null)
+
+function closeRescheduleErrorModal() {
+  showRescheduleErrorModal.value = false
+  rescheduleErrorDetails.value = null
+}
+
 function toDatetimeLocal(iso) {
   const d = iso ? new Date(iso) : new Date()
   const pad = (n) => String(n).padStart(2, '0')
@@ -682,15 +757,30 @@ function updateEntryInLists(id, patch) {
   apply(allEntries.value)
 }
 
+// Matches the server-side floor in server/api/admin/dissolve-queue/[id].patch.js:
+// the launch job fires with delay = max(0, scheduledFor - now), so anything not
+// comfortably in the future would fire almost immediately instead of at the
+// intended time.
+const MIN_LEAD_MS = 60 * 1000
+
 async function saveReschedule(id) {
   rescheduleError.value = ''
   if (!rescheduleLocal.value) {
     rescheduleError.value = 'Please choose a date/time.'
     return
   }
+  const scheduledForDate = new Date(rescheduleLocal.value)
+  if (isNaN(scheduledForDate.getTime())) {
+    rescheduleError.value = 'Please choose a valid date/time.'
+    return
+  }
+  if (scheduledForDate.getTime() < Date.now() + MIN_LEAD_MS) {
+    rescheduleError.value = 'Please choose a date/time at least 1 minute in the future.'
+    return
+  }
   reschedulingSaving.value = true
   try {
-    const scheduledForUtc = new Date(rescheduleLocal.value).toISOString()
+    const scheduledForUtc = scheduledForDate.toISOString()
     await $fetch(`/api/admin/dissolve-queue/${id}`, {
       method: 'PATCH',
       body: { scheduledForUtc }
@@ -699,7 +789,19 @@ async function saveReschedule(id) {
     cancelReschedule()
     await loadData()
   } catch (e) {
+    const entry = [...upcoming.value, ...allEntries.value].find(x => x.id === id)
     rescheduleError.value = e?.data?.statusMessage || 'Failed to reschedule entry.'
+    rescheduleErrorDetails.value = {
+      entryId: id,
+      ctoonName: entry?.ctoonName || null,
+      mintNumber: entry?.mintNumber ?? null,
+      attemptedLocal: rescheduleLocal.value,
+      attemptedUtc: (() => { try { return scheduledForDate.toISOString() } catch { return '—' } })(),
+      statusCode: e?.statusCode ?? e?.data?.statusCode ?? e?.response?.status ?? null,
+      occurredAt: new Date().toISOString(),
+      message: e?.data?.statusMessage || e?.message || String(e),
+    }
+    showRescheduleErrorModal.value = true
   } finally {
     reschedulingSaving.value = false
   }
@@ -836,6 +938,38 @@ async function saveFeaturedConfig() {
     featuredError.value = e?.data?.statusMessage || 'Failed to save featured config.'
   } finally {
     savingFeatured.value = false
+  }
+}
+
+// ── Errors modal (dissolve-queue → live-auction launch failures) ──────────
+const showErrorsModal = ref(false)
+const errorLog        = ref([])
+const errorLogLoading = ref(false)
+const errorLogError   = ref('')
+
+async function openErrorsModal() {
+  showErrorsModal.value = true
+  errorLogError.value   = ''
+  errorLogLoading.value = true
+  try {
+    errorLog.value = await $fetch('/api/admin/dissolve-queue/errors', { headers })
+  } catch (e) {
+    errorLogError.value = e?.data?.statusMessage || 'Failed to load error log.'
+  } finally {
+    errorLogLoading.value = false
+  }
+}
+
+function closeErrorsModal() {
+  showErrorsModal.value = false
+}
+
+async function clearErrorLog() {
+  try {
+    await $fetch('/api/admin/dissolve-queue/errors', { method: 'DELETE' })
+    errorLog.value = []
+  } catch (e) {
+    errorLogError.value = e?.data?.statusMessage || 'Failed to clear error log.'
   }
 }
 </script>

--- a/prisma/migrations/20260816000000_add_dissolve_auction_error_log/migration.sql
+++ b/prisma/migrations/20260816000000_add_dissolve_auction_error_log/migration.sql
@@ -1,0 +1,21 @@
+-- Errors thrown while launching a dissolve-queue entry into a live auction
+-- (server/workers/dissolve-auction-launch.worker.js) were previously
+-- silently swallowed with zero trace. This gives the "Manage Dissolve Queue"
+-- admin page's Errors modal a durable log to read from.
+CREATE TABLE "DissolveAuctionErrorLog" (
+    "id" TEXT NOT NULL,
+    "queueEntryId" TEXT,
+    "userCtoonId" TEXT,
+    "ctoonName" TEXT,
+    "mintNumber" INTEGER,
+    "rarity" TEXT,
+    "series" TEXT,
+    "set" TEXT,
+    "sourceUsername" TEXT,
+    "message" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DissolveAuctionErrorLog_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "DissolveAuctionErrorLog_createdAt_idx" ON "DissolveAuctionErrorLog"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -413,10 +413,10 @@ model User {
   vpnDetected                       Boolean   @default(false)
 
   // cMoon (faction) membership
-  cMoonId           String?
-  cMoon             CMoon?    @relation(fields: [cMoonId], references: [id], onDelete: SetNull)
-  cMoonSelectedAt   DateTime?
-  cMoonAutoAssigned Boolean   @default(false)
+  cMoonId            String?
+  cMoon              CMoon?    @relation(fields: [cMoonId], references: [id], onDelete: SetNull)
+  cMoonSelectedAt    DateTime?
+  cMoonAutoAssigned  Boolean   @default(false)
   // Set once the daily Discord sync grants this user's cMoon role, so the job
   // only touches never-synced members instead of re-checking everyone daily.
   cMoonRoleGrantedAt DateTime?
@@ -2148,6 +2148,28 @@ model DissolveAuctionQueue {
   @@index([scheduledFor])
   @@index([priority])
   @@index([fromInactive])
+}
+
+// Errors thrown while launching a dissolve-queue entry into a live auction
+// (server/workers/dissolve-auction-launch.worker.js). Surfaced via the
+// "Errors" button/modal on the admin "Manage Dissolve Queue" page. The
+// cToon/queue fields are denormalized snapshots taken at failure time since
+// the queue row (and sometimes the userCtoon) may be deleted or altered by
+// the time an admin reads this log.
+model DissolveAuctionErrorLog {
+  id             String   @id @default(uuid())
+  queueEntryId   String? // best-effort reference; the queue row may already be deleted by the time this is read
+  userCtoonId    String?
+  ctoonName      String?
+  mintNumber     Int?
+  rarity         String?
+  series         String?
+  set            String?
+  sourceUsername String?
+  message        String
+  createdAt      DateTime @default(now())
+
+  @@index([createdAt])
 }
 
 model HomepageConfig {

--- a/server/api/admin/dissolve-queue/[id].patch.js
+++ b/server/api/admin/dissolve-queue/[id].patch.js
@@ -49,6 +49,18 @@ export default defineEventHandler(async (event) => {
   const scheduledFor = new Date(scheduledForUtc)
   if (isNaN(scheduledFor.getTime())) throw createError({ statusCode: 400, statusMessage: 'Invalid scheduledForUtc' })
 
+  // The launch job fires with delay = max(0, scheduledFor - now) (see
+  // scheduleDissolveAuctionLaunch), so anything not comfortably in the future
+  // fires almost immediately instead of at the intended time. Require a
+  // minimum lead time so a reschedule always lands on a real future slot.
+  const MIN_LEAD_MS = 60 * 1000
+  if (scheduledFor.getTime() < Date.now() + MIN_LEAD_MS) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'scheduledFor must be at least 1 minute in the future'
+    })
+  }
+
   const pinnedAt = new Date()
   await prisma.dissolveAuctionQueue.update({ where: { id }, data: { scheduledFor, pinnedAt } })
   await scheduleDissolveAuctionLaunch(id, scheduledFor)

--- a/server/api/admin/dissolve-queue/errors.delete.js
+++ b/server/api/admin/dissolve-queue/errors.delete.js
@@ -1,0 +1,18 @@
+// server/api/admin/dissolve-queue/errors.delete.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  await prisma.dissolveAuctionErrorLog.deleteMany({})
+
+  return { ok: true }
+})

--- a/server/api/admin/dissolve-queue/errors.get.js
+++ b/server/api/admin/dissolve-queue/errors.get.js
@@ -1,0 +1,21 @@
+// server/api/admin/dissolve-queue/errors.get.js
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+
+  const rows = await prisma.dissolveAuctionErrorLog.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: 100
+  })
+
+  return rows
+})

--- a/server/utils/dissolveAuctionErrorLog.js
+++ b/server/utils/dissolveAuctionErrorLog.js
@@ -1,0 +1,29 @@
+import { prisma } from '../prisma.js'
+
+/**
+ * Best-effort error log entry for dissolve-queue → live-auction launch
+ * failures, surfaced on the admin "Manage Dissolve Queue" page's Errors
+ * modal. Never throws.
+ * @param {unknown} err
+ * @param {{ queueEntryId?: string|null, userCtoonId?: string|null, ctoonName?: string|null, mintNumber?: number|null, rarity?: string|null, series?: string|null, set?: string|null, sourceUsername?: string|null }} details
+ */
+export async function logDissolveAuctionError(err, details = {}) {
+  try {
+    const message = err?.stack || err?.message || String(err)
+    await prisma.dissolveAuctionErrorLog.create({
+      data: {
+        queueEntryId:   details.queueEntryId ?? null,
+        userCtoonId:    details.userCtoonId ?? null,
+        ctoonName:      details.ctoonName ?? null,
+        mintNumber:     details.mintNumber ?? null,
+        rarity:         details.rarity ?? null,
+        series:         details.series ?? null,
+        set:            details.set ?? null,
+        sourceUsername: details.sourceUsername ?? null,
+        message:        message.slice(0, 4000),
+      }
+    })
+  } catch (e2) {
+    console.error('[dissolve-auction-error-log] failed to record error:', e2?.message)
+  }
+}

--- a/server/workers/dissolve-auction-launch.worker.js
+++ b/server/workers/dissolve-auction-launch.worker.js
@@ -3,6 +3,7 @@ import { prisma } from '../prisma.js'
 import { scheduleAuctionClose } from '../utils/queues.js'
 import { rarityFloor } from '../utils/auctionPriceSuggestion.js'
 import { isAutoAuctionEligibleRarity } from '../utils/autoAuctionEligibility.js'
+import { logDissolveAuctionError } from '../utils/dissolveAuctionErrorLog.js'
 
 const QUEUE_NAME = process.env.DISSOLVE_AUCTION_LAUNCH_QUEUE_KEY || 'dissolveAuctionLaunch'
 const OFFICIAL_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
@@ -13,68 +14,93 @@ const connection = {
   password: process.env.REDIS_PASSWORD?.trim() || undefined,
 }
 
-new Worker(QUEUE_NAME, async (job) => {
+const worker = new Worker(QUEUE_NAME, async (job) => {
   const { queueEntryId } = job.data
+  let entry = null
 
-  const officialUser = await prisma.user.findUnique({
-    where: { username: OFFICIAL_USERNAME },
-    select: { id: true }
-  })
-  if (!officialUser) throw new Error('Official account not found')
+  try {
+    const officialUser = await prisma.user.findUnique({
+      where: { username: OFFICIAL_USERNAME },
+      select: { id: true }
+    })
+    if (!officialUser) throw new Error('Official account not found')
 
-  const entry = await prisma.dissolveAuctionQueue.findUnique({
-    where: { id: queueEntryId },
-    include: {
-      userCtoon: { select: { id: true, ctoon: { select: { rarity: true } } } }
+    entry = await prisma.dissolveAuctionQueue.findUnique({
+      where: { id: queueEntryId },
+      include: {
+        userCtoon: {
+          select: {
+            id: true,
+            mintNumber: true,
+            ctoon: { select: { name: true, rarity: true, series: true, set: true } }
+          }
+        }
+      }
+    })
+    if (!entry) return  // already processed or deleted
+
+    // Not auto-listable (Auction/Prize/Code Only, Crazy Rare, or an
+    // unrecognized rarity with no explicit floor). Clear scheduledFor instead
+    // of leaving the entry stranded with no job: the next applyDissolveSchedule
+    // run picks up any entry with scheduledFor: null and re-queues it.
+    if (!isAutoAuctionEligibleRarity(entry.userCtoon?.ctoon?.rarity)) {
+      await prisma.dissolveAuctionQueue.update({
+        where: { id: entry.id },
+        data: { scheduledFor: null }
+      })
+      return
     }
-  })
-  if (!entry) return  // already processed or deleted
 
-  // Not auto-listable (Auction/Prize/Code Only, Crazy Rare, or an
-  // unrecognized rarity with no explicit floor). Clear scheduledFor instead
-  // of leaving the entry stranded with no job: the next applyDissolveSchedule
-  // run picks up any entry with scheduledFor: null and re-queues it.
-  if (!isAutoAuctionEligibleRarity(entry.userCtoon?.ctoon?.rarity)) {
-    await prisma.dissolveAuctionQueue.update({
-      where: { id: entry.id },
-      data: { scheduledFor: null }
-    })
-    return
-  }
+    const endAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
 
-  const endAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
+    const result = await prisma.$transaction(async (tx) => {
+      const existing = await tx.auction.findFirst({
+        where: { userCtoonId: entry.userCtoonId, status: 'ACTIVE' },
+        select: { id: true }
+      })
 
-  const result = await prisma.$transaction(async (tx) => {
-    const existing = await tx.auction.findFirst({
-      where: { userCtoonId: entry.userCtoonId, status: 'ACTIVE' },
-      select: { id: true }
-    })
+      await tx.dissolveAuctionQueue.delete({ where: { id: entry.id } })
 
-    await tx.dissolveAuctionQueue.delete({ where: { id: entry.id } })
+      if (existing) return null
 
-    if (existing) return null
+      const created = await tx.auction.create({
+        data: {
+          userCtoonId: entry.userCtoonId,
+          initialBet:  rarityFloor(entry.userCtoon?.ctoon?.rarity),
+          duration:    1,
+          endAt,
+          creatorId:   officialUser.id,
+          isFeatured:  entry.isFeatured,
+        },
+        select: { id: true }
+      })
 
-    const created = await tx.auction.create({
-      data: {
-        userCtoonId: entry.userCtoonId,
-        initialBet:  rarityFloor(entry.userCtoon?.ctoon?.rarity),
-        duration:    1,
-        endAt,
-        creatorId:   officialUser.id,
-        isFeatured:  entry.isFeatured,
-      },
-      select: { id: true }
+      await tx.userCtoon.update({
+        where: { id: entry.userCtoonId },
+        data:  { isTradeable: false }
+      })
+
+      return { auctionId: created.id, endAt }
     })
 
-    await tx.userCtoon.update({
-      where: { id: entry.userCtoonId },
-      data:  { isTradeable: false }
+    if (result) {
+      await scheduleAuctionClose(result.auctionId, result.endAt)
+    }
+  } catch (err) {
+    await logDissolveAuctionError(err, {
+      queueEntryId,
+      userCtoonId:    entry?.userCtoonId ?? entry?.userCtoon?.id ?? null,
+      ctoonName:      entry?.userCtoon?.ctoon?.name ?? null,
+      mintNumber:     entry?.userCtoon?.mintNumber ?? null,
+      rarity:         entry?.userCtoon?.ctoon?.rarity ?? null,
+      series:         entry?.userCtoon?.ctoon?.series ?? null,
+      set:            entry?.userCtoon?.ctoon?.set ?? null,
+      sourceUsername: entry?.sourceUsername ?? null,
     })
-
-    return { auctionId: created.id, endAt }
-  })
-
-  if (result) {
-    await scheduleAuctionClose(result.auctionId, result.endAt)
+    throw err
   }
 }, { connection })
+
+worker.on('failed', (job, err) => {
+  console.error(`[dissolve-auction-launch] job ${job?.id} failed:`, err?.message || err)
+})


### PR DESCRIPTION
- PATCH /admin/dissolve-queue/[id] now rejects scheduledFor values under 1
  minute in the future, so a reschedule can no longer silently fire almost
  immediately (matching the delay=max(0, scheduledFor-now) semantics of the
  BullMQ launch job).
- Reschedule failures now surface a modal with full failure details (cToon,
  mint, attempted date/time, HTTP status, raw error) instead of just an
  inline one-line message.
- dissolve-auction-launch.worker.js previously swallowed failures with zero
  trace. It now logs failures (with cToon name/mint/rarity/series/set) to a
  new DissolveAuctionErrorLog table and adds a worker 'failed' handler.
- New Errors button + modal on the dissolve-queue admin page (both the
  standalone page and the embedded admin-console component) to read/clear
  that log via new GET/DELETE /admin/dissolve-queue/errors routes.