### PR TITLE
Fix Games Home tiles collapsing to 0px on mobile

### DIFF
--- a/components/newsite/GamesHome.vue
+++ b/components/newsite/GamesHome.vue
@@ -92,9 +92,17 @@ const isHidden = (slot) => hidden.value.has(slot)
 // collapses to nothing and is present but invisible. Now that a tile can be hidden at runtime
 // the literal cannot be right in both states anyway -- too few rows hides a real tile, too many
 // leaves a 1fr gap at the bottom of the grid.
+//
+// Exposed as a custom property, not a `grid-template-rows` value on the element itself: an
+// inline style always outranks a stylesheet rule, media query or not, so a direct binding here
+// would have permanently pinned the desktop 2-column row count and defeated the mobile
+// breakpoint's own `grid-template-rows: none`. On mobile the container's height is `auto`, so
+// those pinned `1fr` rows had no space to divide and collapsed toward 0px -- tiles were still in
+// the DOM, just rendered at ~0 height, which looked identical to a game "not showing up". Reading
+// the var back inside the stylesheet keeps the cascade -- and the mobile override -- intact.
 const TOTAL_TILES = 15
 const gridStyle = computed(() => ({
-  gridTemplateRows: `repeat(${Math.ceil((TOTAL_TILES - hidden.value.size) / 2)}, 1fr)`
+  '--total-rows': Math.ceil((TOTAL_TILES - hidden.value.size) / 2)
 }))
 </script>
 
@@ -128,8 +136,8 @@ const gridStyle = computed(() => ({
 .gameshome {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  /* 14 tiles in 2 columns needs 7 rows — bump this when a game is added. */
-  grid-template-rows: repeat(8, 1fr);
+  /* Row count comes from the script via --total-rows (see gridStyle above), not a literal here. */
+  grid-template-rows: repeat(var(--total-rows, 8), 1fr);
   /* Belt and braces: a 15th tile would otherwise land in an implicit auto-height row and
      collapse to nothing, because .tile-img is absolutely positioned and has no intrinsic
      height. */

--- a/tests/pokemonBattleWiring.test.js
+++ b/tests/pokemonBattleWiring.test.js
@@ -363,8 +363,14 @@ test('the Games page tile grid derives its rows from the tiles that render', () 
   const tiles = (src.match(/class="quadrant quadrant--/g) || []).length
   const total = Number(/const TOTAL_TILES = (\d+)/.exec(src)?.[1])
   assert.equal(total, tiles, `TOTAL_TILES is ${total} but the template renders ${tiles} tiles`)
-  assert.ok(/gridTemplateRows: `repeat\(\$\{Math\.ceil\(/.test(src),
+  // Exposed as a --total-rows custom property, not a direct gridTemplateRows binding: an inline
+  // style always outranks a stylesheet rule, so binding the property itself would permanently
+  // pin the desktop row count and defeat the mobile breakpoint's own grid-template-rows
+  // override, collapsing every tile to ~0px height on mobile.
+  assert.ok(/'--total-rows':\s*Math\.ceil\(/.test(src),
     'the grid row count is no longer derived from the visible tile count')
+  assert.ok(/grid-template-rows:\s*repeat\(var\(--total-rows/.test(src),
+    'the desktop grid no longer reads the row count from --total-rows')
 })
 
 test('the admin tile panel can reach every tile slot the endpoint accepts', () => {


### PR DESCRIPTION
## Summary
- On mobile, Winball and other game tiles appeared to be "not showing" — they were actually rendering at ~0px height and were invisible.
- Root cause: `GamesHome.vue`'s row count was bound as an **inline** `grid-template-rows` style via `:style`. Inline styles always outrank stylesheet rules regardless of media query, so this silently defeated the mobile breakpoint's own `grid-template-rows: none` override. Mobile kept the desktop 2-column row count applied to a single-column layout with an `auto` container height, so the `1fr` rows had no space to divide and collapsed toward 0px.
- Fix: expose the row count as a `--total-rows` CSS custom property instead of a direct `grid-template-rows` binding, so the mobile media query can still override the real property in the stylesheet.
- Updated the existing regression test in `tests/pokemonBattleWiring.test.js` that asserted the old literal inline-style pattern, to instead assert the new `--total-rows` custom-property wiring.

This branch is based on `dev` (the prior `claude/pokemon-toggle-isolation-h7gism` PR, which added a Pokemon-only cache-invalidation fix for the "Game is live" toggle, already merged into `dev`).

## Test plan
- [x] `node --test tests/pokemonBattleWiring.test.js` — all 33 tests pass
- [ ] Manually verify on a mobile viewport that Winball, Lotto, Win Wheel, etc. tiles render at full height (not 0px) both when Pokemon is live and when it's toggled off

---
_Generated by [Claude Code](https://claude.ai/code/session_0125DKqgz7U6o6Qq8BcbRKRD)_