### PR TITLE
Allow custom auction durations up to 7 days via a calendar picker

### DIFF
--- a/components/AddToAuction.vue
+++ b/components/AddToAuction.vue
@@ -49,58 +49,9 @@
         </p>
 
         <!-- Duration -->
-        <div>
+        <div class="adp-light">
           <p class="block mb-1 font-medium">Duration</p>
-
-          <!-- Presets -->
-          <div class="flex flex-wrap gap-4 mb-2">
-            <label class="inline-flex items-center">
-              <input type="radio" class="form-radio" value="3m" v-model="durationPreset" />
-              <span class="ml-2">Quick: 3 minutes</span>
-            </label>
-            <label class="inline-flex items-center">
-              <input type="radio" class="form-radio" value="30m" v-model="durationPreset" />
-              <span class="ml-2">30 minutes</span>
-            </label>
-            <label class="inline-flex items-center">
-              <input type="radio" class="form-radio" value="1h" v-model="durationPreset" />
-              <span class="ml-2">1 hour</span>
-            </label>
-            <label class="inline-flex items-center">
-              <input type="radio" class="form-radio" value="6h" v-model="durationPreset" />
-              <span class="ml-2">6 hours</span>
-            </label>
-            <label class="inline-flex items-center">
-              <input type="radio" class="form-radio" value="4h" v-model="durationPreset" />
-              <span class="ml-2">4 hours</span>
-            </label>
-            <label class="inline-flex items-center">
-              <input type="radio" class="form-radio" value="12h" v-model="durationPreset" />
-              <span class="ml-2">12 hours</span>
-            </label>
-            <label class="inline-flex items-center">
-              <input type="radio" class="form-radio" value="days" v-model="durationPreset" />
-              <span class="ml-2">Custom days</span>
-            </label>
-          </div>
-
-          <!-- Days slider only when "days" is selected -->
-          <div v-if="durationPreset === 'days'">
-            <label class="block mb-1">
-              Days: <span class="font-semibold">{{ timeframe }} day(s)</span>
-            </label>
-            <input
-              type="range"
-              v-model.number="timeframe"
-              :min="1"
-              :max="5"
-              step="1"
-              class="w-full"
-            />
-            <div class="flex justify-between text-sm mt-1">
-              <span>1</span><span>3</span><span>5</span>
-            </div>
-          </div>
+          <AuctionDurationPicker @update="onDurationUpdate" />
         </div>
       </div>
       <div class="mt-6 flex justify-between items-center">
@@ -115,7 +66,7 @@
           <button @click="closeModal" class="btn-secondary">Cancel</button>
           <button
             @click="sendToAuction"
-            :disabled="sending || initialBet < minInitialBet"
+            :disabled="sending || initialBet < minInitialBet || !duration.valid"
             class="btn-primary"
           >
             {{ sending ? 'Sending...' : 'Send to Auction' }}
@@ -148,11 +99,10 @@ const buttonClass = computed(() => ['btn', attrs.class])
 
 const showModal    = ref(false)
 const initialBet   = ref(props.userCtoon.price)
-const timeframe    = ref(1)     // days
-const quick3m      = ref(false) // 3-minute flag
 const sending      = ref(false)
 const auctionSent  = ref(false)
-const durationPreset = ref('days') // '3m' | '4h' | '12h' | 'days'
+// Populated by AuctionDurationPicker's @update.
+const duration     = ref({ durationDays: 0, durationMinutes: 0, totalMinutes: null, valid: false })
 const toastMessage = ref('')
 const toastType    = ref('error')
 const recentAuctions = ref([])
@@ -183,10 +133,10 @@ function showToast(message, type = 'error') {
   setTimeout(() => { toastMessage.value = '' }, 5000)
 }
 
+function onDurationUpdate(next) { duration.value = next }
+
 function openModal() {
   initialBet.value = Math.max(props.userCtoon.price || 0, minInitialBet.value)
-  timeframe.value = 1
-  durationPreset.value = 'days' // default to days
   showModal.value = true
   // Load recent auctions for this cToon (last 3 closed)
   loadRecentAuctions()
@@ -202,20 +152,11 @@ async function sendToAuction() {
     return
   }
 
-  // Map preset -> payload fields
-  let durationDays = 0
-  let durationMinutes = 0
-  switch (durationPreset.value) {
-    case '3m':  durationMinutes = 3;        break
-    case '30m': durationMinutes = 30;       break
-    case '1h':  durationMinutes = 60;       break
-    case '6h':  durationMinutes = 6 * 60;   break
-    case '4h':  durationMinutes = 4 * 60;   break
-    case '12h': durationMinutes = 12 * 60;  break
-    case 'days':
-    default:
-      durationDays = timeframe.value
+  if (!duration.value.valid) {
+    showToast('Pick a valid auction length.', 'error')
+    return
   }
+  const { durationDays, durationMinutes } = duration.value
 
   sending.value = true
   try {
@@ -245,8 +186,6 @@ async function instaBid() {
   sending.value = true
   try {
     initialBet.value = instaBidValue.value
-    durationPreset.value = 'days'
-    timeframe.value = 1
 
     const { auction } = await $fetch('/api/auctions', {
       method: 'POST',
@@ -289,6 +228,22 @@ function formatDate(d) {
 </script>
 
 <style scoped>
+/* The picker defaults to the dark AuctionModal surface. This host is a white
+   Tailwind panel, so it overrides the --adp-* variables rather than forking the
+   component. color-scheme matters as much as color here: without it, WebKit
+   renders the datetime-local editor's segments for the wrong scheme. */
+.adp-light :deep(.adp) {
+  --adp-fg: #111827;
+  --adp-fg-dim: #4b5563;
+  --adp-fg-faint: #6b7280;
+  --adp-border: #d1d5db;
+  --adp-surface: #f3f4f6;
+  --adp-input-bg: #fff;
+  --adp-accent: #2563eb;
+  --adp-error: #b91c1c;
+  --adp-scheme: light;
+}
+
 .btn {
   @apply px-4 py-2 bg-blue-600 text-white rounded-lg disabled:opacity-50;
 }

--- a/components/newsite/AdminAuctionLogs.vue
+++ b/components/newsite/AdminAuctionLogs.vue
@@ -156,7 +156,7 @@
               <th class="px-1.5 py-1 text-left">Creator</th>
               <th class="px-1.5 py-1 text-left">Status</th>
               <th class="px-1.5 py-1 text-left">Created</th>
-              <th class="px-1.5 py-1 text-right">Days</th>
+              <th class="px-1.5 py-1 text-right">Length</th>
               <th class="px-1.5 py-1 text-right">Hrs Left</th>
               <th class="px-1.5 py-1 text-left">Top Bidder</th>
               <th class="px-1.5 py-1 text-left">Winner</th>
@@ -172,7 +172,7 @@
               <td class="px-1.5 py-1">{{ auc.creator?.username || '—' }}</td>
               <td class="px-1.5 py-1">{{ auc.status }}</td>
               <td class="px-1.5 py-1 whitespace-nowrap">{{ formatDate(auc.createdAt) }}</td>
-              <td class="px-1.5 py-1 text-right tabular-nums">{{ auc.duration }}</td>
+              <td class="px-1.5 py-1 text-right tabular-nums">{{ auctionLength(auc) }}</td>
               <td class="px-1.5 py-1 text-right tabular-nums">{{ hoursLeft(auc.endAt) }}</td>
               <td class="px-1.5 py-1">{{ auc.highestBidder?.username || '—' }}</td>
               <td class="px-1.5 py-1">{{ auc.winner?.username || '—' }}</td>
@@ -197,7 +197,7 @@
             <div><span class="font-medium">Creator:</span> {{ auc.creator?.username || '—' }}</div>
             <div><span class="font-medium">Status:</span> {{ auc.status }}</div>
             <div><span class="font-medium">Created:</span> {{ formatDate(auc.createdAt) }}</div>
-            <div><span class="font-medium">Duration:</span> {{ auc.duration }} days</div>
+            <div><span class="font-medium">Duration:</span> {{ auctionLength(auc) }}</div>
             <div><span class="font-medium">Top Bidder:</span> {{ auc.highestBidder?.username || '—' }}</div>
             <div><span class="font-medium">Winner:</span> {{ auc.winner?.username || '—' }}</div>
             <div><span class="font-medium">Highest Bid:</span> {{ auc.highestBid }}</div>
@@ -223,6 +223,16 @@
 </template>
 
 <script setup>
+import { formatAuctionDuration } from '~/server/utils/auctionDuration'
+
+// Auction.duration is whole days, so every sub-day listing stores 0 and this
+// column read "0 days" for a 3-minute or 12-hour auction. durationMinutes
+// carries the real length where the row has it.
+function auctionLength(auc) {
+  const mins = auc?.durationMinutes
+  if (Number.isInteger(mins)) return formatAuctionDuration(mins)
+  return `${auc?.duration ?? 0} days`
+}
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 
 const pageSize = 100

--- a/components/newsite/AuctionDetails.vue
+++ b/components/newsite/AuctionDetails.vue
@@ -141,6 +141,7 @@
 </template>
 
 <script setup>
+import { formatRemainingShort } from '~/server/utils/auctionDuration'
 const props = defineProps({
   auctionId: { type: [String, Number], required: true },
 })
@@ -205,15 +206,12 @@ function showToast(message, type = 'error') {
   setTimeout(() => { toast.message = '' }, 4000)
 }
 
+// See the note on AuctionHouse.vue's copy: hours as the largest unit meant a
+// 7-day auction counted down from "167h 59m".
 function formatRemaining(endAt) {
   const diff = new Date(endAt) - now.value
   if (diff <= 0) return '0s'
-  const h = Math.floor(diff / 3600000)
-  const m = Math.floor((diff % 3600000) / 60000)
-  const s = Math.floor((diff % 60000) / 1000)
-  if (h > 0)  return `${h}h ${m}m ${s}s`
-  if (m > 0)  return `${m}m ${s}s`
-  return `${s}s`
+  return formatRemainingShort(diff)
 }
 
 function formatDate(d) {
@@ -271,7 +269,7 @@ function openInfoModal() {
 
 function openRelist() {
   if (!auction.value?.canRelist) return
-  const duration = reconstructDurationPrefill(auction.value.createdAt, auction.value.endAt)
+  const duration = reconstructDurationPrefill(auction.value.createdAt, auction.value.endAt, auction.value.durationMinutes)
   openAuctionModal({
     ctoon: {
       id:         auction.value.ctoon.userCtoonId,
@@ -286,8 +284,19 @@ function openRelist() {
       initialBet:     auction.value.initialBet,
       durationPreset: duration.preset,
       timeframe:      duration.timeframe,
+      customEndAtLocal: seedCustomEnd(duration.customMinutes),
     },
   })
+}
+
+// A re-list whose exact length isn't one of the chips reopens the calendar,
+// seeded to the same length measured from now.
+function seedCustomEnd(minutes) {
+  if (!Number.isInteger(minutes)) return ''
+  const d = new Date(Date.now() + minutes * 60000)
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+         `T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 // This page still shows the old, closed auction. Once it's been re-listed the

--- a/components/newsite/AuctionDurationPicker.vue
+++ b/components/newsite/AuctionDurationPicker.vue
@@ -1,0 +1,349 @@
+<template>
+  <div class="adp">
+    <!-- Preset chips. The custom panel REPLACES this row rather than stacking
+         below it: the modal has roughly 148px of vertical slack on a 360x640
+         phone (80px with the cZone warning showing), and stacking spends more
+         than that. -->
+    <div v-if="!custom" class="adp-presets">
+      <button
+        v-for="p in PRESETS" :key="p.value"
+        type="button"
+        class="adp-preset"
+        :class="{ active: preset === p.value }"
+        :aria-pressed="preset === p.value"
+        @click="selectPreset(p.value)"
+      >{{ p.label }}</button>
+      <button
+        type="button"
+        class="adp-preset adp-preset-custom"
+        @click="openCustom"
+      >Pick date…</button>
+    </div>
+
+    <!-- Days slider, unchanged in shape but now reaching the same 7-day
+         ceiling the calendar does. A slider stopping at 5 next to a calendar
+         reaching 7 reads as a bug. -->
+    <div v-if="!custom && preset === 'days'" class="adp-slider-wrap">
+      <div class="adp-slider-label">{{ timeframe }} day{{ timeframe !== 1 ? 's' : '' }}</div>
+      <input
+        class="adp-slider" type="range" v-model.number="timeframe"
+        :min="1" :max="7" step="1" aria-label="Auction length in days"
+      />
+      <div class="adp-slider-ticks">
+        <span>1d</span><span>3d</span><span>5d</span><span>7d</span>
+      </div>
+    </div>
+
+    <!-- Custom end date/time.
+         One datetime-local rather than a hand-built grid, or a date input and a
+         time input side by side. min/max on a bare date input clamp the day
+         only, so on the first and last selectable days the time would be
+         unclamped and the player would hit an error they didn't cause. One
+         field enforces the whole instant, opens the OS date+time picker on
+         mobile, and matches the ~30 datetime-local inputs already in this app. -->
+    <div v-else-if="custom" class="adp-custom">
+      <div class="adp-custom-head">
+        <label class="adp-custom-label" for="adp-end-at">Ends on</label>
+        <button type="button" class="adp-back" @click="closeCustom">← Presets</button>
+      </div>
+
+      <input
+        id="adp-end-at"
+        ref="endAtInput"
+        class="adp-input"
+        type="datetime-local"
+        v-model="endAtLocal"
+        :min="minLocal"
+        :max="maxLocal"
+        step="60"
+        :aria-invalid="!!error"
+        aria-describedby="adp-readout adp-error"
+      />
+
+      <!-- Absolute and relative together, deliberately. When a player's device
+           clock is wrong the two disagree, and the relative figure is the one
+           that's true — showing both is what lets them notice. -->
+      <div id="adp-readout" class="adp-readout" aria-live="polite">
+        <template v-if="resolvedEnd && !error">
+          <div class="adp-readout-abs">{{ absoluteLabel }}</div>
+          <div class="adp-readout-rel">in {{ relativeLabel }} · {{ zoneLabel }}</div>
+        </template>
+        <div v-else-if="!endAtLocal" class="adp-readout-hint">
+          Between 3 minutes and 7 days from now.
+        </div>
+      </div>
+
+      <div v-if="shiftNote" class="adp-note">{{ shiftNote }}</div>
+      <div id="adp-error" class="adp-error" role="alert">{{ error }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import {
+  MIN_AUCTION_MINUTES,
+  MAX_AUCTION_MINUTES,
+  clampMsToAuctionMinutes,
+  isListableMs,
+  formatAuctionDuration
+} from '~/server/utils/auctionDuration'
+
+const props = defineProps({
+  // { preset, timeframe, customEndAtLocal } — used when re-listing.
+  prefill: { type: Object, default: null }
+})
+
+// Emits the resolved duration upward as { durationDays, durationMinutes, totalMinutes, valid }.
+const emit = defineEmits(['update'])
+
+const PRESETS = [
+  { value: '3m',   label: '3 min'  },
+  { value: '30m',  label: '30 min' },
+  { value: '1h',   label: '1 hr'   },
+  { value: '4h',   label: '4 hr'   },
+  { value: '6h',   label: '6 hr'   },
+  { value: '12h',  label: '12 hr'  },
+  { value: 'days', label: 'Days…'  },
+]
+
+const PRESET_MINUTES = {
+  '3m': 3, '30m': 30, '1h': 60, '4h': 240, '6h': 360, '12h': 720
+}
+
+const preset      = ref(props.prefill?.preset && props.prefill.preset !== 'custom' ? props.prefill.preset : 'days')
+const timeframe   = ref(Math.min(7, Math.max(1, props.prefill?.timeframe || 1)))
+const custom      = ref(props.prefill?.preset === 'custom')
+const endAtLocal  = ref(props.prefill?.customEndAtLocal || '')
+
+// Ticks so a modal left open can't submit a duration computed against a stale
+// "now". 30s rather than 1s: the value is recomputed at submit anyway, so the
+// tick only keeps the readout and the min/max honest, and a 1s tick would make
+// the error message flicker under the user's finger on a near-minimum pick.
+const now = ref(Date.now())
+let timer = null
+onMounted(() => { timer = setInterval(() => { now.value = Date.now() }, 30_000) })
+onUnmounted(() => { if (timer) clearInterval(timer) })
+
+// ── Local-time formatting ─────────────────────────────────────────────────
+// Every value below is derived from epoch milliseconds and only formatted for
+// display, which is what keeps this DST-safe: the bounds are elapsed-time
+// bounds, so a fall-back week simply offers a last selectable instant that is
+// 167 wall-clock hours out instead of 168, rather than offering a date the
+// server would then reject.
+function toLocalInputValue(ms) {
+  const d = new Date(ms)
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+         `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// Parse the input's value with the multi-argument Date constructor.
+// new Date('2026-11-04') would parse as UTC midnight — a full day off for every
+// negative-offset user — and the 'YYYY-MM-DDTHH:mm' form is the one browsers
+// historically disagreed about. The field-by-field constructor is unambiguous.
+function parseLocalInputValue(value) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(value || '')
+  if (!m) return null
+  const [, y, mo, d, h, mi] = m.map(Number)
+  const dt = new Date(y, mo - 1, d, h, mi, 0, 0)
+  // Round-trip the fields. A nonexistent local time (2:30 AM on a spring-forward
+  // date) is silently relocated by the constructor, and the user deserves to be
+  // told rather than watching their input change under them.
+  const shifted =
+    dt.getFullYear() !== y || dt.getMonth() !== mo - 1 || dt.getDate() !== d ||
+    dt.getHours() !== h || dt.getMinutes() !== mi
+  return { date: dt, shifted }
+}
+
+const minLocal = computed(() => toLocalInputValue(now.value + MIN_AUCTION_MINUTES * 60000))
+const maxLocal = computed(() => toLocalInputValue(now.value + MAX_AUCTION_MINUTES * 60000))
+
+const parsed = computed(() => custom.value ? parseLocalInputValue(endAtLocal.value) : null)
+const resolvedEnd = computed(() => parsed.value?.date ?? null)
+const rawMs = computed(() =>
+  resolvedEnd.value ? resolvedEnd.value.getTime() - now.value : NaN
+)
+
+const shiftNote = computed(() => {
+  if (!parsed.value?.shifted || !resolvedEnd.value) return ''
+  return `That time doesn't exist on this date — clocks jump forward. Your auction will end at ` +
+         `${resolvedEnd.value.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}.`
+})
+
+const error = computed(() => {
+  if (!custom.value || !endAtLocal.value) return ''
+  if (!resolvedEnd.value) return 'Pick a valid date and time.'
+  if (rawMs.value < MIN_AUCTION_MINUTES * 60000) return `Must be at least ${MIN_AUCTION_MINUTES} minutes from now.`
+  if (rawMs.value > MAX_AUCTION_MINUTES * 60000) return 'Auctions can run for at most 7 days.'
+  return ''
+})
+
+const absoluteLabel = computed(() => {
+  if (!resolvedEnd.value) return ''
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: 'short', month: 'short', day: 'numeric',
+      hour: 'numeric', minute: '2-digit', timeZoneName: 'short'
+    }).format(resolvedEnd.value)
+  } catch { return resolvedEnd.value.toLocaleString() }
+})
+
+// timeZoneName resolves for the formatted instant, not for right now — so a
+// player picking a post-transition date sees "EST" while their clock still
+// reads "EDT". That is the DST disclosure, for free.
+const zoneLabel = computed(() => {
+  try {
+    return `your device's time zone (${Intl.DateTimeFormat().resolvedOptions().timeZone || 'local'})`
+  } catch { return "your device's time zone" }
+})
+
+const relativeLabel = computed(() =>
+  Number.isFinite(rawMs.value) ? formatAuctionDuration(clampMsToAuctionMinutes(rawMs.value)) : ''
+)
+
+// ── Resolved value ────────────────────────────────────────────────────────
+const totalMinutes = computed(() => {
+  if (custom.value) {
+    if (!isListableMs(rawMs.value)) return null
+    return clampMsToAuctionMinutes(rawMs.value)
+  }
+  if (preset.value === 'days') return timeframe.value * 1440
+  return PRESET_MINUTES[preset.value] ?? 1440
+})
+
+// The wire shape stays {durationDays, durationMinutes} — the insta-bid path and
+// the admin/worker callers still send days-only, and the server validates the
+// sum, so the split is never load-bearing.
+const payload = computed(() => {
+  const total = totalMinutes.value
+  if (total == null) return { durationDays: 0, durationMinutes: 0, totalMinutes: null, valid: false }
+  return { durationDays: 0, durationMinutes: total, totalMinutes: total, valid: true }
+})
+
+watch(payload, (v) => emit('update', v), { immediate: true })
+
+function selectPreset(value) { preset.value = value }
+function openCustom() {
+  custom.value = true
+  if (!endAtLocal.value) {
+    const seed = totalMinutes.value ?? 1440
+    endAtLocal.value = toLocalInputValue(Date.now() + seed * 60000)
+  }
+  nextTick(() => endAtInput.value?.focus())
+}
+function closeCustom() { custom.value = false }
+
+const endAtInput = ref(null)
+
+defineExpose({
+  // The modal shows a confirm step for long listings; it needs the label.
+  describe: () => (totalMinutes.value == null ? '' : formatAuctionDuration(totalMinutes.value)),
+  endsAtLabel: () => absoluteLabel.value,
+  totalMinutes: () => totalMinutes.value
+})
+</script>
+
+<style scoped>
+/* Custom properties are namespaced --adp-* on purpose: tests/shortCardVarContract.test.js
+   walks every .vue file under components/, pages/ and layouts/ and fails any
+   --sc-* name that ShortCard doesn't itself read.
+
+   The defaults below are the dark AuctionModal surface. A light host overrides
+   them on the wrapper rather than forking this component. */
+.adp {
+  --adp-fg: #fff;
+  --adp-fg-dim: rgba(255,255,255,0.55);
+  --adp-fg-faint: rgba(255,255,255,0.4);
+  --adp-border: rgba(255,255,255,0.2);
+  --adp-surface: rgba(0,0,0,0.2);
+  --adp-input-bg: rgba(0,0,0,0.3);
+  --adp-accent: var(--OrbitLightBlue);
+  /* #fca5a5, which AuctionModal uses for errors, is 3.10:1 on --OrbitDarkBlue
+     and fails WCAG AA at this size. #fee2e2 is 4.91:1. */
+  --adp-error: #fee2e2;
+  --adp-scheme: dark;
+
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.adp-presets { display: flex; flex-wrap: wrap; gap: 4px; }
+
+.adp-preset {
+  border: 1px solid var(--adp-border);
+  border-radius: 5px;
+  background: var(--adp-surface);
+  color: var(--adp-fg-dim);
+  font-size: 0.65rem;
+  font-weight: bold;
+  padding: 3px 9px;
+  cursor: pointer;
+  transition: all 0.12s;
+}
+.adp-preset.active {
+  background: var(--adp-accent);
+  border-color: var(--adp-accent);
+  color: #fff;
+}
+.adp-preset:not(.active):hover { color: var(--adp-fg); border-color: var(--adp-fg-dim); }
+.adp-preset-custom { border-style: dashed; }
+
+/* Slider */
+.adp-slider-wrap { display: flex; flex-direction: column; gap: 3px; padding-top: 2px; }
+.adp-slider-label { font-size: 0.72rem; font-weight: bold; color: var(--adp-fg); text-align: center; }
+.adp-slider { width: 100%; accent-color: var(--adp-accent); }
+.adp-slider-ticks { display: flex; justify-content: space-between; font-size: 0.58rem; color: var(--adp-fg-faint); }
+
+/* Custom panel */
+.adp-custom { display: flex; flex-direction: column; gap: 4px; }
+.adp-custom-head { display: flex; align-items: baseline; justify-content: space-between; gap: 6px; }
+.adp-custom-label {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--adp-fg-dim);
+}
+.adp-back {
+  border: none;
+  background: none;
+  color: var(--adp-accent);
+  font-size: 0.62rem;
+  font-weight: bold;
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.adp-input {
+  width: 100%;
+  background: var(--adp-input-bg);
+  border: 1px solid var(--adp-border);
+  border-radius: 6px;
+  /* Both are required on a dark surface. `color` alone does not reach WebKit's
+     ::-webkit-datetime-edit-* segments or the calendar-picker indicator, so the
+     field renders near-black on a dark background without color-scheme. */
+  color: var(--adp-fg);
+  color-scheme: var(--adp-scheme);
+  font-size: 0.8rem;
+  padding: 5px 8px;
+  outline: none;
+  box-sizing: border-box;
+}
+.adp-input:focus { border-color: var(--adp-accent); }
+
+.adp-readout { display: flex; flex-direction: column; gap: 1px; min-height: 26px; }
+.adp-readout-abs { font-size: 0.72rem; font-weight: bold; color: var(--adp-fg); }
+.adp-readout-rel { font-size: 0.62rem; color: var(--adp-fg-dim); }
+.adp-readout-hint { font-size: 0.62rem; color: var(--adp-fg-faint); }
+
+.adp-note { font-size: 0.62rem; color: #fde68a; line-height: 1.35; }
+.adp-error { font-size: 0.65rem; color: var(--adp-error); line-height: 1.35; }
+.adp-error:empty { display: none; }
+
+@media (max-width: 768px) {
+  /* Anything under 16px makes iOS Safari zoom the page on focus, which shoves
+     the fixed-position modal half off-screen. */
+  .adp-input { font-size: 16px; }
+  .adp-preset, .adp-back { min-height: 30px; }
+}
+</style>

--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -190,6 +190,7 @@
 </template>
 
 <script setup>
+import { formatRemainingShort } from '~/server/utils/auctionDuration'
 const filter   = useNewSiteCtoonFilter()
 const aFilters = useAuctionHouseFilters()
 const cmartCtoons = useState('cmartCtoons', () => [])
@@ -571,7 +572,7 @@ function openInfoModal(item) {
 // state, active auctions and pending trades before creating anything.
 function openRelist(item) {
   if (!item?.canRelist) return
-  const duration = reconstructDurationPrefill(item.createdAt, item.endAt)
+  const duration = reconstructDurationPrefill(item.createdAt, item.endAt, item.durationMinutes)
   openAuctionModal({
     ctoon: {
       id:         item.userCtoonId,
@@ -587,23 +588,31 @@ function openRelist(item) {
       initialBet:     item.initialBid,
       durationPreset: duration.preset,
       timeframe:      duration.timeframe,
+      customEndAtLocal: seedCustomEnd(duration.customMinutes),
     },
   })
+}
+
+// A re-list whose exact length isn't one of the chips reopens the calendar,
+// seeded to the same length measured from now.
+function seedCustomEnd(minutes) {
+  if (!Number.isInteger(minutes)) return ''
+  const d = new Date(Date.now() + minutes * 60000)
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+         `T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 // ── Formatters ────────────────────────────────────────────────────
 function isEnded(endAt)  { return new Date(endAt) <= now.value }
 function formatDate(d)   { return new Date(d).toLocaleDateString() }
 
+// Hours were the largest unit here, so a multi-day auction rendered as
+// "167h 59m" inside a nowrap badge sitting over the card art. formatRemainingShort
+// adds a day tier and is shared with the detail page, which had its own copy of
+// the same bug.
 function formatRemaining(endAt) {
-  const diff = new Date(endAt) - now.value
-  if (diff <= 0) return 'ended'
-  const h = Math.floor(diff / 3600000)
-  const m = Math.floor((diff % 3600000) / 60000)
-  const s = Math.floor((diff % 60000) / 1000)
-  if (h > 0)  return `${h}h ${m}m`
-  if (m > 0)  return `${m}m ${s}s`
-  return `${s}s`
+  return formatRemainingShort(new Date(endAt) - now.value)
 }
 
 function formatHighestBid(item) {

--- a/components/newsite/AuctionModal.vue
+++ b/components/newsite/AuctionModal.vue
@@ -76,21 +76,31 @@
 
           <hr class="am-divider" />
 
-          <!-- Duration presets -->
+          <!-- Duration -->
           <div class="am-field">
             <label class="am-label">Duration</label>
-            <div class="am-presets">
-              <button
-                v-for="p in PRESETS" :key="p.value"
-                class="am-preset" :class="{ active: durationPreset === p.value }"
-                @click="durationPreset = p.value"
-              >{{ p.label }}</button>
+            <AuctionDurationPicker
+              ref="durationPicker"
+              :prefill="durationPrefill"
+              @update="onDurationUpdate"
+            />
+          </div>
+
+          <!-- Long listings can't be undone: nothing in the app writes
+               AuctionStatus.CANCELLED to an Auction, so there is no withdraw
+               path once this is live. A day-plus listing is worth one tap of
+               confirmation. -->
+          <div v-if="confirming" class="am-confirm">
+            <div class="am-confirm-title">List for {{ durationLabel }}?</div>
+            <div class="am-confirm-body">
+              Ends {{ durationEndsAt }}. An auction can't be withdrawn once it starts,
+              and this cToon can't be traded until it ends.
             </div>
-            <!-- Days slider -->
-            <div v-if="durationPreset === 'days'" class="am-slider-wrap">
-              <div class="am-slider-label">{{ timeframe }} day{{ timeframe !== 1 ? 's' : '' }}</div>
-              <input class="am-slider" type="range" v-model.number="timeframe" :min="1" :max="5" step="1" />
-              <div class="am-slider-ticks"><span>1d</span><span>2d</span><span>3d</span><span>4d</span><span>5d</span></div>
+            <div class="am-confirm-actions">
+              <button class="am-cancel" @click="confirming = false">Back</button>
+              <button class="am-submit" :disabled="sending" @click="submitAuction">
+                {{ sending ? 'Sending…' : 'Confirm' }}
+              </button>
             </div>
           </div>
 
@@ -105,7 +115,7 @@
             <button class="am-cancel" @click="$emit('close')">Cancel</button>
             <button
               class="am-submit"
-              :disabled="sending || initialBet < minInitialBet"
+              :disabled="sending || !canSubmit"
               @click="sendToAuction"
             >{{ sending ? 'Sending…' : 'Send to Auction' }}</button>
           </div>
@@ -128,16 +138,6 @@ const props = defineProps({
 })
 const emit = defineEmits(['close', 'created'])
 
-const PRESETS = [
-  { value: '3m',   label: '3 min'  },
-  { value: '30m',  label: '30 min' },
-  { value: '1h',   label: '1 hr'   },
-  { value: '4h',   label: '4 hr'   },
-  { value: '6h',   label: '6 hr'   },
-  { value: '12h',  label: '12 hr'  },
-  { value: 'days', label: 'Days…'  },
-]
-
 const RARITY_MIN = {
   'common': 25, 'uncommon': 50, 'rare': 100, 'very rare': 187,
   'crazy rare': 312, 'code only': 50, 'prize only': 50, 'auction only': 50,
@@ -155,8 +155,16 @@ const initialBet = ref(
     ? Math.max(props.prefill.initialBet, instaBidValue.value)
     : Math.max(props.ctoon.price || 0, instaBidValue.value)
 )
-const durationPreset = ref(props.prefill?.durationPreset || 'days')
-const timeframe      = ref(props.prefill?.timeframe || 1)
+const durationPrefill = computed(() => ({
+  preset:            props.prefill?.durationPreset || 'days',
+  timeframe:         props.prefill?.timeframe || 1,
+  customEndAtLocal:  props.prefill?.customEndAtLocal || ''
+}))
+
+// Populated by AuctionDurationPicker's @update.
+const duration       = ref({ durationDays: 0, durationMinutes: 0, totalMinutes: null, valid: false })
+const durationPicker = ref(null)
+const confirming     = ref(false)
 const sending        = ref(false)
 const recentAuctions = ref([])
 const suggestion     = ref(null)
@@ -230,22 +238,52 @@ function showToast(message, type = 'error') {
   setTimeout(() => { toast.message = '' }, 4000)
 }
 
+function onDurationUpdate(next) { duration.value = next }
+
+const canSubmit = computed(() =>
+  initialBet.value >= minInitialBet.value && duration.value.valid
+)
+
+const durationLabel  = computed(() => durationPicker.value?.describe?.() || '')
+const durationEndsAt = computed(() => {
+  const label = durationPicker.value?.endsAtLabel?.()
+  if (label) return label
+  const total = duration.value.totalMinutes
+  if (total == null) return ''
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: 'short', month: 'short', day: 'numeric',
+      hour: 'numeric', minute: '2-digit', timeZoneName: 'short'
+    }).format(new Date(Date.now() + total * 60000))
+  } catch { return '' }
+})
+
+// Anything a day or longer gets a confirm step. There is no withdraw path for a
+// live auction, so a mis-set multi-day listing is unrecoverable for its whole
+// length — and with insta-bid it is also a guaranteed sale at the rarity floor.
+const CONFIRM_THRESHOLD_MINUTES = 1440
+
 function buildPayload(createInitialBid = false) {
-  let durationDays = 0, durationMinutes = 0
-  switch (durationPreset.value) {
-    case '3m':  durationMinutes = 3;       break
-    case '30m': durationMinutes = 30;      break
-    case '1h':  durationMinutes = 60;      break
-    case '4h':  durationMinutes = 240;     break
-    case '6h':  durationMinutes = 360;     break
-    case '12h': durationMinutes = 720;     break
-    default:    durationDays    = timeframe.value
+  return {
+    userCtoonId:     props.ctoon.id,
+    initialBet:      initialBet.value,
+    durationDays:    duration.value.durationDays,
+    durationMinutes: duration.value.durationMinutes,
+    createInitialBid
   }
-  return { userCtoonId: props.ctoon.id, initialBet: initialBet.value, durationDays, durationMinutes, createInitialBid }
 }
 
-async function sendToAuction() {
-  if (initialBet.value < minInitialBet.value) return
+function sendToAuction() {
+  if (!canSubmit.value) return
+  if ((duration.value.totalMinutes ?? 0) >= CONFIRM_THRESHOLD_MINUTES) {
+    confirming.value = true
+    return
+  }
+  submitAuction()
+}
+
+async function submitAuction() {
+  if (!canSubmit.value) return
   sending.value = true
   try {
     await $fetch('/api/auctions', { method: 'POST', body: buildPayload(false) })
@@ -254,6 +292,7 @@ async function sendToAuction() {
     setTimeout(() => emit('close'), 1200)
   } catch (e) {
     showToast(e.data?.statusMessage || e.data?.message || 'Failed to create auction.', 'error')
+    confirming.value = false
   } finally {
     sending.value = false
   }
@@ -436,7 +475,8 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
 }
 .am-input:focus { border-color: var(--OrbitLightBlue); }
 
-.am-error { font-size: 0.62rem; color: #fca5a5; }
+/* #fca5a5 on --OrbitDarkBlue is 3.10:1 and fails WCAG AA at this size. */
+.am-error { font-size: 0.62rem; color: #fee2e2; }
 
 /* ── cZone warning ── */
 .am-warning {
@@ -449,28 +489,22 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
   padding: 7px 9px;
 }
 
-/* ── Presets ── */
-.am-presets { display: flex; flex-wrap: wrap; gap: 4px; }
+/* Presets and the days slider now live in AuctionDurationPicker.vue, which
+   themes itself through --adp-* custom properties. */
 
-.am-preset {
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 5px;
-  background: rgba(0,0,0,0.2);
-  color: rgba(255,255,255,0.55);
-  font-size: 0.65rem;
-  font-weight: bold;
-  padding: 3px 9px;
-  cursor: pointer;
-  transition: all 0.12s;
+/* ── Confirm step ── */
+.am-confirm {
+  border: 1px solid rgba(234, 179, 8, 0.35);
+  background: rgba(234, 179, 8, 0.12);
+  border-radius: 6px;
+  padding: 8px 9px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
-.am-preset.active { background: var(--OrbitLightBlue); border-color: var(--OrbitLightBlue); color: #fff; }
-.am-preset:not(.active):hover { color: #fff; border-color: rgba(255,255,255,0.4); }
-
-/* ── Slider ── */
-.am-slider-wrap { display: flex; flex-direction: column; gap: 3px; padding-top: 2px; }
-.am-slider-label { font-size: 0.72rem; font-weight: bold; color: #fff; text-align: center; }
-.am-slider { width: 100%; accent-color: var(--OrbitLightBlue); }
-.am-slider-ticks { display: flex; justify-content: space-between; font-size: 0.58rem; color: rgba(255,255,255,0.4); }
+.am-confirm-title { font-size: 0.75rem; font-weight: bold; color: #fde68a; }
+.am-confirm-body  { font-size: 0.68rem; line-height: 1.4; color: #fef3c7; }
+.am-confirm-actions { display: flex; gap: 6px; justify-content: flex-end; }
 
 /* ── Footer ── */
 .am-footer {
@@ -588,6 +622,6 @@ function formatDate(d) { try { return new Date(d).toLocaleDateString() } catch {
   /* Anything under 16px makes iOS Safari zoom the page on focus, which shoves
      the fixed-position modal half off-screen. */
   .am-input { font-size: 16px; }
-  .am-preset, .am-instabid, .am-cancel, .am-submit { min-height: 30px; }
+  .am-instabid, .am-cancel, .am-submit { min-height: 30px; }
 }
 </style>

--- a/components/newsite/admin/legacy/AdminLegacyAuctions.vue
+++ b/components/newsite/admin/legacy/AdminLegacyAuctions.vue
@@ -118,7 +118,7 @@
           <div class="flex flex-col gap-1">
             <label class="text-xs font-medium">Duration</label>
             <div class="flex items-center gap-3">
-              <input v-model.number="editDurationDays" type="range" min="1" max="5" class="w-full" />
+              <input v-model.number="editDurationDays" type="range" min="1" max="7" class="w-full" />
               <span class="w-10 text-center text-xs">{{ editDurationDays }}d</span>
             </div>
           </div>

--- a/components/newsite/admin/legacy/AdminLegacyAuctionsNew.vue
+++ b/components/newsite/admin/legacy/AdminLegacyAuctionsNew.vue
@@ -87,7 +87,7 @@
         <div class="flex flex-col gap-1">
           <label class="text-xs font-medium">Duration</label>
           <div class="flex items-center gap-3">
-            <input v-model.number="durationDays" type="range" min="1" max="5" class="w-full" />
+            <input v-model.number="durationDays" type="range" min="1" max="7" class="w-full" />
             <span class="w-10 text-center text-xs">{{ durationDays }}d</span>
           </div>
         </div>

--- a/composables/useAuctionModal.js
+++ b/composables/useAuctionModal.js
@@ -1,4 +1,9 @@
-// The durations the modal offers, in minutes.
+import { MIN_AUCTION_MINUTES, MAX_AUCTION_MINUTES } from '~/server/utils/auctionDuration'
+
+// The durations the modal's preset chips offer, in minutes. The days entries
+// must track the picker's slider ceiling — while this table stopped at 5 and the
+// cap was 7, every 6- and 7-day auction that fell through to the snapping path
+// below silently came back as a 5-day re-list.
 const DURATION_CHOICES = [
   { preset: '3m',   timeframe: 1, minutes: 3 },
   { preset: '30m',  timeframe: 1, minutes: 30 },
@@ -6,22 +11,38 @@ const DURATION_CHOICES = [
   { preset: '4h',   timeframe: 1, minutes: 240 },
   { preset: '6h',   timeframe: 1, minutes: 360 },
   { preset: '12h',  timeframe: 1, minutes: 720 },
-  ...[1, 2, 3, 4, 5].map(d => ({ preset: 'days', timeframe: d, minutes: d * 1440 }))
+  ...[1, 2, 3, 4, 5, 6, 7].map(d => ({ preset: 'days', timeframe: d, minutes: d * 1440 }))
 ]
 
 const DEFAULT_DURATION = { preset: 'days', timeframe: 1 }
 
 /**
- * Work out which duration preset a finished auction was listed under.
+ * Work out what duration to prefill when re-listing a finished auction.
  *
- * Auction.duration only stores whole days, so every sub-day listing records a 0
- * and the real length has to come from endAt - createdAt. That delta can't be
- * trusted verbatim: when the server is down across an auction's end time it
- * extends endAt by the whole outage (server/socket-server.js), and that happens
- * regardless of whether anyone bid. Snapping to the nearest offered preset
- * absorbs the drift and keeps the value inside what the server will accept.
+ * Prefers the exact listed length from Auction.durationMinutes. That column
+ * exists because endAt is not a record of how long the auction was listed for:
+ * when the server is down across an auction's end time it extends endAt by the
+ * whole outage (server/socket-server.js), so endAt - createdAt overstates it.
+ *
+ * Rows created before the column existed, and those created by the admin and
+ * worker paths, read as null and fall back to snapping the delta to the nearest
+ * offered preset — lossy, but bounded and always inside what the server accepts.
+ * (Anti-snipe also moves endAt, but it can't affect this: re-listing is only
+ * offered on auctions that closed with zero bids, so anti-snipe never fired.)
+ *
+ * @param createdAt        auction start
+ * @param endAt            auction end, possibly extended
+ * @param durationMinutes  exact listed length, when the row has one
  */
-export function reconstructDurationPrefill(createdAt, endAt) {
+export function reconstructDurationPrefill(createdAt, endAt, durationMinutes = null) {
+  const exact = Number(durationMinutes)
+  if (Number.isInteger(exact) && exact >= MIN_AUCTION_MINUTES && exact <= MAX_AUCTION_MINUTES) {
+    const match = DURATION_CHOICES.find(c => c.minutes === exact)
+    if (match) return { preset: match.preset, timeframe: match.timeframe }
+    // Not one of the chips — reopen the calendar seeded to the same length.
+    return { preset: 'custom', timeframe: 1, customMinutes: exact }
+  }
+
   const start = new Date(createdAt).getTime()
   const end   = new Date(endAt).getTime()
   if (!Number.isFinite(start) || !Number.isFinite(end)) return { ...DEFAULT_DURATION }
@@ -54,8 +75,9 @@ export function useAuctionModal() {
   /**
    * @param ctoon    the cToon being listed; needs at least { id, ctoonId, name,
    *                 assetPath, rarity, mintNumber }
-   * @param prefill  optional { initialBet, durationPreset, timeframe, isRelist }
-   *                 used when re-listing something that didn't sell
+   * @param prefill  optional { initialBet, durationPreset, timeframe,
+   *                 customEndAtLocal, isRelist } used when re-listing
+   *                 something that didn't sell
    */
   function open({ ctoon: nextCtoon, prefill: nextPrefill = null } = {}) {
     if (!nextCtoon) return

--- a/pages/admin/add-auction.vue
+++ b/pages/admin/add-auction.vue
@@ -88,7 +88,7 @@
         <div>
           <label class="block font-medium mb-1">Duration</label>
           <div class="flex items-center gap-3">
-            <input v-model.number="durationDays" type="range" min="1" max="5" class="w-full" />
+            <input v-model.number="durationDays" type="range" min="1" max="7" class="w-full" />
             <span class="w-10 text-center">{{ durationDays }}d</span>
           </div>
         </div>

--- a/pages/admin/auctions.vue
+++ b/pages/admin/auctions.vue
@@ -130,7 +130,7 @@
             <td class="px-4 py-2">{{ auc.creator?.username || '—' }}</td>
             <td class="px-4 py-2">{{ auc.status }}</td>
             <td class="px-4 py-2">{{ formatDate(auc.createdAt) }}</td>
-            <td class="px-4 py-2">{{ auc.duration }} days</td>
+            <td class="px-4 py-2">{{ auctionLength(auc) }}</td>
             <td class="px-4 py-2">{{ hoursLeft(auc.endAt) }}</td>
             <td class="px-4 py-2">{{ auc.highestBidder?.username || '—' }}</td>
             <td class="px-4 py-2">{{ auc.winner?.username || '—' }}</td>
@@ -155,7 +155,7 @@
           <div><span class="font-medium">Creator:</span> {{ auc.creator?.username || '—' }}</div>
           <div><span class="font-medium">Status:</span> {{ auc.status }}</div>
           <div><span class="font-medium">Created:</span> {{ formatDate(auc.createdAt) }}</div>
-          <div><span class="font-medium">Duration:</span> {{ auc.duration }} days</div>
+          <div><span class="font-medium">Duration:</span> {{ auctionLength(auc) }}</div>
           <div><span class="font-medium">Top Bidder:</span> {{ auc.highestBidder?.username || '—' }}</div>
           <div><span class="font-medium">Winner:</span> {{ auc.winner?.username || '—' }}</div>
           <div><span class="font-medium">Highest Bid:</span> {{ auc.highestBid }}</div>
@@ -180,6 +180,16 @@
 </template>
 
 <script setup>
+import { formatAuctionDuration } from '~/server/utils/auctionDuration'
+
+// Auction.duration is whole days, so every sub-day listing stores 0 and this
+// column read "0 days" for a 3-minute or 12-hour auction. durationMinutes
+// carries the real length where the row has it.
+function auctionLength(auc) {
+  const mins = auc?.durationMinutes
+  if (Number.isInteger(mins)) return formatAuctionDuration(mins)
+  return `${auc?.duration ?? 0} days`
+}
 import { ref, computed, watch, onMounted, nextTick } from 'vue'
 import Nav from '@/components/Nav.vue'
 

--- a/pages/admin/manage-auctions.vue
+++ b/pages/admin/manage-auctions.vue
@@ -118,7 +118,7 @@
           <div>
             <label class="block font-medium mb-1">Duration</label>
             <div class="flex items-center gap-3">
-              <input v-model.number="editDurationDays" type="range" min="1" max="5" class="w-full" />
+              <input v-model.number="editDurationDays" type="range" min="1" max="7" class="w-full" />
               <span class="w-10 text-center">{{ editDurationDays }}d</span>
             </div>
           </div>

--- a/prisma/migrations/20260819000000_add_auction_duration_minutes/migration.sql
+++ b/prisma/migrations/20260819000000_add_auction_duration_minutes/migration.sql
@@ -1,0 +1,28 @@
+-- Custom auction durations: exact listed length, and an index for the listing sort.
+--
+-- Written idempotently to match the house style of the surrounding migrations.
+
+-- ── Lock safety ──────────────────────────────────────────────────────────────
+-- Both statements below take ACCESS EXCLUSIVE on "Auction". The ADD COLUMN is
+-- catalog-only on PG11+ (nullable, no default = no table rewrite), so it is
+-- instant *once it has the lock* -- but /api/auctions still fetches every ACTIVE
+-- auction unpaginated, and a slow instance of that query makes the ALTER wait
+-- while every subsequent query on the table queues behind it. Failing fast and
+-- retrying beats stalling the auction house.
+SET lock_timeout = '3s';
+
+-- Exact listed length in minutes.
+--
+-- endAt - createdAt is not a substitute: server/socket-server.js extends endAt
+-- by the full downtime after an outage, so the delta overstates the listed
+-- length for any auction caught in that window. Nullable, so existing rows and
+-- the admin/worker creation paths simply read as "unknown" and fall back.
+ALTER TABLE "Auction" ADD COLUMN IF NOT EXISTS "durationMinutes" INTEGER;
+
+-- The Auction House's default tab filters on status and orders by endAt, and
+-- the ending-soon Discord notifier runs the same shape once a minute. Neither
+-- had an index that covered the ordering. This matters more as durations get
+-- longer, because the active set scales with mean duration.
+CREATE INDEX IF NOT EXISTS "Auction_status_endAt_idx" ON "Auction" ("status", "endAt");
+
+RESET lock_timeout;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1562,7 +1562,12 @@ model Auction {
   id                 String        @id @default(uuid())
   userCtoonId        String
   initialBet         Int
-  duration           Int // days
+  duration           Int // days; 0 for any sub-day listing. Kept for back-compat — read durationMinutes instead.
+  // Exact listed length in minutes. Nullable because rows predating the column,
+  // and the admin/worker creation paths, don't set it. Needed because endAt is
+  // not a reliable record of the listed length: server/socket-server.js extends
+  // it by the full outage after downtime, so endAt - createdAt drifts.
+  durationMinutes    Int?
   endAt              DateTime
   status             AuctionStatus @default(ACTIVE)
   createdAt          DateTime      @default(now())
@@ -1594,6 +1599,10 @@ model Auction {
   // migration 20260803000000_unique_active_auction_per_user_ctoon and shows up
   // as drift in `prisma migrate dev`. Do not drop it.
   @@index([userCtoonId, status])
+  // The Auction House's default view filters status='ACTIVE' and orders by
+  // endAt, and socket-server's ending-soon notifier re-runs that same shape
+  // every 60 seconds. Without this the sort had no index to lean on.
+  @@index([status, endAt])
   @@index([status, winnerId, highestBid])
   @@index([isFeatured, status, highestBidderId])
   // /api/my-auctions filters on creatorId and orders by endAt desc. Postgres

--- a/server/api/admin/auction-only/[id].put.js
+++ b/server/api/admin/auction-only/[id].put.js
@@ -34,8 +34,8 @@ async function handleAuctionOnlyUpdate(event) {
   if (!Number.isInteger(pricePoints) || pricePoints < 0) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid pricePoints' })
   }
-  if (!Number.isInteger(durationDays) || durationDays < 1 || durationDays > 5) {
-    throw createError({ statusCode: 400, statusMessage: 'durationDays must be 1–5' })
+  if (!Number.isInteger(durationDays) || durationDays < 1 || durationDays > 7) {
+    throw createError({ statusCode: 400, statusMessage: 'durationDays must be 1–7' })
   }
   if (!startsAtUtc) throw createError({ statusCode: 400, statusMessage: 'startsAtUtc required' })
   const startsAt = new Date(startsAtUtc)

--- a/server/api/admin/auction-only/index.post.js
+++ b/server/api/admin/auction-only/index.post.js
@@ -46,7 +46,7 @@ async function handleAuctionOnlyCreate(event) {
 
   const isFeaturedFlag = !!isFeatured
   if (!Number.isInteger(pricePoints) || pricePoints < 0) throw createError({ statusCode: 400, statusMessage: 'Invalid pricePoints' })
-  if (!Number.isInteger(durationDays) || durationDays < 1 || durationDays > 5) throw createError({ statusCode: 400, statusMessage: 'durationDays must be 1–5' })
+  if (!Number.isInteger(durationDays) || durationDays < 1 || durationDays > 7) throw createError({ statusCode: 400, statusMessage: 'durationDays must be 1–7' })
   const count = Number(createCount ?? 1)
   if (!Number.isInteger(count) || count < 1) throw createError({ statusCode: 400, statusMessage: 'createCount must be >= 1' })
   const releaseHours = Number(releaseEveryHours ?? 0)

--- a/server/api/admin/auctions.get.js
+++ b/server/api/admin/auctions.get.js
@@ -103,6 +103,7 @@ export default defineEventHandler(async (event) => {
         createdAt: true,
         endAt: true,
         duration: true,
+        durationMinutes: true,
         highestBid: true,
         userCtoon: {
           select: { ctoon: { select: { id: true, name: true, assetPath: true } } }
@@ -125,6 +126,7 @@ export default defineEventHandler(async (event) => {
       createdAt: a.createdAt,
       endAt: a.endAt,
       duration: a.duration,
+      durationMinutes: a.durationMinutes ?? null,
       highestBid: a.highestBid,
       userCtoon: { ctoon: a.userCtoon?.ctoon ?? null },
       creator: a.creator ?? null,

--- a/server/api/admin/remove-cheating.post.js
+++ b/server/api/admin/remove-cheating.post.js
@@ -17,7 +17,7 @@ function rarityPrice(r) {
 
 async function createAuction(tx, userCtoonId, initialBet, endAt, creatorId) {
   return tx.auction.create({
-    data: { userCtoonId, initialBet, duration: 3, endAt, creatorId },
+    data: { userCtoonId, initialBet, duration: 3, durationMinutes: 3 * 1440, endAt, creatorId },
     select: { id: true }
   })
 }

--- a/server/api/auction/[id].get.js
+++ b/server/api/auction/[id].get.js
@@ -99,6 +99,9 @@ export default defineEventHandler(async (event) => {
     endAt:      auction.endAt.toISOString(),
     initialBet: auction.initialBet,
     duration:   auction.duration,
+    // Exact listed length; `duration` is whole days and reads 0 for anything
+    // shorter. Null on rows created before the column existed.
+    durationMinutes: auction.durationMinutes ?? null,
     status:     auction.status,
     bidCount:   bids.length,
     canRelist,

--- a/server/api/auctions.post.js
+++ b/server/api/auctions.post.js
@@ -10,21 +10,12 @@ import fetch from 'node-fetch'
 import { scheduleAuctionClose } from '@/server/utils/queues'
 import { resolveUserCtoonId } from '@/server/utils/userCtoonId'
 import { rarityFloor } from '@/server/utils/auctionPriceSuggestion'
-
-// Longest listing the UI offers: 5 days, or 12 hours for the sub-day presets.
-const MAX_DURATION_DAYS = 5
-const MAX_DURATION_MINUTES = 12 * 60
-
-function formatDuration(days, minutes) {
-  if (minutes > 0) {
-    if (minutes % 60 === 0) {
-      const hours = minutes / 60
-      return `${hours} hour${hours === 1 ? '' : 's'}`
-    }
-    return `${minutes} minute(s)`
-  }
-  return `${days} day(s)`
-}
+import {
+  resolveAuctionDuration,
+  formatAuctionDuration,
+  MAX_INITIAL_BET,
+  MAX_CLOSE_DELAY_MS
+} from '@/server/utils/auctionDuration'
 
 export default defineEventHandler(async (event) => {
   // 1. Authenticate
@@ -41,16 +32,25 @@ export default defineEventHandler(async (event) => {
   }
 
   // 2. Parse & validate
+  //
+  // `|| {}` because h3 returns undefined for an empty body, and a bare
+  // destructure of that throws a TypeError — a 500 where the caller deserves a
+  // 422. A non-JSON content-type can also make readBody return a raw string,
+  // which the object check below catches.
+  const body = (await readBody(event)) || {}
+  if (typeof body !== 'object' || Array.isArray(body)) {
+    throw createError({ statusCode: 422, statusMessage: 'Malformed request body' })
+  }
+
   const {
     userCtoonId,
     initialBet,
     durationDays = 0,
     durationMinutes = 0,
     createInitialBid = false
-  } = await readBody(event)
+  } = body
 
-  if (!userCtoonId || initialBet == null ||
-      durationDays === undefined || durationMinutes === undefined) {
+  if (!userCtoonId || initialBet == null) {
     throw createError({ statusCode: 422, statusMessage: 'Missing required fields' })
   }
 
@@ -58,17 +58,31 @@ export default defineEventHandler(async (event) => {
   // a huge one locks the cToon out of trading for years while overflowing the
   // BullMQ delay. Re-listing sends a duration the client reconstructed from the
   // previous auction, so this can't be left to the UI.
-  const days = Number(durationDays)
-  const minutes = Number(durationMinutes)
-  if (!Number.isInteger(days) || !Number.isInteger(minutes) ||
-      days < 0 || days > MAX_DURATION_DAYS ||
-      minutes < 0 || minutes > MAX_DURATION_MINUTES ||
-      (days === 0 && minutes === 0)) {
-    throw createError({ statusCode: 422, statusMessage: 'Invalid auction duration' })
+  //
+  // resolveAuctionDuration reduces the pair to a single `totalMinutes`, and
+  // that number is the only thing used below — endAt, both stored columns and
+  // the Discord label all derive from it. Keeping days and minutes alive past
+  // this point would mean two arithmetic paths that have to agree forever.
+  const durationResult = resolveAuctionDuration({ durationDays, durationMinutes })
+  if (!durationResult.ok) {
+    throw createError({ statusCode: 422, statusMessage: durationResult.reason })
   }
+  const totalMinutes = durationResult.totalMinutes
 
-  if (!Number.isInteger(Number(initialBet)) || Number(initialBet) <= 0) {
+  // Coerce the bet exactly once, here. Every later use — the floor check, the
+  // DB write, the Discord embed — reads `bet`, never the raw body value. The
+  // embed used to interpolate the raw value, so an initialBet of ["500\n\n\n"]
+  // passed validation as 500, stored as 500, and injected blank lines into the
+  // announcement around the Duration line.
+  const bet = typeof initialBet === 'number'
+    ? initialBet
+    : (typeof initialBet === 'string' && /^\d{1,10}$/.test(initialBet) ? Number(initialBet) : NaN)
+  if (!Number.isSafeInteger(bet) || bet <= 0) {
     throw createError({ statusCode: 422, statusMessage: 'Initial bet must be a positive whole number' })
+  }
+  // Auction.initialBet is an int4; without a ceiling this fails at the DB as a 500.
+  if (bet > MAX_INITIAL_BET) {
+    throw createError({ statusCode: 422, statusMessage: 'Initial bet is too large' })
   }
 
   const resolvedUserCtoonId = await resolveUserCtoonId(userCtoonId)
@@ -98,7 +112,7 @@ export default defineEventHandler(async (event) => {
   const expectedInitialBet = rarityFloor(userCtoonRec.ctoon?.rarity)
 
   // Enforce minimum initial bet
-  if (Number(initialBet) < expectedInitialBet) {
+  if (bet < expectedInitialBet) {
     throw createError({
       statusCode: 422,
       statusMessage: `Initial bet must be at least ${expectedInitialBet} pts for rarity "${userCtoonRec.ctoon?.rarity ?? 'N/A'}"`
@@ -126,10 +140,15 @@ export default defineEventHandler(async (event) => {
   }
 
   // 5. Compute endAt
-  const nowMs    = Date.now()
-  const daysMs   = days * 24 * 60 * 60 * 1000
-  const minsMs   = minutes * 60 * 1000
-  const endAtUtc = new Date(nowMs + daysMs + minsMs).toISOString()
+  // One arithmetic path, derived solely from the validated totalMinutes.
+  const closeDelayMs = totalMinutes * 60000
+  if (closeDelayMs > MAX_CLOSE_DELAY_MS) {
+    // Unreachable while MAX_AUCTION_MINUTES is 7 days; here so that raising it
+    // past BullMQ's ~24.8-day setTimeout ceiling fails loudly instead of
+    // producing auctions that close the instant they are created.
+    throw createError({ statusCode: 422, statusMessage: 'Invalid auction duration' })
+  }
+  const endAtUtc = new Date(Date.now() + closeDelayMs).toISOString()
 
   // 6. Create auction
   //
@@ -140,16 +159,34 @@ export default defineEventHandler(async (event) => {
   // winner closed last — nothing stopped them. The partial unique index
   // "Auction_active_userCtoonId_key" (WHERE status = 'ACTIVE') is the real
   // guard; P2002 here is the loser of that race.
+  //
+  // Creating the auction and clearing isTradeable are one transaction: a crash
+  // between them used to leave an ACTIVE auction on a cToon the collection UI
+  // still offered as tradeable, for the whole life of the listing. Trades never
+  // actually double-spent it — server/utils/tradeOffer.js queries the Auction
+  // table directly rather than trusting the flag — but the UI lied, and a
+  // 7-day listing lies for a week.
   let auction
   try {
-    auction = await prisma.auction.create({
-      data: {
-        userCtoonId: resolvedUserCtoonId,
-        initialBet: Number(initialBet),
-        duration: days,
-        endAt: endAtUtc,
-        ...(userId ? { creatorId: userId } : {})
-      }
+    auction = await prisma.$transaction(async (tx) => {
+      const created = await tx.auction.create({
+        data: {
+          userCtoonId: resolvedUserCtoonId,
+          initialBet: bet,
+          // `duration` stays whole days for back-compat; durationMinutes carries
+          // the exact listed length, which is what admin reporting and the
+          // re-list prefill read.
+          duration: Math.floor(totalMinutes / 1440),
+          durationMinutes: totalMinutes,
+          endAt: endAtUtc,
+          ...(userId ? { creatorId: userId } : {})
+        }
+      })
+      await tx.userCtoon.update({
+        where: { id: resolvedUserCtoonId },
+        data: { isTradeable: false }
+      })
+      return created
     })
   } catch (err) {
     if (err?.code === 'P2002') {
@@ -160,7 +197,7 @@ export default defineEventHandler(async (event) => {
 
   // 7. Optionally create initial bid — only if amount matches rarity mapping
   if (createInitialBid) {
-    if (Number(initialBet) === expectedInitialBet) {
+    if (bet === expectedInitialBet) {
       const initialBidder = await prisma.user.findUnique({
         where: { username: 'CartoonReOrbitOfficial' }
       })
@@ -185,12 +222,6 @@ export default defineEventHandler(async (event) => {
 
   // 7.5 Schedule the BullMQ job that will close this auction at endAt
   await scheduleAuctionClose(auction.id, auction.endAt)
-
-  // 8. Disable tradeability
-  await prisma.userCtoon.update({
-    where: { id: resolvedUserCtoonId },
-    data: { isTradeable: false }
-  })
 
   // 8.5 Holiday flag for Discord message
   const isHolidayItem = !!(await prisma.holidayEventItem.findFirst({
@@ -253,7 +284,7 @@ export default defineEventHandler(async (event) => {
 
       const { name, rarity, assetPath, isSecondEdition } = userCtoonRec.ctoon || {}
       const mintNumber   = userCtoonRec.mintNumber
-      const durationText = formatDuration(days, minutes)
+      const durationText = formatAuctionDuration(totalMinutes)
 
       const auctionLink = `${baseUrl}/auction/${auction.id}`
       const rawImageUrl = assetPath
@@ -265,7 +296,7 @@ export default defineEventHandler(async (event) => {
         `**Rarity:** ${rarity ?? 'N/A'}`,
         ...(!isHolidayItem ? [`**Mint #:** ${mintNumber ?? 'N/A'}`] : []),
         ...(isSecondEdition ? [`**Second Edition**`] : []),
-        `**Starting Bid:** ${initialBet} pts`,
+        `**Starting Bid:** ${bet} pts`,
         `**Duration:** ${durationText}`
       ]
 

--- a/server/api/my-auctions.get.js
+++ b/server/api/my-auctions.get.js
@@ -215,6 +215,9 @@ export default defineEventHandler(async (event) => {
     secondEditionOverlaySize: a.userCtoon?.ctoon?.secondEditionOverlaySize ?? null,
     createdAt:        a.createdAt.toISOString(),
     endAt:            a.endAt.toISOString(),      // <— new
+    // Exact listed length, so re-listing can prefill it rather than snapping
+    // endAt - createdAt to the nearest preset. Null on pre-migration rows.
+    durationMinutes:  a.durationMinutes ?? null,
     initialBid:       a.initialBet,
     highestBid:       a.bids[0]?.amount ?? null,
     winningBid:       a.bids[0]?.amount ?? null,

--- a/server/cron/sync-guild-members.js
+++ b/server/cron/sync-guild-members.js
@@ -14,6 +14,7 @@ import { runEconomyAggregate } from './economy-aggregate.js'
 import { runCzoneDisplayCountAggregate } from './czone-display-count.js'
 import { getFeaturedDissolveConfig, isCtoonFeatured } from '../utils/featuredDissolveConfig.js'
 import { applyDissolveSchedule, getDissolveScheduleConfig } from '../utils/dissolveSchedule.js'
+import { formatAuctionDuration } from '../utils/auctionDuration.js'
 import { logAuctionOnlyError } from '../utils/auctionOnlyErrorLog.js'
 import { activateAuctionOnlyRow, AUCTION_ONLY_ROW_INCLUDE } from '../utils/auctionOnlyActivate.js'
 import { rarityFloor } from '../utils/auctionPriceSuggestion.js'
@@ -148,7 +149,7 @@ async function sendAuctionDiscordAnnouncement(result, isHolidayItem = false) {
       `**Rarity:** ${rarity ?? 'N/A'}`,
       ...(!isHolidayItem ? [`**Mint #:** ${result.mintNumber ?? 'N/A'}`] : []),
       `**Starting Bid:** ${result.initialBet} pts`,
-      `**Duration:** ${result.durationDays} day(s)`
+      `**Duration:** ${formatAuctionDuration(result.totalMinutes ?? result.durationDays * 1440)}`
     ]
 
     const payload = {
@@ -1104,6 +1105,7 @@ async function createDailyFeaturedAuction() {
           userCtoonId: chosen.id,
           initialBet,
           duration: durationDays,
+          durationMinutes: durationDays * 1440,
           endAt,
           creatorId: officialUser.id,
           isFeatured: true

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -3397,6 +3397,49 @@ setInterval(async () => {
 }, 60 * 1000).unref()
 
 
+// ── Overdue-auction reconciliation ──────────────────────────────────────────
+// The BullMQ delayed job is otherwise the ONLY thing that ever closes an
+// auction: performAuctionClose has exactly one caller, the worker below. If
+// Redis loses bull:auctionClose:delayed — a restart without AOF, an eviction, a
+// fresh container — the job is gone and nothing notices. The auction stays
+// ACTIVE forever, its cToon stays isTradeable:false, and every bidder's
+// LockedPoints row stays ACTIVE, stranding their points until an admin releases
+// them by hand.
+//
+// The boot backfill below covers a Redis flush that happens while this process
+// is down. It cannot cover one that happens while it is up, and a 7-day auction
+// can now outlive the deploy cadence that was making that backfill the de facto
+// sweep. Re-asserting the job is idempotent (jobId = auctionId, and
+// scheduleAuctionClose declines to touch a job that is currently active), so
+// this is safe to run on a timer: an overdue auction resolves to delay 0 and
+// the worker picks it up on the next poll.
+let overdueSweepInFlight = false
+setInterval(async () => {
+  if (overdueSweepInFlight) return
+  overdueSweepInFlight = true
+  try {
+    const overdue = await db.auction.findMany({
+      where: { status: 'ACTIVE', endAt: { lte: new Date() } },
+      select: { id: true, endAt: true }
+    })
+    if (overdue.length) {
+      console.warn(`[AuctionSweep] ${overdue.length} ACTIVE auction(s) past endAt — re-scheduling close jobs.`)
+      for (const a of overdue) {
+        try {
+          await scheduleAuctionClose(a.id, a.endAt)
+        } catch (err) {
+          console.error(`[AuctionSweep] Failed to reschedule ${a.id}:`, err)
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[AuctionSweep] Overdue auction sweep failed:', err)
+  } finally {
+    overdueSweepInFlight = false
+  }
+}, 5 * 60 * 1000).unref()
+
+
 // Minimum gap (ms) between last heartbeat and now before we consider it a
 // real downtime event.  One missed 60-second tick is noise; anything longer
 // means the server was actually down.

--- a/server/utils/auctionDuration.js
+++ b/server/utils/auctionDuration.js
@@ -1,0 +1,193 @@
+// server/utils/auctionDuration.js
+// Everything that decides how long an auction may run, in a module with no
+// imports at all.
+//
+// Lives here rather than in the root utils/ directory for three reasons:
+//  1. server/utils/tradeOfferLimits.js already established this pattern — a
+//     dependency-free constants module the client imports as
+//     '~/server/utils/…' (see components/newsite/Trade.vue) so there is one
+//     definition instead of a server constant and a hand-copied client literal.
+//  2. No server file in this repo imports from the root utils/ directory, and
+//     server/socket-server.js and server/workers/* are plain Node processes
+//     where the '@/' alias does not resolve at all (see the note at the top of
+//     socket-server.js). Those processes reach this file with a relative path.
+//  3. The root utils/ directory is auto-imported into the client global scope,
+//     so every export there has to fight for a globally unique name.
+//
+// No imports, so bare `node --test` can load it — same constraint documented in
+// server/utils/userCtoonToken.js.
+
+/// Shortest auction anyone may list. Matches the "3 min" quick preset.
+export const MIN_AUCTION_MINUTES = 3
+
+/// Longest auction anyone may list: 7 days.
+///
+/// This is a bound on ELAPSED time, not on calendar days, and the distinction
+/// is load-bearing. In a fall-back week "same wall clock, seven days later" is
+/// 169 hours, which is 10140 minutes — past this cap. The picker therefore
+/// derives its latest selectable instant from `now + MAX_AUCTION_MINUTES`
+/// rather than from "today's date + 7", so it can never offer a date that this
+/// constant then rejects.
+export const MAX_AUCTION_MINUTES = 7 * 24 * 60 // 10080
+
+/// Hard ceiling on the initial bid.
+///
+/// Auction.initialBet is a Postgres int4. Without this, a bet of 3e9 passes a
+/// positive-integer check and then fails at the DB, surfacing as a 500 instead
+/// of a 422.
+export const MAX_INITIAL_BET = 1_000_000_000
+
+/// Absolute ceiling on the BullMQ close delay, as defence in depth.
+///
+/// BullMQ arms its delayed-set timer with setTimeout, whose ceiling is
+/// 2,147,483,647 ms (~24.8 days); past that a job fires immediately. Seven days
+/// is nowhere near it, but after this change MAX_AUCTION_MINUTES is the only
+/// thing standing between a future config bump and an auction that closes the
+/// instant it is created.
+export const MAX_CLOSE_DELAY_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * Coerce one duration part from a request body.
+ *
+ * Deliberately stricter than Number(): `Number.isInteger(Number(x))` accepts
+ * "0x1f4", "5e2", "+7", " 7 ", "7.", [7], true and null, and is true for 1e21
+ * because isInteger does not imply isSafeInteger. Every one of those reaching
+ * the arithmetic below is a coercion bug waiting to be found by someone else.
+ *
+ * Returns null for anything not a plain non-negative integer.
+ *
+ * @param {unknown} value
+ * @returns {number|null}
+ */
+export function coerceDurationPart(value) {
+  if (value === null || value === undefined) return 0
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null
+  }
+  // Digits only: no sign, no whitespace, no exponent, no hex, no decimal point.
+  if (typeof value === 'string' && /^\d{1,7}$/.test(value)) {
+    const n = Number(value)
+    return Number.isSafeInteger(n) ? n : null
+  }
+  return null
+}
+
+/**
+ * Validate a {durationDays, durationMinutes} pair and reduce it to one number.
+ *
+ * The single returned `totalMinutes` is what the caller must use for every
+ * subsequent decision — endAt, the stored columns, the Discord label. Keeping
+ * days and minutes alive past this point means two arithmetic paths that have
+ * to agree forever.
+ *
+ * Each part is bounded independently as well as in sum, so that the client's
+ * choice of split is never load-bearing: {days:0, minutes:10080} and
+ * {days:7, minutes:0} describe the same auction and both must be accepted.
+ *
+ * @param {{ durationDays?: unknown, durationMinutes?: unknown }} input
+ * @returns {{ ok: true, totalMinutes: number } | { ok: false, reason: string }}
+ */
+export function resolveAuctionDuration({ durationDays, durationMinutes } = {}) {
+  const days = coerceDurationPart(durationDays)
+  const minutes = coerceDurationPart(durationMinutes)
+
+  if (days === null || minutes === null) {
+    return { ok: false, reason: 'Auction duration must be whole non-negative numbers' }
+  }
+  if (days > 7 || minutes > MAX_AUCTION_MINUTES) {
+    return { ok: false, reason: 'Auction duration is too long' }
+  }
+
+  const totalMinutes = days * 1440 + minutes
+  if (!Number.isSafeInteger(totalMinutes)) {
+    return { ok: false, reason: 'Invalid auction duration' }
+  }
+  if (totalMinutes < MIN_AUCTION_MINUTES) {
+    return { ok: false, reason: `Auctions must run for at least ${MIN_AUCTION_MINUTES} minutes` }
+  }
+  if (totalMinutes > MAX_AUCTION_MINUTES) {
+    return { ok: false, reason: 'Auctions may run for at most 7 days' }
+  }
+  return { ok: true, totalMinutes }
+}
+
+/**
+ * Clamp a raw millisecond span to a whole number of minutes the server accepts.
+ *
+ * The clamp is the point, not the rounding. No single rounding mode is safe at
+ * both ends: a target 2.25 minutes out floors to 2 (below the minimum, because
+ * "12:03" read at 12:00:45 is only 2.25 minutes away), and one landing at
+ * 10080.6 rounds to 10081 (above the maximum, reachable when a client clock
+ * steps backward between picking and submitting). Clamped rounding cannot
+ * produce an out-of-range value at either end, which is what makes the 422
+ * unreachable from the picker.
+ *
+ * @param {number} ms
+ * @returns {number} whole minutes within [MIN_AUCTION_MINUTES, MAX_AUCTION_MINUTES]
+ */
+export function clampMsToAuctionMinutes(ms) {
+  if (!Number.isFinite(ms)) return MIN_AUCTION_MINUTES
+  const minutes = Math.round(ms / 60000)
+  if (!Number.isFinite(minutes)) return MIN_AUCTION_MINUTES
+  return Math.min(MAX_AUCTION_MINUTES, Math.max(MIN_AUCTION_MINUTES, minutes))
+}
+
+/**
+ * Whether a raw millisecond span is inside the listable window, before any
+ * rounding. The picker checks this so it can disable Submit with an
+ * explanation rather than letting the server answer with a bare 422.
+ *
+ * @param {number} ms
+ */
+export function isListableMs(ms) {
+  return Number.isFinite(ms) &&
+    ms >= MIN_AUCTION_MINUTES * 60000 &&
+    ms <= MAX_AUCTION_MINUTES * 60000
+}
+
+/**
+ * Human-readable length, e.g. "2 days, 5 hours" / "45 minutes".
+ *
+ * Replaces the old formatDuration(days, minutes) in server/api/auctions.post.js,
+ * which returned early on `minutes > 0` and so dropped the days entirely. That
+ * was dormant while the UI only ever sent one or the other; a custom "6d 3h"
+ * listing would have announced "Duration: 3 hour(s)" to Discord.
+ *
+ * @param {number} totalMinutes
+ * @returns {string}
+ */
+export function formatAuctionDuration(totalMinutes) {
+  const total = Math.max(0, Math.trunc(Number(totalMinutes) || 0))
+  const days = Math.floor(total / 1440)
+  const hours = Math.floor((total % 1440) / 60)
+  const mins = total % 60
+
+  const parts = []
+  if (days) parts.push(`${days} day${days === 1 ? '' : 's'}`)
+  if (hours) parts.push(`${hours} hour${hours === 1 ? '' : 's'}`)
+  if (mins) parts.push(`${mins} minute${mins === 1 ? '' : 's'}`)
+  return parts.length ? parts.join(', ') : '0 minutes'
+}
+
+/**
+ * Compact countdown, e.g. "6d 23h" / "4h 12m" / "45s".
+ *
+ * Shared by the Auction House card badges and the auction detail page, which
+ * each carried their own copy that topped out at hours — a 7-day auction
+ * rendered as "167h 59m" in a nowrap badge sitting over the card art.
+ *
+ * @param {number} ms remaining
+ * @returns {string}
+ */
+export function formatRemainingShort(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return 'ended'
+  const totalSec = Math.floor(ms / 1000)
+  const d = Math.floor(totalSec / 86400)
+  const h = Math.floor((totalSec % 86400) / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  if (d > 0) return `${d}d ${h}h`
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${s}s`
+  return `${s}s`
+}

--- a/server/utils/auctionOnlyActivate.js
+++ b/server/utils/auctionOnlyActivate.js
@@ -9,6 +9,11 @@ import { prisma } from '../prisma.js'
 import { scheduleAuctionClose } from './queues.js'
 import { rarityFloor } from './auctionPriceSuggestion.js'
 import { logAuctionOnlyError } from './auctionOnlyErrorLog.js'
+import {
+  MIN_AUCTION_MINUTES,
+  MAX_AUCTION_MINUTES,
+  formatAuctionDuration
+} from './auctionDuration.js'
 
 const DISCORD_API = 'https://discord.com/api/v10'
 const OFFICIAL_USERNAME = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
@@ -57,7 +62,7 @@ export async function sendAuctionOnlyDiscordAnnouncement(result, isHolidayItem =
       `**Rarity:** ${rarity ?? 'N/A'}`,
       ...(!isHolidayItem ? [`**Mint #:** ${result.mintNumber ?? 'N/A'}`] : []),
       `**Starting Bid:** ${result.initialBet} pts`,
-      `**Duration:** ${result.durationDays} day(s)`
+      `**Duration:** ${formatAuctionDuration(result.totalMinutes ?? result.durationDays * 1440)}`
     ]
 
     const payload = {
@@ -143,14 +148,23 @@ export async function activateAuctionOnlyRow(row) {
     const floor = rarityFloor(row.userCtoon?.ctoon?.rarity)
     const initialBet = Math.max(Number(fresh.pricePoints || 0), floor)
 
+    // Derive the length from the scheduled window. The cap must track the admin
+    // bound in server/api/admin/auction-only/index.post.js — when it said 5 and
+    // the admin bound said 7, a 7-day listing ran for the full 7 days but
+    // recorded duration: 5 and announced "Duration: 5 day(s)" on Discord.
     const ms = new Date(fresh.endsAt).getTime() - new Date(fresh.startsAt).getTime()
-    const durationDays = Math.max(1, Math.min(5, Math.round(ms / 86400000) || 1))
+    const totalMinutes = Math.max(
+      MIN_AUCTION_MINUTES,
+      Math.min(MAX_AUCTION_MINUTES, Math.round(ms / 60000) || MIN_AUCTION_MINUTES)
+    )
+    const durationDays = Math.floor(totalMinutes / 1440)
 
     const created = await tx.auction.create({
       data: {
         userCtoonId: fresh.userCtoonId,
         initialBet,
         duration: durationDays,
+        durationMinutes: totalMinutes,
         endAt: new Date(fresh.endsAt),
         creatorId: userCtoon.userId,
         isFeatured: fresh.isFeatured,
@@ -174,6 +188,7 @@ export async function activateAuctionOnlyRow(row) {
       endAt: new Date(fresh.endsAt),
       initialBet,
       durationDays,
+      totalMinutes,
       ctoon: row.userCtoon.ctoon,
       mintNumber: userCtoon.mintNumber,
       ctoonId: row.userCtoon.ctoon.id,

--- a/server/workers/dissolve-auction-launch.worker.js
+++ b/server/workers/dissolve-auction-launch.worker.js
@@ -68,6 +68,7 @@ const worker = new Worker(QUEUE_NAME, async (job) => {
           userCtoonId: entry.userCtoonId,
           initialBet:  rarityFloor(entry.userCtoon?.ctoon?.rarity),
           duration:    1,
+          durationMinutes: 1440,
           endAt,
           creatorId:   officialUser.id,
           isFeatured:  entry.isFeatured,

--- a/tests/auctionDuration.test.js
+++ b/tests/auctionDuration.test.js
@@ -1,0 +1,173 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  MIN_AUCTION_MINUTES,
+  MAX_AUCTION_MINUTES,
+  coerceDurationPart,
+  resolveAuctionDuration,
+  clampMsToAuctionMinutes,
+  isListableMs,
+  formatAuctionDuration,
+  formatRemainingShort
+} from '../server/utils/auctionDuration.js'
+
+const ok = (input) => {
+  const r = resolveAuctionDuration(input)
+  assert.equal(r.ok, true, `expected ${JSON.stringify(input)} to be accepted, got: ${r.reason}`)
+  return r.totalMinutes
+}
+const rejected = (input) => {
+  const r = resolveAuctionDuration(input)
+  assert.equal(r.ok, false, `expected ${JSON.stringify(input)} to be rejected`)
+}
+
+// ── Bounds ────────────────────────────────────────────────────────────────
+test('the 3-minute floor and the 7-day ceiling are both inclusive', () => {
+  assert.equal(ok({ durationMinutes: 3 }), 3)
+  assert.equal(ok({ durationMinutes: MAX_AUCTION_MINUTES }), 10080)
+  assert.equal(ok({ durationDays: 7 }), 10080)
+})
+
+test('anything shorter than 3 minutes or longer than 7 days is refused', () => {
+  rejected({ durationMinutes: 2 })
+  rejected({ durationMinutes: 0 })
+  rejected({ durationDays: 0, durationMinutes: 0 })
+  rejected({ durationMinutes: MAX_AUCTION_MINUTES + 1 })
+  rejected({ durationDays: 8 })
+})
+
+test('the split between days and minutes is never load-bearing', () => {
+  // These describe the same auction and must both be accepted, so that
+  // simplifying the client later cannot break the endpoint.
+  assert.equal(ok({ durationDays: 7, durationMinutes: 0 }), 10080)
+  assert.equal(ok({ durationDays: 0, durationMinutes: 10080 }), 10080)
+  assert.equal(ok({ durationDays: 6, durationMinutes: 1440 }), 10080)
+})
+
+test('parts summing over the ceiling are refused even when each part is legal', () => {
+  rejected({ durationDays: 7, durationMinutes: 1 })
+  rejected({ durationDays: 4, durationMinutes: 5000 })
+})
+
+// ── Hostile input ─────────────────────────────────────────────────────────
+// Bounds-only tests pass against a broken implementation; these are the ones
+// that pin the coercion. Number.isInteger(Number(x)) accepts every value below.
+test('alternate numeric spellings are refused, not coerced', () => {
+  for (const bad of ['0x1f4', '5e2', '+7', ' 7 ', '7.', '7.0', '-0', '1_0', '']) {
+    assert.equal(coerceDurationPart(bad), null, `${JSON.stringify(bad)} should not coerce`)
+  }
+})
+
+test('non-scalar and non-numeric types are refused', () => {
+  for (const bad of [[7], [[7]], true, false, {}, { valueOf: () => 7 }, () => 7, NaN, Infinity, -Infinity]) {
+    assert.equal(coerceDurationPart(bad), null)
+  }
+})
+
+test('values above MAX_SAFE_INTEGER are refused', () => {
+  // Number.isInteger(1e21) is true, which is exactly why isSafeInteger is used.
+  assert.equal(coerceDurationPart(1e21), null)
+  rejected({ durationMinutes: 1e21 })
+  rejected({ durationDays: Number.MAX_SAFE_INTEGER })
+})
+
+test('negative parts are refused rather than cancelling out', () => {
+  assert.equal(coerceDurationPart(-1), null)
+  rejected({ durationDays: -1, durationMinutes: 2880 })
+  rejected({ durationDays: 1, durationMinutes: -1 })
+})
+
+test('fractional parts are refused even when the sum is a whole number', () => {
+  // A sum-only integer check accepts this pair; the per-part check is what stops it.
+  rejected({ durationDays: 0.5, durationMinutes: 720 })
+  rejected({ durationDays: 1.5, durationMinutes: 0 })
+})
+
+test('missing parts default to zero rather than throwing', () => {
+  assert.equal(coerceDurationPart(undefined), 0)
+  assert.equal(coerceDurationPart(null), 0)
+  assert.equal(ok({ durationMinutes: 30 }), 30)
+  rejected({})
+})
+
+test('plain digit strings are accepted, since that is what a form posts', () => {
+  assert.equal(coerceDurationPart('30'), 30)
+  assert.equal(ok({ durationDays: '2', durationMinutes: '30' }), 2910)
+})
+
+// ── Clamping ──────────────────────────────────────────────────────────────
+test('clamping keeps a near-minimum pick inside the accepted range', () => {
+  // "12:03" chosen at 12:00:45 is only 2.25 minutes out. Rounding or flooring
+  // gives 2 and a 422 the player cannot understand; the clamp gives 3.
+  assert.equal(clampMsToAuctionMinutes(2.25 * 60000), MIN_AUCTION_MINUTES)
+  assert.equal(clampMsToAuctionMinutes(0), MIN_AUCTION_MINUTES)
+  assert.equal(clampMsToAuctionMinutes(-5000), MIN_AUCTION_MINUTES)
+})
+
+test('clamping keeps a near-maximum pick inside the accepted range', () => {
+  // Reachable when a client clock steps backward between picking and submitting.
+  assert.equal(clampMsToAuctionMinutes(10080.6 * 60000), MAX_AUCTION_MINUTES)
+  assert.equal(clampMsToAuctionMinutes(99999 * 60000), MAX_AUCTION_MINUTES)
+})
+
+test('a clamped value is always something the endpoint accepts', () => {
+  for (const ms of [-1, 0, 1000, 2.25 * 60000, 10080.6 * 60000, 1e12, NaN, Infinity]) {
+    const minutes = clampMsToAuctionMinutes(ms)
+    assert.equal(resolveAuctionDuration({ durationMinutes: minutes }).ok, true,
+      `clamp produced an unacceptable ${minutes} from ${ms}`)
+  }
+})
+
+test('isListableMs reports the raw span, before any rounding', () => {
+  assert.equal(isListableMs(3 * 60000), true)
+  assert.equal(isListableMs(2.9 * 60000), false)
+  assert.equal(isListableMs(MAX_AUCTION_MINUTES * 60000), true)
+  assert.equal(isListableMs(MAX_AUCTION_MINUTES * 60000 + 1), false)
+  assert.equal(isListableMs(NaN), false)
+})
+
+// ── DST ───────────────────────────────────────────────────────────────────
+test('the ceiling is elapsed time, so a fall-back week is not listable end-to-end', () => {
+  // "Same wall clock, seven days later" across a fall-back transition is 169
+  // hours = 10140 minutes. The picker derives its max attribute from
+  // now + MAX_AUCTION_MINUTES precisely so it can never offer this instant;
+  // if one ever reaches the endpoint it must be refused, not silently accepted.
+  const fallBackWeek = 169 * 60
+  assert.equal(fallBackWeek > MAX_AUCTION_MINUTES, true)
+  rejected({ durationMinutes: fallBackWeek })
+  // A spring-forward week is 167 hours and is listable.
+  assert.equal(ok({ durationMinutes: 167 * 60 }), 10020)
+})
+
+// ── Labels ────────────────────────────────────────────────────────────────
+test('the duration label keeps the days when minutes are also present', () => {
+  // The old formatDuration returned early on minutes > 0 and dropped the days,
+  // so a 6d 3h listing announced "Duration: 3 hour(s)" to Discord.
+  assert.equal(formatAuctionDuration(6 * 1440 + 180), '6 days, 3 hours')
+  assert.equal(formatAuctionDuration(2 * 1440 + 330), '2 days, 5 hours, 30 minutes')
+})
+
+test('the duration label singularises and drops empty units', () => {
+  assert.equal(formatAuctionDuration(3), '3 minutes')
+  assert.equal(formatAuctionDuration(1), '1 minute')
+  assert.equal(formatAuctionDuration(60), '1 hour')
+  assert.equal(formatAuctionDuration(1440), '1 day')
+  assert.equal(formatAuctionDuration(10080), '7 days')
+  assert.equal(formatAuctionDuration(0), '0 minutes')
+})
+
+test('the countdown has a day tier', () => {
+  // Without one a 7-day auction rendered as "167h 59m" in a nowrap card badge.
+  assert.equal(formatRemainingShort(7 * 86400000), '7d 0h')
+  assert.equal(formatRemainingShort(6 * 86400000 + 23 * 3600000), '6d 23h')
+  assert.equal(formatRemainingShort(5 * 86400000), '5d 0h')
+})
+
+test('the countdown keeps its finer tiers under a day', () => {
+  assert.equal(formatRemainingShort(4 * 3600000 + 12 * 60000), '4h 12m')
+  assert.equal(formatRemainingShort(90 * 1000), '1m 30s')
+  assert.equal(formatRemainingShort(45 * 1000), '45s')
+  assert.equal(formatRemainingShort(0), 'ended')
+  assert.equal(formatRemainingShort(-1), 'ended')
+})


### PR DESCRIPTION
Sellers could only pick from six fixed presets plus a 1–5 day slider. They can now pick the exact instant an auction ends, anywhere from 3 minutes to 7 days out, while the one-tap presets stay for the common case.

## The picker

A single `<input type="datetime-local">` with `min`/`max`, not a hand-built date grid. The repo already has ~30 `datetime-local` inputs and zero custom calendars, so this matches existing convention, opens the native OS date+time picker on mobile, and gets range enforcement plus grid keyboard/ARIA semantics from the platform.

Measured in Chromium at 360×640: the modal is **336px** wide with a **308px** content column, so a 7-column weekday grid could not have reached a 44px tap target, and would have overflowed the body by ~130px. Preset mode now fits with zero scrolling; the worst case (cZone warning + price guide + calendar + confirm panel all showing) overflows by 7px.

The days slider was also raised to 7 so it no longer contradicts the calendar's ceiling.

## Duration bounds are elapsed time, not calendar days

The input's `max` is derived from `now + 10080 minutes`. Verified under `TZ=America/New_York`: in a fall-back week it resolves to `Nov 4 11:00` — 168 elapsed hours, accepted. A naive "today + 7 calendar days" would be 169 hours / 10140 minutes and would be rejected with an incomprehensible 422.

All arithmetic stays in epoch milliseconds; local values are only formatted for display and parsed field-by-field, since `new Date('YYYY-MM-DD')` parses as UTC midnight — a full day off for every negative-offset user. A nonexistent local time (2:30 AM on spring-forward) is detected and explained rather than silently relocated.

## Server-side changes

- Validate on the **sum** of days and minutes, bounding each part independently so the client's choice of split is never load-bearing.
- Stricter coercion than `Number()`. The old check accepted `"0x1f4"`, `"5e2"`, `" 7 "`, `[7]`, `true`, and `1e21` (`Number.isInteger` is true above `MAX_SAFE_INTEGER`), and a sum-only integer check would pass `{days: 0.5, minutes: 720}`.
- Derive `endAt`, both stored columns, and the Discord label from one `totalMinutes`, removing the parallel `daysMs`/`minsMs` arithmetic.
- **Fix a text injection in the Discord embed.** The starting bid interpolated the raw body value, so `["500\n\n\n"]` passed validation as 500, stored as 500, and wrote blank lines into the announcement around the Duration line. Also bounded `initialBet`, which had no ceiling and failed against the `int4` column as a 500.
- Create the auction and clear `isTradeable` in one transaction.

## New column

`Auction.durationMinutes` records the exact listed length. `endAt` is not a substitute: an outage extends it by the full downtime, so `endAt - createdAt` overstates the listed length. Re-listing now prefills the real duration instead of snapping to the nearest preset, and admin reporting shows a real length instead of **"0 days"** for every sub-day auction.

Migration is additive and nullable (catalog-only on PG11+, no table rewrite) and carries a `lock_timeout`, since `ALTER TABLE` takes `ACCESS EXCLUSIVE` and `/api/auctions` still runs an unpaginated query over the same table. It also adds `(status, endAt)`, which the default listing sort and the 60-second ending-soon poll both needed.

## Admin Auction-Only raised to 7 days

This required fixing a clamp in the activation path that would otherwise have recorded `duration: 5` and announced `**Duration:** 5 day(s)` for an auction that ran the full 7 days.

## Two bugs the longer ceiling made worse

- Both countdown formatters topped out at hours, so a 7-day auction rendered as **"167h 59m"** in a `nowrap` badge over the card art. They now share a day tier.
- The BullMQ delayed job was the **only** thing that ever closed an auction. If Redis lost the delayed set while the socket server stayed up, the auction stayed ACTIVE forever, its cToon untradeable and every bidder's `LockedPoints` stranded. A 5-minute sweep now re-asserts close jobs for overdue auctions.

A confirm step was added for listings of a day or more, since there is no path to withdraw a live auction.

## Testing

- 20 new tests in `tests/auctionDuration.test.js` covering bounds, hostile coercion, clamping, the DST ceiling, and label formatting.
- Full suite: 374/376. The 2 failures (`edRpsWiring`, `monsterBattleEngine`) are unrelated and reproduce identically on a clean tree.
- `nuxt build` succeeds.
- `npm run lint` is broken repo-wide — no `eslint.config.js` exists for ESLint 10.

## Decisions worth a look before merge

1. **The 7-day points lock.** Bidding creates an ACTIVE `LockedPoints` row released only on being outbid or at close, so the leading bidder on a 7-day auction is frozen out of cMart, packs, and every other bid for a week. The rational play becomes *don't bid early*, pushing everything into the final 60 seconds of anti-snipe. Lock semantics are unchanged here.
2. **There is no way to cancel an auction.** `AuctionStatus.CANCELLED` exists in the schema but nothing ever writes it to an `Auction`. A mis-set 7-day listing is unrecoverable, and with insta-bid it is a guaranteed sale at the rarity floor. The confirm step is a mitigation; an owner-cancel gated on zero bids would be the real fix.
3. **`AddToAuction.vue` is dead code** — zero references repo-wide. It was updated as requested (via `--adp-*` variable overrides for its white panel rather than a forked component), but deleting it is the better call.

Two out-of-scope issues found along the way, worth separate tickets: `server/utils/centralTime.js:12` mis-converts by an hour for ~6 hours on each DST transition day, affecting live admin scheduling for sales and packs; and `/api/auctions` fetches every active auction unpaginated on a page every player visits, which scales with mean duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tgqwM4dtCLGgZ4hZSC53t

---
_Generated by [Claude Code](https://claude.ai/code/session_011tgqwM4dtCLGgZ4hZSC53t)_