### PR TITLE
Fix "Message not sent." showing with no diagnostic info

### DIFF
--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -1917,35 +1917,50 @@ async function resolveChatMember(socket, { forSending }) {
       }
     })
   } catch {
-    socket.emit('chat:error', { reason: 'unavailable' })
+    emitChatError(socket, 'unavailable')
     return null
   }
 
   if (!row || row.banned || row.active === false || !row.username || !row.discordId) {
-    socket.emit('chat:error', { reason: 'not_allowed' })
+    emitChatError(socket, 'not_allowed')
     return null
   }
 
   // Belt-and-braces on read (middleware/newsite.js already gates the page);
   // live-verified on send, since that's the side that can cause real harm.
   if (!row.inGuild) {
-    socket.emit('chat:error', { reason: 'not_in_guild' })
+    emitChatError(socket, 'not_in_guild')
     return null
   }
 
   if (forSending) {
     if (row.chatMutedUntil && row.chatMutedUntil.getTime() > Date.now()) {
-      socket.emit('chat:error', { reason: 'muted' })
+      emitChatError(socket, 'muted')
       return null
     }
     const stillMember = await verifyGuildMembership(row.discordId)
     if (!stillMember) {
-      socket.emit('chat:error', { reason: 'not_in_guild' })
+      emitChatError(socket, 'not_in_guild')
       return null
     }
   }
 
   return row
+}
+
+// Every reason gets a real message: several call sites used to emit
+// {reason} alone, which the client falls back to a bare "Message not sent."
+// for — impossible to tell apart from a genuine outage in the UI.
+const CHAT_ERROR_MESSAGES = {
+  unavailable: 'Chat is unavailable right now. Try again in a moment.',
+  disabled: 'Chat is turned off right now.',
+  not_allowed: 'You are not able to use chat right now.',
+  not_in_guild: 'Join the Discord server to use chat.',
+  muted: 'You have been muted from chat.'
+}
+
+function emitChatError(socket, reason, extra = {}) {
+  socket.emit('chat:error', { reason, message: CHAT_ERROR_MESSAGES[reason], ...extra })
 }
 
 function chatBaseUrl() {
@@ -1999,13 +2014,13 @@ chatNsp.on('connection', (socket) => {
 
     const config = await loadChatConfig(chatRedis, db)
     if (!config.discordChatEnabled) {
-      socket.emit('chat:error', { reason: 'disabled' })
+      emitChatError(socket, 'disabled')
       return
     }
     const webhook = webhookCredentials()
     if (!webhook) {
       console.error('[DiscordChat] no webhook configured; refusing to relay')
-      socket.emit('chat:error', { reason: 'unavailable' })
+      emitChatError(socket, 'unavailable')
       return
     }
 
@@ -2020,11 +2035,11 @@ chatNsp.on('connection', (socket) => {
       socket.emit('chat:sent', { messageId })
     } catch (err) {
       if (err instanceof ChatContentError || err instanceof ChatRateError) {
-        socket.emit('chat:error', { reason: err.reason, message: err.message, retryAfterMs: err.retryAfterMs ?? 0 })
+        emitChatError(socket, err.reason, { message: err.message, retryAfterMs: err.retryAfterMs ?? 0 })
         return
       }
       console.error('[DiscordChat] relay failed:', err?.message || err)
-      socket.emit('chat:error', { reason: 'unavailable' })
+      emitChatError(socket, 'unavailable')
     }
   })
 })


### PR DESCRIPTION
Follow-up to #951. When testing on dev, sending a chat message failed with a bare "Message not sent." toast and no way to tell why.

## Root cause

Several failure paths in the `/chat` socket handlers (`server/socket-server.js`) emitted `chat:error` with only a `reason` and no `message`:
- no webhook configured (`webhookCredentials()` returned null)
- relay disabled
- user not allowed / not in guild / muted
- the generic catch-all on an unexpected error from `relayMessage`

The client (`DiscordChat.vue`) falls back to `'Message not sent.'` whenever `message` is missing — which made a real outage (e.g. `DISCORD_CHAT_WEBHOOK_URL` not yet set on this environment) indistinguishable from any other failure, and undiagnosable from a screenshot.

## Fix

Centralizes this into `emitChatError(socket, reason, extra)`, which fills in a reason-specific default message (`"Chat is unavailable right now..."`, `"Join the Discord server to use chat."`, etc.) for every emit site. No behavior change to what's blocked or why — only to what's visible about it.

Given the screenshot (chat connected, "No messages yet." shown, message left in the composer, no blocked-state placeholder), the most likely actual cause on dev is that **`DISCORD_CHAT_WEBHOOK_URL` isn't set yet** in that environment's `.env` — that's a manual setup step from #951's description, not a code bug. This PR won't fix that on its own, but the next failure will say so instead of a bare "Message not sent."

## Testing

- Cherry-picked cleanly onto current `dev`.
- Full suite: 427/429 (2 pre-existing, unrelated failures — same as `dev`).
- `node --check` on the modified file.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6ZLaexad9G8iScn4hTt95

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6ZLaexad9G8iScn4hTt95)_