### PR TITLE
Show Going Fast badge on cMart cToon cards

### DIFF
--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -229,6 +229,12 @@
                 class="owned-badge"
                 :class="originalOwnedSet.has(c.id) ? 'owned-badge--owned' : 'owned-badge--unowned'"
               >{{ originalOwnedSet.has(c.id) ? 'Owned' : 'Unowned' }}</span>
+              <img
+                v-if="isGoingFast(c)"
+                src="/images/goingfast.png"
+                alt="Going fast"
+                class="going-fast-badge"
+              />
             </div>
           </template>
           <template #middle>
@@ -655,6 +661,18 @@ function isSoldOut(c) {
 function hasCountdown(c) {
   if (!c.nextReleaseAt) return false
   return new Date(c.nextReleaseAt).getTime() > nowTs.value
+}
+
+// Mirrors the infocard's "Going Fast" condition (10 or fewer left), using the
+// same totalMinted-based remaining-count math isSoldOut() already uses here,
+// rather than the per-cToon highestMint aggregate the single-cToon modal
+// endpoint computes — the sold-out/countdown states in this grid already run
+// on totalMinted, and this keeps the three states derived from one source.
+function isGoingFast(c) {
+  if (isSoldOut(c) || hasCountdown(c)) return false
+  if (typeof c.quantity !== 'number' || typeof c.totalMinted !== 'number') return false
+  const remaining = c.quantity - c.totalMinted
+  return remaining > 0 && remaining <= 10
 }
 
 function formatCountdown(c) {
@@ -1771,6 +1789,16 @@ async function closeOverlay() {
 .owned-badge--unowned {
   background: rgba(0, 0, 0, 0.55);
   color: rgba(255, 255, 255, 0.75);
+}
+
+.going-fast-badge {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 34px;
+  height: 34px;
+  object-fit: contain;
+  pointer-events: none;
 }
 
 .card-name {


### PR DESCRIPTION
Closes #930

## Summary
- The "Going Fast" label already exists on the cToon infocard/modal (`components/newsite/CtoonInfoCard.vue` / `components/CtoonInfoModal.vue`), shown when a cToon is in cMart, not sold out, not in an upcoming/new release window, and has 10 or fewer copies remaining (`quantity - highestMint <= 10`).
- Added a `isGoingFast(c)` helper to `components/newsite/Cmart.vue`'s main cToons tab, reusing the exact fields (`quantity`, `totalMinted`) the `/api/cmart` listing endpoint already returns — no backend change needed. It uses the same `totalMinted`-based remaining-count math the grid's own `isSoldOut()`/`hasCountdown()` helpers already run on, so the sold-out, countdown, and going-fast states all derive from one consistent source rather than mixing in the modal endpoint's separate `highestMint` aggregate.
- Renders the same `/images/goingfast.png` badge used on the infocard, sized down (34×34) and positioned top-left on each card (the existing `Owned`/`Unowned` badge occupies top-right), only on cards where `isGoingFast(c)` is true.
- Scoped to the main cToons tab only — the Holiday Events tab uses a differently-shaped API response (`minted` instead of `totalMinted`, nullable `quantity` meaning "unlimited" instead of a sentinel cap) that would need separate handling logic, so it was left out to keep this change minimal and low-risk.

## Validation
- Parsed the modified `.vue` file with `@vue/compiler-sfc` to confirm the SFC is well-formed.
- Confirmed `/images/goingfast.png` exists in `public/images/`.
- Reused existing badge positioning/sizing conventions (absolute corner pill, `pointer-events: none`) already used by `owned-badge` and `pack-exclusive-badge` in the same file.
- Not exercised against a running app/database in this environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KwSCGFuZJKDiKczEZRLRTa)_