### PR TITLE
Fix the Pokemon battle lobby, mobile layout and menu background

### DIFF
--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -6,7 +6,7 @@
         <GreenButton>Leaderboards</GreenButton>
       </NuxtLink>
     </div>
-    <div class="gameshome">
+    <div class="gameshome" :style="gridStyle">
       <NuxtLink to="/newsite/newwinball" class="quadrant quadrant--shop">
         <img v-if="tiles.winball" :src="tiles.winball" alt="Winball" class="tile-img" />
         <span v-else>Winball</span>
@@ -68,7 +68,7 @@
         <img v-if="tiles.fruitsamurai" :src="tiles.fruitsamurai" alt="Fruit Samurai" class="tile-img" />
         <span v-else>Fruit Samurai</span>
       </NuxtLink>
-      <NuxtLink to="/newsite/pokemonbattle" class="quadrant quadrant--pokemonbattle">
+      <NuxtLink v-if="!isHidden('pokemonbattle')" to="/newsite/pokemonbattle" class="quadrant quadrant--pokemonbattle">
         <img v-if="tiles.pokemonbattle" :src="tiles.pokemonbattle" alt="Pokemon: Fire, Water, Grass!" class="tile-img" />
         <span v-else>Pokemon: Fire, Water, Grass!</span>
       </NuxtLink>
@@ -79,6 +79,23 @@
 <script setup>
 const { data: tileData } = useFetch('/api/game-tile-images', { default: () => ({}) })
 const tiles = computed(() => tileData.value ?? {})
+
+// Games an admin has switched off. Distinct from "no tile image uploaded", which still renders
+// a text tile.
+const hidden = computed(() => new Set(tileData.value?.hidden ?? []))
+const isHidden = (slot) => hidden.value.has(slot)
+
+// Rows are derived from the tiles that actually render, not hard-coded.
+//
+// The count was a literal that a comment asked people to remember to bump, and the row track is
+// load-bearing: .tile-img is absolutely positioned, so a tile that lands in an implicit row
+// collapses to nothing and is present but invisible. Now that a tile can be hidden at runtime
+// the literal cannot be right in both states anyway -- too few rows hides a real tile, too many
+// leaves a 1fr gap at the bottom of the grid.
+const TOTAL_TILES = 15
+const gridStyle = computed(() => ({
+  gridTemplateRows: `repeat(${Math.ceil((TOTAL_TILES - hidden.value.size) / 2)}, 1fr)`
+}))
 </script>
 
 <style scoped>

--- a/components/newsite/admin/legacy/AdminLegacyGames.vue
+++ b/components/newsite/admin/legacy/AdminLegacyGames.vue
@@ -659,6 +659,19 @@
             again in the other.
           </p>
 
+          <label class="flex items-start gap-2 mb-3 p-2 border rounded bg-white">
+            <input type="checkbox" v-model="pkmnEnabled" class="mt-0.5" />
+            <span>
+              <span class="text-xs font-semibold text-gray-800">Game is live</span>
+              <span class="block text-[11px] text-gray-500">
+                Unchecked hides the game from the Games page and closes it for everyone: the page
+                shows an "unavailable" notice, and no new battles can be created or joined, so
+                nothing can be played for points. Battles already in progress are allowed to
+                finish rather than being cut off mid-round.
+              </span>
+            </span>
+          </label>
+
           <div v-if="pkmnConfigError" class="mb-3 p-2 border border-red-300 bg-red-50 rounded">
             <p class="text-xs font-semibold text-red-800">These settings could not be loaded.</p>
             <p class="text-[11px] text-red-700 mt-1">{{ pkmnConfigError }}</p>
@@ -1937,6 +1950,7 @@ const PKMN_AUDIO_SLOTS = [
   { key: 'battlemusic', label: 'Battle music' },
   { key: 'menumusic',   label: 'Menu music' }
 ]
+const pkmnEnabled               = ref(true)
 const pkmnPointsPerWin          = ref(0)
 const pkmnRoundSeconds          = ref(12)
 const pkmnWinsNeeded            = ref(3)
@@ -2239,21 +2253,9 @@ async function loadSettings() {
   const g = await $fetch('/api/admin/global-config')
   globalDailyPointLimit.value = g.dailyPointLimit
   globalTkoDailyPointLimit.value = g.tkoDailyPointLimit
-  gameTileImages.value.winball      = g.gameTileWinballImagePath      || ''
-  gameTileImages.value.lotto        = g.gameTileLottoImagePath        || ''
-  gameTileImages.value.winwheel     = g.gameTileWinwheelImagePath     || ''
-  gameTileImages.value.clash        = g.gameTileClashImagePath        || ''
-  gameTileImages.value.tko          = g.gameTileTkoImagePath          || ''
-  gameTileImages.value.reorbitmatch = g.gameTileReorbitmatchImagePath || ''
-  gameTileImages.value.tower        = g.gameTileTowerImagePath        || ''
-  gameTileImages.value.asteroid     = g.gameTileAsteroidImagePath     || ''
-  gameTileImages.value.flappy       = g.gameTileFlappyImagePath       || ''
-  gameTileImages.value.reorbitmemory = g.gameTileReorbitmemoryImagePath || ''
-  gameTileImages.value.guessctoon   = g.gameTileGuessctoonImagePath   || ''
-  // blackjack was missing here, so its tile always rendered as "not set" in this panel even
-  // when one was uploaded.
-  gameTileImages.value.blackjack    = g.gameTileBlackjackImagePath    || ''
-  gameTileImages.value.edrps        = g.gameTileEdrpsImagePath        || ''
+  // Driven by gameTileSlots, so a game added there is loaded here automatically. The
+  // hand-written version of this block is what silently broke blackjack, then fruitsamurai.
+  for (const t of gameTileSlots) gameTileImages.value[t.slot] = g[t.column] || ''
 
   const wb = await $fetch('/api/admin/game-config?gameName=Winball')
   leftCupPoints.value  = wb.leftCupPoints
@@ -2344,6 +2346,8 @@ async function loadSettings() {
   // after it, leaving those tabs showing defaults that a save would then write over.
   try {
     const pk = await $fetch('/api/admin/game-config?gameName=PokemonBattle')
+    // Only an explicit false is off, so a row predating the migration reads as live.
+    pkmnEnabled.value             = pk.pokemonBattleEnabled !== false
     pkmnPointsPerWin.value        = pk.pointsPerWin ?? 0
     pkmnRoundSeconds.value        = pk.pokemonBattleRoundSeconds ?? 12
     pkmnWinsNeeded.value          = pk.pokemonBattleWinsNeeded ?? 3
@@ -2762,6 +2766,7 @@ async function savePkmnConfig() {
       method: 'POST',
       body: {
         gameName:                         'PokemonBattle',
+        pokemonBattleEnabled:             pkmnEnabled.value,
         pointsPerWin:                     pkmnPointsPerWin.value,
         pokemonBattleRoundSeconds:        pkmnRoundSeconds.value,
         pokemonBattleWinsNeeded:          pkmnWinsNeeded.value,
@@ -2887,25 +2892,37 @@ async function saveTkoConfig() {
 }
 
 // ── Game Tile Images ─────────────────────────
+// ONE list, and everything else is derived from it.
+//
+// This used to be five parallel lists -- the slots rendered, the three state maps, and a block
+// of hand-written assignments in loadSettings() -- and they drifted, twice. Blackjack was
+// missing from the loader (there is still a comment about it), so its tile always read "not
+// set" even with an image uploaded; Fruit Samurai had exactly the same bug; and Pokemon was
+// missing from the list entirely, so its tile could not be changed at all. Each of those is
+// invisible until someone opens the panel and wonders why an upload did nothing.
+//
+// `column` is the GlobalGameConfig field, so adding a game means adding one row here.
 const gameTileSlots = [
-  { slot: 'winball',      label: 'Winball' },
-  { slot: 'lotto',        label: 'Lotto' },
-  { slot: 'winwheel',     label: 'Win Wheel' },
-  { slot: 'clash',        label: 'gToons Clash' },
-  { slot: 'tko',          label: 'TKO' },
-  { slot: 'reorbitmatch', label: 'ReOrbit Match' },
-  { slot: 'tower',        label: 'Tower Stack' },
-  { slot: 'reorbitmemory', label: 'ReOrbit Memory' },
-  { slot: 'guessctoon',   label: 'Guess that cToon!' },
-  { slot: 'asteroid',     label: 'Op. A.S.T.E.R.O.I.D.' },
-  { slot: 'flappy',       label: 'Flappy Powerpuff' },
-  { slot: 'fruitsamurai', label: 'Fruit Samurai' },
-  { slot: 'blackjack',    label: 'ReOrbit Blackjack' },
-  { slot: 'edrps',        label: 'Ed, Edd n Eddy RPS' }
+  { slot: 'winball',       label: 'Winball',                column: 'gameTileWinballImagePath' },
+  { slot: 'lotto',         label: 'Lotto',                  column: 'gameTileLottoImagePath' },
+  { slot: 'winwheel',      label: 'Win Wheel',              column: 'gameTileWinwheelImagePath' },
+  { slot: 'clash',         label: 'gToons Clash',           column: 'gameTileClashImagePath' },
+  { slot: 'tko',           label: 'TKO',                    column: 'gameTileTkoImagePath' },
+  { slot: 'reorbitmatch',  label: 'ReOrbit Match',          column: 'gameTileReorbitmatchImagePath' },
+  { slot: 'tower',         label: 'Tower Stack',            column: 'gameTileTowerImagePath' },
+  { slot: 'reorbitmemory', label: 'ReOrbit Memory',         column: 'gameTileReorbitmemoryImagePath' },
+  { slot: 'guessctoon',    label: 'Guess that cToon!',      column: 'gameTileGuessctoonImagePath' },
+  { slot: 'asteroid',      label: 'Op. A.S.T.E.R.O.I.D.',   column: 'gameTileAsteroidImagePath' },
+  { slot: 'flappy',        label: 'Flappy Powerpuff',       column: 'gameTileFlappyImagePath' },
+  { slot: 'fruitsamurai',  label: 'Fruit Samurai',          column: 'gameTileFruitsamuraiImagePath' },
+  { slot: 'blackjack',     label: 'ReOrbit Blackjack',      column: 'gameTileBlackjackImagePath' },
+  { slot: 'edrps',         label: 'Ed, Edd n Eddy RPS',     column: 'gameTileEdrpsImagePath' },
+  { slot: 'pokemonbattle', label: 'Pokemon: Fire, Water, Grass!', column: 'gameTilePokemonbattleImagePath' }
 ]
-const gameTileImages = ref({ winball: '', lotto: '', winwheel: '', clash: '', tko: '', reorbitmatch: '', tower: '', reorbitmemory: '', guessctoon: '', asteroid: '', flappy: '', blackjack: '', edrps: '', fruitsamurai: '' })
-const gameTileFiles  = ref({ winball: null, lotto: null, winwheel: null, clash: null, tko: null, reorbitmatch: null, tower: null, reorbitmemory: null, guessctoon: null, asteroid: null, flappy: null, blackjack: null, edrps: null, fruitsamurai: null })
-const uploadingGameTile = ref({ winball: false, lotto: false, winwheel: false, clash: false, tko: false, reorbitmatch: false, tower: false, reorbitmemory: false, guessctoon: false, asteroid: false, flappy: false, blackjack: false, edrps: false, fruitsamurai: false })
+const fromSlots = (value) => Object.fromEntries(gameTileSlots.map(t => [t.slot, value]))
+const gameTileImages = ref(fromSlots(''))
+const gameTileFiles  = ref(fromSlots(null))
+const uploadingGameTile = ref(fromSlots(false))
 
 function onGameTileFile(slot, e) {
   gameTileFiles.value[slot] = e.target.files?.[0] || null

--- a/pages/newsite/pokemonbattle.vue
+++ b/pages/newsite/pokemonbattle.vue
@@ -480,8 +480,15 @@ function applyView(v) {
   deadlineAt.value = v.deadlineAt || 0
 }
 
-// Connected lazily: a player who only ever fights the computer never opens a socket at all,
-// and the socket server is a single fork'd process.
+// Connected once the menu is on screen.
+//
+// This was originally deferred until the player clicked "Create a battle", to keep a
+// single-player-only visitor off the socket server (which is a single fork'd process). That was
+// wrong twice over. The button is disabled until `connected` is true, and `connected` only
+// becomes true after this runs -- so the only thing that could start the connection was a click
+// on a button that could never be clicked, and the lobby sat on "Connecting..." forever. It also
+// could not have paid off: the lobby shares a screen with the single-player mode, so every
+// visitor sees the room list, and a room list fed by no socket permanently reads "0 open".
 function connectSocket() {
   if (socket) return
   const url = import.meta.env.PROD ? undefined : `http://localhost:${runtime.public.socketPort}`
@@ -571,7 +578,11 @@ function pickTrainer(id) {
   trainerId.value = id
   try { localStorage.setItem('pfwg:trainer', id) } catch {}
 }
-function createRoom() { error.value = ''; connectSocket(); socket?.emit('pkmnb:createRoom', { character: trainerId.value }) }
+function createRoom() {
+  error.value = ''
+  connectSocket()
+  socket?.emit('pkmnb:createRoom', { character: trainerId.value })
+}
 function joinRoom(id) { error.value = ''; socket?.emit('pkmnb:joinRoom', { roomId: id, character: trainerId.value }) }
 function leaveRoom() { socket?.emit('pkmnb:leave'); myRoomId.value = null }
 
@@ -732,6 +743,9 @@ onMounted(async () => {
   } catch {
     error.value = 'Could not load the game. Try again in a moment.'
   }
+
+  // After the config, so the lobby has its trainer roster before a room can be created.
+  connectSocket()
 
   checkOrientation()
   orientationHandler = () => nextTick(checkOrientation)
@@ -945,13 +959,20 @@ html.pfwg-page body ::selection { background: transparent; }
 
 /* ── Battle ────────────────────────────────────────────────────────────────────────────
    Explicit grid tracks. The text box and the move row are FIXED heights, so nothing that
-   happens mid-round can reflow the controls under the player's thumb. Budget on a 360x640
-   phone: 14 padding + 34 hud + 54 text + 60 moves + gaps = ~180, leaving the stage the rest. */
+   happens mid-round can reflow the controls under the player's thumb.
+
+   Written mobile-first with an INTRINSIC stage, which is the whole point. The layout gives
+   .main-content `height: auto` on mobile (mainContentMobileStyle in newsite-template.vue), so
+   nothing in this subtree has a definite height to resolve against. The first version sized the
+   stage with a `1fr` track and the field with `height: 100%` -- against an indefinite parent
+   both resolve to zero, and the battlefield rendered as a 0px sliver with the rest of the
+   screen left empty below it. blackjack.vue documents the same trap. So the stage gets a
+   definite height from the viewport here, and only takes the flexible track on desktop, where
+   the box really is a fixed 682px. */
 .pfwg-battle {
   display: grid;
-  grid-template-rows: auto 1fr 54px 60px;
+  grid-template-rows: auto auto 54px 60px;
   gap: 6px;
-  flex: 1;
   min-height: 0;
   min-width: 0;
   padding: 6px 8px calc(8px + env(safe-area-inset-bottom));
@@ -971,12 +992,27 @@ html.pfwg-page body ::selection { background: transparent; }
 .pfwg-timer.is-low { color: #f85838; }
 .pfwg-timer--idle { opacity: .35; }
 
-.pfwg-stage { min-height: 0; min-width: 0; display: grid; place-items: center; overflow: hidden; }
+/* The field is sized from its WIDTH, never its height, and that is load-bearing in both
+   directions. Width is the one dimension that is definite everywhere -- the layout hands this
+   subtree an auto height on mobile -- so a height-driven field collapses to nothing there. And
+   deriving width from height overflows: at a 2.14 ratio a 280px-tall stage wants a 600px-wide
+   field, which on a 375px phone is silently cropped by .main-content's `overflow: hidden`
+   rather than scrolled. Width in, height out, capped so a tall portrait screen does not hand
+   the battlefield half the page. */
+.pfwg-stage {
+  max-height: min(42svh, 320px);
+  min-width: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
 .pfwg-field {
   position: relative;
-  height: 100%;
-  width: auto;
-  max-width: 100%;
+  width: 100%;
+  height: auto;
+  /* Only bites where the box is wider than it is tall (landscape, desktop); the field then
+     letterboxes inside the stage rather than overflowing it. */
+  max-height: 100%;
   aspect-ratio: 240 / 112;
   border: 3px solid #202020;
   border-radius: 8px;
@@ -1147,6 +1183,9 @@ html.pfwg-page body ::selection { background: transparent; }
    scroll. The battle screen is unaffected: it fits its box at every size. */
 @media (max-width: 768px) {
   .pfwg-menu { flex: none; overflow-y: visible; min-height: 0; }
+  /* height:100% resolves to auto against the layout's auto-height .main-content, and an
+     explicit 100% there is what collapsed the battlefield. Say `auto` and mean it. */
+  .pfwg { height: auto; }
 }
 
 /* Landscape on a phone that stays in the layout's mobile branch. Stacked, the HUD, text box
@@ -1161,7 +1200,9 @@ html.pfwg-page body ::selection { background: transparent; }
     padding: 4px 6px calc(4px + env(safe-area-inset-bottom));
   }
   .pfwg-hud { grid-area: hud; }
-  .pfwg-stage { grid-area: stage; }
+  /* The landscape grid gives the stage a real `1fr` track inside a viewport-height box, so it
+     drops the portrait viewport cap and fills its cell instead. */
+  .pfwg-stage { grid-area: stage; max-height: none; min-height: 0; }
   .pfwg-moves { grid-area: moves; grid-template-columns: 1fr; grid-template-rows: repeat(3, 1fr); gap: 4px; }
   .pfwg-move { min-height: 38px; flex-direction: row; gap: 6px; }
   /* No room for a two-line box here; the HP bars already carry the state. */
@@ -1169,8 +1210,14 @@ html.pfwg-page body ::selection { background: transparent; }
   .pfwg-hp-name { font-size: 9px; }
 }
 
-/* Desktop: the stage would otherwise blow a 240px-wide backdrop up more than 4x. */
+/* Desktop. Here .main-content is a real fixed box, so the stage can take the leftover space
+   the way the mobile version cannot -- and the 240px-wide backdrop needs a ceiling or it is
+   blown up more than 4x. */
 @media (min-width: 769px) {
+  .pfwg { height: 100%; }
+  .pfwg-battle { grid-template-rows: auto 1fr 54px 60px; flex: 1; height: 100%; }
+  /* A real box with real leftover space, so the cap comes off and the field centres in it. */
+  .pfwg-stage { max-height: none; min-height: 0; }
   .pfwg-field { max-width: 720px; }
 }
 

--- a/pages/newsite/pokemonbattle.vue
+++ b/pages/newsite/pokemonbattle.vue
@@ -1,8 +1,16 @@
 <template>
   <div class="pfwg" ref="wrapper">
 
+    <!-- The route stays reachable by URL when an admin switches the game off, so the closed
+         state is rendered here rather than relying on the Games page hiding the tile. -->
+    <div v-if="!enabled" class="pfwg-menu pfwg-closed">
+      <h1 class="pfwg-title">Pokemon<span class="pfwg-title-sub">Fire, Water, Grass!</span></h1>
+      <p class="pfwg-note">This game is currently unavailable. Check back soon!</p>
+      <NuxtLink to="/newsite/home" class="pfwg-btn pfwg-btn--go pfwg-closed-btn">Back to games</NuxtLink>
+    </div>
+
     <!-- ── Menu ──────────────────────────────────────────────────────────────────────── -->
-    <div v-if="screen === 'menu'" class="pfwg-menu" :style="menuStyle">
+    <div v-else-if="screen === 'menu'" class="pfwg-menu" :style="menuStyle">
       <img
         v-if="art('logo')"
         :src="art('logo').path" :width="art('logo').width" :height="art('logo').height"
@@ -259,6 +267,9 @@ const overBtn = ref(null)
 const blockedLandscape = ref(false)
 const error = ref('')
 
+// Assume on until the config says otherwise, so a slow or failed config fetch does not flash a
+// "closed" screen at a player on a working game.
+const enabled = ref(true)
 const assets = ref({})
 const trainers = ref([])
 const aiTiers = ref([])
@@ -646,6 +657,7 @@ function throwType(t) {
 let aiTimer = null
 
 function startAi() {
+  if (!enabled.value) return
   isAi.value = true
   resetBattle()
   aiHistory.value = []
@@ -751,6 +763,7 @@ onMounted(async () => {
 
   try {
     const cfg = await $fetch('/api/game/pokemonbattle/config')
+    enabled.value = cfg.enabled !== false
     assets.value = cfg.assets || {}
     trainers.value = cfg.trainers || []
     aiTiers.value = cfg.aiTiers || []
@@ -763,8 +776,9 @@ onMounted(async () => {
     error.value = 'Could not load the game. Try again in a moment.'
   }
 
-  // After the config, so the lobby has its trainer roster before a room can be created.
-  connectSocket()
+  // After the config, and not at all when the game is switched off -- an offline game should
+  // not be holding sockets open on a single-process server.
+  if (enabled.value) connectSocket()
 
   checkOrientation()
   orientationHandler = () => nextTick(checkOrientation)
@@ -883,6 +897,8 @@ html.pfwg-page body ::selection { background: transparent; }
   background-repeat: no-repeat;
   background-attachment: scroll;
 }
+.pfwg-closed { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; padding: 32px 16px; }
+.pfwg-closed-btn { width: min(100%, 260px); text-align: center; text-decoration: none; line-height: 28px; }
 .pfwg-logo { display: block; width: min(100%, 420px); height: auto; margin: 0 auto 6px; }
 .pfwg-title {
   margin: 4px 0 8px;

--- a/pages/newsite/pokemonbattle.vue
+++ b/pages/newsite/pokemonbattle.vue
@@ -2,7 +2,7 @@
   <div class="pfwg" ref="wrapper">
 
     <!-- ── Menu ──────────────────────────────────────────────────────────────────────── -->
-    <div v-if="screen === 'menu'" class="pfwg-menu">
+    <div v-if="screen === 'menu'" class="pfwg-menu" :style="menuStyle">
       <img
         v-if="art('logo')"
         :src="art('logo').path" :width="art('logo').width" :height="art('logo').height"
@@ -320,6 +320,25 @@ const secondsLeft = computed(() => {
 const canThrow = computed(() =>
   !over.value && myPick.value === null && !revealed.value && deadlineAt.value > 0
 )
+
+// The uploaded menu backdrop. Scrimmed rather than shown raw: the title, the type chips and
+// the notes sit directly on it, and an arbitrary uploaded image is as likely to be bright as
+// dark. MENU_SCRIM is the alpha at which #f8f8f8 body text still clears 4.5:1 over a pure
+// WHITE image, which is the worst case an admin can produce.
+//
+// 0.66, not the 0.55 a pure-black scrim would need: this scrim is tinted (#0c1c2e), and a
+// tinted overlay composites LIGHTER than black at the same alpha, which quietly costs about
+// a point of contrast. Computed rather than eyeballed, and asserted in
+// tests/pokemonBattleWiring.test.js so a later colour tweak cannot silently undo it.
+const MENU_SCRIM = 0.66
+const menuStyle = computed(() => {
+  const bg = art('menubg')
+  if (!bg) return {}
+  return {
+    backgroundImage:
+      `linear-gradient(rgba(12, 28, 46, ${MENU_SCRIM}), rgba(12, 28, 46, ${MENU_SCRIM})), url('${bg.path}')`
+  }
+})
 
 const fieldStyle = computed(() => {
   const bg = art('battlebg')
@@ -855,6 +874,14 @@ html.pfwg-page body ::selection { background: transparent; }
   padding: 8px 10px calc(10px + env(safe-area-inset-bottom));
   box-sizing: border-box;
   text-align: center;
+  /* Backdrop set inline from the uploaded asset; these only describe how it is drawn.
+     `cover` rather than the battlefield's `100% 100%` -- this one is scenery behind a
+     scrolling column, so cropping it is correct and distorting it is not. Never
+     `background-attachment: fixed`: unsupported and janky on iOS. */
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: scroll;
 }
 .pfwg-logo { display: block; width: min(100%, 420px); height: auto; margin: 0 auto 6px; }
 .pfwg-title {

--- a/prisma/migrations/20260818000000_add_pokemon_battle_enabled/migration.sql
+++ b/prisma/migrations/20260818000000_add_pokemon_battle_enabled/migration.sql
@@ -1,0 +1,6 @@
+-- Pokemon: Fire, Water, Grass! -- admin on/off switch.
+--
+-- Defaults to true so an existing install keeps the game exactly as it is; the admin turns it
+-- off deliberately. Off hides the Games-page tile and refuses to start a battle, because the
+-- route is reachable by URL and a head-to-head win pays points.
+ALTER TABLE "GameConfig" ADD COLUMN IF NOT EXISTS "pokemonBattleEnabled" BOOLEAN DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1326,6 +1326,11 @@ model GameConfig {
   pokemonBattleMaxRounds           Int? @default(9)
   pokemonBattlePairDailyAwardLimit Int? @default(2)
 
+  // Master switch. Off hides the game from the Games page AND refuses to start a battle --
+  // hiding the tile alone would leave the route playable by anyone with the URL, and PvP pays
+  // points, so "not visible" has to mean "not earning" too.
+  pokemonBattleEnabled Boolean? @default(true)
+
   // Uploaded art and music, as one JSON map of { slot: { path, width, height } } rather than
   // eleven more columns. GameConfig already carries 256 of them, several callers still do a
   // bare findUnique that ships every one, and art slots are the kind of thing that gets added

--- a/server/api/admin/game-config.post.js
+++ b/server/api/admin/game-config.post.js
@@ -835,6 +835,10 @@ export default defineEventHandler(async (event) => {
         for (const key of POKEMONBATTLE_FIELDS) {
           if (body[key] != null) pkmnData[key] = body[key]
         }
+        // Explicit null check, not a truthiness one: `false` is the whole point of this field.
+        if (body.pokemonBattleEnabled != null) {
+          pkmnData.pokemonBattleEnabled = Boolean(body.pokemonBattleEnabled)
+        }
         createData = { ...createData, ...pkmnData }
         updateData = { ...updateData, ...pkmnData }
       } else if (gameName === 'Clash' || gameName === 'TKO') {
@@ -1105,6 +1109,18 @@ export default defineEventHandler(async (event) => {
             const next = body[key]
             if (next != null && prev !== next) {
               await logAdminChange(tx, { userId: me.id, area: 'GameConfig:PokemonBattle', key, prevValue: prev, newValue: next })
+            }
+          }
+          // Taking a game offline is the kind of change someone asks about later, so it is
+          // logged like any other.
+          if (body.pokemonBattleEnabled != null) {
+            const wasOn = before?.pokemonBattleEnabled !== false
+            const nowOn = Boolean(body.pokemonBattleEnabled)
+            if (wasOn !== nowOn) {
+              await logAdminChange(tx, {
+                userId: me.id, area: 'GameConfig:PokemonBattle', key: 'pokemonBattleEnabled',
+                prevValue: String(wasOn), newValue: String(nowOn)
+              })
             }
           }
         } else if (gameName === 'Clash' || gameName === 'TKO') {

--- a/server/api/game-tile-images.get.js
+++ b/server/api/game-tile-images.get.js
@@ -1,5 +1,6 @@
 import { defineEventHandler } from 'h3'
 import { prisma as db } from '@/server/prisma'
+import { getPokemonBattleAssets } from '@/server/utils/pokemonBattleAssets'
 
 export default defineEventHandler(async () => {
   const cfg = await db.globalGameConfig.findUnique({
@@ -23,7 +24,14 @@ export default defineEventHandler(async () => {
     }
   })
 
+  // A game an admin has switched off is reported separately from its tile, because an absent
+  // tile only means "no image uploaded" -- GamesHome still renders a text tile in that case,
+  // which would leave a switched-off game plainly visible.
+  const { config } = await getPokemonBattleAssets()
+  const hidden = config.enabled ? [] : ['pokemonbattle']
+
   return {
+    hidden,
     winball:      cfg?.gameTileWinballImagePath      ?? null,
     lotto:        cfg?.gameTileLottoImagePath        ?? null,
     winwheel:     cfg?.gameTileWinwheelImagePath     ?? null,

--- a/server/api/game/pokemonbattle/config.get.js
+++ b/server/api/game/pokemonbattle/config.get.js
@@ -41,6 +41,9 @@ export default defineEventHandler(async (event) => {
   })
 
   return {
+    // Off means the admin has taken the game down: the page refuses to start a battle and the
+    // Games tile is hidden. Public because the page has to render the closed state.
+    enabled: config.enabled,
     assets,
     trainers: roster.list,
     // Difficulty tiers are public rules — the AI runs in the browser and pays nothing, so

--- a/server/utils/duelRuntime.js
+++ b/server/utils/duelRuntime.js
@@ -77,6 +77,10 @@ import { awardCappedGamePoints, COMBAT_POOL_GAME_NAMES } from './gamePoints.js'
  *   isChoice       (v) => boolean
  *   isAvatarId     async (v) => boolean   -- may hit a cached DB roster
  *   breakMs        (cmp) => ms to pause after a round with this result
+ *   isEnabled      optional async () => boolean. False takes the game offline: no new rooms
+ *                  and no joins, so nothing can be played for points while it is off. Live
+ *                  matches are left alone -- yanking a match out from under two players who
+ *                  are mid-round would be a worse outcome than letting it finish.
  *   announce       { emoji, label, url }
  */
 export function createDuelRuntime(spec) {
@@ -843,9 +847,19 @@ export function createDuelRuntime(spec) {
       socket.emit(EV('rooms'), lobbyRoomList())
     })
 
+    // Checked on both entry points, not just one: a room created before the game was taken
+    // offline is still joinable otherwise.
+    const offline = async () => {
+      if (!spec.isEnabled) return false
+      try { return !(await spec.isEnabled()) } catch { return false }
+    }
+
     socket.on(EV('createRoom'), async ({ character } = {}) => {
       const user = await auth()
       if (!user) return
+      if (await offline()) {
+        return socket.emit(EV('error'), { code: 'offline', message: 'This game is currently unavailable.' })
+      }
       if (!(await spec.isAvatarId(character))) {
         return socket.emit(EV('error'), { code: 'badCharacter', message: 'Pick a character first.' })
       }
@@ -887,6 +901,9 @@ export function createDuelRuntime(spec) {
     socket.on(EV('joinRoom'), async ({ roomId, character } = {}) => {
       const user = await auth()
       if (!user) return
+      if (await offline()) {
+        return socket.emit(EV('error'), { code: 'offline', message: 'This game is currently unavailable.' })
+      }
       if (typeof roomId !== 'string' || !ROOM_ID_RE.test(roomId)) {
         return socket.emit(EV('error'), { code: 'badRoom', message: 'That room is no longer available.' })
       }

--- a/server/utils/pokemonBattleAssets.js
+++ b/server/utils/pokemonBattleAssets.js
@@ -68,7 +68,8 @@ export async function getPokemonBattleAssets() {
           pokemonBattleAssets: true,
           pokemonBattleRoundSeconds: true,
           pokemonBattleWinsNeeded: true,
-          pokemonBattleMaxRounds: true
+          pokemonBattleMaxRounds: true,
+          pokemonBattleEnabled: true
         }
       })
       cache = {
@@ -76,14 +77,17 @@ export async function getPokemonBattleAssets() {
         config: {
           roundSeconds: row?.pokemonBattleRoundSeconds ?? null,
           winsNeeded: row?.pokemonBattleWinsNeeded ?? null,
-          maxRounds: row?.pokemonBattleMaxRounds ?? null
+          maxRounds: row?.pokemonBattleMaxRounds ?? null,
+          // Only an explicit `false` disables it. A missing row or a database that predates the
+          // migration must leave the game playable rather than silently switching it off.
+          enabled: row?.pokemonBattleEnabled !== false
         }
       }
       cachedAt = Date.now()
       return cache
     } catch (err) {
       console.error('[pokemonbattle] asset read failed:', err)
-      cache = cache || { assets: {}, config: { roundSeconds: null, winsNeeded: null, maxRounds: null } }
+      cache = cache || { assets: {}, config: { roundSeconds: null, winsNeeded: null, maxRounds: null, enabled: true } }
       cachedAt = Date.now()
       return cache
     } finally {

--- a/server/utils/pokemonBattleRuntime.js
+++ b/server/utils/pokemonBattleRuntime.js
@@ -12,6 +12,7 @@
 import { createDuelRuntime } from './duelRuntime.js'
 import { compareTypes, isType, clampConfig, TYPES, intermissionMs } from '../../lib/pokemonBattle.js'
 import { isTrainerId } from './pokemonBattleConfig.js'
+import { getPokemonBattleAssets } from './pokemonBattleAssets.js'
 import { DUEL_PAIR_SCOPE } from './duelPairScope.js'
 
 const runtime = createDuelRuntime({
@@ -46,6 +47,10 @@ const runtime = createDuelRuntime({
   // client-supplied string is admitted into match state, and that string is echoed to the
   // OPPONENT in the match view — so it must be a real id, not merely a plausible one.
   isAvatarId: isTrainerId,
+
+  // Served from the same 60s cache the public config endpoint uses, so an admin flipping the
+  // switch takes effect within a minute without a socket handler ever hitting the database.
+  isEnabled: async () => (await getPokemonBattleAssets()).config.enabled,
 
   // Per-result: a tie narrates fewer lines than a decisive round, and both need longer than
   // the RPS game's flat banner. lib/pokemonBattle.js keeps these in step with the text budget

--- a/tests/pokemonBattleWiring.test.js
+++ b/tests/pokemonBattleWiring.test.js
@@ -353,13 +353,71 @@ test('the leaderboard endpoint the component points at exists', () => {
   assert.doesNotThrow(() => read(route), `${route} does not exist`)
 })
 
-test('the Games page tile grid has a row for every tile', () => {
+test('the Games page tile grid derives its rows from the tiles that render', () => {
+  // Two columns, so N tiles need ceil(N/2) rows: a short grid drops the last tiles into an
+  // implicit auto-height row which collapses to nothing, because .tile-img is absolutely
+  // positioned -- present but invisible. This used to be a literal with a comment asking people
+  // to bump it. Now that a tile can be hidden at runtime no literal can be right in both
+  // states, so the count is computed instead and only TOTAL_TILES has to match reality.
   const src = read('components/newsite/GamesHome.vue')
   const tiles = (src.match(/class="quadrant quadrant--/g) || []).length
-  const rows = Number(/grid-template-rows: repeat\((\d+), 1fr\)/.exec(src)?.[1])
-  // Two columns, so N tiles need ceil(N/2) explicit rows. A short grid drops the last tiles
-  // into an implicit auto-height row which collapses to nothing -- present but invisible.
-  assert.equal(rows, Math.ceil(tiles / 2), `${tiles} tiles need ${Math.ceil(tiles / 2)} grid rows, found ${rows}`)
+  const total = Number(/const TOTAL_TILES = (\d+)/.exec(src)?.[1])
+  assert.equal(total, tiles, `TOTAL_TILES is ${total} but the template renders ${tiles} tiles`)
+  assert.ok(/gridTemplateRows: `repeat\(\$\{Math\.ceil\(/.test(src),
+    'the grid row count is no longer derived from the visible tile count')
+})
+
+test('the admin tile panel can reach every tile slot the endpoint accepts', () => {
+  // Shipped broken twice by the same mechanism: the slot list was duplicated across the
+  // rendered list, three state maps and a block of hand-written assignments in loadSettings().
+  // Blackjack fell out of the loader, then Fruit Samurai did -- both showed "not set" forever
+  // even with an image uploaded -- and Pokemon was missing from the list entirely, so its tile
+  // could not be changed at all. Everything is derived from one list now; this holds it there.
+  const admin = read('components/newsite/admin/legacy/AdminLegacyGames.vue')
+  const endpoint = read('server/api/admin/game-tile-image.post.js')
+
+  const endpointSlots = [...(/const SLOT_FIELD = \{([\s\S]*?)\n\}/.exec(endpoint)?.[1] || '')
+    .matchAll(/^\s*([a-z]+):\s*'([A-Za-z]+)'/gm)].map(m => ({ slot: m[1], column: m[2] }))
+  assert.ok(endpointSlots.length >= 15, `expected the tile slots, found ${endpointSlots.length}`)
+
+  const listed = [...(/const gameTileSlots = \[([\s\S]*?)\n\]/.exec(admin)?.[1] || '')
+    .matchAll(/slot: '([a-z]+)'[^}]*column: '([A-Za-z]+)'/g)].map(m => ({ slot: m[1], column: m[2] }))
+
+  for (const { slot, column } of endpointSlots) {
+    const hit = listed.find(l => l.slot === slot)
+    assert.ok(hit, `the admin tile panel cannot manage the "${slot}" tile`)
+    assert.equal(hit.column, column,
+      `"${slot}" reads ${hit.column} in the panel but the endpoint writes ${column}`)
+  }
+
+  // And nothing may hand-write the per-slot assignments again, which is what drifted.
+  assert.ok(/for \(const t of gameTileSlots\) gameTileImages\.value/.test(admin),
+    'the tile loader is hand-written again rather than driven by gameTileSlots')
+})
+
+test('switching the game off takes it off the site, not just off the Games page', () => {
+  // "Not visible" has to mean "not playable": the route is reachable by URL and a head-to-head
+  // win pays points, so hiding the tile alone would leave an off game quietly earning.
+  const runtime = read('server/utils/pokemonBattleRuntime.js')
+  assert.ok(runtime.includes('isEnabled:'), 'the runtime has no enabled gate')
+
+  const duel = code('server/utils/duelRuntime.js')
+  assert.ok(/createRoom[\s\S]{0,400}await offline\(\)/.test(duel), 'createRoom is not gated on the switch')
+  assert.ok(/joinRoom[\s\S]{0,400}await offline\(\)/.test(duel),
+    'joinRoom is not gated -- a room made before the game went off would still be joinable')
+
+  // The page renders its own closed state rather than trusting the tile to be hidden.
+  const page = read('pages/newsite/pokemonbattle.vue')
+  assert.ok(page.includes('v-if="!enabled"'), 'the game page has no closed state')
+  assert.ok(page.includes('if (enabled.value) connectSocket()'),
+    'a switched-off game still opens a socket')
+
+  // A missing column or an unreadable config must fail OPEN, or a migration lag takes the game
+  // down on its own.
+  const assets = code('server/utils/pokemonBattleAssets.js')
+  assert.ok(assets.includes('!== false'), 'the enabled flag does not default to on')
+  assert.ok(code('server/api/game-tile-images.get.js').includes('hidden'),
+    'the tile endpoint does not report hidden games')
 })
 
 test('the admin log component and its endpoint agree', () => {

--- a/tests/pokemonBattleWiring.test.js
+++ b/tests/pokemonBattleWiring.test.js
@@ -382,6 +382,46 @@ test('the battle UI depends on no emoji glyph', () => {
   assert.deepEqual(emoji, [], `the template contains emoji (${emoji.join(' ')}) -- use art or a CSS shape`)
 })
 
+test('the lobby can reach the socket without a click it cannot make', () => {
+  // Shipped broken once: the "Create a battle" button was disabled until `connected`, and the
+  // only caller of connectSocket() was that button's own click handler. The socket could
+  // therefore never open, and the lobby sat on "Connecting..." forever. The room list was
+  // permanently empty for the same reason.
+  const page = read('pages/newsite/pokemonbattle.vue')
+  const mounted = page.slice(page.indexOf('onMounted('), page.indexOf('onBeforeUnmount('))
+  assert.ok(mounted.includes('connectSocket()'),
+    'nothing connects the socket on mount, so a lobby gated on `connected` can never enable itself')
+
+  // And the gate itself still has to be a gate: if the button stops being disabled while
+  // disconnected, the emit silently no-ops instead.
+  assert.ok(/createRoom"[^>]*:disabled="!connected"/.test(page) || page.includes(':disabled="!connected"'),
+    'the create button no longer reflects connection state')
+})
+
+test('the battlefield is sized from width, never from height', () => {
+  // Shipped broken once, in both directions. The layout gives .main-content `height: auto` on
+  // mobile, so a height-driven field has nothing definite to resolve against and collapses to
+  // a 0px sliver. Deriving width from height instead overflows: at a 2.14 ratio a 280px-tall
+  // stage wants a 600px-wide field, which a 375px phone crops via `overflow: hidden` rather
+  // than scrolling. Width is the only dimension that is definite in every context.
+  const page = read('pages/newsite/pokemonbattle.vue')
+  const rule = /\.pfwg-field \{([\s\S]*?)\}/.exec(page)?.[1]
+  assert.ok(rule, 'could not find the .pfwg-field rule')
+  // Anchored so `max-width` / `max-height` are not mistaken for the real properties -- the
+  // field legitimately carries a `max-height: 100%` letterbox guard.
+  const prop = (name) => new RegExp(`(^|[;{\\s])${name}:\\s*([^;]+)`, 'm').exec(rule)?.[2]?.trim()
+  assert.equal(prop('width'), '100%', '.pfwg-field must take its width from its container')
+  assert.equal(prop('height'), 'auto', '.pfwg-field must derive its height from its width')
+  assert.ok(/aspect-ratio/.test(rule), '.pfwg-field lost its aspect ratio')
+
+  // The base (mobile) grid must not hand the stage a flexible track either -- `1fr` of an
+  // indefinite parent is zero.
+  const battle = /\.pfwg-battle \{([\s\S]*?)\}/.exec(page)?.[1]
+  assert.ok(battle, 'could not find the .pfwg-battle rule')
+  assert.ok(!/grid-template-rows:[^;]*1fr/.test(battle),
+    'the base battle grid uses a 1fr track; on mobile that resolves to zero height')
+})
+
 test('the page never renders admin-supplied text as HTML', () => {
   // Trainer names are admin-supplied and reach every visitor, including logged-out ones. The
   // natural way to bold a name inside a battle line is exactly the edit that would add v-html.

--- a/tests/pokemonBattleWiring.test.js
+++ b/tests/pokemonBattleWiring.test.js
@@ -398,6 +398,62 @@ test('the lobby can reach the socket without a click it cannot make', () => {
     'the create button no longer reflects connection state')
 })
 
+test('every uploadable asset slot is actually consumed by the game', () => {
+  // Shipped broken once: `menubg` was accepted by the upload endpoint, offered in the admin
+  // panel, stored, and served by the config API -- and rendered by nothing. The admin uploaded
+  // a menu background and it silently went nowhere. An upload slot with no consumer is worse
+  // than a missing feature, because it looks like a working one.
+  const endpoint = read('server/api/admin/pokemonbattle-asset.post.js')
+  const audio = read('server/api/admin/pokemonbattle-audio.post.js')
+  const page = read('pages/newsite/pokemonbattle.vue')
+
+  const imageSlots = [...(/const SLOTS = \{([\s\S]*?)\n\}/.exec(endpoint)?.[1] || '')
+    .matchAll(/^\s*'?([a-z-]+)'?:/gm)].map(m => m[1])
+  assert.ok(imageSlots.length >= 9, `expected the asset slots, found ${imageSlots.length}`)
+
+  const audioSlots = [...(/const SLOTS = new Set\(\[([^\]]*)\]/.exec(audio)?.[1] || '')
+    .matchAll(/'([a-z]+)'/g)].map(m => m[1])
+  assert.ok(audioSlots.length === 2, `expected two audio slots, found ${audioSlots.length}`)
+
+  for (const slot of [...imageSlots, ...audioSlots]) {
+    // The six Pokemon sprites are looked up dynamically as `${mon.id}-front` / `-back`, so a
+    // literal match will not find them; everything else must appear literally.
+    const dynamic = /^(charizard|blastoise|venusaur)-(front|back)$/.test(slot)
+    if (dynamic) continue
+    assert.ok(page.includes(`'${slot}'`), `nothing in the game renders the "${slot}" upload slot`)
+  }
+  // And the dynamic pair really is built, or all six sprite slots would be dead at once.
+  assert.ok(page.includes('-back') && page.includes('-front'),
+    'the page no longer builds the sprite slot names, so every sprite upload is dead')
+
+  // The admin panel must offer exactly what the endpoints accept -- a slot in the panel that
+  // the endpoint rejects is an upload button that always errors.
+  const admin = read('components/newsite/admin/legacy/AdminLegacyGames.vue')
+  for (const slot of [...imageSlots, ...audioSlots]) {
+    assert.ok(admin.includes(`key: '${slot}'`), `the admin panel cannot upload the "${slot}" slot`)
+  }
+})
+
+test('the menu backdrop stays legible under any uploaded image', () => {
+  // The title, chips and notes sit directly on an admin-supplied image that is as likely to be
+  // bright as dark, so the scrim is what guarantees the text survives. Worst case is a pure
+  // white upload; the alpha is computed rather than eyeballed.
+  const page = read('pages/newsite/pokemonbattle.vue')
+  const scrim = Number(/const MENU_SCRIM = ([\d.]+)/.exec(page)?.[1])
+  assert.ok(Number.isFinite(scrim), 'the menu scrim constant is gone')
+
+  const lin = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4))
+  const rel = ([r, g, b]) => 0.2126 * lin(r / 255) + 0.7152 * lin(g / 255) + 0.0722 * lin(b / 255)
+  const scrimRgb = (/rgba\((\d+),\s*(\d+),\s*(\d+),/.exec(page) || []).slice(1).map(Number)
+  assert.equal(scrimRgb.length, 3, 'could not read the scrim colour')
+
+  // White image under the scrim, composited in sRGB.
+  const composited = scrimRgb.map(c => scrim * c + (1 - scrim) * 255)
+  const ratio = (rel([248, 248, 248]) + 0.05) / (rel(composited) + 0.05)
+  assert.ok(ratio >= 4.5,
+    `body text over a pure-white menu upload is only ${ratio.toFixed(2)}:1; raise MENU_SCRIM`)
+})
+
 test('the battlefield is sized from width, never from height', () => {
   // Shipped broken once, in both directions. The layout gives .main-content `height: auto` on
   // mobile, so a height-driven field has nothing definite to resolve against and collapses to


### PR DESCRIPTION
Closed in favour of a pull request targeting `dev`, which supersedes this one.

That PR contains everything here (the lobby, mobile-layout and menu-background fixes) plus the admin tile-management fixes and the on/off switch added since.