### PR TITLE
Invalidate the Pokemon asset cache when the live toggle is saved

### DIFF
--- a/server/api/admin/game-config.post.js
+++ b/server/api/admin/game-config.post.js
@@ -7,6 +7,7 @@ import {
 } from 'h3'
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { invalidateAssets } from '@/server/utils/pokemonBattleAssets'
 
 // ── Operation A.S.T.E.R.O.I.D. field tables ──────────────────────────────────────────────
 // Kept as data rather than 26 hand-written if-blocks so the validation, the Prisma write and
@@ -1156,6 +1157,10 @@ export default defineEventHandler(async (event) => {
 
       return cfg
     })
+
+    // The public asset/config read is cached for a minute; without this the "Game is live"
+    // toggle would silently lag on the Games Home page and the game route itself.
+    if (gameName === 'PokemonBattle') invalidateAssets()
 
     return result
   } catch (err) {


### PR DESCRIPTION
The "Game is live" toggle wrote pokemonBattleEnabled correctly, scoped
to the PokemonBattle row only, but the public read path caches that
row for up to 60s. Other admin writes to Pokemon assets already called
invalidateAssets() after saving; the config toggle was the one path
that didn't, so an admin flipping the switch could see stale state on
Games Home for up to a minute.