### PR TITLE
Stop scheduled listings being consumed without producing an auction, and release batches in mint order

### DIFF
--- a/prisma/auditAuctionOnlyCoverage.js
+++ b/prisma/auditAuctionOnlyCoverage.js
@@ -1,0 +1,142 @@
+// prisma/auditAuctionOnlyCoverage.js
+//
+// Read-only. Answers "why was this mint never auctioned?" for a cToon that was
+// released through the AuctionOnly system.
+//
+// For every copy of the named cToon it reports, side by side: who holds it, the
+// scheduled AuctionOnly listing (if any) and whether it has fired, and every
+// Auction row that has ever existed for it. That is enough to tell apart the
+// reasons a mint can end up with no auction:
+//
+//   NEVER SCHEDULED   - no AuctionOnly row was ever created for it. Usually the
+//                       batch simply did not reach this mint (an admin asking
+//                       for N copies gets the N lowest available), or the copy
+//                       was minted after the batch was created.
+//   SCHEDULED, DUE    - a row exists, its start time has passed, and it has not
+//                       fired. Something is wrong: check the Error Log and the
+//                       Manage Auction Only page.
+//   CONSUMED, NO SALE - the row is marked isStarted but no Auction row exists.
+//                       activateAuctionOnlyRow marks a listing started and
+//                       creates nothing when it finds another ACTIVE auction on
+//                       the same copy, so a listing can be silently used up.
+//                       These need rescheduling by hand.
+//   PRE-EMPTED        - an auction exists that did NOT come from the scheduled
+//                       listing (no auctionOnlyId, or a start price below the
+//                       scheduled one). This is the signature of a copy that was
+//                       auctioned by something else before its release.
+//
+// Usage:
+//   node prisma/auditAuctionOnlyCoverage.js "Gold Edition Edd"
+//   node prisma/auditAuctionOnlyCoverage.js "Gold Edition Edd" --mint 60
+
+import dotenv from 'dotenv'
+dotenv.config()
+
+import { prisma } from '../server/prisma.js'
+
+const LOG = '[auditAuctionOnlyCoverage]'
+const args = process.argv.slice(2)
+const name = args.find(a => !a.startsWith('--'))
+const mintIdx = args.indexOf('--mint')
+const onlyMint = mintIdx !== -1 ? Number(args[mintIdx + 1]) : null
+
+async function main() {
+  if (!name) {
+    console.error(`${LOG} usage: node prisma/auditAuctionOnlyCoverage.js "<cToon name>" [--mint N]`)
+    process.exitCode = 1
+    return
+  }
+
+  const ctoons = await prisma.ctoon.findMany({
+    where: { name: { contains: name, mode: 'insensitive' } },
+    select: { id: true, name: true, rarity: true, quantity: true, totalMinted: true }
+  })
+  if (!ctoons.length) {
+    console.log(`${LOG} no cToon matching "${name}".`)
+    return
+  }
+
+  for (const ctoon of ctoons) {
+    console.log(
+      `\n${LOG} ${ctoon.name} — ${ctoon.rarity}, ` +
+      `${ctoon.totalMinted} minted of ${ctoon.quantity ?? 'unlimited'}`
+    )
+
+    const copies = await prisma.userCtoon.findMany({
+      where: { ctoonId: ctoon.id, ...(onlyMint != null ? { mintNumber: onlyMint } : {}) },
+      orderBy: { mintNumber: 'asc' },
+      select: {
+        id: true,
+        mintNumber: true,
+        isTradeable: true,
+        burnedAt: true,
+        createdAt: true,
+        user: { select: { username: true } },
+        auctionOnlyListings: {
+          select: { id: true, pricePoints: true, startsAt: true, isStarted: true },
+          orderBy: { startsAt: 'asc' }
+        },
+        auctions: {
+          select: {
+            id: true, status: true, initialBet: true, highestBid: true,
+            auctionOnlyId: true, createdAt: true, winnerId: true, isFeatured: true
+          },
+          orderBy: { createdAt: 'asc' }
+        }
+      }
+    })
+
+    if (!copies.length) {
+      console.log(`  no copies${onlyMint != null ? ` with mint #${onlyMint}` : ''}.`)
+      continue
+    }
+
+    const now = new Date()
+    const buckets = {}
+
+    for (const c of copies) {
+      const listing = c.auctionOnlyListings[0] || null
+      const auctions = c.auctions
+      const fromListing = auctions.filter(a => a.auctionOnlyId)
+      const preempting = auctions.filter(
+        a => !a.auctionOnlyId && (!listing || a.initialBet < listing.pricePoints)
+      )
+
+      let verdict
+      if (!listing && !auctions.length) verdict = 'NEVER SCHEDULED'
+      else if (!listing && auctions.length) verdict = 'AUCTIONED, NEVER SCHEDULED'
+      else if (listing && !listing.isStarted && listing.startsAt <= now) verdict = 'SCHEDULED, DUE — NOT FIRED'
+      else if (listing && !listing.isStarted) verdict = 'SCHEDULED, PENDING'
+      else if (listing?.isStarted && !fromListing.length && !auctions.length) verdict = 'CONSUMED, NO AUCTION'
+      else if (listing?.isStarted && !fromListing.length) verdict = 'CONSUMED, NO AUCTION (other auctions exist)'
+      else verdict = 'RELEASED OK'
+      if (preempting.length && verdict !== 'RELEASED OK') verdict += ' + PRE-EMPTED'
+      else if (preempting.length) verdict = 'PRE-EMPTED'
+
+      buckets[verdict] = (buckets[verdict] || 0) + 1
+
+      const flag = verdict === 'RELEASED OK' ? '   ' : '>> '
+      console.log(
+        `${flag}#${String(c.mintNumber ?? '?').padEnd(4)} ${verdict}\n` +
+        `      held by ${c.user?.username ?? 'nobody'}` +
+        `${c.burnedAt ? ' (BURNED)' : ''}, tradeable=${c.isTradeable}, minted ${c.createdAt.toISOString().slice(0, 10)}\n` +
+        `      listing : ${listing
+          ? `${listing.pricePoints} pts, starts ${listing.startsAt.toISOString()}, isStarted=${listing.isStarted}`
+          : 'none'}\n` +
+        `      auctions: ${auctions.length
+          ? auctions.map(a =>
+              `${a.status} start=${a.initialBet} high=${a.highestBid ?? 0}` +
+              `${a.isFeatured ? ' featured' : ''}${a.auctionOnlyId ? ' (from listing)' : ' (NOT from listing)'}` +
+              ` ${a.createdAt.toISOString().slice(0, 10)}`
+            ).join('\n                ')
+          : 'none'}`
+      )
+    }
+
+    console.log(`\n  summary: ${Object.entries(buckets).map(([k, v]) => `${v} ${k}`).join(' | ')}`)
+  }
+}
+
+main()
+  .catch(err => { console.error(`${LOG} failed:`, err); process.exitCode = 1 })
+  .finally(async () => { await prisma.$disconnect() })

--- a/prisma/fixRogueAutoAuctions.js
+++ b/prisma/fixRogueAutoAuctions.js
@@ -1,0 +1,191 @@
+// prisma/fixRogueAutoAuctions.js
+//
+// Finds live auctions that pre-empted a scheduled AuctionOnly release, and
+// retires the ones that can be retired safely.
+//
+// createDailyFeaturedAuction (server/cron/sync-guild-members.js) used to shuffle
+// the official account's entire inventory and list whatever it drew at
+// rarityFloor(). It excluded only "Crazy Rare" and did not check whether a copy
+// was already committed to a pending AuctionOnly listing, so it could take a
+// copy an admin had scheduled to release in mint order at a set price and put it
+// up early at the 50 pt fallback floor instead. Both holes are now closed, but
+// any auction it already created is still live.
+//
+// An offender is an ACTIVE auction whose UserCtoon also has a pending
+// (isStarted = false) AuctionOnly row: the copy is up for sale right now AND
+// still scheduled to be released later.
+//
+// What --apply does, per offender, mirroring the safe-removal path in
+// server/api/admin/auction-only/[id].delete.js:
+//   * refuses any auction carrying real transaction history — bids, max-bid
+//     settings, or a highest bidder. Points are locked against those (see
+//     LockedPoints, contextType 'AUCTION'), and LockedPoints has no foreign key
+//     to Auction, so deleting one would strand ACTIVE locks and permanently
+//     freeze a player's balance. Those need a human decision about refunds.
+//   * cancels the BullMQ auto-close job first, and skips the auction if that job
+//     is mid-flight.
+//   * deletes the auction and restores isTradeable, leaving the pending
+//     AuctionOnly row untouched so the intended release still fires on schedule.
+//
+// Idempotent: re-running finds nothing once the offenders are cleared.
+//
+// Usage:
+//   node prisma/fixRogueAutoAuctions.js            (dry-run, no changes)
+//   node prisma/fixRogueAutoAuctions.js --apply    (retire the safe offenders)
+
+import dotenv from 'dotenv'
+dotenv.config()
+
+import { prisma } from '../server/prisma.js'
+import { cancelAuctionClose } from '../server/utils/queues.js'
+import { isAutoAuctionEligibleRarity } from '../server/utils/autoAuctionEligibility.js'
+
+const APPLY = process.argv.includes('--apply')
+const LOG = '[fixRogueAutoAuctions]'
+
+async function main() {
+  // Pending listings first — this table is small, and it bounds everything after
+  // it. Anything not scheduled for release cannot have been pre-empted.
+  const pending = await prisma.auctionOnly.findMany({
+    where: { isStarted: false },
+    select: {
+      id: true,
+      userCtoonId: true,
+      pricePoints: true,
+      startsAt: true,
+      userCtoon: {
+        select: {
+          mintNumber: true,
+          user: { select: { username: true } },
+          ctoon: { select: { name: true, rarity: true } }
+        }
+      }
+    }
+  })
+
+  if (!pending.length) {
+    console.log(`${LOG} no pending AuctionOnly listings — nothing to check.`)
+    return
+  }
+
+  const scheduled = new Map(pending.map(p => [p.userCtoonId, p]))
+
+  const offenders = await prisma.auction.findMany({
+    where: {
+      status: 'ACTIVE',
+      userCtoonId: { in: Array.from(scheduled.keys()) }
+    },
+    select: {
+      id: true,
+      userCtoonId: true,
+      initialBet: true,
+      highestBid: true,
+      highestBidderId: true,
+      isFeatured: true,
+      endAt: true,
+      createdAt: true,
+      _count: { select: { bids: true, autoBids: true } }
+    },
+    orderBy: { createdAt: 'asc' }
+  })
+
+  console.log(
+    `${LOG} ${pending.length} pending listing(s); ` +
+    `${offenders.length} live auction(s) pre-empting one.`
+  )
+  if (!offenders.length) return
+
+  let retired = 0
+  let blocked = 0
+
+  for (const auction of offenders) {
+    const listing = scheduled.get(auction.userCtoonId)
+    const ctoon = listing.userCtoon?.ctoon
+    const label =
+      `${ctoon?.name ?? 'unknown'} #${listing.userCtoon?.mintNumber ?? '?'} ` +
+      `(${ctoon?.rarity ?? 'no rarity'})`
+
+    const hasHistory =
+      auction._count.bids > 0 || auction._count.autoBids > 0 || !!auction.highestBidderId
+
+    console.log(
+      `\n${LOG} ${label}\n` +
+      `    auction ${auction.id} — start ${auction.initialBet} pts, ` +
+      `highest ${auction.highestBid ?? 0} pts, ${auction._count.bids} bid(s), ` +
+      `${auction._count.autoBids} max-bid(s), ends ${auction.endAt.toISOString()}\n` +
+      `    scheduled listing ${listing.id} — ${listing.pricePoints} pts, ` +
+      `starts ${listing.startsAt.toISOString()}, owner ${listing.userCtoon?.user?.username ?? 'unknown'}` +
+      (isAutoAuctionEligibleRarity(ctoon?.rarity)
+        ? ''
+        : `\n    note: this rarity is no longer auto-auctionable`)
+    )
+
+    if (hasHistory) {
+      blocked++
+      console.log(
+        `    SKIP: has real transaction history. Players have points locked ` +
+        `against this auction; refund/resolve it by hand, then re-run.`
+      )
+      continue
+    }
+
+    if (!APPLY) {
+      console.log(`    would retire this auction and restore the copy to the schedule.`)
+      continue
+    }
+
+    // Stop the auto-close job before touching the row. If it is mid-flight the
+    // auction may be closing right now — leave it alone rather than race it.
+    const jobState = await cancelAuctionClose(auction.id)
+    if (jobState.active) {
+      blocked++
+      console.log(`    SKIP: its auction-close job is processing right now. Re-run shortly.`)
+      continue
+    }
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        await tx.auctionAutoBid.deleteMany({ where: { auctionId: auction.id } })
+        await tx.bid.deleteMany({ where: { auctionId: auction.id } })
+
+        // Re-assert ACTIVE inside the transaction: a bid or a close landing
+        // between the read above and here must abort the whole thing.
+        const deleted = await tx.auction.deleteMany({
+          where: { id: auction.id, status: 'ACTIVE', highestBidderId: null }
+        })
+        if (deleted.count !== 1) {
+          throw new Error('auction changed concurrently (a bid landed or it closed)')
+        }
+
+        await tx.userCtoon.updateMany({
+          where: { id: auction.userCtoonId },
+          data: { isTradeable: true }
+        })
+      })
+      retired++
+      console.log(`    retired. Listing ${listing.id} will release as scheduled.`)
+    } catch (err) {
+      blocked++
+      console.log(`    SKIP: ${err?.message || String(err)}`)
+    }
+  }
+
+  console.log(
+    `\n${LOG} ${retired} retired, ${blocked} left for manual handling.` +
+    (APPLY ? '' : `\n${LOG} dry-run complete. Use --apply to apply.`)
+  )
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+    // Importing queues.js for cancelAuctionClose constructs BullMQ Queue objects,
+    // whose Redis connections hold the event loop open. Nothing here is still
+    // pending at this point, so exit rather than hang.
+    process.exit(0)
+  })
+  .catch(async err => {
+    console.error(`${LOG} failed:`, err)
+    await prisma.$disconnect().catch(() => {})
+    process.exit(1)
+  })

--- a/server/api/admin/auction-only/index.post.js
+++ b/server/api/admin/auction-only/index.post.js
@@ -4,6 +4,7 @@ dotenv.config()
 import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
 import { prisma } from '@/server/prisma'
 import { logAuctionOnlyError } from '@/server/utils/auctionOnlyErrorLog'
+import { selectAuctionOnlyBatch } from '@/server/utils/auctionOnlySchedule'
 const OWNER_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
 
 export default defineEventHandler(async (event) => {
@@ -181,19 +182,9 @@ async function handleAuctionOnlyCreate(event) {
       throw createError({ statusCode: 400, statusMessage: 'No copies available to create auctions' })
     }
 
-    const sorted = [...pool].sort((a, b) => {
-      const aMint = Number.isInteger(a.mintNumber) ? a.mintNumber : Number.POSITIVE_INFINITY
-      const bMint = Number.isInteger(b.mintNumber) ? b.mintNumber : Number.POSITIVE_INFINITY
-      if (aMint !== bMint) return aMint - bMint
-      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-    })
-
-    let userCtoonIds = sorted.map(a => a.id)
-    // Keep the admin's explicitly-selected copy first when present & still available.
-    if (ucIdIn && userCtoonIds.includes(ucIdIn)) {
-      userCtoonIds = [ucIdIn, ...userCtoonIds.filter(id => id !== ucIdIn)]
-    }
-    userCtoonIds = userCtoonIds.slice(0, finalCount)
+    // Includes the admin's explicitly-picked copy, and puts the batch in mint
+    // order so the releases follow the mint numbers. See auctionOnlySchedule.js.
+    const userCtoonIds = selectAuctionOnlyBatch(pool, finalCount, ucIdIn).map(a => a.id)
 
     const rows = userCtoonIds.map((id, idx) => {
       const startsAt = new Date(normStarts.getTime() + idx * releaseHours * 3600000)

--- a/server/utils/auctionOnlyActivate.js
+++ b/server/utils/auctionOnlyActivate.js
@@ -91,16 +91,42 @@ export const AUCTION_ONLY_ROW_INCLUDE = {
   }
 }
 
+// A refused listing stays pending, so startDueAuctions retries it every hour
+// until the blockage clears. Logging every attempt would bury the admin's Error
+// Log under repeats of a single problem, so a given listing is only recorded
+// once per window. The window is deliberately shorter than a typical auction, so
+// a long-running blockage still re-surfaces occasionally rather than going quiet.
+const REFUSAL_LOG_WINDOW_MS = 6 * 60 * 60 * 1000
+
+async function logActivationRefusalOnce(auctionOnlyId, reason) {
+  try {
+    const recent = await prisma.auctionOnlyErrorLog.findFirst({
+      where: {
+        auctionOnlyId,
+        context: 'activation',
+        createdAt: { gte: new Date(Date.now() - REFUSAL_LOG_WINDOW_MS) }
+      },
+      select: { id: true }
+    })
+    if (recent) return
+  } catch {
+    // If the dedupe lookup fails, fall through and log anyway — a duplicate row
+    // is far cheaper than losing the only record that something was refused.
+  }
+  await logAuctionOnlyError('activation', new Error(reason), auctionOnlyId)
+}
+
 // Activates a single AuctionOnly row (id + userCtoon include as above) into a
 // live Auction. Returns:
 //   - the created-auction summary on success
-//   - null if the row was already started / already has a live Auction by the
-//     time the transaction runs (not an error — just lost a race)
-//   - { refused: true, reason } if the official account no longer holds the
-//     copy that was scheduled to be auctioned. The listing is left pending
-//     (not marked isStarted) rather than silently activated against whoever
-//     holds the copy now, and the refusal is logged to AuctionOnlyErrorLog
-//     for the Manage Auction Only page.
+//   - null if the row was already started by the time the transaction runs
+//     (not an error — just lost a race)
+//   - { refused: true, reason } if it cannot be activated right now: the
+//     official account no longer holds the copy, or another auction is already
+//     live for it. The listing is left pending (not marked isStarted) rather
+//     than activated against whoever holds the copy now or silently consumed,
+//     and the refusal is logged to AuctionOnlyErrorLog for the Manage Auction
+//     Only page.
 export async function activateAuctionOnlyRow(row) {
   const result = await prisma.$transaction(async (tx) => {
     const fresh = await tx.auctionOnly.findUnique({
@@ -125,19 +151,42 @@ export async function activateAuctionOnlyRow(row) {
 
     const userCtoon = await tx.userCtoon.findUnique({
       where: { id: fresh.userCtoonId },
-      select: { userId: true, mintNumber: true }
+      select: { userId: true, mintNumber: true, burnedAt: true }
     })
     if (!userCtoon || userCtoon.userId !== official.id) {
       return { refused: true, reason: 'The official account no longer holds this copy — listing left pending.' }
     }
+    // A burned copy stays attached to its owner, so the ownership check above
+    // passes for one. There is nothing left to sell either way.
+    if (userCtoon.burnedAt) {
+      return { refused: true, reason: 'This copy has been burned — listing left pending.' }
+    }
 
+    // Something else already has this copy up for auction. This used to mark the
+    // listing isStarted and return, which spent a scheduled release without ever
+    // creating an auction for it — silently, with nothing logged. A mint
+    // scheduled at 1500 could simply never go up, and no record said why.
+    //
+    // Leave it pending instead, so the listing survives and still fires once the
+    // blocking auction clears:
+    //   * that auction is still running -> retried on the next pass
+    //   * it closed unsold, copy back with the official account -> activates as
+    //     scheduled, at the intended price
+    //   * it closed sold -> the ownership check above refuses, since there is no
+    //     longer anything here to sell
     const active = await tx.auction.findFirst({
       where: { userCtoonId: fresh.userCtoonId, status: 'ACTIVE' },
-      select: { id: true }
+      select: { id: true, initialBet: true, endAt: true, auctionOnlyId: true }
     })
     if (active) {
-      await tx.auctionOnly.update({ where: { id: fresh.id }, data: { isStarted: true } })
-      return null
+      return {
+        refused: true,
+        reason:
+          `Another auction (id ${active.id}, start ${active.initialBet} pts, ends ` +
+          `${new Date(active.endAt).toISOString()}) is already live for this copy` +
+          (active.auctionOnlyId ? '' : ' and did not come from a scheduled listing') +
+          ' — listing left pending and will be retried once that auction clears.'
+      }
     }
 
     const floor = rarityFloor(row.userCtoon?.ctoon?.rarity)
@@ -184,7 +233,7 @@ export async function activateAuctionOnlyRow(row) {
   if (!result) return null
 
   if (result.refused) {
-    await logAuctionOnlyError('activation', new Error(result.reason), row.id)
+    await logActivationRefusalOnce(row.id, result.reason)
     return result
   }
 

--- a/server/utils/auctionOnlySchedule.js
+++ b/server/utils/auctionOnlySchedule.js
@@ -1,0 +1,50 @@
+// server/utils/auctionOnlySchedule.js
+//
+// Which copies make up a scheduled AuctionOnly batch, and what order they go up
+// in. Pure so it can be unit-tested (see tests/auctionOnlyBatchOrder.test.js);
+// the endpoint that uses it is server/api/admin/auction-only/index.post.js.
+
+/**
+ * Mint order, oldest first among copies with no mint number.
+ */
+export function byMintThenAge(a, b) {
+  const aMint = Number.isInteger(a.mintNumber) ? a.mintNumber : Number.POSITIVE_INFINITY
+  const bMint = Number.isInteger(b.mintNumber) ? b.mintNumber : Number.POSITIVE_INFINITY
+  if (aMint !== bMint) return aMint - bMint
+  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+}
+
+/**
+ * Pick `count` copies out of `pool` and put them in release order.
+ *
+ * Two separate decisions, which this deliberately keeps apart:
+ *
+ *  1. Which copies are in the batch. Lowest mints first, except that an
+ *     explicitly picked copy is always included — the admin UI always sends one,
+ *     since it is how a cToon gets chosen, and for a single auction it is the
+ *     whole point. Including a picked copy from outside the window displaces the
+ *     last copy that would otherwise have made it.
+ *  2. What order they are released in. Always mint order.
+ *
+ * These used to be conflated: the picked copy was moved to the front to force it
+ * into the batch and then kept that position when release times were assigned,
+ * so picking #57 while scheduling a run released #57 ahead of #41.
+ *
+ * @param {Array<{id: string, mintNumber: number|null, createdAt: Date|string}>} pool
+ * @param {number} count
+ * @param {string|null} pickedId - userCtoonId the admin explicitly selected
+ * @returns {Array<object>} the chosen copies, in release order
+ */
+export function selectAuctionOnlyBatch(pool, count, pickedId = null) {
+  const finalCount = Math.min(Number(count) || 0, pool.length)
+  if (finalCount < 1) return []
+
+  const sorted = [...pool].sort(byMintThenAge)
+
+  let batch = sorted
+  if (pickedId && sorted.some(a => a.id === pickedId)) {
+    batch = [sorted.find(a => a.id === pickedId), ...sorted.filter(a => a.id !== pickedId)]
+  }
+
+  return batch.slice(0, finalCount).sort(byMintThenAge)
+}

--- a/tests/auctionOnlyBatchOrder.test.js
+++ b/tests/auctionOnlyBatchOrder.test.js
@@ -1,0 +1,67 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { byMintThenAge, selectAuctionOnlyBatch } from '../server/utils/auctionOnlySchedule.js'
+
+const selectBatch = (pool, count, pickedId) =>
+  selectAuctionOnlyBatch(pool, count, pickedId).map(a => a.mintNumber)
+
+const poolOf = (from, to) => {
+  const out = []
+  for (let m = from; m <= to; m++) out.push({ id: `uc-${m}`, mintNumber: m, createdAt: '2026-08-01' })
+  return out
+}
+
+test('a batch is released in mint order whichever copy the admin picked', () => {
+  const pool = poolOf(41, 60)
+  // The client always sends a userCtoonId, so every one of these is a real case.
+  for (const pick of [41, 42, 50, 57, 60]) {
+    assert.deepEqual(
+      selectBatch(pool, 20, `uc-${pick}`),
+      pool.map(p => p.mintNumber),
+      `picking #${pick} must not reorder the release schedule`
+    )
+  }
+})
+
+test('the picked copy no longer jumps ahead of lower mints', () => {
+  const pool = poolOf(41, 60)
+  // The regression: picking #57 used to put #57 first, before #41.
+  const order = selectBatch(pool, 20, 'uc-57')
+  assert.equal(order[0], 41)
+  assert.ok(order.indexOf(57) > order.indexOf(41))
+})
+
+test('the picked copy is still guaranteed a place in the batch', () => {
+  const pool = poolOf(41, 60)
+  // #60 is outside the lowest 17, so including it must displace the last one.
+  const order = selectBatch(pool, 17, 'uc-60')
+  assert.ok(order.includes(60), 'the explicitly picked copy must be scheduled')
+  assert.equal(order.length, 17)
+  assert.ok(!order.includes(57), '#57 is displaced to make room')
+  // ...and the batch is still in mint order despite the displacement.
+  assert.deepEqual(order, [...order].sort((a, b) => a - b))
+})
+
+test('a single auction schedules exactly the copy the admin picked', () => {
+  const pool = poolOf(41, 60)
+  assert.deepEqual(selectBatch(pool, 1, 'uc-57'), [57])
+  assert.deepEqual(selectBatch(pool, 1, 'uc-41'), [41])
+})
+
+test('with no picked copy the lowest mints are taken, in order', () => {
+  assert.deepEqual(selectBatch(poolOf(41, 60), 3, null), [41, 42, 43])
+})
+
+test('asking for more than exists schedules everything, in order', () => {
+  assert.deepEqual(selectBatch(poolOf(41, 43), 99, 'uc-43'), [41, 42, 43])
+})
+
+test('copies with no mint number sort last, oldest first', () => {
+  const pool = [
+    { id: 'b', mintNumber: null, createdAt: '2026-08-02' },
+    { id: 'a', mintNumber: null, createdAt: '2026-08-01' },
+    { id: 'm', mintNumber: 7, createdAt: '2026-08-03' }
+  ]
+  assert.deepEqual([...pool].sort(byMintThenAge).map(x => x.id), ['m', 'a', 'b'])
+})


### PR DESCRIPTION
Follow-on to the featured-auction fix already on `dev` (PR #904's content landed there). This branch was restarted from `dev` so it contains only what is still missing — 6 files, one commit.

Three remaining gaps, all of which can leave a scheduled mint never auctioned. Prompted by "mint #60 of Gold Edition Edd has not been auctioned".

## 1. Listings consumed without producing an auction

`activateAuctionOnlyRow` finds another ACTIVE auction on the same copy, marks the listing `isStarted`, and returns. The scheduled release is spent, nothing is created, and nothing is logged. A mint scheduled at 1500 can simply never go up, with no record of why.

The listing is now left pending, so it survives and fires once the blocking auction clears:

| Blocking auction | Outcome |
|---|---|
| still running | retried next pass |
| closed **unsold** | activates at the intended price |
| closed **sold** | existing ownership check refuses — nothing left to sell |

This is only safe because the ownership check is already on `dev`. Without it, retrying after a sale is precisely what would auction the buyer's copy.

Because a refused listing now retries hourly, refusals are logged **at most once per six hours per listing**, so one stuck listing cannot bury the Error Log.

## 2. Burned copies

The ownership check passes for a burned copy — burning leaves it attached to its owner. There is nothing to sell either way, so it is now refused explicitly.

## 3. Release order

Batch membership and release order were conflated. The admin's explicitly-picked copy was moved to the front to force it into the batch, then **kept that position** when release times were assigned. The client always sends a picked copy (`AdminLegacyAuctionsNew.vue:355` — it is how a cToon is chosen), so scheduling a run of mints and picking #57 in the search box released **#57 before #41**.

Selection and ordering are now separate steps in `server/utils/auctionOnlySchedule.js`. The picked copy is still guaranteed a place in the batch; releases always follow mint order. Extracted as a pure module so the test exercises the real logic rather than a copy — the endpoint's Nuxt `@/server` aliases do not resolve under `node --test`.

## Two operational scripts

```
node prisma/auditAuctionOnlyCoverage.js "Gold Edition Edd" --mint 60
```
Read-only. Explains per mint why a copy was never auctioned, classifying each as `NEVER SCHEDULED` / `SCHEDULED, DUE` / `CONSUMED` / `PRE-EMPTED`. This is what answers the #60 question against production — most likely `NEVER SCHEDULED`, which is not a bug (a batch of N takes the N lowest mints), but the script distinguishes that from the real failure modes.

```
node prisma/fixRogueAutoAuctions.js            # dry run
node prisma/fixRogueAutoAuctions.js --apply
```
Finds auctions that pre-empted a scheduled release and retires those carrying no bids. Mirrors the safe-removal path in `auction-only/[id].delete.js` and **refuses anything with bids**: `LockedPoints` has no foreign key to `Auction`, so deleting one would strand ACTIVE locks and freeze a player's balance. Dry-run by default.

## Verification

Against a real Postgres running dev's migrations:

- Listing blocked by a live auction stays pending, and logs **once across three passes** (dedupe holds).
- That auction closes unsold → listing **recovers and fires at 1500**, the case that previously lost the mint entirely.
- Closes sold → refuses; buyer keeps the copy, still tradeable, not seized.
- Burned copy → refuses.
- Audit script correctly classifies all outcomes; repair script dry-run and `--apply` both exit 0.
- 7 new unit tests covering batch order, guaranteed inclusion, displacement, and null mint numbers.

## Notes for the reviewer

- **No migration in this branch.** `dev` already carries the `AuctionOnly(userCtoonId, isStarted)` index as `20260813000000_add_auctiononly_userctoonid_isstarted_index`; mine was dropped to avoid a duplicate.
- **Two pre-existing test failures** on `dev`, unchanged by this branch: `the Games page tile grid has a row for every tile` and `attack-vs-attack KO prevents counterattack`. Both fail identically on a clean `dev` checkout. `npm run lint` is also broken repo-wide (no `eslint.config.js` for ESLint 10).

---
_Generated by [Claude Code](https://claude.ai/code/session_015XaixRnxV7RTLVyTBvVmNu)_