### PR TITLE
Add Discord #general chat relay to the newsite sidebar

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,31 @@ DISCORD_ANNOUNCEMENTS_BOT_TOKEN="Bot WhateverTokenFromDiscordDeveloperPortal"
 # (e.g. achievements, cZone Contest) isn't set in the admin Global Settings page
 DISCORD_ANNOUNCEMENTS_CHANNEL=
 
+# DISCORD CHAT RELAY (sidebar "Chat" panel)
+# Everything else about the relay is configured in Admin > Global Settings > Discord.
+# Two things live here instead, and both are required before it can work:
+#
+# 1. The MESSAGE CONTENT privileged intent must be enabled on the bot:
+#      Developer Portal > your app > Bot > Privileged Gateway Intents.
+#    Without it the gateway refuses the connection with close code 4014. There is
+#    deliberately no REST fallback: that intent gates the message DATA as well as
+#    the gateway, so polling would return messages with empty content and the
+#    sidebar would render blank rows instead of failing visibly.
+#    The bot also needs View Channel + Read Message History on the chat channel.
+#
+# 2. The webhook the site posts through. Create it on the chat channel
+#    (Channel Settings > Integrations > Webhooks) and paste the URL here.
+#    NEVER commit this value. A webhook token is an unauthenticated bearer
+#    credential: anyone holding it can post to that channel under any name and
+#    avatar, and the ONLY way to revoke it is to delete the webhook -- rotating
+#    BOT_TOKEN does nothing. It is kept out of the database on purpose, because
+#    the admin config endpoints return that row wholesale to the browser.
+DISCORD_CHAT_WEBHOOK_URL=
+# Optional: a separate bot for the chat gateway. Defaults to BOT_TOKEN.
+# Either form works -- the "Bot " prefix is stripped before IDENTIFY, which needs
+# the bare token even though every REST call here wants the prefix.
+DISCORD_CHAT_BOT_TOKEN=
+
 NUXT_PORT=3000
 SOCKET_PORT=3001
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ DISCORD_PUBLIC_KEY=<from/Discord/General-Information>
   node server/socket-server.js
   ```
 
+- The sidebar Discord chat is off by default and needs no local setup. If you want to
+  run it, start its gateway process in another terminal (see the section below):
+  ```bash
+  npm run discord-chat
+  ```
+
 - If you are NOT using `npm run dev`, start the worker manually in a third terminal:
   ```bash
   npm run worker
@@ -240,6 +246,76 @@ DISCORD_PUBLIC_KEY=<from/Discord/General-Information>
     ```
 - Set OFFICIAL_USERNAME in `.env` to be your username, this is so features like Auction insta-bidding and Auction Only cToons work.
 
+
+### Discord chat relay (sidebar "Chat" panel)
+
+Mirrors one Discord channel into the site sidebar and lets signed-in members post back into
+it. It is **off by default** and has to be switched on deliberately in
+**Admin → Global Settings → Discord**.
+
+How it fits together:
+
+| Piece | Where |
+|---|---|
+| Gateway connection (Discord → site) | `discord-chat` PM2 app / `npm run discord-chat` |
+| Fan-out to browsers, and sends (site → Discord) | `socket-server`, `/chat` namespace |
+| Rendering | `components/newsite/DiscordChat.vue` |
+| Shared logic | `server/utils/discordChat/` |
+
+The gateway runs as its **own process** rather than inside `socket-server`. `socket-server`
+has no `uncaughtException` handler and does not persist live Clash matches when it crashes, so
+a stray rejection from reconnect code would destroy every in-progress match on the site; it
+also runs a 60Hz physics loop that must not compete with a gateway heartbeat.
+
+#### Setup
+
+1. **Enable the MESSAGE CONTENT privileged intent.** Developer Portal → your app → Bot →
+   *Privileged Gateway Intents* → **Message Content Intent**.
+
+   Without it the gateway is refused with close code `4014` and the relay stops with a loud
+   log. There is deliberately **no REST polling fallback**: that intent gates the message
+   *data* as well as the gateway, so polling would return messages with empty `content` and
+   the sidebar would quietly render blank rows instead of failing visibly.
+
+2. **Give the bot channel permissions** on the chat channel: `View Channel` and
+   `Read Message History`. Losing `View Channel` is otherwise invisible — the relay reports
+   "connected" while no messages arrive — so the worker checks for it on connect and logs.
+
+3. **Create a webhook** on that channel (Channel Settings → Integrations → Webhooks) and put
+   its URL in `.env`:
+
+   ```
+   DISCORD_CHAT_WEBHOOK_URL=https://discord.com/api/webhooks/…/…
+   ```
+
+   This is **not** stored in the database, on purpose: the admin config endpoints return the
+   `GlobalGameConfig` row wholesale to the browser, and a webhook token is an unauthenticated
+   bearer credential — anyone holding it can post to the channel under any name and avatar,
+   and the only way to revoke it is to delete the webhook (rotating `BOT_TOKEN` does nothing).
+
+4. **Turn it on** in Admin → Global Settings → Discord and set the channel ID. The channel is
+   verified on save: it must be a standard text channel in this guild.
+
+#### Things worth knowing
+
+- **Messages sent from the site are posted by a webhook**, shown as
+  `Username · ReOrbit` with the player's site avatar and Discord's `APP` tag. Discord has no
+  API that lets a site post *as* a user. The `·` suffix cannot appear in a site username, so
+  it cannot be forged — which matters because setting a site username also sets that user's
+  Discord guild nickname.
+- **Tell the channel it is being mirrored.** Its members did not sign up for a website.
+  A dedicated channel is a better fit than `#general` for exactly this reason.
+- **Moderation is asymmetric.** Every relayed message reaches Discord as one webhook identity,
+  so Discord's per-user tools (timeout, kick, AutoMod) cannot single out a site user. The site
+  side has two levers: per-user **Mute chat** in Admin → Manage Users, and the global
+  **Enable the chat relay** switch, which takes effect immediately and clears the buffer.
+- Deletes and edits made in Discord propagate to the site, and the buffer is re-seeded hourly
+  so anything missed during a disconnect converges.
+- Image attachments are **off by default**. Turning them on lets any guild member put an image
+  on the website, and Discord's attachment URLs are signed and expire after about a day.
+- Rate limits are layered: a per-user slowmode plus a global token bucket. The global one is
+  not redundant — Discord's limit is per *webhook*, so twenty users each obeying a 5-second
+  personal slowmode would still exceed it.
 
 ### Quick troubleshooting
 - If Prisma cannot connect, verify `DATABASE_URL` and that PostgreSQL is running.

--- a/components/newsite/AdminManageUsers.vue
+++ b/components/newsite/AdminManageUsers.vue
@@ -90,6 +90,26 @@
                     class="w-full text-left px-2 py-1 text-[11px] text-emerald-700 hover:bg-emerald-50"
                     @click="openActionModal(u, 'UNBAN'); closeMenu()"
                   >Unban user</button>
+                  <!-- Chat relay timeout. Narrower than a ban: it blocks posting
+                       into Discord and nothing else. Needed because a relayed
+                       message reaches Discord as a single webhook identity, so
+                       Discord's own per-user moderation cannot reach a site
+                       user. -->
+                  <button
+                    v-if="!u.isAdmin && !isChatMuted(u)"
+                    class="w-full text-left px-2 py-1 text-[11px] text-amber-700 hover:bg-amber-50"
+                    @click="muteChat(u, 60); closeMenu()"
+                  >Mute chat (1 hour)</button>
+                  <button
+                    v-if="!u.isAdmin && !isChatMuted(u)"
+                    class="w-full text-left px-2 py-1 text-[11px] text-amber-700 hover:bg-amber-50"
+                    @click="muteChat(u, 1440); closeMenu()"
+                  >Mute chat (1 day)</button>
+                  <button
+                    v-if="!u.isAdmin && isChatMuted(u)"
+                    class="w-full text-left px-2 py-1 text-[11px] text-emerald-700 hover:bg-emerald-50"
+                    @click="muteChat(u, 0); closeMenu()"
+                  >Unmute chat</button>
                   <button
                     v-if="!u.isAdmin && !u.active && !u.banned"
                     class="w-full text-left px-2 py-1 text-[11px] text-emerald-700 hover:bg-emerald-50"
@@ -782,6 +802,24 @@ const noteTone = (action) => {
   if (action === 'UNBAN') return 'text-emerald-700'
   if (action === 'DISSOLVE') return 'text-rose-700'
   return 'text-gray-700'
+}
+
+// Discord chat relay timeout — see server/api/admin/users/[id]/chat-mute.post.js
+function isChatMuted (u) {
+  return Boolean(u?.chatMutedUntil && new Date(u.chatMutedUntil).getTime() > Date.now())
+}
+
+async function muteChat (u, minutes) {
+  try {
+    const res = await $fetch(`/api/admin/users/${u.id}/chat-mute`, {
+      method: 'POST',
+      body: { minutes }
+    })
+    // Patch in place so the menu flips without a full refetch.
+    u.chatMutedUntil = res?.chatMutedUntil ?? null
+  } catch (e) {
+    console.error('chat mute failed', e)
+  }
 }
 
 // Ban/Unban modal state + actions

--- a/components/newsite/DiscordChat.vue
+++ b/components/newsite/DiscordChat.vue
@@ -1,0 +1,652 @@
+<template>
+  <div
+    class="dchat"
+    :class="{ 'dchat-sheet': sheet }"
+    @focusin="focusWithin = true"
+    @focusout="onFocusOut"
+  >
+    <div class="dchat-head">
+      <span class="dchat-title">Discord Chat</span>
+      <span class="dchat-dot" :class="dotClass" :title="statusTitle" aria-hidden="true" />
+      <button v-if="sheet" class="dchat-close" type="button" aria-label="Close chat" @click="$emit('close')">✕</button>
+    </div>
+
+    <!--
+      role="log" carries an implicit aria-live="polite", so aria-live is NOT
+      also set here — some screen readers would announce twice. It is forced to
+      "off" whenever focus is outside the panel: a busy #general announced
+      message-by-message is unusable, because each new arrival interrupts the
+      queue and the user can never finish reading the one they are on.
+    -->
+    <div
+      ref="scroller"
+      class="dchat-list"
+      role="log"
+      aria-relevant="additions"
+      :aria-live="focusWithin ? 'polite' : 'off'"
+      aria-atomic="false"
+      tabindex="0"
+      @scroll="onScroll"
+    >
+      <p v-if="!enabled" class="dchat-empty">Chat is turned off right now.</p>
+      <p v-else-if="!messages.length" class="dchat-empty">No messages yet.</p>
+
+      <div
+        v-for="(m, i) in messages"
+        :key="m.id"
+        class="dchat-msg"
+        :class="{ 'dchat-msg-site': m.viaSite, 'dchat-msg-grouped': isGrouped(i) }"
+      >
+        <div v-if="!isGrouped(i)" class="dchat-msg-head">
+          <img
+            v-if="m.avatarUrl"
+            :src="m.avatarUrl"
+            alt=""
+            class="dchat-avatar"
+            width="16"
+            height="16"
+            loading="lazy"
+            decoding="async"
+            referrerpolicy="no-referrer"
+          />
+          <span class="dchat-name">{{ m.authorName }}</span>
+          <time class="dchat-time" :datetime="new Date(m.createdAt).toISOString()">{{ clock(m.createdAt) }}</time>
+        </div>
+
+        <!--
+          Tokens only. Every branch renders a text node or an element we built;
+          nothing here interpolates message data into markup. Raw-HTML
+          directives and DOM sinks are banned in this file by design and by
+          test — see the header of server/utils/discordChat/normalize.js.
+        -->
+        <p class="dchat-body">
+          <template v-for="(t, ti) in m.tokens" :key="ti">
+            <a
+              v-if="t.type === 'link'"
+              :href="t.href"
+              target="_blank"
+              rel="noopener noreferrer nofollow ugc"
+              referrerpolicy="no-referrer"
+              class="dchat-link"
+            >{{ t.value }}</a>
+            <span v-else-if="t.type === 'mention'" class="dchat-mention">{{ t.value }}</span>
+            <code v-else-if="t.type === 'code'" class="dchat-code">{{ t.value }}</code>
+            <span v-else-if="t.type === 'codeblock'" class="dchat-codeblock">{{ t.value }}</span>
+            <img
+              v-else-if="t.type === 'emoji'"
+              :src="t.url"
+              :alt="`:${t.name}:`"
+              class="dchat-emoji"
+              width="18"
+              height="18"
+              loading="lazy"
+              decoding="async"
+              referrerpolicy="no-referrer"
+            />
+            <span v-else-if="t.type === 'time'">{{ clock(t.at) }}</span>
+            <template v-else>{{ t.value }}</template>
+          </template>
+          <span v-if="m.editedAt" class="dchat-edited"> (edited)</span>
+        </p>
+
+        <template v-for="(a, ai) in m.attachments" :key="ai">
+          <a
+            v-if="!isExpired(a)"
+            :href="a.url"
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            class="dchat-att"
+            :style="{ aspectRatio: `${a.width} / ${a.height}` }"
+          >
+            <img
+              :src="a.url"
+              :alt="a.name"
+              loading="lazy"
+              decoding="async"
+              referrerpolicy="no-referrer"
+            />
+          </a>
+          <span v-else class="dchat-att-expired">Image expired — open in Discord</span>
+        </template>
+      </div>
+    </div>
+
+    <button v-if="unread" class="dchat-unread" type="button" @click="jumpToBottom">
+      {{ unread }} new ▼
+    </button>
+
+    <!-- Errors get their own assertive region; messages never do. -->
+    <p v-if="notice" class="dchat-notice" role="status" aria-live="assertive">{{ notice }}</p>
+
+    <form class="dchat-compose" @submit.prevent="send">
+      <textarea
+        ref="input"
+        v-model="draft"
+        class="dchat-input"
+        :maxlength="maxLength"
+        :disabled="!canSend"
+        :placeholder="placeholder"
+        rows="1"
+        @keydown="onKeydown"
+      />
+      <button class="dchat-send" type="submit" :disabled="!canSend || !draft.trim()">Send</button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+// socket.io-client is imported HERE and nowhere the layout touches. Nuxt's
+// component and composable auto-imports are compile-time STATIC imports, so a
+// composable that imported it would put all ~14.7 KB gzipped into the layout
+// chunk of every /newsite page, for a feature most sessions never open. This
+// component is rendered as <LazyDiscordChat>, which compiles to
+// defineAsyncComponent and therefore lands in its own chunk.
+import { io } from 'socket.io-client'
+import { markRaw, nextTick, onBeforeUnmount, onMounted, ref, computed } from 'vue'
+
+const props = defineProps({
+  sheet: { type: Boolean, default: false }
+})
+defineEmits(['close'])
+
+const runtime = useRuntimeConfig()
+
+// Cap the DOM at 100. Nobody scrolls 100 messages back in a 224px column, and
+// each row is ~5 nodes.
+const MAX_MESSAGES = 100
+const BOTTOM_THRESHOLD = 24
+const GROUP_WINDOW_MS = 5 * 60 * 1000
+
+const messages = ref([])
+const draft = ref('')
+const notice = ref('')
+const unread = ref(0)
+const enabled = ref(true)
+const connected = ref(false)
+const blockedReason = ref('')
+const maxLength = ref(400)
+const focusWithin = ref(false)
+const sending = ref(false)
+
+const scroller = ref(null)
+const input = ref(null)
+
+let socket = null
+let stickToBottom = true
+let resizeObserver = null
+
+const canSend = computed(() => enabled.value && connected.value && !blockedReason.value && !sending.value)
+
+const dotClass = computed(() => {
+  if (!enabled.value) return 'dchat-dot-off'
+  return connected.value ? 'dchat-dot-on' : 'dchat-dot-wait'
+})
+
+const statusTitle = computed(() => {
+  if (!enabled.value) return 'Chat is off'
+  return connected.value ? 'Connected' : 'Connecting…'
+})
+
+const placeholder = computed(() => {
+  if (!enabled.value) return 'Chat is off'
+  if (blockedReason.value === 'muted') return 'You are muted'
+  if (blockedReason.value === 'not_in_guild') return 'Join the Discord to chat'
+  if (!connected.value) return 'Connecting…'
+  return 'Message #general'
+})
+
+// Drives the aria-live toggle on the log. relatedTarget is null when focus
+// leaves the document entirely (tab switch), which should not count as leaving
+// the panel.
+function onFocusOut(e) {
+  if (!e.relatedTarget) return
+  if (!e.currentTarget.contains(e.relatedTarget)) focusWithin.value = false
+}
+
+function clock(ms) {
+  try {
+    return new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(new Date(ms))
+  } catch {
+    return ''
+  }
+}
+
+function isExpired(a) {
+  return Boolean(a.expiresAt && a.expiresAt < Date.now())
+}
+
+function isGrouped(i) {
+  if (i === 0) return false
+  const prev = messages.value[i - 1]
+  const cur = messages.value[i]
+  return prev.authorName === cur.authorName && cur.createdAt - prev.createdAt < GROUP_WINDOW_MS
+}
+
+// Read BEFORE mutating: appending fires no scroll event, so a listener-driven
+// flag would be one message stale.
+function atBottom() {
+  const el = scroller.value
+  if (!el) return true
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_THRESHOLD
+}
+
+function pin() {
+  const el = scroller.value
+  if (el) el.scrollTop = el.scrollHeight
+}
+
+function onScroll() {
+  stickToBottom = atBottom()
+  if (stickToBottom) unread.value = 0
+}
+
+function jumpToBottom() {
+  stickToBottom = true
+  unread.value = 0
+  const el = scroller.value
+  // Smooth is used only here. On the list itself, consecutive appends each
+  // interrupt the animation and it never settles at the bottom.
+  if (el) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+}
+
+async function append(message) {
+  const wasAtBottom = stickToBottom
+  // push + splice, never a spread-reassign: reallocating the array makes Vue
+  // diff every keyed node instead of fast-pathing an append.
+  messages.value.push(markRaw(message))
+  if (messages.value.length > MAX_MESSAGES) {
+    messages.value.splice(0, messages.value.length - MAX_MESSAGES)
+  }
+  await nextTick()
+  if (wasAtBottom) pin()
+  else unread.value += 1
+}
+
+function replaceAll(list) {
+  messages.value = list.slice(-MAX_MESSAGES).map((m) => markRaw(m))
+  nextTick(pin)
+}
+
+function onKeydown(e) {
+  if (e.key !== 'Enter') return
+  // During IME composition Enter commits the candidate. Sending on it would
+  // post half a word and clear the box.
+  if (e.isComposing || e.keyCode === 229) return
+  if (e.shiftKey) return
+  e.preventDefault()
+  send()
+}
+
+function send() {
+  const content = draft.value.trim()
+  if (!content || !canSend.value || !socket) return
+  sending.value = true
+  notice.value = ''
+  socket.emit('chat:send', { content })
+}
+
+function connect() {
+  socket = io(
+    import.meta.env.PROD ? '/chat' : `http://localhost:${runtime.public.socketPort}/chat`,
+    {
+      // websocket only: skips the 4 extra polling requests of a default
+      // handshake. The session cookie rides the handshake for auth.
+      transports: ['websocket'],
+      withCredentials: true,
+      reconnectionDelayMax: 5000
+    }
+  )
+
+  socket.on('connect', () => {
+    connected.value = true
+    socket.emit('chat:join')
+  })
+  socket.on('disconnect', () => {
+    connected.value = false
+  })
+
+  socket.on('chat:state', (s) => {
+    enabled.value = s.enabled !== false
+    if (s.maxLength) maxLength.value = s.maxLength
+  })
+
+  socket.on('chat:gateway', (s) => {
+    if (typeof s?.connected === 'boolean') connected.value = s.connected
+    if (s?.fatal) notice.value = 'Chat is temporarily unavailable.'
+  })
+
+  // A snapshot REPLACES rather than merges, so a client that missed a delete
+  // while disconnected self-heals.
+  socket.on('chat:snapshot', ({ messages: list }) => replaceAll(list || []))
+
+  socket.on('chat:message', (m) => append(m))
+
+  socket.on('chat:update', ({ id, patch }) => {
+    const i = messages.value.findIndex((m) => m.id === id)
+    if (i === -1) return
+    messages.value[i] = markRaw({ ...messages.value[i], ...patch })
+  })
+
+  socket.on('chat:delete', ({ ids }) => {
+    const drop = new Set(ids || [])
+    messages.value = messages.value.filter((m) => !drop.has(m.id))
+  })
+
+  socket.on('chat:sent', () => {
+    sending.value = false
+    draft.value = ''
+  })
+
+  socket.on('chat:error', (e) => {
+    sending.value = false
+    if (e?.reason === 'muted' || e?.reason === 'not_in_guild' || e?.reason === 'not_allowed') {
+      blockedReason.value = e.reason
+    }
+    notice.value = e?.message || 'Message not sent.'
+  })
+
+  socket.on('authError', () => {
+    notice.value = 'Please sign in again.'
+  })
+}
+
+onMounted(() => {
+  connect()
+  // Images and font swaps change row heights after paint, which would silently
+  // push a pinned view off the bottom.
+  if (scroller.value && typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => {
+      if (stickToBottom) pin()
+    })
+    resizeObserver.observe(scroller.value)
+  }
+  // Focusing the composer on mobile would summon the keyboard before the user
+  // has seen a single message.
+  if (!props.sheet) input.value?.focus?.()
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  try {
+    socket?.emit('chat:leave')
+    socket?.disconnect()
+  } catch {
+    // already gone
+  }
+  socket = null
+})
+</script>
+
+<style scoped>
+.dchat {
+  display: flex;
+  flex-direction: column;
+  /* min-height:0 on BOTH the panel and the scroller. A flex item's automatic
+     minimum size is its content size, so without these the list refuses to
+     shrink, the panel grows past the sidebar, and `.sidebar { overflow:hidden }`
+     clips the composer away with no scrollbar anywhere to reveal it. */
+  min-height: 0;
+  height: 100%;
+  /* Darker ground than the sidebar panel. This is what makes the text legible:
+     white on --OrbitDarkBlue is 5.99:1 but the muted tones and the Send button
+     fail against it, and white on --OrbitLightBlue is only 3.20:1. Over this
+     (~#264C73) white is 8.9:1, timestamps at 62% reach 4.6:1 and the Send
+     button clears 3:1 as a UI component. Same rgba(0,0,0,0.25) treatment the
+     cToon filter's search field already uses. */
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: var(--sidebar-middle-radius, 8px);
+  overflow: hidden;
+  font-family: inherit;
+  color: #fff;
+}
+
+.dchat-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  background: var(--OrbitDarkBlue);
+}
+
+.dchat-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.dchat-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-left: auto;
+}
+.dchat-dot-on { background: var(--OrbitGreen); }
+.dchat-dot-wait { background: #ffd166; }
+.dchat-dot-off { background: rgba(255, 255, 255, 0.35); }
+
+.dchat-close {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+}
+
+.dchat-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  /* overscroll-behavior alone does not stop pull-to-refresh on mobile here (the
+     document scrolls, not this element) — the sheet also pins the body. */
+  overscroll-behavior: contain;
+  /* Chrome's scroll anchoring repositions scrollTop when content is inserted,
+     which silently un-pins an append. Both directions are handled manually. */
+  overflow-anchor: none;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--OrbitDarkBlue) transparent;
+  padding: 4px 6px;
+  /* Isolates the list's layout/paint from the rest of the scaled chrome. */
+  contain: layout paint style;
+}
+
+.dchat-empty {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.62);
+  text-align: center;
+  margin: 10px 0;
+}
+
+.dchat-msg {
+  /* Virtualization-grade behaviour with no JS: off-screen rows skip style,
+     layout and paint. A real virtual scroller would cost more than it saves at
+     100 rows, and image loads make row heights variable anyway. */
+  content-visibility: auto;
+  contain-intrinsic-size: 0 44px;
+  padding: 1px 0;
+  margin-top: 7px;
+}
+
+.dchat-msg-grouped { margin-top: 1px; }
+
+/* Site-relayed messages get a rule rather than a badge — cheaper, and it reads
+   as period-appropriate. */
+.dchat-msg-site {
+  border-left: 2px solid var(--OrbitGreen);
+  padding-left: 5px;
+}
+
+.dchat-msg-head {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
+}
+
+.dchat-avatar {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.dchat-name {
+  font-weight: 700;
+  /* Counter-scales the chrome's transform. computeSiteScale floors at ~0.72 on
+     a narrow desktop window, which would render 12.5px type at 9 physical px,
+     grayscale-antialiased. The clamp keeps it readable without changing
+     anything at scale 1. */
+  font-size: clamp(12.5px, calc(12.5px / var(--site-scale, 1)), 16px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.dchat-time {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.62);
+  white-space: nowrap;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.dchat-body {
+  font-size: clamp(12.5px, calc(12.5px / var(--site-scale, 1)), 16px);
+  line-height: 1.35;
+  margin: 0;
+  /* pre-wrap keeps Discord's newlines; `anywhere` (not break-word) is what
+     actually shrinks min-content so a 200-char CDN URL cannot blow the row out
+     to 1400px and get clipped by the sidebar's overflow:hidden. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+.dchat-link { color: #bfe3ff; text-decoration: underline; }
+.dchat-mention {
+  color: #cfe4ff;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 3px;
+  padding: 0 2px;
+}
+.dchat-code,
+.dchat-codeblock {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 3px;
+  padding: 0 3px;
+  font-size: 0.92em;
+}
+.dchat-codeblock { display: block; white-space: pre-wrap; padding: 3px 5px; margin: 2px 0; }
+.dchat-emoji { width: 18px; height: 18px; vertical-align: -3px; }
+.dchat-edited { font-size: 10px; color: rgba(255, 255, 255, 0.5); }
+
+.dchat-att {
+  display: block;
+  width: 100%;
+  max-height: 120px;
+  margin-top: 3px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.dchat-att img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.dchat-att-expired {
+  display: block;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.62);
+  margin-top: 3px;
+}
+
+.dchat-unread {
+  flex: 0 0 auto;
+  margin: 0 6px 3px;
+  padding: 2px 0;
+  font-size: 11px;
+  font-weight: 700;
+  color: #fff;
+  background: var(--OrbitLightBlue);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.dchat-notice {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 3px 8px;
+  font-size: 11px;
+  color: #ffd166;
+}
+
+.dchat-compose {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+  padding: 5px 6px;
+  background: var(--OrbitDarkBlue);
+}
+
+.dchat-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  resize: none;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.28);
+  /* Explicit, and required. assets/css/tailwind.css sets
+     `textarea { color: #111827 }` in @layer base for the ~1300 fields on light
+     backgrounds; scoped CSS wins, but without this the composer would render
+     gray-900 on dark navy — invisible, and formFieldContrast.test.js would not
+     catch it because that test only inspects Tailwind-classed fields.
+     -webkit-text-fill-color is deliberately NOT set; see that file's note. */
+  color: #ffffff;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.3;
+  padding: 4px 6px;
+  max-height: 62px;
+}
+
+.dchat-input::placeholder { color: rgba(255, 255, 255, 0.5); }
+.dchat-input:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.dchat-send {
+  flex: 0 0 auto;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 2px solid #1a5a9a;
+  background: var(--OrbitLightBlue);
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+}
+.dchat-send:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* Mobile sheet. The chrome drops its transform below 768px, which is what makes
+   a fixed-position sheet resolve against the real viewport here and only here. */
+.dchat-sheet {
+  border-radius: 0;
+  height: 100%;
+}
+
+@media (max-width: 768px) {
+  .dchat-name,
+  .dchat-body { font-size: 14px; }
+  .dchat-time { font-size: 12px; }
+  .dchat-input {
+    /* 16px minimum, non-negotiable: the viewport meta sets no maximum-scale
+       (correctly), so iOS Safari zooms the page on focus for anything smaller
+       and does not zoom back out. */
+    font-size: 16px;
+  }
+}
+</style>

--- a/components/newsite/NavRight.vue
+++ b/components/newsite/NavRight.vue
@@ -24,6 +24,21 @@
     <NuxtLink v-if="!isMobile" to="/newsite/settings" class="nav-link">
       <BlueButton :style="{ height: buttonHeight }">Settings</BlueButton>
     </NuxtLink>
+    <!-- Labelled "Chat", not "Toggle Chat". `.topbar-nav-right` is
+         `overflow: hidden` and these buttons are `white-space: nowrap`, so they
+         are CLIPPED rather than wrapped on desktop. An admin's NavLeft carries
+         an extra "Admin" button, which leaves roughly 50px of slack in the row
+         at a ~1060px window — "Toggle Chat" (~112px) would eat the right edge
+         of Settings, "Chat" (~67px) fits.
+         Hidden where the sidebar is (7 pages set `showSidebar: false`, incl.
+         the whole admin console), because the panel has nowhere to render
+         there and the button would silently do nothing. -->
+    <BlueButton
+      v-if="chatAvailable"
+      :style="{ height: buttonHeight }"
+      :aria-pressed="chatOpen ? 'true' : 'false'"
+      @click="toggleChat"
+    >Chat</BlueButton>
   </div>
 </template>
 
@@ -38,6 +53,10 @@ const props = defineProps({
     default: false
   }
 })
+
+const route = useRoute()
+const { chatOpen, toggleChat } = useNewsiteLayout()
+const chatAvailable = computed(() => route.meta.showSidebar !== false && route.meta.fluidLayout !== true)
 </script>
 
 <style scoped>

--- a/components/newsite/admin/legacy/AdminLegacyGlobalSettings.vue
+++ b/components/newsite/admin/legacy/AdminLegacyGlobalSettings.vue
@@ -464,6 +464,88 @@
             Leave blank to use the DISCORD_ANNOUNCEMENTS_CHANNEL environment variable.
           </p>
         </div>
+
+        <hr class="my-4" />
+
+        <h3 class="text-sm font-semibold">Live Chat Relay</h3>
+        <p class="text-xs text-gray-600">
+          Mirrors a Discord channel into the site sidebar and lets signed-in members post back
+          into it. Messages sent from the site arrive in Discord through a webhook, shown under
+          the player's site username with an <span class="font-mono">APP</span> tag.
+        </p>
+        <p class="text-[10px] text-gray-500">
+          Requires two things that are not set here: the <span class="font-mono">MESSAGE CONTENT</span>
+          privileged intent enabled on the bot (Developer Portal → Bot → Privileged Gateway Intents),
+          and <span class="font-mono">DISCORD_CHAT_WEBHOOK_URL</span> in the server environment.
+          The webhook credential is deliberately not stored in the database.
+        </p>
+
+        <label class="flex items-center gap-2 text-xs font-medium">
+          <input v-model="discordChatEnabled" type="checkbox" class="h-4 w-4" />
+          Enable the chat relay
+        </label>
+        <p class="text-[10px] text-gray-500 -mt-2">
+          Turning this off takes effect immediately, stops the feed, and clears the buffered
+          history. Use it as the kill switch if the channel is being abused.
+        </p>
+
+        <div class="max-w-md flex flex-col gap-1">
+          <label for="discordChatChannelId" class="text-xs font-medium">Chat Channel ID</label>
+          <input
+            id="discordChatChannelId"
+            v-model.trim="discordChatChannelId"
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            class="border rounded-md px-2 py-1.5 text-sm"
+            placeholder="123456789012345678"
+          />
+          <p class="text-[10px] text-gray-500">
+            Must be a standard text channel in this Discord server; it is verified on save. The
+            bot needs View Channel and Read Message History on it. Everyone in the channel should
+            be told their messages appear on the website — consider a dedicated channel rather
+            than #general.
+          </p>
+        </div>
+
+        <div class="max-w-md grid grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1">
+            <label for="discordChatSlowmodeSeconds" class="text-xs font-medium">Slowmode (seconds)</label>
+            <input
+              id="discordChatSlowmodeSeconds"
+              v-model.number="discordChatSlowmodeSeconds"
+              type="number"
+              min="0"
+              max="300"
+              class="border rounded-md px-2 py-1.5 text-sm"
+            />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label for="discordChatMaxLength" class="text-xs font-medium">Max message length</label>
+            <input
+              id="discordChatMaxLength"
+              v-model.number="discordChatMaxLength"
+              type="number"
+              min="1"
+              max="2000"
+              class="border rounded-md px-2 py-1.5 text-sm"
+            />
+          </div>
+        </div>
+        <p class="text-[10px] text-gray-500 -mt-1">
+          Slowmode is per player. A separate global limit protects the webhook itself, because
+          Discord caps requests per webhook regardless of how many different people are sending.
+        </p>
+
+        <label class="flex items-center gap-2 text-xs font-medium">
+          <input v-model="discordChatShowAttachments" type="checkbox" class="h-4 w-4" />
+          Show image attachments in the site feed
+        </label>
+        <p class="text-[10px] text-gray-500 -mt-2">
+          Off by default. Any guild member can put an image on the website this way, and Discord's
+          attachment links expire after about a day, so older buffered images stop loading.
+        </p>
+
         <div>
           <button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50" :disabled="savingDiscord" @click="saveDiscord">
             {{ savingDiscord ? 'Saving…' : 'Save' }}
@@ -492,6 +574,11 @@ const savingAuctions = ref(false)
 const savingCmart = ref(false)
 const savingDiscord = ref(false)
 const czoneContestDiscordChannelId = ref('')
+const discordChatEnabled           = ref(false)
+const discordChatChannelId         = ref('')
+const discordChatSlowmodeSeconds   = ref(5)
+const discordChatMaxLength         = ref(400)
+const discordChatShowAttachments   = ref(false)
 
 // cMart state
 const firstAdditionalCzoneCost      = ref(25000)
@@ -604,6 +691,11 @@ async function loadGlobal() {
     secondEditionOverlayWidth.value  = g?.secondEditionOverlayWidth  ?? null
     secondEditionOverlayHeight.value = g?.secondEditionOverlayHeight ?? null
     czoneContestDiscordChannelId.value = g?.czoneContestDiscordChannelId ?? ''
+    discordChatEnabled.value           = g?.discordChatEnabled === true
+    discordChatChannelId.value         = g?.discordChatChannelId ?? ''
+    discordChatSlowmodeSeconds.value   = Number(g?.discordChatSlowmodeSeconds ?? 5)
+    discordChatMaxLength.value         = Number(g?.discordChatMaxLength ?? 400)
+    discordChatShowAttachments.value   = g?.discordChatShowAttachments === true
     if (g?.timeBasedPurchaseLimits) {
       for (const r of timeBasedRarities) {
         const def = g.timeBasedPurchaseLimits[r]
@@ -776,7 +868,12 @@ async function saveDiscord() {
       method: 'POST',
       body: {
         dailyPointLimit: Number(dailyPointLimit.value),
-        czoneContestDiscordChannelId: czoneContestDiscordChannelId.value
+        czoneContestDiscordChannelId: czoneContestDiscordChannelId.value,
+        discordChatEnabled: discordChatEnabled.value,
+        discordChatChannelId: discordChatChannelId.value,
+        discordChatSlowmodeSeconds: Number(discordChatSlowmodeSeconds.value),
+        discordChatMaxLength: Number(discordChatMaxLength.value),
+        discordChatShowAttachments: discordChatShowAttachments.value
       }
     })
     toast.value = { type: 'ok', msg: 'Discord settings saved.' }

--- a/composables/useNewsiteLayout.js
+++ b/composables/useNewsiteLayout.js
@@ -2,6 +2,25 @@ export const useNewsiteLayout = () => {
   const sidebarMiddleComponent = useState('newsiteSidebarMiddle', () => null)
   const mobileSidebarCollapsed = useState('newsiteMobileSidebarCollapsed', () => true)
 
+  // Discord chat panel.
+  //
+  // Deliberately orthogonal to both of its neighbours:
+  //
+  //  • `sidebarMiddleComponent` keeps tracking the route underneath. Chat is not
+  //    a ninth value of it, because 35 pages call setSidebarMiddle()/
+  //    clearSidebarMiddle() at the top level of setup — so a chat "value" would
+  //    be clobbered by the next navigation. Closing chat therefore reveals
+  //    whatever sidebar the current page set, with no special-casing.
+  //  • `mobileSidebarCollapsed` must not touch it either. On mobile the chat
+  //    renders in a teleported sheet rather than inside the sidebar, precisely
+  //    so the existing "Hide Sidebar" button cannot unmount it (the sidebar
+  //    body is behind a v-if) and so the two buttons can never fight over one
+  //    piece of visible state.
+  //
+  // Plain useState, no localStorage: nothing else in composables/ persists, and
+  // reading localStorage during setup would mismatch on SSR.
+  const chatOpen = useState('newsiteChatOpen', () => false)
+
   const setSidebarMiddle = (componentName) => {
     sidebarMiddleComponent.value = componentName
   }
@@ -10,5 +29,16 @@ export const useNewsiteLayout = () => {
     sidebarMiddleComponent.value = null
   }
 
-  return { sidebarMiddleComponent, setSidebarMiddle, clearSidebarMiddle, mobileSidebarCollapsed }
+  const toggleChat = () => {
+    chatOpen.value = !chatOpen.value
+  }
+
+  return {
+    sidebarMiddleComponent,
+    setSidebarMiddle,
+    clearSidebarMiddle,
+    mobileSidebarCollapsed,
+    chatOpen,
+    toggleChat
+  }
 }

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -18,6 +18,7 @@
  *   worker-achieve                – BullMQ worker: daily achievements
  *   worker-content-analyzer       – BullMQ worker: survey content analysis
  *   guild-checker                 – Cron: Discord guild member sync
+ *   discord-chat                  – Discord gateway relay for the sidebar chat
  *
  * Workers run as single fork-mode instances to prevent double-processing of jobs.
  */
@@ -171,6 +172,36 @@ module.exports = {
       script:    'server/cron/sync-guild-members.js',
       exec_mode: 'fork',
       instances: 1,
+      env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
+      env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
+    },
+
+    // ── Discord chat relay: gateway connection ────────────────────────────
+    // Holds the single Discord Gateway WebSocket and republishes messages onto
+    // Redis for socket-server to fan out. Its own process, not part of
+    // socket-server, for the reasons in the header of the worker file — chiefly
+    // that socket-server has no uncaughtException handler and does not persist
+    // live Clash matches on a crash, so gateway code must not be able to take
+    // it down.
+    //
+    // instances: 1 is load-bearing: it is what guarantees a single gateway
+    // connection, so there is no distributed lock anywhere in this feature.
+    {
+      name:      'discord-chat',
+      script:    'server/workers/discord-chat.worker.js',
+      exec_mode: 'fork',
+      instances: 1,
+      // The only PM2 app here with backoff, and it needs it. Discord resets the
+      // bot token if an app exceeds 1000 IDENTIFYs in 24h, and PM2's default is
+      // to restart a crashing process immediately — which would burn that budget
+      // in under an hour and break OAuth login, DMs and every announcement path
+      // site-wide. The worker also keeps its own persisted IDENTIFY counter;
+      // this is the outer guard.
+      exp_backoff_restart_delay: 1000,
+      max_restarts: 20,
+      wait_ready:     true,
+      listen_timeout: 15000,
+      kill_timeout:   5000,
       env:             { NODE_ENV: 'production',   OFFICIAL_USERNAME: OFFICIAL_USERNAME_PROD },
       env_development: { NODE_ENV: 'development', OFFICIAL_USERNAME: OFFICIAL_USERNAME_DEV },
     },

--- a/layouts/newsite-template.vue
+++ b/layouts/newsite-template.vue
@@ -265,20 +265,45 @@ html.newsite-active body {
       </button>
       <template v-if="!isMobile || !mobileSidebarCollapsed">
         <div class="sidebar-top"    :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto' } : {}"><UserInfo /></div>
-        <div class="sidebar-middle" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', marginTop: 'var(--sidebar-middle-mt)', marginBottom: 'var(--sidebar-middle-mb)' } : {}">
-          <MiddleSidebarImages v-show="!sidebarMiddleComponent" />
-          <CmartSidebar        v-show="sidebarMiddleComponent === 'CmartSidebar'" />
-          <NewcmartSidebar     v-show="sidebarMiddleComponent === 'NewcmartSidebar'" />
-          <AuctionHouseSidebar v-show="sidebarMiddleComponent === 'AuctionHouseSidebar'" />
-          <MyCollectionSidebar v-show="sidebarMiddleComponent === 'MyCollectionSidebar'" />
-          <AllCtoonsSidebar    v-show="sidebarMiddleComponent === 'AllCtoonsSidebar'" />
-          <MyWishlistSidebar   v-show="sidebarMiddleComponent === 'MyWishlistSidebar'" />
-          <TradeSidebarWrapper v-show="sidebarMiddleComponent === 'TradeSidebarWrapper'" />
-          <CzoneSidebarMiddle  v-show="sidebarMiddleComponent === 'CzoneSidebarMiddle'" />
-        </div>
-        <div class="sidebar-bottom" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', marginTop: 'var(--sidebar-bottom-mt)' } : {}"><WinballPromo /></div>
+        <!-- Desktop chat replaces the middle + bottom regions. It is deliberately
+             NOT given a fixed height: `--sidebar-middle-height` is overridden by
+             five pages (384px on newcmart, 490px on trade, 504px on cmart), and
+             `.sidebar-bottom` pins itself with `margin-top: auto`, so any
+             hard-coded number would gap on some routes and be clipped on others.
+             `flex: 1 1 auto; min-height: 0` takes exactly the space left after
+             UserInfo, on every page, automatically. -->
+        <div v-if="showChatInSidebar" class="sidebar-chat"><LazyDiscordChat /></div>
+        <template v-else>
+          <div class="sidebar-middle" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', marginTop: 'var(--sidebar-middle-mt)', marginBottom: 'var(--sidebar-middle-mb)' } : {}">
+            <MiddleSidebarImages v-show="!sidebarMiddleComponent" />
+            <CmartSidebar        v-show="sidebarMiddleComponent === 'CmartSidebar'" />
+            <NewcmartSidebar     v-show="sidebarMiddleComponent === 'NewcmartSidebar'" />
+            <AuctionHouseSidebar v-show="sidebarMiddleComponent === 'AuctionHouseSidebar'" />
+            <MyCollectionSidebar v-show="sidebarMiddleComponent === 'MyCollectionSidebar'" />
+            <AllCtoonsSidebar    v-show="sidebarMiddleComponent === 'AllCtoonsSidebar'" />
+            <MyWishlistSidebar   v-show="sidebarMiddleComponent === 'MyWishlistSidebar'" />
+            <TradeSidebarWrapper v-show="sidebarMiddleComponent === 'TradeSidebarWrapper'" />
+            <CzoneSidebarMiddle  v-show="sidebarMiddleComponent === 'CzoneSidebarMiddle'" />
+          </div>
+          <div class="sidebar-bottom" :style="isMobile ? { width: 'auto', alignSelf: 'stretch', height: 'auto', marginTop: 'var(--sidebar-bottom-mt)' } : {}"><WinballPromo /></div>
+        </template>
       </template>
     </div>
+    <!-- Mobile chat is a teleported sheet, not a sidebar region, for two
+         reasons. The sidebar body above sits behind a `v-if` keyed on
+         `mobileSidebarCollapsed`, so a panel inside it would be UNMOUNTED —
+         dropping the socket and the scrollback — whenever someone used the
+         existing "Hide Sidebar" button, and the two toggles would fight over
+         one piece of visible state. And `position: fixed` resolves against the
+         real viewport here precisely because `scaleStyle` drops the transform
+         below 768px; on desktop the transform makes `.site-container` the
+         containing block, which is the trap documented above the Onboarding
+         component below. -->
+    <Teleport to="body">
+      <div v-if="showChatSheet" class="chat-sheet" role="dialog" aria-modal="true" aria-label="Discord chat">
+        <LazyDiscordChat sheet @close="chatOpen = false" />
+      </div>
+    </Teleport>
     <div class="main-content" :class="{ 'main-content-full': !showSidebar && !isMobile, 'main-content-expand': !showFooter }" :style="[{ border: mainContentBorder }, mainContentMobileStyle]"><slot /></div>
     <div class="footer" :style="[{ display: showFooter ? '' : 'none' }, isMobile ? { width: '100%', height: 'auto', aspectRatio: '800 / 60' } : {}]"><slot name="footer" /></div>
     <CtoonInfoCard v-if="ctoonModalIsOpen" />
@@ -318,7 +343,7 @@ const {
 function onAuctionCreated(userCtoonId) {
   notifyAuctionCreated(userCtoonId)
 }
-const { sidebarMiddleComponent, mobileSidebarCollapsed } = useNewsiteLayout()
+const { sidebarMiddleComponent, mobileSidebarCollapsed, chatOpen } = useNewsiteLayout()
 const czoneState = useNewSiteCzoneState()
 
 const siteName = 'Cartoon ReOrbit'
@@ -352,6 +377,13 @@ const showAdbar = computed(() => route.meta.showAdbar !== false)
 const showNav = computed(() => route.meta.showNav !== false)
 const showSidebar = computed(() => route.meta.showSidebar !== false)
 const showFooter = computed(() => route.meta.showFooter !== false)
+
+// Chat only exists where the sidebar does. Seven pages set `showSidebar: false`
+// (the games and the admin console), and the layout hides `.sidebar` outright
+// on those, so the nav button is hidden there too rather than being a no-op.
+const chatAvailable = computed(() => showSidebar.value && !fluidLayout.value)
+const showChatInSidebar = computed(() => chatOpen.value && chatAvailable.value && !isMobile.value)
+const showChatSheet = computed(() => chatOpen.value && chatAvailable.value && isMobile.value)
 const mainContentBorder = computed(() => route.meta.mainContentBorder === false ? 'none' : undefined)
 
 
@@ -450,6 +482,61 @@ onUnmounted(() => {
   if (frame !== null) cancelAnimationFrame(frame)
   mql?.removeEventListener('change', applyMobile)
   window.removeEventListener('resize', computeLayout)
+  releaseChatSheet()
+})
+
+// ── Mobile chat sheet: keyboard + pull-to-refresh ──────────────────────────
+// `100dvh` tracks the URL bar but does NOT shrink for the iOS keyboard, which
+// changes only the visual viewport — so a dvh-sized sheet puts the composer
+// behind the keyboard. visualViewport reports the height actually visible and
+// fires on both resize and scroll (iOS scrolls the visual viewport, not the
+// layout one). Same instrument pages/newsite/blackjack.vue uses, for the same
+// reason.
+//
+// The body pin is separate and also necessary: on mobile the DOCUMENT scrolls,
+// so `overscroll-behavior` on an inner element does nothing and dragging up
+// past the top of the scrollback triggers pull-to-refresh — which would reload
+// the page and discard the socket, the history, and any half-typed message.
+// pages/newsite/flappypowerpuff.vue documents the same trap.
+let sheetScrollY = 0
+let sheetPinned = false
+
+const syncChatSheet = () => {
+  const el = document.querySelector('.chat-sheet')
+  const vv = window.visualViewport
+  if (!el || !vv) return
+  el.style.height = `${vv.height}px`
+  el.style.transform = `translateY(${vv.offsetTop}px)`
+}
+
+function holdChatSheet() {
+  if (sheetPinned) return
+  sheetPinned = true
+  sheetScrollY = window.scrollY
+  document.body.style.position = 'fixed'
+  document.body.style.top = `-${sheetScrollY}px`
+  document.body.style.width = '100%'
+  document.documentElement.style.overscrollBehaviorY = 'none'
+  window.visualViewport?.addEventListener('resize', syncChatSheet)
+  window.visualViewport?.addEventListener('scroll', syncChatSheet)
+  nextTick(syncChatSheet)
+}
+
+function releaseChatSheet() {
+  if (!sheetPinned) return
+  sheetPinned = false
+  document.body.style.position = ''
+  document.body.style.top = ''
+  document.body.style.width = ''
+  document.documentElement.style.overscrollBehaviorY = ''
+  window.visualViewport?.removeEventListener('resize', syncChatSheet)
+  window.visualViewport?.removeEventListener('scroll', syncChatSheet)
+  window.scrollTo(0, sheetScrollY)
+}
+
+watch(showChatSheet, (open) => {
+  if (open) holdChatSheet()
+  else releaseChatSheet()
 })
 
 const mainContentMobileStyle = computed(() => {
@@ -481,7 +568,13 @@ const scaleStyle = computed(() => {
   return {
     transform: `scale(${scale.value})`,
     transformOrigin: 'top center',
-    marginBottom: `${scaleMarginBottom(scale.value)}px`
+    marginBottom: `${scaleMarginBottom(scale.value)}px`,
+    // Published so descendants can counter-scale. The chat panel is the first
+    // surface here anyone actually READS rather than glances at, and the scale
+    // floors at (768-20)/1040 = 0.719 on a narrow desktop window — which would
+    // render 12.5px type at ~9 physical px, grayscale-antialiased. Everything
+    // else in the chrome is short labels and is fine shrinking.
+    '--site-scale': String(scale.value)
   }
 })
 </script>
@@ -724,6 +817,40 @@ const scaleStyle = computed(() => {
   flex-shrink: 0;
   overflow: hidden;
   align-self: center;
+}
+
+/* Takes whatever vertical space is left after `.sidebar-top`, rather than a
+   fixed height — see the template comment. `min-height: 0` is required, not
+   cosmetic: a flex item's automatic minimum size is its content size, so
+   without it the panel refuses to shrink, grows past the 682px sidebar, and
+   `.sidebar { overflow: hidden }` clips the composer off the bottom with no
+   scrollbar anywhere to reach it. */
+.sidebar-chat {
+  flex: 1 1 auto;
+  min-height: 0;
+  width: var(--sidebar-middle-width);
+  align-self: center;
+  margin-top: var(--sidebar-middle-mt);
+  margin-bottom: var(--sidebar-bottom-mb);
+  overflow: hidden;
+}
+
+/* Mobile-only full-screen sheet, teleported to body. Safe here and only here:
+   `scaleStyle` applies no transform below 768px, so `position: fixed` resolves
+   against the real viewport instead of against `.site-container`.
+   z-index clears Onboarding's z-50. The height is a pre-JS fallback; the
+   visualViewport handler in the script sets the real value so the composer
+   stays above the soft keyboard. */
+.chat-sheet {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100dvh;
+  z-index: 60;
+  background: var(--sidebar-bg);
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar-bottom {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start": "nuxt start",
     "lint": "eslint .",
     "seed": "node prisma/seed.js",
-    "socket": "node server/socket-server.js"
+    "socket": "node server/socket-server.js",
+    "discord-chat": "node server/workers/discord-chat.worker.js"
   },
   "keywords": [],
   "author": "",

--- a/prisma/migrations/20260819120000_add_discord_chat_relay/migration.sql
+++ b/prisma/migrations/20260819120000_add_discord_chat_relay/migration.sql
@@ -1,0 +1,40 @@
+-- Discord chat relay: admin-facing config on the singleton GlobalGameConfig row,
+-- plus a per-user chat timeout on User.
+--
+-- Written idempotently to match the house style of the surrounding migrations.
+
+-- ── Lock safety ──────────────────────────────────────────────────────────────
+-- Every statement below takes ACCESS EXCLUSIVE on its table. All of them are
+-- nullable-or-defaulted ADD COLUMNs, which are catalog-only on PG11+ (no table
+-- rewrite), so each is instant *once it has the lock*. "User" in particular is
+-- read by essentially every request, so failing fast and retrying beats queuing
+-- the whole site behind a lock wait.
+SET lock_timeout = '3s';
+
+-- ── GlobalGameConfig: relay settings ─────────────────────────────────────────
+-- Deliberately absent: the webhook id/token. Both admin config endpoints return
+-- this row wholesale, so a secret stored here would be serialized into every
+-- admin's browser on every settings page load. The webhook credential lives in
+-- env (DISCORD_CHAT_WEBHOOK_ID / DISCORD_CHAT_WEBHOOK_TOKEN) alongside BOT_TOKEN.
+--
+-- Default false: switching this on republishes a Discord channel to the website
+-- and opens an ingress from the website into Discord. That is a deliberate act,
+-- not a side effect of deploying.
+ALTER TABLE "GlobalGameConfig"
+  ADD COLUMN IF NOT EXISTS "discordChatEnabled"         BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "discordChatChannelId"       TEXT,
+  ADD COLUMN IF NOT EXISTS "discordChatSlowmodeSeconds" INTEGER NOT NULL DEFAULT 5,
+  ADD COLUMN IF NOT EXISTS "discordChatMaxLength"       INTEGER NOT NULL DEFAULT 400,
+  -- Off by default: an attachment is an arbitrary image chosen by any guild
+  -- member and rendered to every logged-in site user, and Discord's attachment
+  -- CDN URLs are signed and expire after roughly a day.
+  ADD COLUMN IF NOT EXISTS "discordChatShowAttachments" BOOLEAN NOT NULL DEFAULT false;
+
+-- ── User: chat timeout ───────────────────────────────────────────────────────
+-- Null or in the past = not muted. "banned" already stops chat entirely; this is
+-- the narrower lever, because a relayed message reaches Discord as a single
+-- webhook identity and so cannot be timed out with Discord's own moderation
+-- tools.
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "chatMutedUntil" TIMESTAMP(3);
+
+RESET lock_timeout;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -474,6 +474,16 @@ model User {
   additionalCzones                  Int       @default(0)
   usernameChangedAt                 DateTime?
   vpnDetected                       Boolean   @default(false)
+  // Discord chat relay timeout. `banned` already stops chat outright (the socket
+  // auth helper refuses banned users), so this is the lesser lever: it blocks
+  // sending into Discord without touching the rest of the account. Null or past
+  // = not muted. Set from Admin > Manage Users.
+  //
+  // This exists because the relay is asymmetric: every site message reaches
+  // Discord as one webhook identity, so a Discord moderator's own tools
+  // (timeout/kick/ban) cannot single out a site user. Without this column the
+  // only lever is banning the account outright.
+  chatMutedUntil                    DateTime?
 
   // cMoon (faction) membership
   cMoonId            String?
@@ -1438,6 +1448,31 @@ model GlobalGameConfig {
   cMoonEnabled                       Boolean   @default(false)
   cMoonEnabledAt                     DateTime?
   cMoonSelectionDeadlineAt           DateTime?
+
+  // ── Discord chat relay (sidebar "Chat" panel) ───────────────────────────────
+  // Off by default: the relay republishes a guild channel to the website and
+  // gives every site user an ingress into Discord, so it is switched on
+  // deliberately rather than by deploying.
+  //
+  // The webhook credential is deliberately NOT here. Both admin config
+  // endpoints return this row wholesale (global-config.get.js returns `config`,
+  // .post.js returns `result`), so any secret in this model is shipped to every
+  // admin's browser on every settings load. A webhook token is an
+  // unauthenticated bearer credential that can post to the channel as any
+  // name and avatar, and it is revocable only by deleting the webhook. It
+  // lives in env alongside BOT_TOKEN and JWT_SECRET. See server/utils/discordChat/config.js.
+  discordChatEnabled                 Boolean   @default(false)
+  discordChatChannelId               String?
+  // Per-user floor between sends. Note this bounds ONE user; the per-webhook
+  // ceiling is enforced separately by a global token bucket, because N users
+  // each obeying their own slowmode still exceed Discord's per-webhook limit.
+  discordChatSlowmodeSeconds         Int       @default(5)
+  discordChatMaxLength               Int       @default(400)
+  // Off by default. Rendering attachments means any guild member can put an
+  // image on the website, and Discord's attachment CDN URLs are signed and
+  // expire, so buffered images rot after roughly a day.
+  discordChatShowAttachments         Boolean   @default(false)
+
   createdAt                          DateTime  @default(now())
   updatedAt                          DateTime  @updatedAt
 }

--- a/server/api/admin/global-config.post.js
+++ b/server/api/admin/global-config.post.js
@@ -8,6 +8,9 @@ import {
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { clearUpgradesConfigCache } from '@/server/utils/upgradesConfigCache'
+import { fetchChannel } from '@/server/utils/discordChat/rest'
+import { rawBotToken, invalidateChatConfig } from '@/server/utils/discordChat/config'
+import { getRedis } from '@/server/utils/redis'
 
 export default defineEventHandler(async (event) => {
   // 1) Authenticate & authorize
@@ -43,7 +46,12 @@ export default defineEventHandler(async (event) => {
     packPriceDecayDays,
     packPriceFloor,
     packMaxDefaultBuysPerUser,
-    czoneContestDiscordChannelId
+    czoneContestDiscordChannelId,
+    discordChatEnabled,
+    discordChatChannelId,
+    discordChatSlowmodeSeconds,
+    discordChatMaxLength,
+    discordChatShowAttachments
   } = body
 
   // minimally require the existing cap; other fields optional with defaults
@@ -61,6 +69,46 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, statusMessage: 'Discord Channel ID must be a numeric channel/snowflake ID' })
     }
     czoneContestDiscordChannelIdValue = trimmed || null
+  }
+
+  // ── Discord chat relay ──────────────────────────────────────────────────────
+  // The channel id gets a stronger check than the announcement channels above:
+  // this one is a live two-way bridge, so pointing it at the wrong place would
+  // both republish that channel onto the website and open a write path into it.
+  // The snowflake shape is necessary but not sufficient — the channel must also
+  // be a plain text channel IN THIS GUILD. Note webhook execution outright fails
+  // on forum/media channels, and an announcement channel behaves differently, so
+  // type 0 is also a correctness requirement, not just a safety one.
+  let discordChatChannelIdValue
+  if (discordChatChannelId !== undefined) {
+    const trimmed = typeof discordChatChannelId === 'string' ? discordChatChannelId.trim() : ''
+    if (trimmed && !/^\d{17,20}$/.test(trimmed)) {
+      throw createError({ statusCode: 400, statusMessage: 'Chat Channel ID must be a numeric channel/snowflake ID' })
+    }
+    if (trimmed) {
+      let channel = null
+      try {
+        channel = await fetchChannel(trimmed, rawBotToken())
+      } catch {
+        throw createError({
+          statusCode: 400,
+          statusMessage: 'Could not read that channel. Check the ID and that the bot can see it.'
+        })
+      }
+      if (!channel || String(channel.guild_id || '') !== String(process.env.DISCORD_GUILD_ID || '')) {
+        throw createError({ statusCode: 400, statusMessage: 'That channel is not in this Discord server.' })
+      }
+      if (Number(channel.type) !== 0) {
+        throw createError({ statusCode: 400, statusMessage: 'Chat channel must be a standard text channel.' })
+      }
+    }
+    discordChatChannelIdValue = trimmed || null
+  }
+
+  const clampInt = (value, min, max) => {
+    const n = Number(value)
+    if (!Number.isInteger(n)) return undefined
+    return Math.min(max, Math.max(min, n))
   }
 
   const payload = {
@@ -87,7 +135,12 @@ export default defineEventHandler(async (event) => {
     packPriceDecayDays:        (typeof packPriceDecayDays        === 'number') ? Math.max(1, packPriceDecayDays)        : undefined,
     packPriceFloor:            (typeof packPriceFloor            === 'number') ? Math.max(0, packPriceFloor)            : undefined,
     packMaxDefaultBuysPerUser: (typeof packMaxDefaultBuysPerUser === 'number') ? Math.max(1, packMaxDefaultBuysPerUser) : undefined,
-    czoneContestDiscordChannelId: czoneContestDiscordChannelIdValue
+    czoneContestDiscordChannelId: czoneContestDiscordChannelIdValue,
+    discordChatEnabled: (typeof discordChatEnabled === 'boolean') ? discordChatEnabled : undefined,
+    discordChatChannelId: discordChatChannelIdValue,
+    discordChatSlowmodeSeconds: (discordChatSlowmodeSeconds !== undefined) ? clampInt(discordChatSlowmodeSeconds, 0, 300) : undefined,
+    discordChatMaxLength: (discordChatMaxLength !== undefined) ? clampInt(discordChatMaxLength, 1, 2000) : undefined,
+    discordChatShowAttachments: (typeof discordChatShowAttachments === 'boolean') ? discordChatShowAttachments : undefined
   }
 
   // 3) Upsert the singleton global config row
@@ -121,7 +174,12 @@ export default defineEventHandler(async (event) => {
         packPriceDecayDays:        payload.packPriceDecayDays        ?? 7,
         packPriceFloor:            payload.packPriceFloor            ?? 700,
         packMaxDefaultBuysPerUser: payload.packMaxDefaultBuysPerUser ?? 5,
-        czoneContestDiscordChannelId: payload.czoneContestDiscordChannelId ?? null
+        czoneContestDiscordChannelId: payload.czoneContestDiscordChannelId ?? null,
+        discordChatEnabled:         payload.discordChatEnabled         ?? false,
+        discordChatChannelId:       payload.discordChatChannelId       ?? null,
+        discordChatSlowmodeSeconds: payload.discordChatSlowmodeSeconds ?? 5,
+        discordChatMaxLength:       payload.discordChatMaxLength       ?? 400,
+        discordChatShowAttachments: payload.discordChatShowAttachments ?? false
       },
       update: {
         dailyPointLimit: payload.dailyPointLimit,
@@ -143,7 +201,12 @@ export default defineEventHandler(async (event) => {
         ...(payload.packPriceDecayDays        !== undefined ? { packPriceDecayDays:        payload.packPriceDecayDays }        : {}),
         ...(payload.packPriceFloor            !== undefined ? { packPriceFloor:            payload.packPriceFloor }            : {}),
         ...(payload.packMaxDefaultBuysPerUser !== undefined ? { packMaxDefaultBuysPerUser: payload.packMaxDefaultBuysPerUser } : {}),
-        ...(payload.czoneContestDiscordChannelId !== undefined ? { czoneContestDiscordChannelId: payload.czoneContestDiscordChannelId } : {})
+        ...(payload.czoneContestDiscordChannelId !== undefined ? { czoneContestDiscordChannelId: payload.czoneContestDiscordChannelId } : {}),
+        ...(payload.discordChatEnabled         !== undefined ? { discordChatEnabled:         payload.discordChatEnabled }         : {}),
+        ...(payload.discordChatChannelId       !== undefined ? { discordChatChannelId:       payload.discordChatChannelId }       : {}),
+        ...(payload.discordChatSlowmodeSeconds !== undefined ? { discordChatSlowmodeSeconds: payload.discordChatSlowmodeSeconds } : {}),
+        ...(payload.discordChatMaxLength       !== undefined ? { discordChatMaxLength:       payload.discordChatMaxLength }       : {}),
+        ...(payload.discordChatShowAttachments !== undefined ? { discordChatShowAttachments: payload.discordChatShowAttachments } : {})
       }
     })
     clearUpgradesConfigCache()
@@ -166,7 +229,16 @@ export default defineEventHandler(async (event) => {
       'packPriceDecayDays',
       'packPriceFloor',
       'packMaxDefaultBuysPerUser',
-      'czoneContestDiscordChannelId'
+      'czoneContestDiscordChannelId',
+      // Every new field is listed here or the change is silently unaudited.
+      // Note there is deliberately no webhook token among them: that secret
+      // lives in env, so it can never reach AdminChangeLog (which admins can
+      // browse) or the JSON this endpoint returns.
+      'discordChatEnabled',
+      'discordChatChannelId',
+      'discordChatSlowmodeSeconds',
+      'discordChatMaxLength',
+      'discordChatShowAttachments'
     ]
     for (const k of fields) {
       const prevVal = before ? before[k] : undefined
@@ -191,6 +263,11 @@ export default defineEventHandler(async (event) => {
         newValue: result?.timeBasedPurchaseLimits ?? null
       })
     }
+    // Push the change to the socket server and the gateway worker straight
+    // away. Without this the kill switch would wait out a cache TTL, or need a
+    // PM2 restart -- which is exactly what a kill switch must not require.
+    try { await invalidateChatConfig(getRedis()) } catch {}
+
     return result
   } catch (err) {
     console.error('Error upserting GlobalGameConfig:', err)

--- a/server/api/admin/users.get.js
+++ b/server/api/admin/users.get.js
@@ -32,6 +32,7 @@ export default defineEventHandler(async (event) => {
       isAdmin: true,
       active: true,
       banned: true,
+      chatMutedUntil: true,
       warning180: true,
       warning210: true,
       warning240: true,
@@ -86,6 +87,7 @@ export default defineEventHandler(async (event) => {
     isAdmin:       u.isAdmin,
     active:        u.active,
     banned:        u.banned,
+    chatMutedUntil: u.chatMutedUntil,
     additionalCzones: u.additionalCzones ?? 0,
 
     // keep flat flags for convenience

--- a/server/api/admin/users/[id]/chat-mute.post.js
+++ b/server/api/admin/users/[id]/chat-mute.post.js
@@ -1,0 +1,66 @@
+// server/api/admin/users/[id]/chat-mute.post.js
+//
+// Times a user out of the Discord chat relay without touching the rest of their
+// account.
+//
+// This exists because the relay is asymmetric. Every message the site sends
+// reaches Discord through one webhook identity, so a Discord moderator's own
+// tools — timeout, kick, ban, per-user AutoMod — cannot single out a site user.
+// Without this endpoint the only lever a moderator could ask for is banning the
+// whole account, which is wildly disproportionate for someone being annoying in
+// chat.
+import { defineEventHandler, getRequestHeader, readBody, createError } from 'h3'
+import { prisma } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+
+const MAX_MINUTES = 60 * 24 * 30 // 30 days
+
+export default defineEventHandler(async (event) => {
+  const cookie = getRequestHeader(event, 'cookie') || ''
+  let me
+  try {
+    me = await $fetch('/api/auth/me', { headers: { cookie } })
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+  if (!me?.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  }
+
+  const { id } = event.context.params || {}
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing user id' })
+
+  const body = await readBody(event)
+  // minutes === 0 clears the mute.
+  const minutes = Number(body?.minutes)
+  if (!Number.isInteger(minutes) || minutes < 0 || minutes > MAX_MINUTES) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `minutes must be an integer between 0 and ${MAX_MINUTES}`
+    })
+  }
+
+  const target = await prisma.user.findUnique({
+    where: { id },
+    select: { id: true, username: true, chatMutedUntil: true }
+  })
+  if (!target) throw createError({ statusCode: 404, statusMessage: 'User not found' })
+
+  const chatMutedUntil = minutes === 0 ? null : new Date(Date.now() + minutes * 60_000)
+
+  await prisma.user.update({ where: { id }, data: { chatMutedUntil } })
+
+  await logAdminChange(prisma, {
+    userId: me.id,
+    targetUserId: id,
+    area: 'User',
+    key: 'chatMutedUntil',
+    prevValue: target.chatMutedUntil ? target.chatMutedUntil.toISOString() : null,
+    newValue: chatMutedUntil ? chatMutedUntil.toISOString() : null
+  })
+
+  // No cache to invalidate: the socket handler re-reads this column on every
+  // send precisely so a mute takes effect on the user's next message rather
+  // than whenever their tab happens to reconnect.
+  return { ok: true, chatMutedUntil }
+})

--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -16,6 +16,14 @@ import { resolveAuctionCloseOutcome, AUCTION_CLOSE_DOUBLE_SALE } from './utils/a
 import { notifyAuctionWon } from './utils/notifications.js'
 import { getRedis } from './utils/redis.js'
 import * as redisState from './utils/redisState.js'
+import { CHAT_CHANNELS } from './utils/discordChat/constants.js'
+import { loadChatConfig, webhookCredentials } from './utils/discordChat/config.js'
+import { bufferSnapshot } from './utils/discordChat/buffer.js'
+import { relayMessage, ChatRateError } from './utils/discordChat/send.js'
+import { ChatContentError } from './utils/discordChat/sanitize.js'
+import { rawBotToken } from './utils/discordChat/config.js'
+import { discordFetch, botAuth } from './utils/discordChat/rest.js'
+import { encryptIp } from './utils/ip-encrypt.js'
 
 import fs                 from 'node:fs'
 import path               from 'node:path'
@@ -105,12 +113,6 @@ const syncPvpRoom = (roomId, room) =>
   redisState.setPvpRoom(roomId, room).catch(e => console.error('[redisState] setPvpRoom:', e))
 const syncDeletePvpRoom = (roomId) =>
   redisState.delPvpRoom(roomId).catch(e => console.error('[redisState] delPvpRoom:', e))
-/* ────────────────────────────────────────────────────────────
- *  cZone visitors & chat (unchanged)
- * ────────────────────────────────────────────────────────── */
-const zoneVisitors = {}        // zone → count
-const zoneSockets  = {}        // zone → Set(socketId)
-
 // near top, alongside pveMatches:
 const pvpRooms   = new Map();    // roomId -> { players: [userId], decks: {userId: deck} }
 const pvpMatches = new Map();    // roomId -> { battle, recordId }
@@ -1854,6 +1856,283 @@ async function requireSocketUser(socket, errorEvent = 'authError') {
   return user
 }
 
+/* ────────────────────────────────────────────────────────────
+ *  Discord chat relay — /chat namespace
+ *
+ *  A NAMESPACE, not a second connection: socket.io-client multiplexes
+ *  namespaces over one engine.io transport, so on a page that already has a
+ *  game socket open the chat rides it for free, and on any other page it costs
+ *  one connection. A second io() would instead register all ~49 game handlers
+ *  from io.on('connection') on a socket that needs three of them, and would pay
+ *  a fresh 5-request polling handshake every time the panel is opened.
+ *
+ *  The gateway itself lives in server/workers/discord-chat.worker.js — see that
+ *  file's header for why it is a separate process. This side only fans out what
+ *  that process publishes, and relays sends outbound.
+ * ────────────────────────────────────────────────────────── */
+const chatNsp = io.of('/chat')
+const CHAT_ROOM = 'discord-chat'
+const CHAT_JOIN_COOLDOWN_MS = 2000
+const GUILD_CHECK_TTL_SECONDS = 300
+
+const chatRedis = getRedis()
+// Subscriber connections cannot issue ordinary commands, so this is its own.
+const chatSub = chatRedis.duplicate()
+
+/**
+ * Confirms the user is still in the Discord guild.
+ *
+ * This deliberately does NOT trust User.inGuild. That column defaults to true
+ * and is only refreshed by the hourly guild-sync cron, because
+ * server/middleware/guild-check.js calls refreshDiscordTokenAndRoles(prisma,
+ * user, config) against a (user, config) signature — the arguments are shifted,
+ * so the function early-returns and the live re-check has never run. That is a
+ * pre-existing bug and fixing it is out of scope here (it would put two Discord
+ * API calls on every authenticated request), but it does mean the flag cannot
+ * be the gate for writing into Discord.
+ *
+ * Cached in Redis so a chatty user costs at most one membership check per five
+ * minutes.
+ */
+async function verifyGuildMembership(discordId) {
+  const guildId = process.env.DISCORD_GUILD_ID
+  const token = rawBotToken()
+  if (!guildId || !token || !discordId) return false
+
+  const key = `discordchat:guild:${discordId}`
+  try {
+    const cached = await chatRedis.get(key)
+    if (cached !== null) return cached === '1'
+  } catch {
+    // fall through to a live check
+  }
+
+  let member = false
+  try {
+    const res = await discordFetch(`/guilds/${guildId}/members/${discordId}`, {
+      auth: botAuth(token),
+      attempts: 1
+    })
+    member = Boolean(res?.user?.id || res?.roles)
+  } catch {
+    // 404 means not a member; anything else is treated as "not verified" so the
+    // relay fails closed.
+    member = false
+  }
+  try {
+    await chatRedis.set(key, member ? '1' : '0', 'EX', GUILD_CHECK_TTL_SECONDS)
+  } catch {
+    // best effort
+  }
+  return member
+}
+
+/**
+ * Resolves the caller and re-reads the fields that gate chat.
+ *
+ * resolveSocketUser() selects only {id, username, banned} and caches the result
+ * for the life of the connection, which is right for game handlers but wrong
+ * here: a chat panel stays open for hours, so a user banned or muted mid-session
+ * would keep posting into Discord until they closed the tab.
+ */
+async function resolveChatMember(socket, { forSending }) {
+  const base = await requireSocketUser(socket, 'chat:error')
+  if (!base) return null
+
+  let row
+  try {
+    row = await db.user.findUnique({
+      where: { id: base.id },
+      select: {
+        id: true,
+        username: true,
+        banned: true,
+        active: true,
+        inGuild: true,
+        discordId: true,
+        avatar: true,
+        chatMutedUntil: true
+      }
+    })
+  } catch {
+    socket.emit('chat:error', { reason: 'unavailable' })
+    return null
+  }
+
+  if (!row || row.banned || row.active === false || !row.username || !row.discordId) {
+    socket.emit('chat:error', { reason: 'not_allowed' })
+    return null
+  }
+
+  // Reading is gated on the cached flag only. Every /newsite page already
+  // redirects a non-member away (middleware/newsite.js), so this is a
+  // belt-and-braces check rather than the primary control, and it must not put
+  // a Discord API call on every panel open.
+  if (!row.inGuild) {
+    socket.emit('chat:error', { reason: 'not_in_guild' })
+    return null
+  }
+
+  if (forSending) {
+    if (row.chatMutedUntil && row.chatMutedUntil.getTime() > Date.now()) {
+      socket.emit('chat:error', { reason: 'muted' })
+      return null
+    }
+    // Writing into Discord gets the live check, because this is the side that
+    // can cause harm in someone else's community.
+    const stillMember = await verifyGuildMembership(row.discordId)
+    if (!stillMember) {
+      socket.emit('chat:error', { reason: 'not_in_guild' })
+      return null
+    }
+  }
+
+  return row
+}
+
+function chatBaseUrl() {
+  return process.env.NODE_ENV === 'production'
+    ? 'https://www.cartoonreorbit.com'
+    : `http://localhost:${process.env.NUXT_PORT || 3000}`
+}
+
+async function emitChatState(target) {
+  let config
+  try {
+    config = await loadChatConfig(chatRedis, db)
+  } catch {
+    config = { discordChatEnabled: false }
+  }
+  target.emit('chat:state', {
+    enabled: config.discordChatEnabled === true,
+    maxLength: config.discordChatMaxLength ?? 400,
+    slowmodeSeconds: config.discordChatSlowmodeSeconds ?? 5
+  })
+}
+
+chatNsp.on('connection', (socket) => {
+  socket.on('chat:join', async () => {
+    // Cheap guard against a client looping join to farm buffer snapshots.
+    const now = Date.now()
+    if (socket.data.lastChatJoin && now - socket.data.lastChatJoin < CHAT_JOIN_COOLDOWN_MS) return
+    socket.data.lastChatJoin = now
+
+    const member = await resolveChatMember(socket, { forSending: false })
+    if (!member) return
+
+    const config = await loadChatConfig(chatRedis, db)
+    if (!config.discordChatEnabled) {
+      socket.emit('chat:state', { enabled: false })
+      return
+    }
+
+    socket.join(CHAT_ROOM)
+    await emitChatState(socket)
+    // A full snapshot the client REPLACES rather than merges, so a client that
+    // missed a delete while disconnected self-heals on rejoin.
+    socket.emit('chat:snapshot', { messages: await bufferSnapshot(chatRedis) })
+  })
+
+  socket.on('chat:leave', () => {
+    socket.leave(CHAT_ROOM)
+  })
+
+  socket.on('chat:send', async ({ content } = {}) => {
+    const member = await resolveChatMember(socket, { forSending: true })
+    if (!member) return
+
+    const config = await loadChatConfig(chatRedis, db)
+    if (!config.discordChatEnabled) {
+      socket.emit('chat:error', { reason: 'disabled' })
+      return
+    }
+    const webhook = webhookCredentials()
+    if (!webhook) {
+      console.error('[DiscordChat] no webhook configured; refusing to relay')
+      socket.emit('chat:error', { reason: 'unavailable' })
+      return
+    }
+
+    // Hashed, never raw. encryptIp is deterministic, which is exactly what a
+    // rate-limit key needs, and it returns null rather than the plaintext if the
+    // key is missing.
+    const rawIp =
+      socket.handshake.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+      socket.handshake.address
+    let ipHash = null
+    try {
+      ipHash = encryptIp(rawIp)
+    } catch {
+      ipHash = null
+    }
+
+    try {
+      const messageId = await relayMessage(chatRedis, {
+        user: member,
+        rawContent: content,
+        config,
+        webhook,
+        baseUrl: chatBaseUrl(),
+        ipHash
+      })
+      // The id lets the client reconcile its optimistic bubble against the
+      // gateway echo. Matching on content instead would collide whenever two
+      // people send the same text in the same second.
+      socket.emit('chat:sent', { messageId })
+    } catch (err) {
+      if (err instanceof ChatContentError || err instanceof ChatRateError) {
+        // `reason` is a fixed enum and `message` is composed from our own
+        // strings, never from other users' data.
+        socket.emit('chat:error', {
+          reason: err.reason,
+          message: err.message,
+          retryAfterMs: err.retryAfterMs ?? 0
+        })
+        return
+      }
+      console.error('[DiscordChat] relay failed:', err?.message || err)
+      socket.emit('chat:error', { reason: 'unavailable' })
+    }
+  })
+})
+
+// Fan out what the gateway process publishes. Deliberately no per-message DB or
+// Discord work here — this is the only room that will contain every online
+// user, so nothing high-frequency (typing indicators, presence) belongs in it.
+chatSub.subscribe(CHAT_CHANNELS.events).catch((err) => {
+  console.error('[DiscordChat] subscribe failed:', err?.message || err)
+})
+chatSub.on('message', (channel, raw) => {
+  if (channel !== CHAT_CHANNELS.events) return
+  let event
+  try {
+    event = JSON.parse(raw)
+  } catch {
+    return
+  }
+  switch (event.kind) {
+    case 'message':
+      chatNsp.to(CHAT_ROOM).emit('chat:message', event.message)
+      break
+    case 'update':
+      chatNsp.to(CHAT_ROOM).emit('chat:update', { id: event.id, patch: event.patch })
+      break
+    case 'delete':
+      // Emitted unconditionally: clients hold more messages than the server
+      // buffers, so a moderator's delete must reach them either way.
+      chatNsp.to(CHAT_ROOM).emit('chat:delete', { ids: event.ids })
+      break
+    case 'reseed':
+      chatNsp.to(CHAT_ROOM).emit('chat:snapshot', { messages: event.messages })
+      break
+    case 'state':
+      chatNsp.to(CHAT_ROOM).emit('chat:gateway', event.state)
+      break
+    default:
+      break
+  }
+})
+
 io.on('connection', socket => {
   // Ed, Edd n Eddy RPS lives in its own module and resolves identity from the session cookie
   // on every event rather than trusting a payload userId. It keeps its own socket.data keys
@@ -2603,38 +2882,16 @@ io.on('connection', socket => {
     }
   })
 
-  socket.on('join-zone', ({ zone }) => {
-    const prevZone = socket.zone
-    if (prevZone && prevZone !== zone) {
-      socket.leave(prevZone)
-      if (zoneSockets[prevZone]) {
-        zoneSockets[prevZone].delete(socket.id)
-      }
-      if (zoneVisitors[prevZone]) {
-        zoneVisitors[prevZone] = Math.max(zoneVisitors[prevZone] - 1, 0)
-        if (zoneVisitors[prevZone] === 0) {
-          delete zoneVisitors[prevZone]
-          delete zoneSockets[prevZone]
-        } else {
-          io.to(prevZone).emit('visitor-count', zoneVisitors[prevZone])
-        }
-      }
-    }
-
-    socket.zone = zone
-    socket.join(zone)
-
-    zoneSockets[zone] = (zoneSockets[zone] || new Set());
-    if (!zoneSockets[zone].has(socket.id)) {
-      zoneSockets[zone].add(socket.id)
-      zoneVisitors[zone] = (zoneVisitors[zone] || 0) + 1
-      io.to(zone).emit('visitor-count', zoneVisitors[zone])
-    }
-  })
-
-  socket.on('chat-message', ({ zone, user, message }) => {
-    io.to(zone).emit('chat-message', { user, message })
-  })
+  // NOTE: the old `join-zone` / `visitor-count` / `chat-message` cZone handlers
+  // were removed when the Discord chat relay was added. They were dead — no Vue
+  // file emitted or listened for any of them — and `chat-message` in particular
+  // was a broadcast primitive with no authentication at all: it took both the
+  // room name AND the display name from the client, so any anonymous socket
+  // could emit into any room as any user. It survived only because nothing
+  // listened. Adding a real chat feature next to a generically-named
+  // `chat-message` relay is precisely how something eventually gets pointed at
+  // it, so it is gone rather than fixed. The relay's own handlers are in the
+  // `/chat` namespace below and resolve identity with requireSocketUser.
 
   // ── Reconnect rejoin handlers ──────────────────────────────────────────────
   // Emitted by clients on socket reconnect to restore their session.
@@ -2699,28 +2956,6 @@ io.on('connection', socket => {
   // ──────────────────────────────────────────────────────────────────────────
 
 
-  socket.on('leave-zone', ({ zone }) => {
-    if (zone) {
-      socket.leave(zone)
-      if (socket.zone === zone) {
-        socket.zone = null
-      }
-    }
-    if (zone && zoneVisitors[zone]) {
-      zoneVisitors[zone]--
-      if (zoneSockets[zone]) {
-        zoneSockets[zone].delete(socket.id)
-      }
-
-      if (zoneVisitors[zone] <= 0) {
-        delete zoneVisitors[zone]
-        delete zoneSockets[zone]
-      } else {
-        io.to(zone).emit('visitor-count', zoneVisitors[zone])
-      }
-    }
-  })
-
   socket.on('disconnecting', async () => {
     // During a graceful server reload state has already been saved to Redis —
     // skip PvP leave logic so active matches aren't ended prematurely.
@@ -2750,19 +2985,6 @@ io.on('connection', socket => {
             scheduleMonsterDisconnect(io, battle, loserKey)
           }
         }
-      }
-    }
-
-    const zone = socket.zone
-    if (zone && zoneSockets[zone] && zoneSockets[zone].has(socket.id)) {
-      zoneSockets[zone].delete(socket.id)
-      zoneVisitors[zone] = Math.max((zoneVisitors[zone] || 1) - 1, 0)
-
-      if (zoneVisitors[zone] === 0) {
-        delete zoneVisitors[zone]
-        delete zoneSockets[zone]
-      } else {
-        io.to(zone).emit('visitor-count', zoneVisitors[zone])
       }
     }
 
@@ -2909,18 +3131,6 @@ io.on('connection', socket => {
 async function sweepStaleState() {
   const now = Date.now()
   const activeSocketIds = new Set(io.sockets.sockets.keys())
-
-  for (const [zone, socketSet] of Object.entries(zoneSockets)) {
-    for (const socketId of Array.from(socketSet)) {
-      if (!activeSocketIds.has(socketId)) socketSet.delete(socketId)
-    }
-    if (socketSet.size === 0) {
-      delete zoneSockets[zone]
-      delete zoneVisitors[zone]
-    } else {
-      zoneVisitors[zone] = socketSet.size
-    }
-  }
 
   for (const [roomId, room] of pvpRooms.entries()) {
     if (roomSize(io, roomId) === 0 && isIdle(room, now, PVP_ROOM_IDLE_MS)) {

--- a/server/utils/discordChat/buffer.js
+++ b/server/utils/discordChat/buffer.js
@@ -1,0 +1,156 @@
+// Redis-backed ring buffer of recent chat messages.
+//
+// See constants.js for the import rules.
+//
+// ── Why Redis and not process memory ─────────────────────────────────────────
+// The buffer is written by the gateway worker and read by socket-server, which
+// are separate processes, so it has to be shared state regardless. It would
+// also be wrong in memory even in a single process: a restart takes 3-15
+// seconds here, and every client that joins in that window would get an empty
+// panel with no way to recover until someone happened to speak.
+//
+// Stored newest-first (LPUSH + LTRIM). Callers that render reverse it.
+
+import { CHAT_KEYS, BUFFER_SIZE } from './constants.js'
+
+/**
+ * Inserts or replaces a message, keeping the list capped and de-duplicated.
+ *
+ * De-duplication is required, not defensive: RESUMEing a gateway session
+ * replays events that were already delivered, so the same message id will
+ * legitimately arrive twice.
+ */
+export async function bufferPut(redis, message) {
+  if (!message?.id) return
+  try {
+    const existing = await redis.lrange(CHAT_KEYS.buffer, 0, BUFFER_SIZE - 1)
+    const kept = existing.filter((raw) => {
+      try {
+        return JSON.parse(raw).id !== message.id
+      } catch {
+        return false
+      }
+    })
+    kept.unshift(JSON.stringify(message))
+    // Rewrite the whole list in one round trip. At 50 entries this is cheaper
+    // and simpler than maintaining a parallel index, and it keeps insert
+    // idempotent by construction.
+    const pipeline = redis.multi()
+    pipeline.del(CHAT_KEYS.buffer)
+    if (kept.length) pipeline.rpush(CHAT_KEYS.buffer, ...kept.slice(0, BUFFER_SIZE))
+    await pipeline.exec()
+  } catch (err) {
+    console.error('[DiscordChat] buffer put failed:', err?.message || err)
+  }
+}
+
+/**
+ * Merges a partial MESSAGE_UPDATE into an existing entry.
+ *
+ * MESSAGE_UPDATE payloads are PARTIAL in practice even though the docs read as
+ * though they are complete: when Discord's embed service unfurls a link it
+ * emits an update carrying essentially only id/channel_id/embeds, with no
+ * author and no content. Replacing the stored entry with a normalized version
+ * of that would blank the message.
+ *
+ * So this merges by KEY PRESENCE, and returns null when the id is unknown —
+ * a partial must never be inserted as a new message.
+ */
+export async function bufferMerge(redis, id, patch) {
+  if (!id) return null
+  try {
+    const existing = await redis.lrange(CHAT_KEYS.buffer, 0, BUFFER_SIZE - 1)
+    let updated = null
+    const next = existing.map((raw) => {
+      let parsed
+      try {
+        parsed = JSON.parse(raw)
+      } catch {
+        return raw
+      }
+      if (parsed.id !== id) return raw
+      // 'key' in patch, not `patch.key ?? existing.key`: clearing content while
+      // keeping an attachment is a legitimate edit, and ?? would swallow it.
+      for (const key of ['tokens', 'attachments', 'editedAt']) {
+        if (key in patch) parsed[key] = patch[key]
+      }
+      updated = parsed
+      return JSON.stringify(parsed)
+    })
+    if (!updated) return null
+    const pipeline = redis.multi()
+    pipeline.del(CHAT_KEYS.buffer)
+    if (next.length) pipeline.rpush(CHAT_KEYS.buffer, ...next)
+    await pipeline.exec()
+    return updated
+  } catch (err) {
+    console.error('[DiscordChat] buffer merge failed:', err?.message || err)
+    return null
+  }
+}
+
+/** Removes ids from the buffer. Safe to call for ids that are not present. */
+export async function bufferDelete(redis, ids) {
+  const wanted = new Set((Array.isArray(ids) ? ids : [ids]).map(String))
+  if (!wanted.size) return
+  try {
+    const existing = await redis.lrange(CHAT_KEYS.buffer, 0, BUFFER_SIZE - 1)
+    const kept = existing.filter((raw) => {
+      try {
+        return !wanted.has(String(JSON.parse(raw).id))
+      } catch {
+        return false
+      }
+    })
+    const pipeline = redis.multi()
+    pipeline.del(CHAT_KEYS.buffer)
+    if (kept.length) pipeline.rpush(CHAT_KEYS.buffer, ...kept)
+    await pipeline.exec()
+  } catch (err) {
+    console.error('[DiscordChat] buffer delete failed:', err?.message || err)
+  }
+}
+
+/** Oldest-first snapshot, ready to render. */
+export async function bufferSnapshot(redis) {
+  try {
+    const raw = await redis.lrange(CHAT_KEYS.buffer, 0, BUFFER_SIZE - 1)
+    const parsed = []
+    for (const entry of raw) {
+      try {
+        parsed.push(JSON.parse(entry))
+      } catch {
+        // skip corrupt entries rather than failing the whole join
+      }
+    }
+    return parsed.reverse()
+  } catch (err) {
+    console.error('[DiscordChat] buffer read failed:', err?.message || err)
+    return []
+  }
+}
+
+/** Drops everything. Used by the kill switch and on a channel change. */
+export async function bufferClear(redis) {
+  try {
+    await redis.del(CHAT_KEYS.buffer)
+  } catch {
+    // best effort
+  }
+}
+
+/** Replaces the buffer wholesale from a REST re-seed. */
+export async function bufferReplace(redis, messagesOldestFirst) {
+  try {
+    const entries = messagesOldestFirst
+      .slice(-BUFFER_SIZE)
+      .reverse()
+      .map((m) => JSON.stringify(m))
+    const pipeline = redis.multi()
+    pipeline.del(CHAT_KEYS.buffer)
+    if (entries.length) pipeline.rpush(CHAT_KEYS.buffer, ...entries)
+    await pipeline.exec()
+  } catch (err) {
+    console.error('[DiscordChat] buffer replace failed:', err?.message || err)
+  }
+}

--- a/server/utils/discordChat/config.js
+++ b/server/utils/discordChat/config.js
@@ -1,0 +1,138 @@
+// Discord chat relay configuration.
+//
+// See server/utils/discordChat/constants.js for the import rules that apply to
+// every module in this directory. Prisma is a parameter, never an import.
+//
+// Config lives in two places on purpose:
+//   • Tunables (enabled, channel, slowmode, length, attachments) are on the
+//     singleton GlobalGameConfig row, edited from Admin > Global Settings >
+//     Discord, and cached in Redis so neither hot path reads Postgres per
+//     message.
+//   • The webhook credential is in env ONLY. Both admin config endpoints return
+//     the GlobalGameConfig row wholesale, so a token stored there would be
+//     serialized into every admin's browser on every settings load. A webhook
+//     token is an unauthenticated bearer credential: anyone holding it can post
+//     to the channel under any name and avatar, and it cannot be revoked by
+//     rotating BOT_TOKEN — only by deleting the webhook.
+
+import { CHAT_KEYS, CHAT_CHANNELS } from './constants.js'
+
+const CONFIG_TTL_SECONDS = 60
+
+export const CHAT_CONFIG_DEFAULTS = {
+  discordChatEnabled: false,
+  discordChatChannelId: null,
+  discordChatSlowmodeSeconds: 5,
+  discordChatMaxLength: 400,
+  discordChatShowAttachments: false
+}
+
+/**
+ * The bot token with any `Bot ` prefix removed.
+ *
+ * This matters more than it looks. .env.template ships BOT_TOKEN *with* the
+ * prefix ("Bot xxx") because every REST caller in this repo passes it straight
+ * through as an Authorization header. The gateway IDENTIFY payload is not an
+ * HTTP header: it wants the bare token, and sending the prefixed value is
+ * rejected with close code 4004 — which is `Reconnect: false`, so it presents
+ * as a permanent authentication failure indistinguishable from a bad token.
+ */
+export function rawBotToken() {
+  const token = process.env.DISCORD_CHAT_BOT_TOKEN || process.env.BOT_TOKEN || ''
+  return token.trim().replace(/^bot\s+/i, '')
+}
+
+/**
+ * Webhook credentials, from env only.
+ *
+ * Accepts either the full URL (what the Discord UI gives you when you click
+ * "Copy Webhook URL") or the id/token pair, because operators will paste
+ * whichever they have.
+ */
+export function webhookCredentials() {
+  const url = (process.env.DISCORD_CHAT_WEBHOOK_URL || '').trim()
+  if (url) {
+    const m = /\/webhooks\/(\d{17,20})\/([A-Za-z0-9_.-]+)/.exec(url)
+    if (m) return { id: m[1], token: m[2] }
+  }
+  const id = (process.env.DISCORD_CHAT_WEBHOOK_ID || '').trim()
+  const token = (process.env.DISCORD_CHAT_WEBHOOK_TOKEN || '').trim()
+  if (/^\d{17,20}$/.test(id) && token) return { id, token }
+  return null
+}
+
+function coerce(row) {
+  if (!row) return { ...CHAT_CONFIG_DEFAULTS }
+  return {
+    discordChatEnabled: row.discordChatEnabled === true,
+    discordChatChannelId: /^\d{17,20}$/.test(String(row.discordChatChannelId || ''))
+      ? String(row.discordChatChannelId)
+      : null,
+    discordChatSlowmodeSeconds: clampInt(row.discordChatSlowmodeSeconds, 0, 300, CHAT_CONFIG_DEFAULTS.discordChatSlowmodeSeconds),
+    discordChatMaxLength: clampInt(row.discordChatMaxLength, 1, 2000, CHAT_CONFIG_DEFAULTS.discordChatMaxLength),
+    discordChatShowAttachments: row.discordChatShowAttachments === true
+  }
+}
+
+function clampInt(value, min, max, fallback) {
+  const n = Number(value)
+  if (!Number.isInteger(n)) return fallback
+  return Math.min(max, Math.max(min, n))
+}
+
+/**
+ * Reads the relay config, preferring a short-lived Redis cache.
+ *
+ * Falls back to the DB on a cache miss and to CHAT_CONFIG_DEFAULTS (i.e. disabled) if both
+ * fail. Failing closed is deliberate: an unreadable config must never leave the
+ * relay running with a stale channel id.
+ */
+export async function loadChatConfig(redis, prisma) {
+  try {
+    const cached = await redis.get(CHAT_KEYS.config)
+    if (cached) return { ...CHAT_CONFIG_DEFAULTS, ...JSON.parse(cached) }
+  } catch {
+    // fall through to the DB
+  }
+
+  let row = null
+  try {
+    row = await prisma.globalGameConfig.findUnique({
+      where: { id: 'singleton' },
+      select: {
+        discordChatEnabled: true,
+        discordChatChannelId: true,
+        discordChatSlowmodeSeconds: true,
+        discordChatMaxLength: true,
+        discordChatShowAttachments: true
+      }
+    })
+  } catch (err) {
+    console.error('[DiscordChat] config read failed:', err?.message || err)
+    return { ...CHAT_CONFIG_DEFAULTS }
+  }
+
+  const config = coerce(row)
+  try {
+    await redis.set(CHAT_KEYS.config, JSON.stringify(config), 'EX', CONFIG_TTL_SECONDS)
+  } catch {
+    // caching is best-effort
+  }
+  return config
+}
+
+/**
+ * Drops the cache and tells the other two processes to re-read.
+ *
+ * Called from the admin save handler. Without this the kill switch would only
+ * take effect after the cache expired, or after a PM2 restart — which is
+ * exactly when you least want to be restarting things.
+ */
+export async function invalidateChatConfig(redis) {
+  try {
+    await redis.del(CHAT_KEYS.config)
+    await redis.publish(CHAT_CHANNELS.configChanged, String(Date.now()))
+  } catch (err) {
+    console.error('[DiscordChat] config invalidate failed:', err?.message || err)
+  }
+}

--- a/server/utils/discordChat/constants.js
+++ b/server/utils/discordChat/constants.js
@@ -1,0 +1,142 @@
+// Shared constants for the Discord chat relay.
+//
+// ── Import rules (please read before editing) ────────────────────────────────
+// Every module under server/utils/discordChat/ is imported from THREE runtimes:
+//   • Nuxt API handlers / admin endpoints, as '@/server/utils/discordChat/...'
+//   • server/socket-server.js, as './utils/discordChat/...'
+//   • server/workers/discord-chat.worker.js, likewise relative
+//
+// The last two are plain `node foo.js` processes. The `@/` alias, `#imports`
+// and Nitro's `$fetch` global are Nuxt/Vite-only and are NOT available there —
+// see the header of server/utils/notifications.js for the same rule and the
+// reason it is written down. So: relative imports only, global `fetch` only,
+// and Prisma is passed in as a parameter rather than imported.
+//
+// Note server/utils/discord.js cannot be imported wholesale from the plain-Node
+// side either: several of its helpers call `$fetch`. The pieces this feature
+// needs are re-exported from there through globalThis.fetch-based wrappers.
+
+// ── Redis keys ───────────────────────────────────────────────────────────────
+// One namespace so an operator can see the whole feature's state with
+// `KEYS discordchat:*` and drop it with a single scan.
+export const CHAT_KEYS = {
+  // Ring buffer of normalized messages, newest first (LPUSH + LTRIM).
+  buffer: 'discordchat:buffer',
+  // Gateway session so a deploy RESUMEs instead of burning an IDENTIFY.
+  session: 'discordchat:session',
+  // Rolling IDENTIFY timestamps. Persisted because the failure this guards
+  // against is a PM2 crash-loop, which resets any in-memory counter.
+  identifyLog: 'discordchat:identifylog',
+  // Terminal gateway failure, surfaced to clients and to the admin panel.
+  fatal: 'discordchat:fatal',
+  // Cached copy of the DB config, so neither hot path hits Postgres per message.
+  config: 'discordchat:config',
+  // messageId -> userId for messages this site relayed. Lets a moderator answer
+  // "who actually sent this?" without a Postgres table that grows forever.
+  relay: (messageId) => `discordchat:relay:${messageId}`,
+  // Rate limiting.
+  gap: (userId) => `discordchat:gap:${userId}`,
+  burst: (userId, window) => `discordchat:burst:${userId}:${window}`,
+  hourly: (userId, hour) => `discordchat:hourly:${userId}:${hour}`,
+  ipBurst: (ipHash, window) => `discordchat:ipburst:${ipHash}:${window}`,
+  globalBucket: (window) => `discordchat:global:${window}`,
+  // Set when a webhook 404s. Discord's docs are explicit that repeatedly using
+  // a 404ing webhook earns a temporary IP restriction, so re-resolution is
+  // gated behind this rather than retried per message.
+  webhookCooldown: 'discordchat:webhookcooldown'
+}
+
+// Pub/sub channels between the three processes.
+export const CHAT_CHANNELS = {
+  // gateway worker -> socket-server: a normalized message event to fan out.
+  events: 'discordchat:events',
+  // Nuxt admin endpoint -> gateway worker + socket-server: config changed.
+  // Without this, the kill switch would need a PM2 restart, which defeats it.
+  configChanged: 'discordchat:config-changed'
+}
+
+// ── Ring buffer ──────────────────────────────────────────────────────────────
+// 50 is what a client gets on join. Clients keep more than this in the DOM, so
+// delete events must be emitted unconditionally rather than only when the id is
+// still inside this window.
+export const BUFFER_SIZE = 50
+
+// ── Gateway ──────────────────────────────────────────────────────────────────
+// GUILDS (1<<0) | GUILD_MESSAGES (1<<9) | MESSAGE_CONTENT (1<<15).
+//
+// GUILD_MESSAGES alone is enough to receive MESSAGE_CREATE, and GUILDS costs a
+// large GUILD_CREATE payload on every connect. It is included anyway for three
+// things nothing else provides:
+//   1. GUILD_CREATE carries the guild's `channels` and `roles`, which is the
+//      only way to render <#id> and <@&id> mentions as names without a REST
+//      call per message.
+//   2. CHANNEL_UPDATE / CHANNEL_DELETE is how we learn the configured channel
+//      was renamed or deleted underneath us.
+//   3. The configured channel being absent from GUILD_CREATE.channels is the
+//      ONLY signal that the bot has lost VIEW_CHANNEL. Without it, losing that
+//      permission presents as "connected, but nobody is talking" — silent, and
+//      undiagnosable from logs.
+// The payload is parsed for those three things and then dropped, not retained.
+export const INTENTS = (1 << 0) | (1 << 9) | (1 << 15) // 33281
+
+export const GATEWAY_VERSION = 10
+
+// Discord terminates all sessions AND RESETS THE BOT TOKEN if an app exceeds
+// 1000 IDENTIFYs in 24h. BOT_TOKEN here is load-bearing for OAuth guild-join,
+// DMs, achievement/auction announcements and the guild-sync cron, so tripping
+// that would take down every Discord integration on the site at once, and the
+// only recovery is a manual token rotation.
+//
+// A healthy client IDENTIFYs about once a day. 20 in an hour is already
+// pathological, so it is treated as a permanent fault rather than something to
+// retry through. Losing the chat sidebar for an hour is enormously cheaper.
+export const IDENTIFY_LIMIT_PER_HOUR = 20
+export const IDENTIFY_WINDOW_MS = 60 * 60 * 1000
+
+// Close codes Discord documents as Reconnect: false. Retrying these is what
+// burns the IDENTIFY budget above, so they are terminal.
+//   4004 auth failed — nearly always the "Bot " prefix left on the token
+//   4010 invalid shard, 4011 sharding required — we never shard
+//   4012 invalid API version, 4013 invalid intents — our bug
+//   4014 disallowed intents — MESSAGE CONTENT not enabled in the dev portal
+export const FATAL_CLOSE_CODES = new Set([4004, 4010, 4011, 4012, 4013, 4014])
+
+// Close codes after which the session is gone and a fresh IDENTIFY is required.
+// Everything else resumable is RESUMEd, which does not count against the budget.
+export const SESSION_INVALIDATING_CLOSE_CODES = new Set([4003, 4005, 4007, 4009, 1000, 1001])
+
+// ── Message filtering ────────────────────────────────────────────────────────
+// An ALLOW-list, not a deny-list. Every other message type carries empty
+// `content` and would render as a blank row, and Discord keeps adding types
+// (36-39, 44 and 46 are all recent), so a deny-list silently starts leaking
+// blank rows as the platform evolves.
+//   0  = DEFAULT
+//   19 = REPLY
+export const RENDERABLE_MESSAGE_TYPES = new Set([0, 19])
+
+// Message flags worth skipping.
+//   1<<6  EPHEMERAL — shouldn't reach us; skip anyway
+//   1<<7  LOADING — a bot "thinking" placeholder, edited later
+//   1<<15 IS_COMPONENTS_V2 — content is empty and everything lives in
+//         `components`, so these render as blank rows. Increasingly common.
+export const FLAG_EPHEMERAL = 1 << 6
+export const FLAG_LOADING = 1 << 7
+export const FLAG_COMPONENTS_V2 = 1 << 15
+
+// Discord's hard ceiling on message content. The admin-configured max is
+// clamped to just under it so that escaping (which expands the string) cannot
+// push a legal message over the wire limit.
+export const DISCORD_CONTENT_LIMIT = 2000
+export const OUTBOUND_HARD_CAP = 1900
+
+// Suppresses link previews on relayed messages. Without it, an allow-listed URL
+// still renders an attacker-influenced image card in the Discord channel.
+export const FLAG_SUPPRESS_EMBEDS = 1 << 2
+
+// ── Attachment rendering ─────────────────────────────────────────────────────
+// Only these two hosts, and only under /attachments/. Anything else is rendered
+// as a link chip instead of an <img>.
+export const ALLOWED_ATTACHMENT_HOSTS = new Set(['cdn.discordapp.com', 'media.discordapp.net'])
+export const MAX_RENDERED_ATTACHMENTS = 1
+export const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
+export const MAX_ATTACHMENT_PIXELS = 40_000_000

--- a/server/utils/discordChat/gateway.js
+++ b/server/utils/discordChat/gateway.js
@@ -1,0 +1,703 @@
+// Discord Gateway v10 client for the chat relay.
+//
+// See constants.js for the import rules. Uses Node's global WebSocket (Node 22),
+// so there is no new dependency.
+//
+// ── Scope ────────────────────────────────────────────────────────────────────
+// One shard, JSON encoding, no compression, receive-only, one guild, one
+// channel. That is small enough to own outright, and owning it means the
+// reconnect policy is ours and is boring. If this ever grows a zlib inflater,
+// sharding, or a generic event dispatcher, replace it with @discordjs/ws
+// instead of continuing.
+//
+// ── The failure that actually matters ────────────────────────────────────────
+// Discord terminates every session AND RESETS THE BOT TOKEN if an app exceeds
+// 1000 IDENTIFYs in 24 hours. BOT_TOKEN in this repo is load-bearing for OAuth
+// guild-join, DMs, achievement and auction announcements, and the guild-sync
+// cron — so an IDENTIFY loop here would take down Discord login for the whole
+// site, silently, and recovery is a manual token rotation.
+//
+// Three things guard that, and none of them are optional:
+//   1. A persisted IDENTIFY budget (Redis, so a crash-loop cannot reset it).
+//   2. RESUME is preferred everywhere it is legal; RESUMEs are not counted.
+//   3. Zombie and reconnect closes use code 4000. Closing with 1000/1001
+//      INVALIDATES the session server-side and forces a fresh IDENTIFY, which
+//      would turn every routine reconnect into budget spend.
+
+import {
+  CHAT_KEYS,
+  CHAT_CHANNELS,
+  INTENTS,
+  GATEWAY_VERSION,
+  IDENTIFY_LIMIT_PER_HOUR,
+  IDENTIFY_WINDOW_MS,
+  FATAL_CLOSE_CODES,
+  SESSION_INVALIDATING_CLOSE_CODES
+} from './constants.js'
+import { normalizeMessage } from './normalize.js'
+import { bufferPut, bufferMerge, bufferDelete, bufferReplace, bufferClear } from './buffer.js'
+import { fetchRecentMessages, discordFetch, botAuth } from './rest.js'
+
+const CONNECT_TIMEOUT_MS = 20_000
+const RESEED_INTERVAL_MS = 60 * 60 * 1000
+
+export class DiscordChatGateway {
+  constructor({ redis, prisma, loadConfig, rawToken, guildId, webhookId }) {
+    this.redis = redis
+    this.prisma = prisma
+    this.loadConfig = loadConfig
+    this.rawToken = rawToken
+    this.guildId = guildId
+    this.webhookId = webhookId
+
+    this.ws = null
+    this.stopped = false
+    this.fatal = null
+
+    this.sessionId = null
+    this.resumeUrl = null
+    this.lastSeq = null
+    this.heartbeatMs = null
+    this.heartbeatTimer = null
+    this.firstBeatTimer = null
+    this.connectTimer = null
+    this.reseedTimer = null
+    this.ackPending = false
+    this.backoffAttempt = 0
+    this.wantResume = false
+
+    // Populated from GUILD_CREATE so <#id> and <@&id> render as names without
+    // a REST call per message.
+    this.nameCache = { channels: new Map(), roles: new Map() }
+
+    this.config = null
+    this.emptyContentStreak = 0
+  }
+
+  log(...args) {
+    console.log('[DiscordChat]', ...args)
+  }
+
+  error(...args) {
+    console.error('[DiscordChat]', ...args)
+  }
+
+  // ── IDENTIFY budget ────────────────────────────────────────────────────────
+
+  async mayIdentify() {
+    const now = Date.now()
+    try {
+      const raw = await this.redis.get(CHAT_KEYS.identifyLog)
+      const log = raw ? JSON.parse(raw) : []
+      const recent = log.filter((t) => now - t < IDENTIFY_WINDOW_MS)
+      if (recent.length >= IDENTIFY_LIMIT_PER_HOUR) return false
+      recent.push(now)
+      await this.redis.set(CHAT_KEYS.identifyLog, JSON.stringify(recent), 'PX', IDENTIFY_WINDOW_MS * 2)
+      return true
+    } catch {
+      // If Redis is unreachable we cannot prove we are within budget. Refusing
+      // is the safe answer: a chat outage is recoverable, a reset bot token is
+      // a manual incident.
+      return false
+    }
+  }
+
+  async loadSession() {
+    try {
+      const raw = await this.redis.get(CHAT_KEYS.session)
+      if (!raw) return
+      const s = JSON.parse(raw)
+      this.sessionId = s.sessionId ?? null
+      this.resumeUrl = s.resumeUrl ?? null
+      this.lastSeq = s.lastSeq ?? null
+    } catch {
+      // start fresh
+    }
+  }
+
+  async saveSession() {
+    try {
+      await this.redis.set(
+        CHAT_KEYS.session,
+        JSON.stringify({ sessionId: this.sessionId, resumeUrl: this.resumeUrl, lastSeq: this.lastSeq }),
+        'EX',
+        3600
+      )
+    } catch {
+      // best effort
+    }
+  }
+
+  async clearSession() {
+    this.sessionId = null
+    this.resumeUrl = null
+    this.lastSeq = null
+    try {
+      await this.redis.del(CHAT_KEYS.session)
+    } catch {
+      // best effort
+    }
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  async start() {
+    this.stopped = false
+    await this.loadSession()
+    await this.connect()
+    // Periodic re-seed. Two jobs: it closes the gap where a delete or edit was
+    // missed during a disconnect, and it refreshes attachment CDN signatures,
+    // which expire after roughly a day and would otherwise serve dead images.
+    this.reseedTimer = setInterval(() => {
+      this.reseed().catch((err) => this.error('reseed failed:', err?.message || err))
+    }, RESEED_INTERVAL_MS)
+    this.reseedTimer.unref?.()
+  }
+
+  async stop() {
+    this.stopped = true
+    this.clearTimers()
+    if (this.reseedTimer) clearInterval(this.reseedTimer)
+    await this.saveSession()
+    // 4000, never 1000/1001: this keeps the session alive server-side for a few
+    // minutes so the next boot RESUMEs — costing no IDENTIFY and replaying the
+    // messages sent during the restart.
+    try {
+      this.ws?.close(4000, 'shutdown')
+    } catch {
+      // already gone
+    }
+    this.ws = null
+  }
+
+  clearTimers() {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer)
+    if (this.firstBeatTimer) clearTimeout(this.firstBeatTimer)
+    if (this.connectTimer) clearTimeout(this.connectTimer)
+    this.heartbeatTimer = null
+    this.firstBeatTimer = null
+    this.connectTimer = null
+  }
+
+  async goFatal(code, reason) {
+    this.fatal = { code, reason, at: Date.now() }
+    this.stopped = true
+    this.clearTimers()
+    this.error(`FATAL gateway close ${code}: ${reason}. Chat relay stopped and will not retry.`)
+    if (code === 4014) {
+      this.error(
+        'Close 4014 means the MESSAGE CONTENT privileged intent is not enabled for this bot. ' +
+          'Enable it at Discord Developer Portal > your app > Bot > Privileged Gateway Intents. ' +
+          'There is deliberately no REST polling fallback: the intent gates the message DATA, ' +
+          'not just the gateway, so REST would return messages with empty content and the ' +
+          'sidebar would render blank rows instead of failing visibly.'
+      )
+    }
+    try {
+      await this.redis.set(CHAT_KEYS.fatal, JSON.stringify(this.fatal), 'EX', 86400)
+      await this.publishState()
+    } catch {
+      // best effort
+    }
+    try {
+      this.ws?.close(4000, 'fatal')
+    } catch {
+      // already gone
+    }
+  }
+
+  async connect() {
+    if (this.stopped) return
+    this.clearTimers()
+
+    this.config = await this.loadConfig()
+    if (!this.config?.discordChatEnabled || !this.config?.discordChatChannelId) {
+      this.log('relay disabled or unconfigured; not connecting')
+      await this.publishState()
+      return
+    }
+    if (!this.rawToken) {
+      await this.goFatal(0, 'no bot token configured')
+      return
+    }
+
+    // RESUME uses the url Discord handed us at READY; a fresh session uses the
+    // discovery endpoint. Either way the query string must be appended by us —
+    // resume_gateway_url comes back without one, and resuming requires the same
+    // version and encoding as the original connection.
+    this.wantResume = Boolean(this.sessionId && this.lastSeq !== null)
+    let base = this.wantResume && this.resumeUrl ? this.resumeUrl : null
+    if (!base) {
+      try {
+        const info = await discordFetch('/gateway/bot', { auth: botAuth(this.rawToken) })
+        base = info?.url || 'wss://gateway.discord.gg'
+      } catch (err) {
+        this.error('gateway discovery failed:', err?.message || err)
+        base = 'wss://gateway.discord.gg'
+      }
+    }
+
+    if (!this.wantResume) {
+      const allowed = await this.mayIdentify()
+      if (!allowed) {
+        await this.goFatal(
+          0,
+          `IDENTIFY budget exceeded (>${IDENTIFY_LIMIT_PER_HOUR}/hour). Refusing to reconnect: ` +
+            'exceeding 1000 IDENTIFYs in 24h causes Discord to reset the bot token, which would ' +
+            'break OAuth login, DMs and every announcement path on the site.'
+        )
+        return
+      }
+    }
+
+    const url = `${base}?v=${GATEWAY_VERSION}&encoding=json`
+    this.log(`connecting (${this.wantResume ? 'resume' : 'identify'})`)
+
+    let ws
+    try {
+      ws = new WebSocket(url)
+    } catch (err) {
+      this.error('socket construction failed:', err?.message || err)
+      this.scheduleReconnect()
+      return
+    }
+    this.ws = ws
+
+    this.connectTimer = setTimeout(() => {
+      this.error('no HELLO within timeout; reconnecting')
+      this.hardReconnect()
+    }, CONNECT_TIMEOUT_MS)
+    this.connectTimer.unref?.()
+
+    // Every callback is wrapped. An unhandled rejection is fatal under Node 22,
+    // and while this runs in its own process, a crash still costs an IDENTIFY
+    // on restart — which is the budget above.
+    ws.onmessage = (event) => {
+      this.onMessage(event).catch((err) => this.error('message handler:', err?.message || err))
+    }
+    ws.onclose = (event) => {
+      this.onClose(event).catch((err) => this.error('close handler:', err?.message || err))
+    }
+    ws.onerror = (event) => {
+      this.error('socket error:', event?.message || 'unknown')
+    }
+  }
+
+  scheduleReconnect() {
+    if (this.stopped) return
+    // Full jitter. Reset only on READY/RESUMED, never merely on TCP connect —
+    // otherwise a gateway that accepts the socket and immediately closes it
+    // produces an infinite fast loop.
+    const base = Math.min(1000 * 2 ** this.backoffAttempt, 60_000)
+    const delay = Math.random() * base
+    this.backoffAttempt = Math.min(this.backoffAttempt + 1, 6)
+    this.log(`reconnecting in ${Math.round(delay)}ms`)
+    setTimeout(() => {
+      this.connect().catch((err) => this.error('reconnect failed:', err?.message || err))
+    }, delay).unref?.()
+  }
+
+  hardReconnect() {
+    this.clearTimers()
+    try {
+      // 4000 preserves the session for a RESUME. See the class header.
+      this.ws?.close(4000, 'reconnect')
+    } catch {
+      // already gone
+    }
+    // The close frame may never flush if the socket is genuinely wedged, and
+    // Node's WebSocket has no terminate(). This guarantees forward progress.
+    setTimeout(() => {
+      if (!this.stopped && (!this.ws || this.ws.readyState !== 1)) this.scheduleReconnect()
+    }, 5000).unref?.()
+  }
+
+  send(payload) {
+    try {
+      if (this.ws?.readyState === 1) this.ws.send(JSON.stringify(payload))
+    } catch (err) {
+      this.error('send failed:', err?.message || err)
+    }
+  }
+
+  // ── Protocol ───────────────────────────────────────────────────────────────
+
+  async onMessage(event) {
+    let payload
+    try {
+      payload = JSON.parse(event.data)
+    } catch {
+      return
+    }
+    if (payload.s !== null && payload.s !== undefined) this.lastSeq = payload.s
+
+    switch (payload.op) {
+      case 10:
+        await this.onHello(payload.d)
+        break
+      case 11:
+        this.ackPending = false
+        break
+      case 1:
+        // Discord asking for a beat out of band. Answer immediately and restart
+        // the interval so we do not double-beat.
+        this.beat()
+        this.restartHeartbeat()
+        break
+      case 7:
+        // Routine load-shedding, not an error: do not count it against backoff.
+        this.log('op 7 RECONNECT')
+        this.hardReconnect()
+        break
+      case 9:
+        await this.onInvalidSession(payload.d)
+        break
+      case 0:
+        await this.onDispatch(payload.t, payload.d)
+        break
+      default:
+        break
+    }
+  }
+
+  async onHello(d) {
+    if (this.connectTimer) clearTimeout(this.connectTimer)
+    this.connectTimer = null
+    this.heartbeatMs = Number(d?.heartbeat_interval) || 41250
+    this.ackPending = false
+
+    // The jitter is a FIRST-BEAT offset only, not a per-beat wobble.
+    this.firstBeatTimer = setTimeout(() => {
+      this.beat()
+      this.restartHeartbeat()
+    }, this.heartbeatMs * Math.random())
+    this.firstBeatTimer.unref?.()
+
+    if (this.wantResume && this.sessionId && this.lastSeq !== null) {
+      this.send({ op: 6, d: { token: this.rawToken, session_id: this.sessionId, seq: this.lastSeq } })
+    } else {
+      this.send({
+        op: 2,
+        d: {
+          token: this.rawToken,
+          intents: INTENTS,
+          properties: { os: 'linux', browser: 'cartoon-reorbit', device: 'cartoon-reorbit' },
+          // The bot has been REST-only until now, so it has always rendered as
+          // offline in the member list. Staying invisible keeps that true.
+          presence: { since: null, activities: [], status: 'invisible', afk: false }
+        }
+      })
+    }
+  }
+
+  restartHeartbeat() {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer)
+    this.heartbeatTimer = setInterval(() => this.beat(), this.heartbeatMs)
+    this.heartbeatTimer.unref?.()
+  }
+
+  beat() {
+    if (this.ackPending) {
+      // Zombie connection: the socket is open but Discord is not answering.
+      this.error('heartbeat not acked; reconnecting')
+      this.hardReconnect()
+      return
+    }
+    this.ackPending = true
+    this.send({ op: 1, d: this.lastSeq })
+  }
+
+  async onInvalidSession(resumable) {
+    this.log(`op 9 INVALID_SESSION (resumable=${resumable === true})`)
+    if (resumable !== true) await this.clearSession()
+    this.clearTimers()
+    try {
+      this.ws?.close(4000, 'invalid session')
+    } catch {
+      // already gone
+    }
+    // The 1-5s wait is convention rather than spec, but it exists because
+    // IDENTIFY is concurrency-capped and hammering earns another op 9.
+    setTimeout(() => {
+      this.connect().catch((err) => this.error('reconnect failed:', err?.message || err))
+    }, 1000 + Math.random() * 4000).unref?.()
+  }
+
+  async onClose(event) {
+    const code = event?.code
+    const reason = event?.reason || ''
+    this.clearTimers()
+    this.ws = null
+    if (this.stopped) return
+
+    this.log(`socket closed ${code} ${reason}`)
+
+    if (FATAL_CLOSE_CODES.has(code)) {
+      let hint = reason
+      if (code === 4004) {
+        hint =
+          'authentication failed. The most common cause here is the "Bot " prefix: .env stores ' +
+          'BOT_TOKEN with it for REST calls, but the gateway IDENTIFY needs the bare token.'
+      }
+      await this.goFatal(code, hint)
+      return
+    }
+
+    if (SESSION_INVALIDATING_CLOSE_CODES.has(code)) await this.clearSession()
+    else await this.saveSession()
+
+    // 4008 means the 120-events-per-60s command budget was blown. Nothing here
+    // should ever approach that, so treat it as a real problem and wait.
+    if (code === 4008) {
+      setTimeout(() => {
+        this.connect().catch((err) => this.error('reconnect failed:', err?.message || err))
+      }, 30_000).unref?.()
+      return
+    }
+
+    this.scheduleReconnect()
+  }
+
+  // ── Dispatch ───────────────────────────────────────────────────────────────
+
+  async onDispatch(type, d) {
+    switch (type) {
+      case 'READY':
+        this.sessionId = d?.session_id ?? null
+        this.resumeUrl = d?.resume_gateway_url ?? null
+        this.backoffAttempt = 0
+        await this.saveSession()
+        this.log('READY')
+        await this.publishState()
+        break
+
+      case 'RESUMED':
+        this.backoffAttempt = 0
+        this.log('RESUMED')
+        await this.publishState()
+        break
+
+      case 'GUILD_CREATE':
+        if (String(d?.id) === String(this.guildId)) await this.onGuildCreate(d)
+        break
+
+      case 'CHANNEL_UPDATE':
+        if (d?.id && d?.name) this.nameCache.channels.set(String(d.id), String(d.name))
+        break
+
+      case 'CHANNEL_DELETE':
+        if (d?.id) {
+          this.nameCache.channels.delete(String(d.id))
+          if (String(d.id) === String(this.config?.discordChatChannelId)) {
+            this.error('the configured chat channel was deleted')
+            await this.publishState({ channelMissing: true })
+          }
+        }
+        break
+
+      case 'GUILD_ROLE_CREATE':
+      case 'GUILD_ROLE_UPDATE':
+        if (d?.role?.id) this.nameCache.roles.set(String(d.role.id), String(d.role.name || 'role'))
+        break
+
+      case 'GUILD_ROLE_DELETE':
+        if (d?.role_id) this.nameCache.roles.delete(String(d.role_id))
+        break
+
+      case 'MESSAGE_CREATE':
+        await this.onMessageCreate(d)
+        break
+
+      case 'MESSAGE_UPDATE':
+        await this.onMessageUpdate(d)
+        break
+
+      case 'MESSAGE_DELETE':
+        if (this.isOurChannel(d?.channel_id)) await this.onMessageDelete([d?.id])
+        break
+
+      case 'MESSAGE_DELETE_BULK':
+        // A moderator purge. `ids` is an array.
+        if (this.isOurChannel(d?.channel_id)) await this.onMessageDelete(d?.ids || [])
+        break
+
+      default:
+        break
+    }
+  }
+
+  isOurChannel(channelId) {
+    return Boolean(channelId) && String(channelId) === String(this.config?.discordChatChannelId)
+  }
+
+  async onGuildCreate(d) {
+    // Extract the two name caches and the permission signal, then drop the
+    // payload — it can be a megabyte and none of the rest is needed.
+    this.nameCache.channels.clear()
+    this.nameCache.roles.clear()
+    for (const c of d?.channels || []) {
+      if (c?.id && c?.name) this.nameCache.channels.set(String(c.id), String(c.name))
+    }
+    for (const r of d?.roles || []) {
+      if (r?.id && r?.name) this.nameCache.roles.set(String(r.id), String(r.name))
+    }
+
+    // The configured channel being absent is the ONLY signal that the bot has
+    // lost VIEW_CHANNEL. Without this check, losing that permission presents as
+    // "connected, but nobody is talking" — which is undiagnosable from logs.
+    const channelId = this.config?.discordChatChannelId
+    const visible = channelId ? this.nameCache.channels.has(String(channelId)) : false
+    if (channelId && !visible) {
+      this.error(
+        `the bot cannot see channel ${channelId}. Check that it has VIEW_CHANNEL (and ` +
+          'READ_MESSAGE_HISTORY for backfill) on that channel.'
+      )
+    }
+    await this.publishState({ channelMissing: Boolean(channelId) && !visible })
+    await this.reseed()
+  }
+
+  async onMessageCreate(raw) {
+    if (!this.isOurChannel(raw?.channel_id)) return
+
+    // Detects a silently mis-scoped intent. Our own relayed messages always
+    // have readable content (an app can always see content in messages it
+    // sent), so a run of empty inbound messages from real users means
+    // MESSAGE_CONTENT is off even though the connection succeeded.
+    if (
+      raw?.content === '' &&
+      !raw?.webhook_id &&
+      !raw?.attachments?.length &&
+      !raw?.embeds?.length &&
+      !raw?.sticker_items?.length &&
+      Number(raw?.type ?? 0) === 0
+    ) {
+      this.emptyContentStreak++
+      if (this.emptyContentStreak === 5) {
+        this.error(
+          'five consecutive inbound messages had empty content. The MESSAGE CONTENT ' +
+            'privileged intent is probably disabled for this bot.'
+        )
+      }
+    } else if (raw?.content) {
+      this.emptyContentStreak = 0
+    }
+
+    const message = this.normalize(raw)
+    if (!message) return
+    await bufferPut(this.redis, message)
+    await this.publish({ kind: 'message', message })
+  }
+
+  async onMessageUpdate(raw) {
+    if (!this.isOurChannel(raw?.channel_id)) return
+    const id = String(raw?.id ?? '')
+    if (!id) return
+
+    // Build a patch of only the keys this payload actually carries. An
+    // embed-unfurl update carries neither author nor content, so normalizing it
+    // wholesale would blank the message.
+    const patch = {}
+    if ('content' in raw) {
+      const full = this.normalize({ ...raw, type: raw.type ?? 0, author: raw.author ?? { id: '0' } })
+      if (full) patch.tokens = full.tokens
+    }
+    if ('attachments' in raw) {
+      const full = this.normalize({ ...raw, type: raw.type ?? 0, author: raw.author ?? { id: '0' } })
+      patch.attachments = full ? full.attachments : []
+    }
+    if ('edited_timestamp' in raw) {
+      patch.editedAt = raw.edited_timestamp ? Date.parse(raw.edited_timestamp) : null
+    }
+    if (!Object.keys(patch).length) return
+
+    const updated = await bufferMerge(this.redis, id, patch)
+    // Emitted even when the id has scrolled out of the server buffer: clients
+    // hold more messages than the buffer does.
+    await this.publish({ kind: 'update', id, patch, message: updated })
+  }
+
+  async onMessageDelete(ids) {
+    const list = (Array.isArray(ids) ? ids : [ids]).filter(Boolean).map(String)
+    if (!list.length) return
+    await bufferDelete(this.redis, list)
+    // Unconditional. A moderator removing something must see it disappear from
+    // the site whether or not the server still has it buffered.
+    await this.publish({ kind: 'delete', ids: list })
+  }
+
+  normalize(raw) {
+    return normalizeMessage(raw, {
+      webhookId: this.webhookId,
+      guildId: this.guildId,
+      nameCache: this.nameCache,
+      showAttachments: this.config?.discordChatShowAttachments === true
+    })
+  }
+
+  /**
+   * Re-seeds the buffer from REST.
+   *
+   * Runs on connect (so a restart never leaves clients with an empty panel) and
+   * hourly (so missed deletes converge and attachment signatures stay fresh).
+   */
+  async reseed() {
+    const channelId = this.config?.discordChatChannelId
+    if (!channelId) return
+    try {
+      const rawList = await fetchRecentMessages(channelId, this.rawToken, 50)
+      const messages = []
+      for (const raw of rawList) {
+        const m = this.normalize(raw)
+        if (m) messages.push(m)
+      }
+      await bufferReplace(this.redis, messages)
+      await this.publish({ kind: 'reseed', messages })
+    } catch (err) {
+      // Never block on Discord. An empty buffer is a worse-looking panel, not a
+      // broken one.
+      this.error('reseed failed:', err?.message || err)
+    }
+  }
+
+  async publish(event) {
+    try {
+      await this.redis.publish(CHAT_CHANNELS.events, JSON.stringify(event))
+    } catch (err) {
+      this.error('publish failed:', err?.message || err)
+    }
+  }
+
+  async publishState(extra = {}) {
+    await this.publish({
+      kind: 'state',
+      state: {
+        enabled: this.config?.discordChatEnabled === true,
+        connected: !this.fatal && this.ws?.readyState === 1,
+        fatal: this.fatal ? { code: this.fatal.code } : null,
+        ...extra
+      }
+    })
+  }
+
+  /** Called when an admin saves new config. */
+  async onConfigChanged() {
+    const previous = this.config
+    this.config = await this.loadConfig()
+
+    const channelChanged = previous?.discordChatChannelId !== this.config?.discordChatChannelId
+    if (channelChanged) {
+      // Otherwise the panel would show a mixed history from two channels.
+      await bufferClear(this.redis)
+      await this.reseed()
+    }
+
+    if (!this.config?.discordChatEnabled) {
+      await bufferClear(this.redis)
+      await this.publishState()
+      return
+    }
+    if (!this.ws && !this.fatal) await this.connect()
+    else await this.publishState()
+  }
+}

--- a/server/utils/discordChat/normalize.js
+++ b/server/utils/discordChat/normalize.js
@@ -1,0 +1,358 @@
+// Turns a raw Discord message into the shape the sidebar renders.
+//
+// See constants.js for the import rules.
+//
+// ── The security contract this file exists to enforce ────────────────────────
+// Everything in a Discord message is controlled by whoever can join the guild:
+// content, display names, emoji names, attachment filenames, reply snippets.
+// All of it gets rendered to every logged-in site user, on every page, and the
+// site has no CSP today. So the renderer is never handed a string to interpret.
+//
+// This module emits an array of TOKENS — `{ type, ... }` objects with plain
+// string fields — and the component renders them with v-for and `{{ }}`. There
+// is no path by which message text becomes markup. Concretely, the component
+// must never use v-html, innerHTML, insertAdjacentHTML, `<component :is>`, or
+// bind :style / :href / :src to a raw message field.
+//
+// The only two places a message can influence a URL are `link` tokens (whose
+// href is validated by the URL parser below, so `javascript:` and `data:` can
+// never survive) and `emoji` / avatar / attachment URLs, which are BUILT here
+// from validated snowflakes rather than taken from the payload.
+
+import {
+  RENDERABLE_MESSAGE_TYPES,
+  FLAG_EPHEMERAL,
+  FLAG_LOADING,
+  FLAG_COMPONENTS_V2,
+  ALLOWED_ATTACHMENT_HOSTS,
+  MAX_RENDERED_ATTACHMENTS,
+  MAX_ATTACHMENT_BYTES,
+  MAX_ATTACHMENT_PIXELS
+} from './constants.js'
+
+const CDN = 'https://cdn.discordapp.com'
+
+const SNOWFLAKE = /^\d{17,20}$/
+const AVATAR_HASH = /^a?_?[0-9a-f]{32}$/i
+
+// Control characters, zero-width joiners/spaces, bidi overrides and the BOM.
+// Bidi overrides in particular are a live spoofing primitive in a message list:
+// they let a display name render right-to-left and impersonate another user.
+// eslint-disable-next-line no-control-regex
+const INVISIBLE = /[\u0000-\u0008\u000B-\u001F\u007F\u200B-\u200F\u202A-\u202E\u2066-\u2069\uFEFF]/g
+
+const MAX_NAME_LENGTH = 32
+const MAX_CONTENT_LENGTH = 2000
+
+/** Strips invisibles, normalizes, and truncates a display name. */
+export function safeName(raw, max = MAX_NAME_LENGTH) {
+  const s = String(raw ?? '')
+    .normalize('NFKC')
+    .replace(INVISIBLE, '')
+    .trim()
+  if (!s) return 'unknown'
+  const chars = Array.from(s)
+  return chars.length > max ? `${chars.slice(0, max).join('')}…` : s
+}
+
+/**
+ * Avatar URL, built rather than trusted.
+ *
+ * The guild-member avatar wins over the global one, otherwise per-server
+ * avatars never show. The default-avatar index MUST be computed with BigInt:
+ * snowflakes exceed Number.MAX_SAFE_INTEGER, so `Number(id) >> 22` silently
+ * gives the wrong answer for every user.
+ */
+export function avatarUrl(author, member, guildId) {
+  const id = String(author?.id ?? '')
+  if (!SNOWFLAKE.test(id)) return null
+
+  const memberHash = String(member?.avatar ?? '')
+  if (AVATAR_HASH.test(memberHash) && SNOWFLAKE.test(String(guildId ?? ''))) {
+    return `${CDN}/guilds/${guildId}/users/${id}/avatars/${memberHash}.png?size=32`
+  }
+  const hash = String(author?.avatar ?? '')
+  if (AVATAR_HASH.test(hash)) return `${CDN}/avatars/${id}/${hash}.png?size=32`
+
+  const discriminator = String(author?.discriminator ?? '0')
+  let index
+  if (discriminator === '0') {
+    index = Number((BigInt(id) >> 22n) % 6n)
+  } else {
+    const n = Number(discriminator)
+    index = Number.isFinite(n) ? n % 5 : 0
+  }
+  return `${CDN}/embed/avatars/${index}.png`
+}
+
+// One pass, one regex. Chained .replace() calls are unsafe here: a resolved
+// username containing something like `<#123>` would be re-parsed by the next
+// pass, letting one user's display name forge another token type.
+const TOKEN_RE = new RegExp(
+  [
+    '<(a?):(\\w{2,32}):(\\d{17,20})>', // 1 animated, 2 name, 3 id  — custom emoji
+    '<@!?(\\d{17,20})>', //               4 user id
+    '<@&(\\d{17,20})>', //                5 role id
+    '<#(\\d{17,20})>', //                 6 channel id
+    '</([\\w -]{1,100}):(\\d{17,20})>', //  7 command name, 8 id
+    '<t:(-?\\d{1,17})(?::([tTdDfFsSR]))?>', // 9 unix seconds, 10 style
+    '<id:([a-z-]+)(?::(\\d{17,20}))?>' //  11 nav kind, 12 id
+  ].join('|'),
+  'g'
+)
+
+// Deliberately narrow: a scheme we allow, then non-whitespace. Trailing
+// punctuation is trimmed below so "see https://x.com." doesn't swallow the dot.
+const URL_RE = /\bhttps?:\/\/[^\s<>"']+/gi
+
+function pushText(out, text) {
+  if (!text) return
+  const last = out[out.length - 1]
+  if (last && last.type === 'text') last.value += text
+  else out.push({ type: 'text', value: text })
+}
+
+/**
+ * Splits text into link and text tokens.
+ *
+ * The href is produced by the URL parser, never by the regex. That is what
+ * makes `javascript:`, `data:` and control-character-prefixed schemes
+ * impossible to express, which a string test cannot guarantee.
+ *
+ * Markdown link syntax `[label](url)` is deliberately NOT rendered as a link:
+ * the label is attacker-controlled, and a relayed message already carries a
+ * real community member's name and avatar, so a masked link is the phishing
+ * primitive here. The raw text is shown instead.
+ */
+function tokenizeUrls(text, out) {
+  let last = 0
+  for (const match of text.matchAll(URL_RE)) {
+    const start = match.index
+    let raw = match[0]
+
+    // Trailing punctuation is almost never part of the URL.
+    const trimmed = raw.replace(/[.,;:!?)\]}'"]+$/, '')
+    let url = null
+    try {
+      url = new URL(trimmed)
+    } catch {
+      url = null
+    }
+
+    pushText(out, text.slice(last, start))
+    if (url && (url.protocol === 'http:' || url.protocol === 'https:')) {
+      out.push({ type: 'link', href: url.href, value: trimmed, host: url.hostname })
+      pushText(out, raw.slice(trimmed.length))
+    } else {
+      pushText(out, raw)
+    }
+    last = start + raw.length
+  }
+  pushText(out, text.slice(last))
+}
+
+function tokenizeSegment(text, ctx, out) {
+  let last = 0
+  for (const m of text.matchAll(TOKEN_RE)) {
+    tokenizeUrls(text.slice(last, m.index), out)
+    last = m.index + m[0].length
+
+    if (m[3]) {
+      out.push({
+        type: 'emoji',
+        name: safeName(m[2], 32),
+        url: `${CDN}/emojis/${m[3]}.webp?size=24&quality=lossless${m[1] === 'a' ? '&animated=true' : ''}`
+      })
+    } else if (m[4]) {
+      // msg.mentions carries the resolved user objects, so this needs no REST
+      // call. A mention can legitimately be absent from that array (the user
+      // left the guild, or the token sits inside a code span), hence the
+      // fallback rather than a non-null assertion.
+      out.push({ type: 'mention', value: `@${ctx.users.get(m[4]) || 'unknown'}` })
+    } else if (m[5]) {
+      out.push({ type: 'mention', value: `@${ctx.roles.get(m[5]) || 'role'}` })
+    } else if (m[6]) {
+      out.push({ type: 'mention', value: `#${ctx.channels.get(m[6]) || 'channel'}` })
+    } else if (m[8]) {
+      out.push({ type: 'mention', value: `/${safeName(m[7], 40)}` })
+    } else if (m[9]) {
+      // Unix SECONDS, not milliseconds.
+      out.push({ type: 'time', at: Number(m[9]) * 1000, style: m[10] || 'f' })
+    } else if (m[11]) {
+      pushText(out, '')
+    }
+  }
+  tokenizeUrls(text.slice(last), out)
+}
+
+/**
+ * Content -> tokens.
+ *
+ * Code spans and fenced blocks are split out FIRST and never have their
+ * contents resolved, so a `<@123>` typed inside backticks stays literal rather
+ * than being turned into someone's name.
+ */
+export function tokenizeContent(content, ctx) {
+  const text = String(content ?? '')
+    .normalize('NFKC')
+    .replace(INVISIBLE, '')
+    .slice(0, MAX_CONTENT_LENGTH)
+  if (!text) return []
+
+  const out = []
+  // Fenced blocks first, then inline spans, so ``` wins over `.
+  const parts = text.split(/(```[\s\S]*?```|`[^`\n]+`)/g)
+  for (const part of parts) {
+    if (!part) continue
+    if (part.startsWith('```') && part.endsWith('```') && part.length >= 6) {
+      const inner = part.slice(3, -3).replace(/^[\w+-]*\n/, '')
+      out.push({ type: 'codeblock', value: inner })
+    } else if (part.startsWith('`') && part.endsWith('`') && part.length >= 2) {
+      out.push({ type: 'code', value: part.slice(1, -1) })
+    } else {
+      tokenizeSegment(part, ctx, out)
+    }
+  }
+  return out
+}
+
+/**
+ * Attachments worth rendering as images.
+ *
+ * Host allow-list plus an /attachments/ path check, because the URL is
+ * attacker-chosen. `content_type` is attacker-influenced too and is therefore
+ * only a hint — safety comes from rendering exclusively into an <img>, which
+ * cannot execute script whatever the bytes turn out to be. Nothing here is ever
+ * routed into an iframe, object, embed, or a CSS background.
+ *
+ * Note the `ex` query parameter: Discord's attachment CDN URLs are SIGNED and
+ * expire (roughly a day). It is surfaced so the client can show an "expired"
+ * placeholder instead of a broken image for anything that has aged out of the
+ * buffer.
+ */
+export function normalizeAttachments(list) {
+  if (!Array.isArray(list)) return []
+  const out = []
+  for (const a of list) {
+    if (out.length >= MAX_RENDERED_ATTACHMENTS) break
+    let url
+    try {
+      url = new URL(String(a?.url ?? ''))
+    } catch {
+      continue
+    }
+    if (url.protocol !== 'https:') continue
+    if (!ALLOWED_ATTACHMENT_HOSTS.has(url.hostname)) continue
+    if (!url.pathname.startsWith('/attachments/')) continue
+
+    const width = Number(a?.width) || 0
+    const height = Number(a?.height) || 0
+    const size = Number(a?.size) || 0
+    const isImage = width > 0 && height > 0
+    if (!isImage) continue
+    // Decompression-bomb and bandwidth guards.
+    if (size > MAX_ATTACHMENT_BYTES) continue
+    if (width * height > MAX_ATTACHMENT_PIXELS) continue
+
+    // Ask the resizing host for something the 224px column can actually use.
+    // The original is routinely several megabytes and 2000px wide, and every
+    // open panel would download it.
+    const thumb = new URL(url.href)
+    thumb.hostname = 'media.discordapp.net'
+    thumb.searchParams.set('width', '400')
+
+    const expiresHex = url.searchParams.get('ex')
+    const expiresAt = expiresHex ? parseInt(expiresHex, 16) * 1000 : null
+
+    out.push({
+      url: thumb.href,
+      width,
+      height,
+      name: safeName(a?.filename, 40),
+      expiresAt: Number.isFinite(expiresAt) ? expiresAt : null
+    })
+  }
+  return out
+}
+
+/**
+ * Raw gateway/REST message -> rendered shape, or null if it should be dropped.
+ *
+ * `nameCache` supplies channel and role names (populated from GUILD_CREATE), so
+ * mention resolution costs no API calls.
+ */
+export function normalizeMessage(raw, { webhookId, guildId, nameCache, showAttachments } = {}) {
+  if (!raw || !SNOWFLAKE.test(String(raw.id ?? ''))) return null
+
+  // Allow-list, not deny-list: every other type has empty content and would
+  // render as a blank row, and #general is exactly where join/boost/pin/
+  // thread-created system messages live.
+  const type = Number(raw.type ?? 0)
+  if (!RENDERABLE_MESSAGE_TYPES.has(type)) return null
+
+  const flags = Number(raw.flags ?? 0)
+  if (flags & FLAG_EPHEMERAL) return null
+  if (flags & FLAG_LOADING) return null
+  // Components V2 messages carry empty content with everything in `components`.
+  if (flags & FLAG_COMPONENTS_V2) return null
+
+  const author = raw.author || {}
+  const viaSite = Boolean(webhookId && String(raw.webhook_id ?? '') === String(webhookId))
+
+  // Bots other than our own relay are dropped. Their output is usually embeds
+  // or components, which this feature does not render, so they would otherwise
+  // appear as a stream of blank rows.
+  if (author.bot === true && !viaSite) return null
+
+  const users = new Map()
+  if (Array.isArray(raw.mentions)) {
+    for (const u of raw.mentions) {
+      if (!SNOWFLAKE.test(String(u?.id ?? ''))) continue
+      users.set(String(u.id), safeName(u.member?.nick ?? u.global_name ?? u.username))
+    }
+  }
+
+  const tokens = tokenizeContent(raw.content, {
+    users,
+    roles: nameCache?.roles ?? new Map(),
+    channels: nameCache?.channels ?? new Map()
+  })
+
+  const attachments = showAttachments ? normalizeAttachments(raw.attachments) : []
+
+  // Nothing renderable: no text, no image, and embeds are deliberately not
+  // rendered at all (an embed's image/footer URLs point at arbitrary
+  // attacker-chosen hosts, which would beam every viewer's IP and User-Agent
+  // to that host from one pasted link).
+  const hasEmbedOnly = Array.isArray(raw.embeds) && raw.embeds.length > 0
+  const hasSticker = Array.isArray(raw.sticker_items) && raw.sticker_items.length > 0
+  if (!tokens.length && !attachments.length) {
+    if (hasSticker) tokens.push({ type: 'text', value: '[sticker]' })
+    else if (hasEmbedOnly) tokens.push({ type: 'text', value: '[link preview]' })
+    else if (Array.isArray(raw.attachments) && raw.attachments.length) {
+      tokens.push({ type: 'text', value: '[attachment]' })
+    } else return null
+  }
+
+  // `member` is a partial guild member on gateway messages, and is absent for
+  // webhook messages — hence the chain rather than a direct read.
+  const display = viaSite
+    ? safeName(author.username)
+    : safeName(raw.member?.nick ?? author.global_name ?? author.username)
+
+  return {
+    id: String(raw.id),
+    authorId: SNOWFLAKE.test(String(author.id ?? '')) ? String(author.id) : null,
+    authorName: display,
+    avatarUrl: avatarUrl(author, raw.member, guildId),
+    tokens,
+    attachments,
+    createdAt: Date.parse(raw.timestamp) || Date.now(),
+    editedAt: raw.edited_timestamp ? Date.parse(raw.edited_timestamp) : null,
+    viaSite,
+    replyToId:
+      type === 19 && SNOWFLAKE.test(String(raw.message_reference?.message_id ?? ''))
+        ? String(raw.message_reference.message_id)
+        : null
+  }
+}

--- a/server/utils/discordChat/rest.js
+++ b/server/utils/discordChat/rest.js
@@ -1,0 +1,167 @@
+// Discord REST calls for the chat relay.
+//
+// See constants.js for the import rules. Uses globalThis.fetch, not Nitro's
+// $fetch, because two of the three callers are plain Node processes.
+//
+// ── Why this is careful about failures ───────────────────────────────────────
+// Discord temporarily restricts an IP that makes too many *invalid* requests —
+// 10,000 per 10 minutes, where 401/403/429 all count. Those restrictions apply
+// to the whole production IP, which on this host also serves OAuth login, DMs,
+// the guild-sync cron and every announcement path. So a retry loop in the chat
+// relay can take down Discord login for the entire site. Nothing here retries
+// more than twice, 429s are always honoured rather than hammered through, and a
+// 404 on a webhook is treated as terminal (Discord's docs single that case out:
+// repeatedly using a 404ing webhook is itself grounds for a restriction).
+
+const DISCORD_API = 'https://discord.com/api/v10'
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export class DiscordRestError extends Error {
+  constructor(message, { status = 0, code = null, terminal = false, retryAfterMs = 0 } = {}) {
+    super(message)
+    this.name = 'DiscordRestError'
+    this.status = status
+    this.code = code
+    this.terminal = terminal
+    this.retryAfterMs = retryAfterMs
+  }
+}
+
+/**
+ * One request, with bounded 429 handling.
+ *
+ * `attempts` counts total tries, not retries. Two is the ceiling everywhere:
+ * one honoured 429 backoff is worth waiting for, a second means something is
+ * structurally wrong and hammering it is how the IP restriction above happens.
+ */
+export async function discordFetch(path, { method = 'GET', body, auth, attempts = 2, timeoutMs = 8000 } = {}) {
+  const url = path.startsWith('http') ? path : `${DISCORD_API}${path}`
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    let res
+    try {
+      res = await fetch(url, {
+        method,
+        headers: {
+          ...(auth ? { Authorization: auth } : {}),
+          ...(body !== undefined ? { 'Content-Type': 'application/json' } : {})
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+        signal: AbortSignal.timeout(timeoutMs)
+      })
+    } catch (err) {
+      // Network error or timeout. Retry once; a second failure is reported so
+      // the caller can degrade rather than spin.
+      if (attempt < attempts) {
+        await sleep(500 * attempt)
+        continue
+      }
+      throw new DiscordRestError(`network: ${err?.message || err}`, { terminal: false })
+    }
+
+    if (res.status === 429) {
+      // Three distinct cases, distinguished by scope. A `global` 429 means every
+      // request from this process must pause, not just this route — which
+      // matters because the same host runs the guild cron and the announcement
+      // paths.
+      const scope = res.headers.get('x-ratelimit-scope') || 'user'
+      let retryAfter = Number(res.headers.get('retry-after')) || 1
+      try {
+        const payload = await res.json()
+        if (typeof payload?.retry_after === 'number') retryAfter = payload.retry_after
+      } catch {
+        // header value stands
+      }
+      const retryAfterMs = Math.ceil(retryAfter * 1000)
+
+      if (attempt < attempts && scope !== 'global') {
+        await sleep(retryAfterMs)
+        continue
+      }
+      throw new DiscordRestError(`rate limited (${scope})`, {
+        status: 429,
+        terminal: false,
+        retryAfterMs
+      })
+    }
+
+    if (res.status === 204) return null
+
+    if (!res.ok) {
+      let code = null
+      let message = `HTTP ${res.status}`
+      try {
+        const payload = await res.json()
+        code = payload?.code ?? null
+        if (payload?.message) message = payload.message
+      } catch {
+        // non-JSON error body
+      }
+      // 401/403/404 are not transient. Retrying them is precisely what feeds the
+      // invalid-request counter that gets the IP restricted.
+      const terminal = res.status === 401 || res.status === 403 || res.status === 404
+      throw new DiscordRestError(message, { status: res.status, code, terminal })
+    }
+
+    try {
+      return await res.json()
+    } catch {
+      return null
+    }
+  }
+  throw new DiscordRestError('exhausted attempts', { terminal: false })
+}
+
+/** Bot-authenticated call. Re-prefixes defensively, like the rest of the repo. */
+export function botAuth(rawToken) {
+  if (!rawToken) return null
+  return rawToken.startsWith('Bot ') ? rawToken : `Bot ${rawToken}`
+}
+
+/**
+ * Recent messages for the backfill seed.
+ *
+ * Two things bite here:
+ *   • The API returns NEWEST FIRST. Callers render oldest-first, so this
+ *     reverses before returning — getting it wrong renders history upside down
+ *     in a bottom-anchored scrollback.
+ *   • Missing READ_MESSAGE_HISTORY returns 200 with an EMPTY ARRAY, not a 403.
+ *     So "no messages" is indistinguishable from "misconfigured" at this layer;
+ *     the admin connection test reports on it explicitly instead.
+ */
+export async function fetchRecentMessages(channelId, rawToken, limit = 50) {
+  const auth = botAuth(rawToken)
+  if (!auth || !channelId) return []
+  const list = await discordFetch(`/channels/${channelId}/messages?limit=${limit}`, { auth })
+  if (!Array.isArray(list)) return []
+  return list.reverse()
+}
+
+/** Channel metadata, used by the admin save handler to validate a channel id. */
+export async function fetchChannel(channelId, rawToken) {
+  const auth = botAuth(rawToken)
+  if (!auth || !channelId) return null
+  return await discordFetch(`/channels/${channelId}`, { auth })
+}
+
+/**
+ * Posts one relayed message through the configured webhook.
+ *
+ * `?wait=true` is not optional. Without it Discord answers 204 and — per its
+ * own docs — "a message that is not saved does not return an error", so sends
+ * would fail silently. It also returns the created message id, which is the
+ * only sound way to reconcile the sender's optimistic bubble against the echo
+ * that arrives over the gateway (matching on content would collide whenever two
+ * people send the same text in the same second).
+ *
+ * No Authorization header: the token in the path *is* the credential. Adding one
+ * changes the rate-limit identity and buys nothing.
+ */
+export async function executeWebhook({ id, token }, payload) {
+  return await discordFetch(`/webhooks/${id}/${token}?wait=true`, {
+    method: 'POST',
+    body: payload,
+    attempts: 2
+  })
+}

--- a/server/utils/discordChat/sanitize.js
+++ b/server/utils/discordChat/sanitize.js
@@ -1,0 +1,188 @@
+// Sanitizes a site user's message before it is relayed into Discord.
+//
+// See constants.js for the import rules.
+//
+// ── Why this is strict ───────────────────────────────────────────────────────
+// A relayed message arrives in Discord carrying a real site username and that
+// user's real avatar. To everyone reading the channel it looks like an ordinary
+// message from a community member. That is exactly what makes it a good vehicle
+// for a scam link or a faked moderator announcement, so the text is treated as
+// hostile even though the sender is authenticated.
+//
+// ── Order matters ────────────────────────────────────────────────────────────
+// NFKC runs FIRST. Normalizing after the @everyone check would let a fullwidth
+// "＠everyone" pass the check and then decay into a real one. Escaping runs
+// near the end, and truncation runs LAST, because escaping expands the string
+// (400 backticks becomes 800 characters) and would otherwise push a legal
+// message past Discord's wire limit.
+
+import { OUTBOUND_HARD_CAP } from './constants.js'
+
+// Same class as the inbound normalizer: control chars (keeping \t and \n),
+// zero-width, bidi overrides, BOM.
+const INVISIBLE = /[\u0000-\u0008\u000B-\u001F\u007F\u200B-\u200F\u202A-\u202E\u2066-\u2069\uFEFF]/g
+
+const MAX_LINES = 8
+
+// Hosts a relayed message may link to. Anything else is refused outright rather
+// than stripped, so the sender finds out instead of silently posting a message
+// with a hole in it.
+const ALLOWED_LINK_HOSTS = new Set([
+  'cartoonreorbit.com',
+  'www.cartoonreorbit.com',
+  'dev.cartoonreorbit.com',
+  'cdn.discordapp.com',
+  'media.discordapp.net',
+  'tenor.com',
+  'youtube.com',
+  'www.youtube.com',
+  'youtu.be'
+])
+
+const URL_RE = /\bhttps?:\/\/[^\s<>"']+/gi
+
+export class ChatContentError extends Error {
+  constructor(reason, message) {
+    super(message)
+    this.name = 'ChatContentError'
+    this.reason = reason
+  }
+}
+
+/**
+ * Site username -> webhook display name.
+ *
+ * Site usernames are a closed vocabulary (three words from fixed ASCII lists,
+ * see server/api/auth/set-username.post.js), so homoglyph impersonation is
+ * structurally impossible here — a real strength of this codebase worth not
+ * undermining.
+ *
+ * The suffix still matters, because setting a username also sets the user's
+ * Discord guild NICKNAME to the same string. Site usernames and guild nicknames
+ * therefore share a namespace, and without a marker a relayed message would be
+ * visually identical to a genuine message from that member apart from the small
+ * grey APP tag, which people do not read. The middot cannot occur in a site
+ * username, so the suffix cannot be forged.
+ *
+ * Discord rejects webhook usernames containing "clyde" or "discord" with a 400,
+ * and 80 characters is the ceiling.
+ */
+export function webhookDisplayName(username) {
+  const base = String(username ?? '').trim()
+  if (!/^([A-Z][a-z]+){3}$/.test(base)) {
+    throw new ChatContentError('bad_username', 'Your username cannot be used in chat.')
+  }
+  if (/clyde|discord|everyone|here/i.test(base)) {
+    throw new ChatContentError('bad_username', 'Your username cannot be used in chat.')
+  }
+  const name = `${base} · ReOrbit`
+  return name.length > 80 ? name.slice(0, 80) : name
+}
+
+/**
+ * Site avatar filename -> absolute URL Discord can fetch.
+ *
+ * Re-validated rather than interpolated. The stored value is not guaranteed to
+ * be a bare filename, and this value becomes the user's apparent identity in
+ * the guild, so anything unexpected falls back to no avatar (the webhook's
+ * default) rather than pointing Discord at an arbitrary path.
+ *
+ * On localhost the URL is unreachable from Discord and the webhook silently
+ * uses its default avatar. That is expected in dev, not an error.
+ */
+export function avatarUrlFor(avatar, baseUrl) {
+  const file = String(avatar ?? '')
+  if (!/^[A-Za-z0-9_-]+\.(png|gif|jpe?g|webp)$/i.test(file)) return null
+  if (!baseUrl) return null
+  return `${baseUrl}/avatars/${encodeURIComponent(file)}`
+}
+
+/**
+ * Validates and escapes one outbound message.
+ *
+ * Throws ChatContentError with a machine-readable `reason` so the socket
+ * handler can map it to a fixed enum for the client rather than echoing text
+ * back.
+ */
+export function sanitizeOutbound(raw, { maxLength = 400 } = {}) {
+  // 0. Bound the input before doing any string work on it. Everything below —
+  //    NFKC normalization, several regex passes, Array.from — is superlinear
+  //    enough that an authenticated client emitting a multi-megabyte payload
+  //    would stall the socket server's event loop, which also runs the games.
+  //    The client caps the textarea, so anything past a generous multiple of
+  //    the configured limit is not a real message.
+  if (typeof raw !== 'string' || raw.length > Math.max(4000, maxLength * 4)) {
+    throw new ChatContentError('too_long', `Messages are limited to ${maxLength} characters.`)
+  }
+
+  // 1. Normalize first.
+  let text = raw.normalize('NFKC')
+
+  // 2. Remove invisibles, including bidi overrides.
+  text = text.replace(INVISIBLE, '')
+
+  // 3. Normalize newlines and cap vertical space. One message must not be able
+  //    to fill a 224px sidebar column.
+  text = text.replace(/\r\n|\r/g, '\n').replace(/\n{3,}/g, '\n\n')
+  const lines = text.split('\n')
+  if (lines.length > MAX_LINES) text = lines.slice(0, MAX_LINES).join('\n')
+  text = text.replace(/[^\S\n]{9,}/g, '        ')
+
+  // 4. Trim and reject empty.
+  text = text.trim()
+  if (!text) throw new ChatContentError('empty', 'Type a message first.')
+
+  // Length is checked against the ADMIN limit here, before escaping, so the
+  // user is judged on what they typed rather than on what escaping did to it.
+  if (Array.from(text).length > maxLength) {
+    throw new ChatContentError('too_long', `Messages are limited to ${maxLength} characters.`)
+  }
+
+  // 5. Mass-ping attempts. allowed_mentions blocks the notification, but
+  //    @everyone still renders as attention-grabbing text, so it is refused.
+  if (/@everyone|@here/i.test(text)) {
+    throw new ChatContentError('mention_blocked', 'Messages cannot contain @everyone or @here.')
+  }
+  if (/discord\.gg|discord(app)?\.com\/invite/i.test(text)) {
+    throw new ChatContentError('invite_blocked', 'Messages cannot contain Discord invite links.')
+  }
+
+  // 6. Link host allow-list. A relayed message looks like it came from a
+  //    trusted community member, so an arbitrary link is a laundering vector.
+  for (const match of text.matchAll(URL_RE)) {
+    let url
+    try {
+      url = new URL(match[0].replace(/[.,;:!?)\]}'"]+$/, ''))
+    } catch {
+      throw new ChatContentError('bad_link', 'That link could not be read.')
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new ChatContentError('bad_link', 'Only http and https links are allowed.')
+    }
+    if (!ALLOWED_LINK_HOSTS.has(url.hostname)) {
+      throw new ChatContentError('bad_link', `Links to ${url.hostname} are not allowed in chat.`)
+    }
+  }
+
+  // 7. Escape Discord markdown. Backslash FIRST, or the escapes get escaped.
+  text = text.replace(/([\\`*_~|])/g, '\\$1')
+
+  // 8. Break mention and timestamp syntax with a SPACE. allowed_mentions stops
+  //    the ping but a role mention still RENDERS as a highlighted chip, which
+  //    is the part people actually react to. A space is used rather than a
+  //    zero-width character because step 2 strips those, for good reason.
+  text = text.replace(/<(@|#|a?:|t:)/g, '< $1')
+
+  // 9. Neutralize per-line markdown that would fake a heading or a quote.
+  text = text
+    .split('\n')
+    .map((line) => line.replace(/^(\s*)([>#\-+]|\d+\.)/, '$1\\$2'))
+    .join('\n')
+
+  // 10. Truncate LAST, by code point. .slice() would split a surrogate pair and
+  //     emit mojibake.
+  const chars = Array.from(text)
+  if (chars.length > OUTBOUND_HARD_CAP) text = chars.slice(0, OUTBOUND_HARD_CAP).join('')
+
+  return text
+}

--- a/server/utils/discordChat/send.js
+++ b/server/utils/discordChat/send.js
@@ -1,0 +1,202 @@
+// Relays one site user's message into Discord through the channel webhook.
+//
+// See constants.js for the import rules.
+//
+// ── Rate limiting has two independent jobs ───────────────────────────────────
+// Per-user limits stop one person flooding. They do NOT protect the webhook:
+// Discord's execute limit is per-webhook (about 5 requests per 5 seconds), so
+// twenty users each politely obeying a 5-second personal slowmode still produce
+// ~4 requests/second and get throttled. The global token bucket is what keeps
+// the relay inside Discord's ceiling, and it is the reason this runs in
+// socket-server, which PM2 runs as a single fork instance — an in-process
+// bucket there is globally correct, whereas the Nuxt tier runs two instances
+// and would count every limit at half strength.
+//
+// All counters still live in Redis so they survive a restart and so a future
+// second instance cannot double the effective allowance.
+
+import { CHAT_KEYS, FLAG_SUPPRESS_EMBEDS } from './constants.js'
+import { sanitizeOutbound, webhookDisplayName, avatarUrlFor, ChatContentError } from './sanitize.js'
+import { executeWebhook, DiscordRestError } from './rest.js'
+
+// Deliberately under Discord's per-webhook ceiling, leaving headroom for the
+// other bot traffic this host generates (announcements, DMs, the guild cron).
+const GLOBAL_MAX_PER_WINDOW = 4
+const GLOBAL_WINDOW_SECONDS = 5
+
+const BURST_MAX = 5
+const BURST_WINDOW_SECONDS = 30
+const HOURLY_MAX = 120
+const IP_BURST_MAX = 10
+
+// A relay is not a lock: if the limiter cannot be consulted, the request is
+// refused rather than allowed. server/utils/lockRequest.js fails open, which is
+// right for a lock and wrong here.
+export class ChatRateError extends Error {
+  constructor(reason, message, retryAfterMs = 0) {
+    super(message)
+    this.name = 'ChatRateError'
+    this.reason = reason
+    this.retryAfterMs = retryAfterMs
+  }
+}
+
+/**
+ * Per-user minimum gap. `SET NX EX` is the whole mechanism: it is atomic, so
+ * two concurrent sends cannot both observe an empty slot.
+ */
+async function enforceSlowmode(redis, userId, seconds) {
+  if (seconds <= 0) return
+  const ok = await redis.set(CHAT_KEYS.gap(userId), '1', 'EX', seconds, 'NX')
+  if (ok !== 'OK') {
+    const ttl = await redis.pttl(CHAT_KEYS.gap(userId))
+    throw new ChatRateError('slowmode', 'You are sending messages too quickly.', Math.max(ttl, 0))
+  }
+}
+
+/**
+ * Fixed-window counter. INCR and EXPIRE go in one MULTI so a crash between them
+ * cannot leave a key without a TTL, which would wedge the user permanently.
+ */
+async function enforceWindow(redis, key, max, windowSeconds, reason, message) {
+  const [[, count]] = await redis.multi().incr(key).expire(key, windowSeconds).exec()
+  if (count > max) {
+    const ttl = await redis.pttl(key)
+    throw new ChatRateError(reason, message, Math.max(ttl, 0))
+  }
+}
+
+async function enforceGlobalBucket(redis) {
+  const window = Math.floor(Date.now() / (GLOBAL_WINDOW_SECONDS * 1000))
+  const key = CHAT_KEYS.globalBucket(window)
+  const [[, count]] = await redis.multi().incr(key).expire(key, GLOBAL_WINDOW_SECONDS * 2).exec()
+  if (count > GLOBAL_MAX_PER_WINDOW) {
+    throw new ChatRateError('busy', 'Chat is busy right now — try again in a moment.', GLOBAL_WINDOW_SECONDS * 1000)
+  }
+}
+
+/**
+ * Applies every limit, in cheapest-first order.
+ *
+ * `ipHash` should already be hashed/encrypted by the caller — this module never
+ * sees a raw IP.
+ */
+export async function enforceRateLimits(redis, { userId, ipHash, slowmodeSeconds }) {
+  try {
+    await enforceSlowmode(redis, userId, slowmodeSeconds)
+
+    const now = Date.now()
+    await enforceWindow(
+      redis,
+      CHAT_KEYS.burst(userId, Math.floor(now / (BURST_WINDOW_SECONDS * 1000))),
+      BURST_MAX,
+      BURST_WINDOW_SECONDS * 2,
+      'burst',
+      'You are sending messages too quickly.'
+    )
+    await enforceWindow(
+      redis,
+      CHAT_KEYS.hourly(userId, Math.floor(now / 3_600_000)),
+      HOURLY_MAX,
+      3600,
+      'hourly',
+      'You have hit the hourly chat limit.'
+    )
+    // Alt accounts are a known problem on this site (it already runs device
+    // fingerprinting and VPN detection), and a Discord account is nearly free
+    // to make, so a per-user limit alone is trivially evaded.
+    if (ipHash) {
+      await enforceWindow(
+        redis,
+        CHAT_KEYS.ipBurst(ipHash, Math.floor(now / (BURST_WINDOW_SECONDS * 1000))),
+        IP_BURST_MAX,
+        BURST_WINDOW_SECONDS * 2,
+        'burst',
+        'You are sending messages too quickly.'
+      )
+    }
+
+    // Last, because it is the only limit that is not the user's own fault. If
+    // the webhook is saturated by other people, release this user's slowmode
+    // slot so "try again in a moment" is actually actionable rather than
+    // colliding with their own cooldown.
+    try {
+      await enforceGlobalBucket(redis)
+    } catch (err) {
+      if (err instanceof ChatRateError && err.reason === 'busy') {
+        await redis.del(CHAT_KEYS.gap(userId)).catch(() => {})
+      }
+      throw err
+    }
+  } catch (err) {
+    if (err instanceof ChatRateError) throw err
+    // Redis unreachable. Fail closed — see the note above.
+    throw new ChatRateError('unavailable', 'Chat is unavailable right now.', 5000)
+  }
+}
+
+/**
+ * Sanitizes, rate-limits and relays. Returns the created Discord message id.
+ *
+ * The caller is responsible for having authenticated and authorized the user
+ * (not banned, in the guild, not muted) — this function does not re-check that,
+ * because doing so from here would need Prisma and this module is shared.
+ */
+export async function relayMessage(redis, { user, rawContent, config, webhook, baseUrl, ipHash }) {
+  const content = sanitizeOutbound(rawContent, { maxLength: config.discordChatMaxLength })
+  const username = webhookDisplayName(user.username)
+
+  await enforceRateLimits(redis, {
+    userId: user.id,
+    ipHash,
+    slowmodeSeconds: config.discordChatSlowmodeSeconds
+  })
+
+  const avatarUrl = avatarUrlFor(user.avatar, baseUrl)
+
+  let created
+  try {
+    created = await executeWebhook(webhook, {
+      content,
+      username,
+      ...(avatarUrl ? { avatar_url: avatarUrl } : {}),
+      // Hardcoded, never assembled from config or from the request. This is the
+      // real control over mass-pings; the textual escaping in sanitize.js is
+      // what stops the message merely *looking* like one.
+      allowed_mentions: { parse: [] },
+      // Stops a relayed link generating a preview card, which would otherwise
+      // render an attacker-influenced image in the channel.
+      flags: FLAG_SUPPRESS_EMBEDS
+    })
+  } catch (err) {
+    if (err instanceof DiscordRestError) {
+      if (err.status === 404) {
+        // Discord's docs single this case out: repeatedly using a 404ing
+        // webhook earns a temporary IP restriction, which would break every
+        // Discord integration on this host. Back off hard rather than retry.
+        await redis.set(CHAT_KEYS.webhookCooldown, '1', 'EX', 300).catch(() => {})
+        throw new ChatRateError('unavailable', 'Chat is misconfigured. An admin has been notified.')
+      }
+      if (err.status === 429) {
+        throw new ChatRateError('busy', 'Chat is busy right now — try again in a moment.', err.retryAfterMs)
+      }
+      if (err.code === 50035) {
+        throw new ChatContentError('bad_username', 'Your username cannot be used in chat.')
+      }
+    }
+    throw new ChatRateError('unavailable', 'Could not reach Discord. Your message was not sent.')
+  }
+
+  const messageId = created?.id ? String(created.id) : null
+
+  // Who really sent this, for moderation. Deliberately Redis with a TTL rather
+  // than a Postgres table: Discord already shows the site username on every
+  // relayed message, so this only answers "which account was that?", and a
+  // per-message table would become the highest-volume table in the schema
+  // inside a year.
+  if (messageId) {
+    await redis.set(CHAT_KEYS.relay(messageId), user.id, 'EX', 30 * 24 * 3600).catch(() => {})
+  }
+
+  return messageId
+}

--- a/server/workers/discord-chat.worker.js
+++ b/server/workers/discord-chat.worker.js
@@ -1,0 +1,108 @@
+// Discord chat relay — gateway process.
+//
+// Holds the single Discord Gateway WebSocket and republishes normalized
+// messages onto Redis for socket-server to fan out. Run by PM2 as
+// `discord-chat` (ecosystem.config.cjs), and by `npm run discord-chat`.
+//
+// ── Why this is its own process ──────────────────────────────────────────────
+// It could technically live inside socket-server, and that was the first plan.
+// Three things ruled it out:
+//
+//  1. socket-server has no uncaughtException/unhandledRejection handler, and
+//     its shutdown() — which persists live Clash matches — does not run on a
+//     crash. A stray rejection from reconnect code would therefore destroy
+//     every in-progress PvP/PvE match and trade room on the site. A separate
+//     process cannot do that.
+//  2. socket-server runs a 60Hz cannon-es physics world for the marble race
+//     plus several DB-heavy intervals on the same event loop. Discord drops a
+//     gateway connection whose heartbeat is late, and the traffic runs both
+//     ways: a burst of chat would jitter a 60Hz simulation.
+//  3. `pm2 reload socket-server` would otherwise drop the gateway, and during
+//     the drain window two processes would briefly hold sessions and both
+//     broadcast through the Redis adapter — duplicate messages on every deploy.
+//
+// Being a dedicated `instances: 1` fork is also what makes the single-connection
+// guarantee structural, so there is no distributed lock here to rot.
+
+import dotenv from 'dotenv'
+dotenv.config()
+
+import { prisma } from '../prisma.js'
+import { getRedis } from '../utils/redis.js'
+import { CHAT_CHANNELS } from '../utils/discordChat/constants.js'
+import { loadChatConfig, rawBotToken, webhookCredentials } from '../utils/discordChat/config.js'
+import { DiscordChatGateway } from '../utils/discordChat/gateway.js'
+
+const redis = getRedis()
+// A dedicated subscriber: an ioredis connection in subscriber mode cannot serve
+// ordinary commands, and the gateway needs both.
+const subscriber = redis.duplicate()
+
+// Node 22 makes an unhandled rejection fatal. This process is deliberately
+// isolated so that a crash costs only the chat sidebar, but a crash still costs
+// an IDENTIFY on restart, and that budget is the one thing here that can damage
+// the rest of the site. So: log and keep running.
+process.on('unhandledRejection', (err) => {
+  console.error('[DiscordChat] unhandled rejection:', err)
+})
+process.on('uncaughtException', (err) => {
+  console.error('[DiscordChat] uncaught exception:', err)
+})
+
+const gateway = new DiscordChatGateway({
+  redis,
+  prisma,
+  loadConfig: () => loadChatConfig(redis, prisma),
+  rawToken: rawBotToken(),
+  guildId: process.env.DISCORD_GUILD_ID,
+  webhookId: webhookCredentials()?.id ?? null
+})
+
+async function main() {
+  const config = await loadChatConfig(redis, prisma)
+  if (!config.discordChatEnabled) {
+    // Not an error, and deliberately not a crash loop: a developer with no bot
+    // token or an operator who has not switched the feature on should get a
+    // quiet idle process, not a restart storm.
+    console.log('[DiscordChat] relay is disabled; idling until an admin enables it.')
+  }
+
+  await subscriber.subscribe(CHAT_CHANNELS.configChanged)
+  subscriber.on('message', (channel) => {
+    if (channel !== CHAT_CHANNELS.configChanged) return
+    gateway.onConfigChanged().catch((err) => {
+      console.error('[DiscordChat] config reload failed:', err?.message || err)
+    })
+  })
+
+  await gateway.start()
+
+  // PM2 waits for this before considering the process up.
+  if (process.send) process.send('ready')
+}
+
+async function shutdown(signal) {
+  console.log(`[DiscordChat] ${signal} received, closing gateway`)
+  try {
+    // Closes with 4000 and persists the session, so the next boot RESUMEs
+    // instead of spending an IDENTIFY, and replays anything sent meanwhile.
+    await gateway.stop()
+  } catch (err) {
+    console.error('[DiscordChat] shutdown error:', err?.message || err)
+  }
+  try {
+    await prisma.$disconnect()
+  } catch {
+    // best effort
+  }
+  process.exit(0)
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'))
+process.on('SIGTERM', () => shutdown('SIGTERM'))
+
+main().catch((err) => {
+  console.error('[DiscordChat] failed to start:', err)
+  // Exit non-zero so PM2's backoff restart applies rather than spinning.
+  process.exit(1)
+})

--- a/tests/discordChat.test.js
+++ b/tests/discordChat.test.js
@@ -1,0 +1,279 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { sanitizeOutbound, webhookDisplayName, avatarUrlFor, ChatContentError } from '../server/utils/discordChat/sanitize.js'
+import { tokenizeContent, normalizeMessage, safeName, avatarUrl, normalizeAttachments } from '../server/utils/discordChat/normalize.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const read = (p) => readFileSync(join(here, '..', p), 'utf8')
+
+const ctx = { users: new Map(), roles: new Map(), channels: new Map() }
+const reject = (fn) => {
+  try {
+    fn()
+    return null
+  } catch (err) {
+    return err instanceof ChatContentError ? err.reason : 'other'
+  }
+}
+
+// ── Outbound: site -> Discord ────────────────────────────────────────────────
+
+test('outbound refuses mass-ping attempts, including normalization bypasses', () => {
+  assert.equal(reject(() => sanitizeOutbound('hi @everyone')), 'mention_blocked')
+  assert.equal(reject(() => sanitizeOutbound('hi @here')), 'mention_blocked')
+  // NFKC has to run BEFORE the check, or a fullwidth @ passes it and then decays
+  // into a real mention on Discord's side.
+  assert.equal(reject(() => sanitizeOutbound('hi ＠everyone')), 'mention_blocked')
+})
+
+test('outbound breaks mention syntax so a role cannot render as a chip', () => {
+  // allowed_mentions stops the notification but the chip still renders, and the
+  // chip is what people react to.
+  const out = sanitizeOutbound('cc <@&555555555555555555>')
+  assert.ok(!out.includes('<@&'), `role mention syntax survived: ${out}`)
+})
+
+test('outbound escapes markdown so relayed text cannot fake formatting', () => {
+  const out = sanitizeOutbound('# Announcement **official**')
+  assert.ok(out.startsWith('\\#'), `heading not escaped: ${out}`)
+  assert.ok(out.includes('\\*\\*'), `bold not escaped: ${out}`)
+})
+
+test('outbound allows known hosts and refuses everything else', () => {
+  assert.ok(sanitizeOutbound('see https://www.cartoonreorbit.com/newsite/home'))
+  assert.equal(reject(() => sanitizeOutbound('free stuff https://evil.example/x')), 'bad_link')
+  assert.equal(reject(() => sanitizeOutbound('join discord.gg/abc')), 'invite_blocked')
+})
+
+test('outbound enforces the configured length before escaping expands it', () => {
+  assert.equal(reject(() => sanitizeOutbound('x'.repeat(50), { maxLength: 10 })), 'too_long')
+  // 400 backticks escape to 800 characters; that must still be under the wire cap.
+  const out = sanitizeOutbound('`'.repeat(400), { maxLength: 400 })
+  assert.ok(out.length <= 1900, `escaped output exceeded the hard cap: ${out.length}`)
+})
+
+test('outbound rejects empty and whitespace-only messages', () => {
+  assert.equal(reject(() => sanitizeOutbound('   ')), 'empty')
+  assert.equal(reject(() => sanitizeOutbound('')), 'empty')
+})
+
+test('the webhook display name carries an unforgeable suffix', () => {
+  // Setting a site username also sets the Discord guild nickname, so the two
+  // share a namespace. Without a marker a relayed message is visually identical
+  // to a real one from that member.
+  const name = webhookDisplayName('QuirkyStormMercenary')
+  assert.ok(name.includes('·'), 'no marker in the relayed display name')
+  assert.ok(name.length <= 80, 'webhook usernames are capped at 80 characters')
+  // A site username cannot contain the middot, so the suffix cannot be forged.
+  assert.equal(reject(() => webhookDisplayName('Quirky · ReOrbit')), 'bad_username')
+  // Discord 400s on these substrings.
+  assert.equal(reject(() => webhookDisplayName('DiscordCoolGuy')), 'bad_username')
+  assert.equal(reject(() => webhookDisplayName('not a real username')), 'bad_username')
+})
+
+test('the relayed avatar url is re-validated, not interpolated', () => {
+  const base = 'https://www.cartoonreorbit.com'
+  assert.equal(avatarUrlFor('1.png', base), `${base}/avatars/1.png`)
+  // server/api/auth/set-avatar.post.js has no traversal guard, so the stored
+  // value is not trustworthy on its own.
+  assert.equal(avatarUrlFor('../cToons/secret.png', base), null)
+  assert.equal(avatarUrlFor('', base), null)
+  assert.equal(avatarUrlFor(null, base), null)
+})
+
+// ── Inbound: Discord -> site ─────────────────────────────────────────────────
+
+test('inbound never produces a link token for a dangerous scheme', () => {
+  for (const bad of ['javascript:alert(1)', 'data:text/html,<script>x</script>', 'vbscript:x']) {
+    const tokens = tokenizeContent(bad, ctx)
+    assert.ok(
+      tokens.every((t) => t.type !== 'link'),
+      `${bad} produced a link token`
+    )
+  }
+})
+
+test('inbound does not render markdown link syntax as a link', () => {
+  // The label is attacker-controlled and the message already carries a real
+  // member's name and avatar, so a masked link is the phishing primitive here.
+  const tokens = tokenizeContent('[totally safe](https://evil.example/phish)', ctx)
+  const link = tokens.find((t) => t.type === 'link')
+  assert.ok(link, 'expected the bare URL to still be linkified')
+  assert.equal(link.value, 'https://evil.example/phish', 'the label must not become the link text')
+})
+
+test('inbound leaves markup inert as text', () => {
+  const tokens = tokenizeContent('<img src=x onerror=alert(1)>', ctx)
+  assert.deepEqual(tokens, [{ type: 'text', value: '<img src=x onerror=alert(1)>' }])
+})
+
+test('inbound does not resolve mentions inside code spans', () => {
+  const users = new Map([['123456789012345678', 'Alice']])
+  const tokens = tokenizeContent('`<@123456789012345678>`', { ...ctx, users })
+  assert.deepEqual(tokens, [{ type: 'code', value: '<@123456789012345678>' }])
+})
+
+test('inbound resolves mentions from the payload with no API call', () => {
+  const users = new Map([['123456789012345678', 'Alice']])
+  const roles = new Map([['555555555555555555', 'Moderator']])
+  const channels = new Map([['777777777777777777', 'general']])
+  const tokens = tokenizeContent(
+    '<@123456789012345678> <@&555555555555555555> <#777777777777777777>',
+    { users, roles, channels }
+  )
+  const values = tokens.filter((t) => t.type === 'mention').map((t) => t.value)
+  assert.deepEqual(values, ['@Alice', '@Moderator', '#general'])
+})
+
+test('display names are stripped of bidi overrides and zero-width characters', () => {
+  // A right-to-left override in a display name is a live spoofing primitive in
+  // a message list.
+  const spoofed = `Ali${String.fromCharCode(0x202e)}ce${String.fromCharCode(0x200b)}`
+  assert.equal(safeName(spoofed), 'Alice')
+  assert.equal(safeName(''), 'unknown')
+  assert.ok(safeName('x'.repeat(100)).length <= 33)
+})
+
+test('the default avatar index uses BigInt', () => {
+  // Snowflakes exceed Number.MAX_SAFE_INTEGER, so Number(id) >> 22 is wrong for
+  // every user.
+  const id = '859384984934198272'
+  const expected = Number((BigInt(id) >> 22n) % 6n)
+  assert.equal(
+    avatarUrl({ id, discriminator: '0' }, null, null),
+    `https://cdn.discordapp.com/embed/avatars/${expected}.png`
+  )
+})
+
+test('only renderable message types survive normalization', () => {
+  const base = { id: '1'.repeat(18), author: { id: '2'.repeat(18) }, content: 'hi', timestamp: new Date().toISOString() }
+  assert.ok(normalizeMessage({ ...base, type: 0 }), 'type 0 should render')
+  assert.ok(normalizeMessage({ ...base, type: 19 }), 'type 19 (reply) should render')
+  // #general is full of these and they all carry empty content.
+  for (const type of [1, 2, 6, 7, 8, 18, 22, 46]) {
+    assert.equal(normalizeMessage({ ...base, type }), null, `type ${type} should be dropped`)
+  }
+  // Components V2 puts everything in `components` and leaves content empty.
+  assert.equal(normalizeMessage({ ...base, type: 0, flags: 1 << 15 }), null)
+})
+
+test('attachments are host-allow-listed and capped', () => {
+  const ok = normalizeAttachments([
+    { url: 'https://cdn.discordapp.com/attachments/1/2/a.png', width: 100, height: 100, size: 1000, filename: 'a.png' }
+  ])
+  assert.equal(ok.length, 1)
+  assert.equal(new URL(ok[0].url).hostname, 'media.discordapp.net', 'should use the resizing host')
+
+  // Wrong host, wrong path, oversized, and bomb-shaped inputs are all dropped.
+  assert.deepEqual(normalizeAttachments([{ url: 'https://evil.example/a.png', width: 10, height: 10, size: 10 }]), [])
+  assert.deepEqual(normalizeAttachments([{ url: 'https://cdn.discordapp.com/other/a.png', width: 10, height: 10, size: 10 }]), [])
+  assert.deepEqual(
+    normalizeAttachments([{ url: 'https://cdn.discordapp.com/attachments/1/2/a.png', width: 10, height: 10, size: 99 * 1024 * 1024 }]),
+    []
+  )
+  assert.deepEqual(
+    normalizeAttachments([{ url: 'https://cdn.discordapp.com/attachments/1/2/a.png', width: 99999, height: 99999, size: 10 }]),
+    []
+  )
+
+  // Only one image per message is rendered, whatever arrives.
+  const many = Array.from({ length: 5 }, (_, i) => ({
+    url: `https://cdn.discordapp.com/attachments/1/2/${i}.png`, width: 10, height: 10, size: 10, filename: `${i}.png`
+  }))
+  assert.equal(normalizeAttachments(many).length, 1)
+})
+
+test('embeds are never rendered', () => {
+  // An embed's image/footer URLs point at arbitrary attacker-chosen hosts, so
+  // rendering one would beam every viewer's IP and User-Agent to that host from
+  // a single pasted link.
+  const m = normalizeMessage({
+    id: '1'.repeat(18),
+    type: 0,
+    author: { id: '2'.repeat(18) },
+    content: '',
+    embeds: [{ image: { url: 'https://tracker.example/pixel.png' } }],
+    timestamp: new Date().toISOString()
+  })
+  const serialized = JSON.stringify(m)
+  assert.ok(!serialized.includes('tracker.example'), 'an embed URL reached the client payload')
+})
+
+test('our own relayed messages are flagged by webhook id, not by name', () => {
+  // A guild member can set their nickname to any site username, so matching on
+  // the display name would let them forge the "sent from the site" marker.
+  const raw = {
+    id: '1'.repeat(18),
+    type: 0,
+    content: 'hello',
+    webhook_id: '9'.repeat(18),
+    author: { id: '9'.repeat(18), username: 'QuirkyStormMercenary · ReOrbit', bot: true },
+    timestamp: new Date().toISOString()
+  }
+  assert.equal(normalizeMessage(raw, { webhookId: '9'.repeat(18) })?.viaSite, true)
+  assert.equal(normalizeMessage(raw, { webhookId: '8'.repeat(18) }), null, 'a foreign bot message should be dropped')
+})
+
+// ── Renderer contract ────────────────────────────────────────────────────────
+
+test('the chat component never interpolates message data into markup', () => {
+  const src = read('components/newsite/DiscordChat.vue')
+  for (const banned of ['v-html', 'innerHTML', 'insertAdjacentHTML', 'outerHTML', 'document.write']) {
+    assert.ok(!src.includes(banned), `DiscordChat.vue uses ${banned} — message content is attacker-controlled`)
+  }
+})
+
+test('the chat composer sets an explicit colour', () => {
+  // assets/css/tailwind.css @layer base sets `textarea { color: #111827 }` for
+  // the ~1300 fields on light backgrounds. On the dark chat panel that renders
+  // invisible, and formFieldContrast.test.js will not catch it because that test
+  // only inspects Tailwind-classed fields.
+  // Comments are stripped first: the rule documents a `textarea { ... }` base
+  // rule inside a comment, and that brace would end the match early.
+  const src = read('components/newsite/DiscordChat.vue').replace(/\/\*[\s\S]*?\*\//g, '')
+  const rule = src.match(/\.dchat-input\s*\{[^}]*\}/)
+  assert.ok(rule, 'no .dchat-input rule found')
+  assert.match(rule[0], /color:\s*#ffffff/i, 'the composer must set its own colour')
+  assert.ok(
+    !/-webkit-text-fill-color/.test(rule[0]),
+    'do not set -webkit-text-fill-color here — see the note in assets/css/tailwind.css'
+  )
+  // iOS zooms the page on focus for anything under 16px and does not zoom back.
+  assert.match(src, /font-size:\s*16px/, 'the composer needs a 16px font size on mobile')
+})
+
+test('the sidebar chat region is not given a fixed height', () => {
+  // --sidebar-middle-height is overridden by five pages (384-504px) and
+  // .sidebar-bottom pins itself with margin-top:auto, so any hard-coded height
+  // would gap on some routes and be clipped on others.
+  const layout = read('layouts/newsite-template.vue')
+  const rule = layout.match(/\.sidebar-chat\s*\{[^}]*\}/)
+  assert.ok(rule, 'no .sidebar-chat rule found')
+  assert.match(rule[0], /flex:\s*1 1 auto/, '.sidebar-chat must flex to fill the sidebar')
+  // Without min-height:0 the flex item refuses to shrink and the composer is
+  // clipped away by .sidebar { overflow: hidden }.
+  assert.match(rule[0], /min-height:\s*0/, '.sidebar-chat must set min-height: 0')
+})
+
+test('the webhook credential is not stored in the database', () => {
+  // Both admin config endpoints return the GlobalGameConfig row wholesale, so a
+  // token column would be serialized into every admin's browser.
+  const schema = read('prisma/schema.prisma')
+  assert.ok(
+    !/discordChatWebhook(Token|Id|Url)/i.test(schema),
+    'the webhook credential must live in env, never on GlobalGameConfig'
+  )
+})
+
+test('outbound bounds the payload before doing string work on it', () => {
+  // An authenticated client can emit anything. NFKC + several regex passes over
+  // a multi-megabyte string would stall the socket server's event loop, which
+  // also runs the live games.
+  assert.equal(reject(() => sanitizeOutbound('x'.repeat(5_000_000), { maxLength: 400 })), 'too_long')
+  assert.equal(reject(() => sanitizeOutbound({ toString: () => 'x' })), 'too_long')
+  assert.equal(reject(() => sanitizeOutbound(12345)), 'too_long')
+})

--- a/tests/socketAuthContract.test.js
+++ b/tests/socketAuthContract.test.js
@@ -128,3 +128,81 @@ test('the socket server does not allow every origin with credentials', () => {
   )
   assert.ok(SERVER.includes('credentials: true'), 'socket.io CORS does not allow credentials')
 })
+
+// ── Discord chat relay ───────────────────────────────────────────────────────
+// The chat handlers deliberately do NOT call requireSocketUser directly. They go
+// through resolveChatMember(), which calls it and then re-reads the row, because
+// resolveSocketUser caches {id, username, banned} for the life of the connection
+// and knows nothing about inGuild, active, or chatMutedUntil. A chat panel stays
+// open for hours, so a user banned or muted mid-session would otherwise keep
+// posting into Discord until they closed the tab.
+const CHAT_HANDLERS = ['chat:join', 'chat:send']
+
+test('chat handlers do not take a user id from the payload', () => {
+  const paramList = /socket\.on\(\s*'[^']+'\s*,\s*(?:async\s*)?\(\s*\{([^}]*)\}/
+  for (const name of CHAT_HANDLERS) {
+    const src = handlerSource(name)
+    const params = paramList.exec(src)?.[1] ?? ''
+    const offenders = params
+      .split(',')
+      .map(s => s.trim().split(':')[0].trim())
+      .filter(k => /^(userId|username|uid|user)$/i.test(k))
+    assert.deepEqual(
+      offenders, [],
+      `${name} destructures ${offenders.join(', ')} from its payload — the relay posts into a ` +
+      'real Discord community under that name, so identity must come from the session cookie'
+    )
+  }
+})
+
+test('chat handlers resolve the caller through resolveChatMember', () => {
+  for (const name of CHAT_HANDLERS) {
+    const src = handlerSource(name)
+    assert.ok(
+      src.includes('resolveChatMember(socket'),
+      `${name} never calls resolveChatMember — it cannot know who is calling`
+    )
+  }
+})
+
+test('resolveChatMember authenticates and re-reads the gating fields', () => {
+  const start = SERVER.indexOf('async function resolveChatMember')
+  assert.notEqual(start, -1, 'resolveChatMember not found — was it renamed?')
+  const src = SERVER.slice(start, start + 2500)
+
+  assert.ok(src.includes('requireSocketUser(socket'), 'resolveChatMember does not authenticate')
+  assert.ok(src.includes('db.user.findUnique'), 'resolveChatMember does not re-read the user row')
+  for (const field of ['banned', 'active', 'inGuild', 'chatMutedUntil']) {
+    assert.ok(src.includes(field), `resolveChatMember does not check ${field}`)
+  }
+})
+
+test('sending into Discord verifies guild membership live, not from the cached flag', () => {
+  // User.inGuild defaults to true and is only refreshed by the hourly guild-sync
+  // cron: server/middleware/guild-check.js calls
+  // refreshDiscordTokenAndRoles(prisma, user, config) against a (user, config)
+  // signature, so the arguments are shifted and the live re-check never runs.
+  // That is a pre-existing bug, but it means the flag cannot be the gate for
+  // writing into someone else's Discord community.
+  const start = SERVER.indexOf('async function resolveChatMember')
+  const src = SERVER.slice(start, start + 2500)
+  assert.ok(
+    src.includes('verifyGuildMembership'),
+    'the send path does not verify guild membership against Discord'
+  )
+})
+
+test('the unauthenticated cZone chat-message relay is gone', () => {
+  // It took both the room name and the display name from the client, so any
+  // anonymous socket could broadcast into any room as any user. It was dead
+  // code, but shipping a chat feature beside it is how something gets pointed
+  // at it later.
+  assert.ok(
+    !/socket\.on\(\s*'chat-message'/.test(SERVER),
+    "the unauthenticated 'chat-message' handler is back — it must not be reintroduced"
+  )
+  assert.ok(
+    !/socket\.on\(\s*'join-zone'/.test(SERVER),
+    "the unauthenticated 'join-zone' handler is back — it let a client pick any room name"
+  )
+})


### PR DESCRIPTION
Adds a **Chat** button to the top-bar nav that swaps the sidebar's middle and bottom regions for a live feed of a Discord channel, and lets signed-in guild members post back into it.

**Off by default.** Enable in Admin → Global Settings → Discord.

---

## How it fits together

| Piece | Where |
|---|---|
| Gateway connection (Discord → site) | `server/workers/discord-chat.worker.js` — new `discord-chat` PM2 app |
| Fan-out + sends (site → Discord) | `server/socket-server.js`, new `/chat` namespace |
| Shared logic | `server/utils/discordChat/` |
| Rendering | `components/newsite/DiscordChat.vue`, via `<LazyDiscordChat>` |

**The gateway is its own process.** It could have lived inside `socket-server`, and that was the first plan. Three things ruled it out:

1. `socket-server` has no `uncaughtException`/`unhandledRejection` handler, and its `shutdown()` — which persists live Clash matches — does not run on a crash. A stray rejection from reconnect code would have destroyed every in-progress PvP/PvE match and trade room on the site.
2. `socket-server` runs a 60 Hz `cannon-es` physics world for the marble race plus several DB-heavy intervals on the same event loop. Discord drops a gateway connection whose heartbeat is late, and it cuts both ways — a burst of chat would jitter a 60 Hz simulation.
3. `pm2 reload socket-server` would drop the gateway, and during the drain window two processes would briefly hold sessions and both broadcast through the Redis adapter — duplicate messages on every deploy.

Being a dedicated `instances: 1` fork is also what makes the single-connection guarantee structural, so there is no distributed lock to rot.

**A namespace, not a second connection.** `io.of('/chat')` multiplexes over whatever transport a game page already has open. A second `io()` would have registered all ~49 unrelated game handlers on a socket that needs three, and paid a fresh 5-request polling handshake on every panel open.

Sends live in `socket-server` rather than a Nuxt endpoint because PM2 runs it singly, which makes an in-process token bucket globally correct for Discord's per-webhook limit. It also means no new `/api` surface and no CSRF question.

---

## Notable decisions

- **The webhook credential lives in env, never on `GlobalGameConfig`.** Both admin config endpoints return that row wholesale to the browser (`global-config.get.js:65` returns `config`), so a token column would ship the secret into every admin's devtools. A webhook token is an unauthenticated bearer credential that posts under any name and avatar, revocable only by deleting the webhook — rotating `BOT_TOKEN` does nothing.
- **No REST-polling fallback.** `MESSAGE CONTENT` gates the message *data*, not just the gateway, so polling without it returns empty `content` and the sidebar would render 50 blank rows. A 4014 close stops the relay loudly instead.
- **A persisted IDENTIFY budget guards the reconnect loop.** Exceeding 1000 IDENTIFYs in 24h makes Discord reset the bot token — which would break OAuth login, DMs, the guild cron and every announcement path at once. Reconnects use close code 4000 (never 1000/1001, which invalidate the session and force a fresh IDENTIFY).
- **The `Bot ` prefix is stripped before IDENTIFY.** `.env` stores `BOT_TOKEN` *with* it for REST calls; the gateway needs it bare or you get a permanent 4004 that looks exactly like a bad token.
- **Inbound content is tokenized server-side and rendered as text nodes only.** The component has no raw-HTML directive or DOM sink, enforced by test. Link hrefs come from the URL parser, so `javascript:`/`data:` cannot survive; markdown `[label](url)` is deliberately not linkified, since a relayed message already carries a real member's name and avatar.
- **Embeds are not rendered.** Their image/footer URLs point at arbitrary attacker-chosen hosts, which would leak every viewer's IP and User-Agent from one pasted link.
- **Outbound is escaped and host-allow-listed**, and mention syntax is broken as well as suppressed — `allowed_mentions` stops the ping but a role mention still renders as a chip.
- **Sending verifies guild membership live against Discord**, cached in Redis, rather than trusting `User.inGuild` (see the pre-existing bug below).
- **Per-user limits are paired with a global token bucket**, because Discord's limit is per *webhook*: twenty users each obeying a 5-second personal slowmode still exceed it.
- **`User.chatMutedUntil` + the kill switch** give moderators a lever, since every relayed message reaches Discord as one webhook identity and cannot be timed out with Discord's own per-user tools.

Also removes the dead cZone `join-zone` / `visitor-count` / `chat-message` socket handlers. Nothing emitted or listened for them, but `chat-message` took both the room name *and* the display name from the client — a spoofable broadcast primitive sitting next to a new chat feature.

---

## Layout notes

- The panel is `flex: 1 1 auto; min-height: 0`, **not** a fixed height. `--sidebar-middle-height` is overridden on five pages (384px newcmart, 490px trade, 504px cmart) and `.sidebar-bottom` pins itself with `margin-top: auto`.
- **Mobile uses a teleported sheet**, not a sidebar region: `newsite-template.vue:266` is a `v-if` on `mobileSidebarCollapsed`, so a panel inside it would be unmounted — dropping the socket and scrollback — whenever someone used the existing "Hide Sidebar" button. A fixed sheet is safe below 768px precisely because the layout drops its `transform` there. Soft-keyboard sizing uses `visualViewport`; the body is pinned to defeat pull-to-refresh.
- The button is labelled **Chat**, not "Toggle Chat" — `.topbar-nav-right` is `overflow: hidden` with `nowrap` buttons, and an admin's `NavLeft` is ~85px wider, so the longer label would clip Settings. It is hidden on the 7 pages that set `showSidebar: false`.
- Chat scrollback sits on `rgba(0,0,0,0.25)` over the panel. On the raw panel colour, muted text and the Send button fail WCAG (white on `--OrbitLightBlue` is 3.20:1; the button against the panel is 1.87:1). The darker ground brings white to ~8.9:1 and the button over 3:1.

---

## Setup required before it works

1. Enable the **MESSAGE CONTENT** privileged intent (Developer Portal → Bot).
2. Give the bot **View Channel** + **Read Message History** on the channel.
3. Create a webhook on that channel and set `DISCORD_CHAT_WEBHOOK_URL`.
4. Enable it and set the channel ID in the admin panel.

Documented in the README.

---

## Pre-existing bug found, deliberately NOT fixed here

`server/utils/refreshDiscordTokenAndRoles.js:9` is declared `(user, config)`, but both call sites — `server/middleware/guild-check.js:27` and `server/api/auth/me.get.js:61` — pass `(prisma, user, config)`. The arguments are shifted, so `user` is the Prisma client, `user.refreshToken` is `undefined`, and it returns at line 13. **Token refresh and live guild re-checks have never run.** Separately, line 88 reads `config.discord.botToken`, which does not exist (`nuxt.config.js` puts it at `config.botToken`).

Not fixed here because the fix would fire two Discord API calls on every authenticated request site-wide and could start logging people out — well beyond this feature's scope. This feature does not depend on it: sending verifies membership live. Worth a separate PR behind a `lastRoleSyncAt` TTL gate.

---

## Worth knowing before merging

**Moderation is asymmetric by design.** Every relayed message reaches Discord as one webhook identity, so a Discord mod's timeout/kick/AutoMod tools cannot single out a site user — they have to ask a site admin. The levers that make this workable are built (per-user **Mute chat** in Manage Users, plus a kill switch that clears the buffer instantly), but your mods should know the escalation path exists.

Relatedly: consider pointing this at a dedicated `#website-chat` rather than `#general`. Its regulars joined a Discord server, not a website. The channel is admin-configurable either way.

---

## Testing

- **24 new unit tests** covering XSS vectors, the fullwidth `＠everyone` bypass, masked-link phishing, bidi-override name spoofing, the BigInt default-avatar index, attachment allow-listing, and the payload size guard.
- **5 new socket-auth contract tests**, including one asserting the removed `chat-message` handler cannot be reintroduced.
- Full suite: **427/429 pass**. The 2 failures (`edRpsWiring`, `monsterBattleEngine`) **fail identically on a clean tree** — verified by stashing.
- `nuxt build` clean. Bundle boundary verified: socket.io appears in exactly one chunk and the layout chunk has no static import of it.

**Not verified:** this has not been run against a live Discord guild. The gateway state machine is correct by construction and review, but a real connection is the obvious next check.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6ZLaexad9G8iScn4hTt95

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6ZLaexad9G8iScn4hTt95)_