### PR TITLE
Add "Give to Official" admin action for fully sold-out cToons

### DIFF
--- a/components/GiveToOfficialModal.vue
+++ b/components/GiveToOfficialModal.vue
@@ -1,0 +1,101 @@
+<!-- components/GiveToOfficialModal.vue -->
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 overflow-y-auto">
+    <div class="bg-white rounded-lg w-full max-w-md my-8 shadow-xl">
+      <div class="flex items-center justify-between px-6 py-4 border-b">
+        <h2 class="text-lg font-semibold">Give to Official</h2>
+        <button @click="$emit('close')" class="text-gray-400 hover:text-gray-600 text-2xl leading-none">&times;</button>
+      </div>
+
+      <div class="p-6 space-y-4">
+        <div class="flex items-center gap-3">
+          <img :src="ctoon.assetPath" :alt="ctoon.name" class="h-14 w-auto rounded flex-shrink-0" />
+          <div>
+            <p class="font-medium">{{ ctoon.name }}</p>
+            <p class="text-xs text-gray-500">Highest Mint: {{ ctoon.highestMint }} / Quantity: {{ formatQuantity(ctoon.quantity) }}</p>
+          </div>
+        </div>
+
+        <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800 space-y-2">
+          <p>This will:</p>
+          <ul class="list-disc list-inside space-y-1">
+            <li>Mint <strong>5 new copies</strong> of this exact cToon</li>
+            <li>Give all 5 copies to the <strong>{{ officialUsername }}</strong> account</li>
+            <li>Permanently raise this cToon's mint total and quantity cap by 5</li>
+          </ul>
+          <p class="font-semibold">This action is one-time-only per cToon and cannot be undone.</p>
+        </div>
+
+        <label class="flex items-start gap-2 text-sm text-gray-700">
+          <input type="checkbox" v-model="acknowledged" class="mt-0.5" />
+          <span>I understand this is permanent and cannot be undone.</span>
+        </label>
+
+        <p v-if="errorMsg" class="text-sm text-red-600">{{ errorMsg }}</p>
+
+        <div class="flex justify-end gap-3 pt-2">
+          <button
+            @click="$emit('close')"
+            :disabled="submitting"
+            class="px-4 py-2 border border-gray-300 rounded text-sm hover:bg-gray-100 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            @click="submit"
+            :disabled="!acknowledged || submitting"
+            class="px-4 py-2 rounded text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {{ submitting ? 'Giving…' : 'Give 5 to Official' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { formatQuantity } from '~/utils/formatQuantity'
+
+const props = defineProps({
+  ctoon: { type: Object, required: true },
+})
+const emit = defineEmits(['close', 'given'])
+
+const acknowledged = ref(false)
+const submitting = ref(false)
+const errorMsg = ref('')
+const officialUsername = ref('the Official')
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/api/admin/official', { credentials: 'include' })
+    if (res.ok) {
+      const data = await res.json()
+      if (data?.username) officialUsername.value = data.username
+    }
+  } catch {}
+})
+
+async function submit() {
+  if (!acknowledged.value || submitting.value) return
+  submitting.value = true
+  errorMsg.value = ''
+  try {
+    const res = await fetch(`/api/admin/ctoons/${props.ctoon.id}/give-to-official`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+    const data = await res.json().catch(() => null)
+    if (!res.ok) {
+      throw new Error(data?.statusMessage || data?.message || 'Failed to give to Official.')
+    }
+    emit('given', data.ctoon)
+  } catch (err) {
+    errorMsg.value = err.message || 'Failed to give to Official.'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>

--- a/pages/admin/ctoons.vue
+++ b/pages/admin/ctoons.vue
@@ -90,7 +90,7 @@
               <th class="px-4 py-2 text-right">Highest Mint</th>
               <th class="px-4 py-2 text-right">Quantity</th>
               <th class="px-4 py-2 text-center">In C-mart</th>
-              <th class="px-4 py-2 text-right">Edit</th>
+              <th class="px-4 py-2 text-right">Actions</th>
             </tr>
           </thead>
           <!-- Skeleton rows while loading or searching -->
@@ -163,10 +163,26 @@
                 {{ c.inCmart ? 'Yes' : 'No' }}
               </td>
               <td class="px-4 py-2 text-right">
-                <NuxtLink
-                  :to="`/admin/editCtoon/${c.id}`"
-                  class="text-blue-600 hover:text-blue-800"
-                >Edit</NuxtLink>
+                <div class="flex flex-col items-end gap-1.5">
+                  <NuxtLink
+                    :to="`/admin/editCtoon/${c.id}`"
+                    class="bg-blue-600 text-white px-3 py-1.5 rounded hover:bg-blue-700 text-xs font-medium"
+                  >Edit</NuxtLink>
+                  <button
+                    type="button"
+                    :disabled="!!giveToOfficialDisabledReason(c)"
+                    :title="giveToOfficialDisabledReason(c) || 'Mint 5 more and give them to Official'"
+                    @click="openGiveToOfficial(c)"
+                    :class="[
+                      'px-3 py-1.5 rounded text-xs font-medium whitespace-nowrap',
+                      giveToOfficialDisabledReason(c)
+                        ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                        : 'bg-amber-600 text-white hover:bg-amber-700'
+                    ]"
+                  >
+                    Give to Official
+                  </button>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -234,12 +250,28 @@
                 <p class="text-sm"><strong>Series:</strong> {{ c.series }}</p>
               </div>
             </div>
-            <NuxtLink
-              :to="`/admin/editCtoon/${c.id}`"
-              class="mt-4 inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-center text-sm font-medium self-end"
-            >
-              Edit
-            </NuxtLink>
+            <div class="mt-4 flex gap-2 self-end">
+              <NuxtLink
+                :to="`/admin/editCtoon/${c.id}`"
+                class="inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-center text-sm font-medium"
+              >
+                Edit
+              </NuxtLink>
+              <button
+                type="button"
+                :disabled="!!giveToOfficialDisabledReason(c)"
+                :title="giveToOfficialDisabledReason(c) || 'Mint 5 more and give them to Official'"
+                @click="openGiveToOfficial(c)"
+                :class="[
+                  'px-4 py-2 rounded text-sm font-medium whitespace-nowrap',
+                  giveToOfficialDisabledReason(c)
+                    ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                    : 'bg-amber-600 text-white hover:bg-amber-700'
+                ]"
+              >
+                Give to Official
+              </button>
+            </div>
           </div>
         </template>
       </div>
@@ -289,6 +321,14 @@
       @close="showMakeSecondEditionModal = false"
       @saved="onMakeSecondEditionSaved"
     />
+
+    <!-- Give to Official Modal -->
+    <GiveToOfficialModal
+      v-if="giveToOfficialTarget"
+      :ctoon="giveToOfficialTarget"
+      @close="giveToOfficialTarget = null"
+      @given="onGivenToOfficial"
+    />
   </div>
 </template>
 
@@ -299,7 +339,41 @@ import { ref, onMounted, onBeforeUnmount, computed, watch, nextTick } from 'vue'
 import Nav from '~/components/Nav.vue'
 import BulkEditCtoonModal from '~/components/BulkEditCtoonModal.vue'
 import MakeSecondEditionModal from '~/components/MakeSecondEditionModal.vue'
+import GiveToOfficialModal from '~/components/GiveToOfficialModal.vue'
 import { formatQuantity, TIME_BASED_CAP } from '~/utils/formatQuantity'
+
+/* Give to Official */
+const giveToOfficialTarget = ref(null)
+function giveToOfficialDisabledReason(c) {
+  if (c.givenToOfficialAt) return 'Already given to Official for this cToon.'
+  if (c.quantity == null || c.highestMint !== c.quantity) {
+    return 'Not eligible until highest mint equals quantity (fully sold out).'
+  }
+  return ''
+}
+function openGiveToOfficial(c) {
+  if (giveToOfficialDisabledReason(c)) return
+  giveToOfficialTarget.value = c
+}
+function patchCtoonEverywhere(id, patch) {
+  const applyTo = (list) => {
+    const idx = list.value.findIndex(c => c.id === id)
+    if (idx !== -1) list.value[idx] = { ...list.value[idx], ...patch }
+  }
+  applyTo(rawCtoons)
+  applyTo(searchResults)
+}
+function onGivenToOfficial(updatedCtoon) {
+  if (updatedCtoon?.id) {
+    patchCtoonEverywhere(updatedCtoon.id, {
+      totalMinted: updatedCtoon.totalMinted,
+      highestMint: updatedCtoon.highestMint,
+      quantity: updatedCtoon.quantity,
+      givenToOfficialAt: updatedCtoon.givenToOfficialAt,
+    })
+  }
+  giveToOfficialTarget.value = null
+}
 
 /* Meta options from API */
 const setsOptions   = ref([])

--- a/prisma/migrations/20260819000000_add_ctoon_given_to_official/migration.sql
+++ b/prisma/migrations/20260819000000_add_ctoon_given_to_official/migration.sql
@@ -1,0 +1,5 @@
+-- "Give to Official" admin action: mints 5 more copies of a fully-minted cToon
+-- and gives them to the Official system account. One-time-ever per cToon —
+-- this timestamp is both the audit marker and the DB-level guard preventing a
+-- second use (see the WHERE clause in the give-to-official endpoint).
+ALTER TABLE "Ctoon" ADD COLUMN IF NOT EXISTS "givenToOfficialAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -359,6 +359,11 @@ model Ctoon {
   // unanswerable question. Excluded cToons can still be used as wrong answers.
   guessCtoonExcluded Boolean @default(false)
 
+  // Set once an admin uses "Give to Official" (mints 5 more copies for the Official
+  // system account). One-time-ever per cToon — also used as the DB-level guard so a
+  // double-click/race can only succeed once.
+  givenToOfficialAt DateTime?
+
   @@index([isSecondEdition])
   @@index([name])
 }

--- a/server/api/admin/all-ctoons.get.js
+++ b/server/api/admin/all-ctoons.get.js
@@ -33,6 +33,7 @@ export default defineEventHandler(async (event) => {
       rarity: true,
       inCmart: true,
       totalMinted: true, // ← pull aggregate
+      givenToOfficialAt: true,
       isSecondEdition: true,
       secondEditionOverlayX: true,
       secondEditionOverlayY: true,

--- a/server/api/admin/ctoons/[id]/give-to-official.post.js
+++ b/server/api/admin/ctoons/[id]/give-to-official.post.js
@@ -1,0 +1,109 @@
+// server/api/admin/ctoons/[id]/give-to-official.post.js
+//
+// One-time admin action: mints 5 more copies of a fully sold-out cToon and
+// gives them to the Official system account. Only eligible while
+// highestMint === quantity (fully minted) and only once ever per cToon —
+// enforced atomically in SQL so a double-click/race can only ever succeed
+// once, regardless of what the client's (possibly stale) button state shows.
+import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+
+const GIFT_COUNT = 5
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const { id } = event.context.params || {}
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing cToon id' })
+
+  const officialUsername = process.env.OFFICIAL_USERNAME || 'CartoonReOrbitOfficial'
+  const official = await prisma.user.findUnique({
+    where: { username: officialUsername },
+    select: { id: true, username: true }
+  })
+  if (!official) {
+    throw createError({ statusCode: 400, statusMessage: `Official account not found: ${officialUsername}` })
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    // Atomic guard: only succeeds if the cToon has a defined (non-null)
+    // quantity cap, is fully minted (sold out), and has never been given to
+    // Official before. This is the single source of truth for eligibility —
+    // the client-side button state is advisory only.
+    const rows = await tx.$queryRaw`
+      UPDATE "Ctoon"
+      SET "totalMinted" = "totalMinted" + ${GIFT_COUNT},
+          "quantity" = "quantity" + ${GIFT_COUNT},
+          "givenToOfficialAt" = now()
+      WHERE id = ${id}
+        AND "givenToOfficialAt" IS NULL
+        AND "quantity" IS NOT NULL
+        AND "totalMinted" = "quantity"
+      RETURNING "totalMinted", "quantity", "givenToOfficialAt", "initialQuantity"`
+
+    if (!rows || !rows.length) {
+      const existing = await tx.ctoon.findUnique({
+        where: { id },
+        select: { givenToOfficialAt: true }
+      })
+      if (!existing) throw createError({ statusCode: 404, statusMessage: 'cToon not found' })
+      if (existing.givenToOfficialAt) {
+        throw createError({ statusCode: 409, statusMessage: 'This cToon has already been given to Official.' })
+      }
+      throw createError({ statusCode: 409, statusMessage: 'Not eligible — highest mint must equal quantity (fully sold out).' })
+    }
+
+    const { totalMinted: newTotalMinted, quantity: newQuantity, givenToOfficialAt, initialQuantity } = rows[0]
+    const startMint = Number(newTotalMinted) - GIFT_COUNT
+    const iq = initialQuantity == null ? null : Number(initialQuantity)
+
+    const userCtoonIds = []
+    for (let mintNumber = startMint + 1; mintNumber <= Number(newTotalMinted); mintNumber++) {
+      const isFirstEdition = iq === null || mintNumber <= iq
+      const uc = await tx.userCtoon.create({
+        data: { userId: official.id, ctoonId: id, mintNumber, isFirstEdition, pricePaid: null },
+        select: { id: true }
+      })
+      await tx.ctoonOwnerLog.create({
+        data: { userId: official.id, ctoonId: id, userCtoonId: uc.id, mintNumber, method: 'ADMIN_GRANT' }
+      })
+      userCtoonIds.push(uc.id)
+    }
+
+    await logAdminChange(tx, {
+      userId: me.id,
+      area: `Ctoon:${id}`,
+      key: 'give-to-official',
+      prevValue: null,
+      newValue: {
+        count: GIFT_COUNT,
+        mintNumbers: Array.from({ length: GIFT_COUNT }, (_, i) => startMint + 1 + i),
+        userCtoonIds,
+        officialUserId: official.id,
+        officialUsername: official.username
+      },
+      targetUserId: official.id,
+      targetUsername: official.username
+    })
+
+    return {
+      id,
+      totalMinted: Number(newTotalMinted),
+      highestMint: Number(newTotalMinted),
+      quantity: Number(newQuantity),
+      givenToOfficialAt
+    }
+  })
+
+  return { success: true, ctoon: result }
+})

--- a/server/api/admin/search-ctoons.get.js
+++ b/server/api/admin/search-ctoons.get.js
@@ -56,6 +56,7 @@ export default defineEventHandler(async (event) => {
       quantity: true,
       rarity: true,
       inCmart: true,
+      givenToOfficialAt: true,
       isSecondEdition: true,
       secondEditionOverlayX: true,
       secondEditionOverlayY: true,


### PR DESCRIPTION
## Summary
Adds a new one-time admin action that allows minting 5 additional copies of a fully sold-out cToon and granting them to the Official system account. The action is protected by atomic database constraints to prevent accidental double-execution.

## Key Changes

- **New API endpoint** (`server/api/admin/ctoons/[id]/give-to-official.post.js`):
  - Mints 5 new copies of a cToon and assigns them to the Official account
  - Uses atomic SQL transaction with WHERE clause guards to ensure the action can only succeed once per cToon, regardless of client state or race conditions
  - Eligibility checks: cToon must have a quantity cap, be fully minted (highestMint === quantity), and never have been given to Official before
  - Creates UserCtoon records and ownership logs for audit trail
  - Logs the admin action with full details (mint numbers, user IDs, etc.)

- **New modal component** (`components/GiveToOfficialModal.vue`):
  - Confirmation dialog with clear warnings about the permanent, one-time nature of the action
  - Requires explicit acknowledgment before submission
  - Displays cToon details and explains the consequences
  - Fetches Official account username from API for display

- **Updated admin cToons page** (`pages/admin/ctoons.vue`):
  - Adds "Give to Official" button alongside existing "Edit" button in both table and card views
  - Button is disabled with tooltip when cToon is ineligible
  - Integrates GiveToOfficialModal and handles successful completion by updating local cToon state

- **Database schema** (`prisma/schema.prisma` + migration):
  - Adds `givenToOfficialAt` timestamp column to Ctoon model
  - Serves dual purpose: audit marker and database-level guard preventing re-execution

- **API updates**:
  - Both `all-ctoons.get.js` and `search-ctoons.get.js` now include `givenToOfficialAt` in responses for UI eligibility checks

## Notable Implementation Details

- The atomic SQL UPDATE with specific WHERE conditions is the single source of truth for eligibility—client-side button state is advisory only
- Race conditions and double-clicks are safely handled: only the first successful transaction will update the cToon; subsequent attempts will fail with appropriate error messages
- First edition status is correctly determined based on the cToon's `initialQuantity` field
- Admin changes are fully logged for audit purposes

https://claude.ai/code/session_01NCRc2AFcM7sVyWUu7r4rog