### PR TITLE
Show Pack Exclusive badge in pack preview modal

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -77,6 +77,7 @@
                   class="owned-badge"
                   :class="originalOwnedSet.has(item.ctoonId) ? 'owned-badge--owned' : 'owned-badge--unowned'"
                 >{{ originalOwnedSet.has(item.ctoonId) ? 'Owned' : 'Unowned' }}</span>
+                <span v-if="item.inCmart === false" class="pack-exclusive-badge pack-exclusive-badge--preview">Pack Exclusive</span>
                 <img v-if="item.assetPath" :src="item.assetPath" :alt="item.name" class="pack-preview-ctoon-img" />
                 <SecondEditionOverlay :ctoon="item" />
                 <p class="pack-preview-ctoon-name">{{ item.name }}</p>
@@ -1481,6 +1482,13 @@ async function closeOverlay() {
   padding: 2px 5px;
   border-radius: 10px;
   text-align: right;
+}
+
+:global(.pack-exclusive-badge--preview) {
+  top: 4px;
+  right: auto;
+  left: 4px;
+  text-align: left;
 }
 
 :global(.pack-reveal-img-wrap) {

--- a/server/api/cmart/packs/[id].get.js
+++ b/server/api/cmart/packs/[id].get.js
@@ -66,6 +66,7 @@ export default defineEventHandler(async (event) => {
             ctoon:   {
               select: {
                 name: true, rarity: true, assetPath: true, isGtoon: true, cost: true, power: true,
+                inCmart: true,
                 isSecondEdition: true,
                 secondEditionOverlayX: true,
                 secondEditionOverlayY: true,
@@ -104,6 +105,7 @@ export default defineEventHandler(async (event) => {
     isGtoon: o.ctoon.isGtoon,
     cost:    o.ctoon.cost,
     power:   o.ctoon.power,
+    inCmart: o.ctoon.inCmart,
     weight:  o.weight,
     isSecondEdition:          o.ctoon.isSecondEdition,
     secondEditionOverlayX:    o.ctoon.secondEditionOverlayX,


### PR DESCRIPTION
Closes #920

## Summary
- The "Pack Exclusive" badge already existed for cToons not sold in cMart (`Ctoon.inCmart === false`) — it's shown in the post-purchase reveal grid and in the admin pack editor — but was missing from the pre-purchase pack preview modal on the cMart Packs tab.
- `server/api/cmart/packs/[id].get.js` now selects and returns `inCmart` on each pack's cToon options.
- `components/newsite/Cmart.vue`'s preview modal now renders the same `Pack Exclusive` badge for any cToon with `inCmart === false`, positioned top-left (a new `.pack-exclusive-badge--preview` modifier) so it doesn't collide with the existing top-right `Owned`/`Unowned` badge on the same card.

## Validation
- `node --check` on the modified server route.
- Parsed the modified `.vue` file with `@vue/compiler-sfc` to confirm the SFC is well-formed.
- Reused the existing badge markup/styling rather than introducing new visual patterns, so it matches the look already shipped in the reveal grid and admin editor.
- Not exercised against a running app/database in this environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KwSCGFuZJKDiKczEZRLRTa)_