### PR TITLE
Add cMoon-themed cToon modal redesign and cMoon pages

### DIFF
--- a/components/CtoonCMoonSelect.vue
+++ b/components/CtoonCMoonSelect.vue
@@ -1,0 +1,35 @@
+<template>
+  <select
+    :value="modelValue || ''"
+    class="w-full border rounded p-2 bg-white"
+    style="font-size:16px"
+    @change="$emit('update:modelValue', $event.target.value || null)"
+  >
+    <option value="">— None —</option>
+    <option v-for="c in cmoons" :key="c.id" :value="c.id">{{ c.name }}</option>
+  </select>
+</template>
+
+<script setup>
+// Shared across all four admin cToon create/edit forms (old standalone pages
+// + the new admin-console legacy copies) so the cMoon list is fetched and
+// rendered in exactly one place instead of being hand-copied four times.
+// Reads the admin-gated list (not the public /api/cmoons, which returns an
+// empty list whenever the cMoon faction system's feature flag is off — this
+// display/catalog feature is independent of that flag).
+defineProps({
+  modelValue: { type: String, default: null }
+})
+defineEmits(['update:modelValue'])
+
+const cmoons = ref([])
+
+onMounted(async () => {
+  try {
+    const res = await $fetch('/api/admin/cmoons')
+    cmoons.value = res?.cmoons || []
+  } catch {
+    cmoons.value = []
+  }
+})
+</script>

--- a/components/newsite/AdminCMoon.vue
+++ b/components/newsite/AdminCMoon.vue
@@ -46,6 +46,10 @@
             Prize cToons: {{ c.prizeCtoons.map(p => `${p.name} ×${p.quantity}`).join(', ') || 'none' }}
           </div>
           <div class="text-xs text-gray-600 break-words">Discord role ID: {{ c.discordRoleId || 'none' }}</div>
+          <div class="text-xs text-gray-600 break-words">
+            cToons displayed: {{ c.displayedCtoonCount }}
+            <NuxtLink :to="`/newsite/cmoon/${c.id}`" class="text-indigo-600 hover:underline ml-1">View cMoon page</NuxtLink>
+          </div>
           <p v-if="c.memberCount > 0" class="text-xs text-gray-600 mt-1">
             Reassign members before this cMoon can be deleted.
           </p>
@@ -75,11 +79,57 @@
                 Badge contrast {{ colorContrast.toFixed(1) }}:1{{ colorContrast >= 4.5 ? '' : ' — below the 4.5:1 minimum, pick a darker or lighter color' }}
               </span>
             </p>
+            <!-- This color now also drives an entire cToon-modal/cMoon-page theme (not just the
+                 small badge above), so preview it in that actual context rather than a swatch alone. -->
+            <div v-if="palettePreview" class="cm-theme-preview" :style="{ background: palettePreview.bg, color: palettePreview.text }">
+              <div class="cm-theme-preview-banner" :style="{ background: palettePreview.banner, color: palettePreview.bannerText }">
+                {{ form.name || 'cMoon name' }}
+              </div>
+              <div class="cm-theme-preview-tile" :style="{ background: palettePreview.tileBg }">
+                <div style="font-size:0.65rem;opacity:0.8;">cWorld</div>
+                <div :style="{ color: palettePreview.linkText }">{{ form.name || 'cMoon name' }} ›</div>
+              </div>
+              <p style="font-size:0.72rem;" :style="{ color: palettePreview.textMuted }">This is how the themed cToon modal &amp; cMoon page will look.</p>
+            </div>
           </div>
           <div>
             <label class="block text-xs font-medium mb-1">Discord Role ID (optional)</label>
             <input v-model="form.discordRoleId" class="w-full border rounded px-2 py-1" style="font-size:16px" inputmode="numeric" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="123456789012345678" />
           </div>
+        </div>
+
+        <div class="mt-3">
+          <label class="block text-xs font-medium mb-1">cMoon page description (optional)</label>
+          <textarea
+            v-model="form.pageDescription"
+            rows="3"
+            maxlength="2000"
+            class="w-full border rounded px-2 py-1"
+            style="font-size:16px"
+            placeholder="Shown on this cMoon's public page"
+          ></textarea>
+        </div>
+
+        <div class="mt-3">
+          <label class="block text-xs font-medium mb-1">cMoon page image (exactly 800×600 after processing)</label>
+          <template v-if="!editId">
+            <p class="text-xs text-gray-600">Save this cMoon first, then Edit it to upload a page image.</p>
+          </template>
+          <template v-else>
+            <img v-if="pageImagePreview" :src="pageImagePreview" class="cm-page-image-preview" alt="Selected image preview" />
+            <img v-else-if="currentPageImagePath" :src="currentPageImagePath" class="cm-page-image-preview" alt="Current cMoon page image" />
+            <p v-else class="text-xs text-gray-600 mb-1">No image uploaded yet.</p>
+            <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" class="cm-field" @change="handlePageImageFile" />
+            <p class="text-xs text-gray-500 mt-1">Any photo works — it's auto-cropped/resized to 800×600 on upload.</p>
+            <button
+              type="button"
+              class="cm-tap mt-2 px-3 border rounded bg-white"
+              :disabled="!pageImageFile || pageImageUploading"
+              @click="uploadPageImage"
+            >{{ pageImageUploading ? 'Uploading…' : 'Upload image' }}</button>
+            <p v-if="pageImageError" class="text-xs text-red-600 mt-1">{{ pageImageError }}</p>
+            <NuxtLink :to="`/newsite/cmoon/${editId}`" class="block text-xs text-indigo-600 hover:underline mt-2">View cMoon page</NuxtLink>
+          </template>
         </div>
 
         <div class="mt-3">
@@ -153,6 +203,7 @@
 
 <script setup>
 import { cMoonPillStyle, isSafeCMoonColor, cMoonContrastRatio } from '~/utils/cmoonColor'
+import { cMoonPalette } from '~/utils/cmoonPalette'
 
 const loading = ref(false)
 const saving = ref(false)
@@ -166,10 +217,47 @@ const cMoonEnabledAt = ref(null)
 const cMoonSelectionDeadlineAt = ref(null)
 
 const editId = ref('')
-const emptyForm = () => ({ name: '', color: '', discordRoleId: '', captainIds: [], prizeCtoons: [] })
+const emptyForm = () => ({ name: '', color: '', discordRoleId: '', pageDescription: '', captainIds: [], prizeCtoons: [] })
 const form = reactive(emptyForm())
 const prizeCtoonSearch = ref('')
 const prizeCtoonQty = ref(1)
+
+// ── cMoon page image (separate step — needs an existing cMoon row) ─────
+const pageImageFile = ref(null)
+const pageImagePreview = ref('')
+const pageImageUploading = ref(false)
+const pageImageError = ref('')
+const currentPageImagePath = ref('')
+
+const palettePreview = computed(() => isValidColor(form.color) ? cMoonPalette(form.color) : null)
+
+function handlePageImageFile(e) {
+  const file = e.target.files?.[0] || null
+  pageImageFile.value = file
+  pageImageError.value = ''
+  if (pageImagePreview.value) URL.revokeObjectURL(pageImagePreview.value)
+  pageImagePreview.value = file ? URL.createObjectURL(file) : ''
+}
+
+async function uploadPageImage() {
+  if (!editId.value || !pageImageFile.value || pageImageUploading.value) return
+  pageImageUploading.value = true
+  pageImageError.value = ''
+  try {
+    const body = new FormData()
+    body.append('image', pageImageFile.value)
+    const res = await $fetch(`/api/admin/cmoons/${editId.value}/page-image`, { method: 'POST', body })
+    currentPageImagePath.value = res.pageImagePath
+    pageImageFile.value = null
+    if (pageImagePreview.value) URL.revokeObjectURL(pageImagePreview.value)
+    pageImagePreview.value = ''
+    await load()
+  } catch (e) {
+    pageImageError.value = e?.data?.statusMessage || 'Upload failed'
+  } finally {
+    pageImageUploading.value = false
+  }
+}
 
 // Share the validation/contrast helpers with the player-facing badges so the admin
 // preview here matches exactly what renders on leaderboards and cZones.
@@ -243,9 +331,15 @@ function startEdit(c) {
     name: c.name,
     color: c.color,
     discordRoleId: c.discordRoleId || '',
+    pageDescription: c.pageDescription || '',
     captainIds: c.captains.map(cap => cap.userId),
     prizeCtoons: c.prizeCtoons.map(p => ({ ctoonId: p.ctoonId, quantity: p.quantity })),
   })
+  currentPageImagePath.value = c.pageImagePath || ''
+  pageImageFile.value = null
+  if (pageImagePreview.value) URL.revokeObjectURL(pageImagePreview.value)
+  pageImagePreview.value = ''
+  pageImageError.value = ''
   formError.value = ''
 }
 
@@ -253,6 +347,11 @@ function resetForm() {
   Object.assign(form, emptyForm())
   editId.value = ''
   formError.value = ''
+  currentPageImagePath.value = ''
+  pageImageFile.value = null
+  if (pageImagePreview.value) URL.revokeObjectURL(pageImagePreview.value)
+  pageImagePreview.value = ''
+  pageImageError.value = ''
 }
 
 async function load() {
@@ -300,6 +399,7 @@ async function save() {
       name: form.name.trim(),
       color: form.color,
       discordRoleId: form.discordRoleId.trim(),
+      pageDescription: form.pageDescription,
       captainIds: form.captainIds,
       prizeCtoons: form.prizeCtoons,
     }
@@ -394,5 +494,35 @@ onMounted(load)
   border-radius: 999px;
   font-size: 0.7rem;
   font-weight: 700;
+}
+
+.cm-theme-preview {
+  margin-top: 8px;
+  border-radius: 6px;
+  overflow: hidden;
+  max-width: 320px;
+}
+.cm-theme-preview-banner {
+  padding: 8px 10px;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+.cm-theme-preview-tile {
+  margin: 8px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+.cm-theme-preview p { margin: 0 8px 8px; }
+
+.cm-page-image-preview {
+  display: block;
+  width: 100%;
+  max-width: 320px;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 6px;
 }
 </style>

--- a/components/newsite/AuctionDetails.vue
+++ b/components/newsite/AuctionDetails.vue
@@ -264,6 +264,7 @@ function openInfoModal() {
     userCtoonId: auction.value.ctoon.userCtoonId || null,
     assetPath:   auction.value.ctoon.assetPath   || null,
     name:        auction.value.ctoon.name        || null,
+    context:     { source: 'auction' },
   })
 }
 

--- a/components/newsite/AuctionHouse.vue
+++ b/components/newsite/AuctionHouse.vue
@@ -564,6 +564,7 @@ function openInfoModal(item) {
     userCtoonId: item.userCtoonId || null,
     assetPath:   item.assetPath  || null,
     name:        item.name       || null,
+    context:     { source: 'auction' },
   })
 }
 

--- a/components/newsite/CMoonPage.vue
+++ b/components/newsite/CMoonPage.vue
@@ -1,0 +1,217 @@
+<template>
+  <div class="cmp-wrap" :style="paletteStyle">
+    <div v-if="loading" class="cmp-status">Loading…</div>
+    <div v-else-if="error" class="cmp-status cmp-status--error">{{ error }}</div>
+    <template v-else-if="cmoon">
+      <div class="cmp-banner">
+        <h1 class="cmp-title">{{ cmoon.name }}</h1>
+      </div>
+
+      <div class="cmp-body">
+        <div class="cmp-image-wrap">
+          <img
+            v-if="cmoon.pageImagePath"
+            :src="cmoon.pageImagePath"
+            :alt="`${cmoon.name} cMoon`"
+            class="cmp-image"
+          />
+          <div v-else class="cmp-image-placeholder">No image uploaded yet</div>
+        </div>
+
+        <p v-if="cmoon.pageDescription" class="cmp-description">{{ cmoon.pageDescription }}</p>
+
+        <h2 class="cmp-section-title">cToons ({{ cmoon.ctoonCount.toLocaleString() }})</h2>
+        <div v-if="!cmoon.ctoons.length" class="cmp-empty">No cToons are displayed under this cMoon yet.</div>
+        <div v-else class="cmp-grid">
+          <button
+            v-for="c in cmoon.ctoons"
+            :key="c.id"
+            type="button"
+            class="cmp-card"
+            @click="openInfo(c)"
+          >
+            <img :src="c.assetPath" :alt="c.name" class="cmp-card-img" loading="lazy" />
+            <span class="cmp-card-name">{{ c.name }}</span>
+          </button>
+        </div>
+        <p v-if="cmoon.ctoonsTruncated" class="cmp-truncated-note">
+          Showing the first {{ cmoon.ctoons.length.toLocaleString() }} of {{ cmoon.ctoonCount.toLocaleString() }} cToons.
+        </p>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { cMoonPaletteStyle } from '@/utils/cmoonPalette'
+import { useCtoonModal } from '@/composables/useCtoonModal'
+
+const route = useRoute()
+const { open: openCtoonModal } = useCtoonModal()
+
+const loading = ref(true)
+const error = ref('')
+const cmoon = ref(null)
+
+const paletteStyle = computed(() => cmoon.value ? cMoonPaletteStyle(cmoon.value.color) : {})
+
+useHead({
+  title: computed(() => cmoon.value ? `${cmoon.value.name} · cMoon` : 'cMoon')
+})
+
+function openInfo(c) {
+  openCtoonModal({ ctoonId: c.id, assetPath: c.assetPath, name: c.name })
+}
+
+async function load(id) {
+  if (!id) return
+  loading.value = true
+  error.value = ''
+  try {
+    cmoon.value = await $fetch(`/api/cmoon/${encodeURIComponent(id)}`)
+  } catch (err) {
+    cmoon.value = null
+    error.value = err?.data?.statusMessage || 'Failed to load this cMoon.'
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => route.params.id, (id) => load(id), { immediate: true })
+</script>
+
+<style scoped>
+.cmp-wrap {
+  width: 100%;
+  min-height: 100%;
+  box-sizing: border-box;
+}
+
+.cmp-status {
+  padding: 24px 16px;
+  color: #ffffff;
+  font-size: 0.95rem;
+}
+.cmp-status--error { color: #fca5a5; }
+
+.cmp-banner {
+  background: var(--cm-banner, var(--OrbitDarkBlue));
+  color: var(--cm-banner-text, #ffffff);
+  padding: 18px 16px;
+}
+
+.cmp-title {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.cmp-body {
+  padding: 16px;
+  background: var(--cm-bg, transparent);
+  color: var(--cm-text, #ffffff);
+  box-sizing: border-box;
+}
+
+/* 800x600 (4:3), same resolution as a cZone background. */
+.cmp-image-wrap {
+  width: 100%;
+  max-width: 800px;
+  aspect-ratio: 4 / 3;
+  margin: 0 auto 16px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--cm-tile-bg, rgba(255,255,255,0.08));
+}
+@supports not (aspect-ratio: 4 / 3) {
+  .cmp-image-wrap { height: 0; padding-bottom: 75%; position: relative; }
+  .cmp-image-wrap .cmp-image,
+  .cmp-image-wrap .cmp-image-placeholder { position: absolute; inset: 0; }
+}
+
+.cmp-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.cmp-image-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--cm-text-muted, rgba(255,255,255,0.6));
+  font-size: 0.9rem;
+}
+
+.cmp-description {
+  white-space: pre-line;
+  overflow-wrap: anywhere;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0 0 20px;
+}
+
+.cmp-section-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0 0 10px;
+}
+
+.cmp-empty {
+  color: var(--cm-text-muted, rgba(255,255,255,0.6));
+  font-size: 0.9rem;
+}
+
+.cmp-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 8px;
+}
+
+@media (max-width: 768px) {
+  .cmp-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+.cmp-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: var(--cm-tile-bg, rgba(255,255,255,0.08));
+  border: none;
+  border-radius: 6px;
+  padding: 8px;
+  cursor: pointer;
+  color: var(--cm-text, #ffffff);
+  font-family: inherit;
+  /* Real touch target on top of whatever internal padding the image adds. */
+  min-height: 44px;
+  box-sizing: border-box;
+}
+.cmp-card:hover { opacity: 0.85; }
+.cmp-card:focus-visible { outline: 2px solid var(--cm-focus-ring, var(--OrbitLightBlue)); outline-offset: 1px; }
+
+.cmp-card-img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+}
+
+.cmp-card-name {
+  font-size: 0.75rem;
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.cmp-truncated-note {
+  margin-top: 12px;
+  font-size: 0.8rem;
+  color: var(--cm-text-muted, rgba(255,255,255,0.6));
+}
+</style>

--- a/components/newsite/Cmart.vue
+++ b/components/newsite/Cmart.vue
@@ -426,7 +426,7 @@ function rarityInfo(rarity) {
 
 const ctoonModal = useCtoonModal()
 function openInfo(c) {
-  ctoonModal.open({ ctoonId: c.id, assetPath: c.assetPath, name: c.name })
+  ctoonModal.open({ ctoonId: c.id, assetPath: c.assetPath, name: c.name, context: { source: 'market' } })
 }
 
 const { user, fetchSelf } = useAuth()

--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
   <div class="ctic-overlay" @click.self="close">
-    <div class="ctic-panel">
+    <div class="ctic-panel" :class="{ 'ctic-panel--cmoon': showCMoonTheme }" :style="cMoonStyle">
       <!-- Status banner image -->
       <img
         v-if="activeTab === 'info' && statusImage"
@@ -106,6 +106,15 @@
               <p>{{ ctoonDescription }}</p>
             </div>
             <div class="ctic-grid">
+              <div v-if="showCMoonTheme" class="ctic-tile ctic-tile-wide">
+                <div class="ctic-label">cWorld</div>
+                <NuxtLink
+                  :to="`/newsite/cmoon/${ctoon.cMoon.id}`"
+                  class="ctic-value ctic-value--link ctic-value--wrap"
+                  :aria-label="`View the ${ctoon.cMoon.name} cMoon page`"
+                  @click="close"
+                >{{ ctoon.cMoon.name }} <span aria-hidden="true">&rsaquo;</span></NuxtLink>
+              </div>
               <div class="ctic-tile">
                 <div class="ctic-label">Highest Mint</div>
                 <div class="ctic-value">{{ formatValue(ctoon.highestMint) }}</div>
@@ -421,9 +430,21 @@ import abilities from '@/data/abilities.json'
 import { useCtoonModal } from '@/composables/useCtoonModal'
 import { useAuth } from '@/composables/useAuth'
 import { formatQuantity, TIME_BASED_CAP } from '@/utils/formatQuantity'
+import { cMoonPaletteStyle } from '@/utils/cmoonPalette'
 
 const { isAdmin } = useAuth()
 const { isOpen, loading, error, data, context, close, open, notifyHolidayRedeem } = useCtoonModal()
+
+// cMart and Auction House/Details modals must stay pixel-identical to today —
+// this is the one flag that suppresses the cMoon-themed variant everywhere else
+// (My Collection, AllCtoons, Trade, Wishlist, cZone all get it by default).
+const isMarketContext = computed(() => ['market', 'auction'].includes(context.value?.source))
+// Wait for `loading` to clear before ever applying the theme: the skeleton
+// always renders in the standard (untheme) look, so there is exactly one
+// clean transition into the cMoon palette once real data lands, never a
+// flash of the wrong color while loading.
+const showCMoonTheme = computed(() => !isMarketContext.value && !loading.value && !!ctoon.value?.cMoon)
+const cMoonStyle = computed(() => showCMoonTheme.value ? cMoonPaletteStyle(ctoon.value.cMoon.color) : {})
 
 function openRelatedEdition(ctoonId) {
   if (!ctoonId) return
@@ -1183,7 +1204,8 @@ function formatDate(value) {
   border-radius: 4px;
   padding: 5px 8px;
   margin: -5px -8px;
-  min-height: 28px;
+  /* Real touch target, matching the 44px convention used elsewhere (e.g. AdminCMoon.vue's .cm-tap). */
+  min-height: 44px;
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
 }
@@ -1201,6 +1223,19 @@ function formatDate(value) {
 .ctic-value--link:focus-visible {
   outline: 2px solid var(--OrbitLightBlue);
   outline-offset: 1px;
+}
+/* A cMoon name has no length limit, so this variant wraps as normal text
+   instead of staying on one inline-flex line — the trailing "›" is real text
+   content (not a positioned ::after) precisely so it flows with the wrap
+   instead of floating beside the middle of a two-line block. */
+.ctic-value--wrap {
+  display: block;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  align-items: flex-start;
+}
+.ctic-value--wrap::after {
+  content: none;
 }
 
 .ctic-sub {
@@ -1485,4 +1520,82 @@ function formatDate(value) {
 }
 .ctic-submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .ctic-submit-btn:hover:not(:disabled) { background: #2288bb; }
+
+/* ── cMoon-themed variant ────────────────────────────────────────────────
+   Applied only in non-market contexts (My Collection, AllCtoons, Trade,
+   Wishlist, cZone) once a cToon's assigned cMoon has loaded — never in
+   cMart/Auction, and never during the loading skeleton (see showCMoonTheme
+   in the script), so there is one clean transition into the palette instead
+   of a flash of the wrong color. Every rule below reads a --cm-* custom
+   property set by utils/cmoonPalette.js's cMoonPaletteStyle(), which is
+   always bound through Vue's :style object binding (never a raw string), so
+   an admin-chosen color can never smuggle extra CSS declarations. Status/
+   semantic colors (sold/locked-amber, 2nd-edition badge, tradeable badge)
+   are intentionally left alone below — those are self-contained bg+text
+   pairs whose own internal contrast doesn't depend on the panel background. */
+.ctic-panel--cmoon {
+  background: var(--cm-bg);
+  border-color: var(--cm-border);
+  color: var(--cm-text);
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+.ctic-panel--cmoon .ctic-head { border-bottom-color: var(--cm-hairline); }
+.ctic-panel--cmoon .ctic-thumb { background: var(--cm-thumb-bg); }
+.ctic-panel--cmoon .ctic-subtitle { color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-edition-link { color: var(--cm-link-text); }
+.ctic-panel--cmoon .ctic-edition-link:hover { opacity: 0.8; }
+.ctic-panel--cmoon .ctic-sound-btn { color: var(--cm-link-text); }
+.ctic-panel--cmoon .ctic-sound-btn:hover { opacity: 0.8; }
+.ctic-panel--cmoon .ctic-close-x { color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-close-x:hover { color: var(--cm-text); }
+
+.ctic-panel--cmoon .ctic-tabs { border-bottom-color: var(--cm-hairline); }
+.ctic-panel--cmoon .ctic-tab { background: var(--cm-tile-bg); color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-tab:hover { color: var(--cm-text); }
+.ctic-panel--cmoon .ctic-tab--active { background: var(--cm-banner); color: var(--cm-banner-text); }
+
+.ctic-panel--cmoon .ctic-body { scrollbar-color: var(--cm-border) transparent; }
+.ctic-panel--cmoon .ctic-tile { background: var(--cm-tile-bg); }
+.ctic-panel--cmoon .ctic-desc p { color: var(--cm-text); }
+.ctic-panel--cmoon .ctic-label { color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-value { color: var(--cm-text); }
+.ctic-panel--cmoon .ctic-value--link { color: var(--cm-link-text); background: var(--cm-link-bg); }
+.ctic-panel--cmoon .ctic-value--link:hover,
+.ctic-panel--cmoon .ctic-value--link:active { opacity: 0.82; }
+.ctic-panel--cmoon .ctic-value--link:focus-visible { outline-color: var(--cm-focus-ring); }
+.ctic-panel--cmoon .ctic-sub { color: var(--cm-text-muted); }
+
+.ctic-panel--cmoon .ctic-mint-title { color: var(--cm-text-muted); }
+/* :not(.ctic-lock-row--on) so the amber "locked" state (a semantic warning
+   color) is never overridden by the themed default/off state below it. */
+.ctic-panel--cmoon .ctic-lock-row:not(.ctic-lock-row--on) {
+  background: var(--cm-tile-bg);
+  border-color: var(--cm-border);
+  color: var(--cm-text-muted);
+}
+.ctic-panel--cmoon .ctic-lock-row:not(.ctic-lock-row--on) .ctic-lock-glyph { color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-lock-error { color: var(--cm-danger); }
+
+.ctic-panel--cmoon .ctic-owner-row { background: var(--cm-tile-bg); }
+.ctic-panel--cmoon .ctic-owner-mint { color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-owner-link { color: var(--cm-link-text); }
+.ctic-panel--cmoon .ctic-owner-link:hover { opacity: 0.82; }
+.ctic-panel--cmoon .ctic-owner-value { color: var(--cm-success); }
+
+.ctic-panel--cmoon .ctic-suggest-intro { color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-input {
+  background: var(--cm-tile-bg);
+  border-color: var(--cm-border);
+  color: var(--cm-text);
+}
+.ctic-panel--cmoon .ctic-input:focus { outline-color: var(--cm-focus-ring); }
+.ctic-panel--cmoon .ctic-success { color: var(--cm-success); }
+.ctic-panel--cmoon .ctic-no-change { color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-error { color: var(--cm-danger); }
+.ctic-panel--cmoon .ctic-empty { color: var(--cm-text-muted); }
+
+.ctic-panel--cmoon .ctic-countdown { color: var(--cm-text-muted); }
+.ctic-panel--cmoon .ctic-countdown-time { color: var(--cm-text); }
+
+.ctic-panel--cmoon .ctic-foot { border-top-color: var(--cm-hairline); }
 </style>

--- a/components/newsite/MyCzone.vue
+++ b/components/newsite/MyCzone.vue
@@ -213,7 +213,7 @@
                   <img
                     :src="item.ctoon.assetPath" :alt="item.ctoon.name"
                     class="cz-wl-img cz-wl-img--clickable"
-                    @click="openCtoonModal({ ctoonId: item.ctoon.id, assetPath: item.ctoon.assetPath, name: item.ctoon.name })"
+                    @click="openCtoonModal({ ctoonId: item.ctoon.id, assetPath: item.ctoon.assetPath, name: item.ctoon.name, context: { source: 'czone', isOwner: isOwnZone, username: viewedUsername || '' } })"
                   />
                   <p class="cz-wl-name">{{ item.ctoon.name }}</p>
                   <p class="cz-wl-pts">Offer: {{ item.offeredPoints.toLocaleString() }} pts</p>
@@ -335,7 +335,7 @@ function canvasH() { return CANVAS_H }
 
 const { user, fetchSelf } = useAuth()
 const cz = useNewSiteCzoneState()
-const { open: openCtoonModal, setContext, clearContext, holidaySignal, holidayRedeem } = useCtoonModal()
+const { open: openCtoonModal, holidaySignal, holidayRedeem } = useCtoonModal()
 const { mobileSidebarCollapsed } = useNewsiteLayout()
 const route  = useRoute()
 const router = useRouter()
@@ -722,11 +722,6 @@ function goToTradeWithCtoon(item) {
 const currentZone = computed(() => cz.value.zones?.[cz.value.activeZone] ?? { background: '', toons: [] })
 const isOwnZone   = computed(() => !!user.value && viewedUsername.value === user.value.username)
 
-// Keep ctoon modal context in sync so the "Open cToon" button appears on owned zones
-watch([isOwnZone, viewedUsername], ([own, uname]) => {
-  setContext({ source: 'czone', isOwner: own, username: uname || '' })
-}, { immediate: true })
-
 watch(holidaySignal, async () => {
   if (holidayRedeem.value?.reward?.name) {
     showSearchToast(`Opened! You received ${holidayRedeem.value.reward.name} 🎉`, 'success')
@@ -940,7 +935,8 @@ function onToonClick(toon) {
     ctoonId: toon.ctoonId,
     userCtoonId: isOwnZone.value ? toon.id : undefined,
     assetPath: toon.assetPath,
-    name: toon.name
+    name: toon.name,
+    context: { source: 'czone', isOwner: isOwnZone.value, username: viewedUsername.value || '' }
   })
 }
 

--- a/components/newsite/admin/legacy/AdminLegacyCtoonsEdit.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCtoonsEdit.vue
@@ -85,6 +85,12 @@
               </select>
               <p class="text-[11px] text-gray-500">Drives the default price, quantity, and c-mart placement below.</p>
             </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">cMoon (optional)</label>
+              <CtoonCMoonSelect v-model="cMoonId" />
+              <p class="text-[11px] text-gray-500">If set, this cToon's modal (outside cMart/Auction) is redesigned in this cMoon's colors, with a link to its cMoon page.</p>
+            </div>
           </section>
 
           <!-- ── Pricing ───────────────────────────────────────────── -->
@@ -332,6 +338,7 @@ const id = props.subPath[0] ?? route.params.id
 /* core refs */
 const name = ref(''); const type = ref('')
 const series = ref(''); const rarity = ref('')
+const cMoonId = ref(null)
 const price = ref(0); const releaseDate = ref('')
 const rarityDefaults = ref(null)
 const ctoonLoaded = ref(false)
@@ -475,6 +482,7 @@ onMounted(async ()=>{
     type.value = ctoon.type
     series.value = ctoon.series
     rarity.value = ctoon.rarity
+    cMoonId.value = ctoon.cMoonId || null
     price.value = ctoon.price
     releaseDate.value = toDateTimeLocal(ctoon.releaseDate)
     perUserLimit.value = ctoon.perUserLimit
@@ -602,6 +610,7 @@ async function submitForm(){
     fd.append('name', name.value.trim())
     fd.append('series', series.value.trim())
     fd.append('rarity', rarity.value)
+    fd.append('cMoonId', cMoonId.value || '')
     fd.append('price', String(price.value))
     fd.append('releaseDate', localToUtcIso(releaseDate.value))
     fd.append('mintLimitType', mintLimitType.value)
@@ -659,6 +668,7 @@ async function submitForm(){
     name:            name.value.trim(),
     series:          series.value.trim(),
     rarity:          rarity.value,
+    cMoonId:         cMoonId.value || null,
     price:           price.value,
     releaseDate:     localToUtcIso(releaseDate.value),
 

--- a/components/newsite/admin/legacy/AdminLegacyCtoonsNew.vue
+++ b/components/newsite/admin/legacy/AdminLegacyCtoonsNew.vue
@@ -78,6 +78,12 @@
             </div>
 
             <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium">cMoon (optional)</label>
+              <CtoonCMoonSelect v-model="cMoonId" />
+              <p class="text-[11px] text-gray-500">If set, this cToon's modal (outside cMart/Auction) is redesigned in this cMoon's colors, with a link to its cMoon page.</p>
+            </div>
+
+            <div class="flex flex-col gap-1">
               <label class="text-xs font-medium">Name</label>
               <input v-model="name" type="text" required class="border rounded-md px-2 py-1.5 text-sm" placeholder="Enter cToon name" />
               <p class="text-[11px] text-gray-500">The display name for this cToon.</p>
@@ -339,6 +345,7 @@ const name = ref('')
 const series = ref('')
 const type = ref('')
 const rarity = ref('')
+const cMoonId = ref(null)
 const set = ref('')
 const characters = ref('')
 const releaseDate = ref('')
@@ -588,6 +595,7 @@ async function submitForm() {
   formData.append('series', series.value)
   formData.append('type', type.value)
   formData.append('rarity', rarity.value)
+  if (cMoonId.value) formData.append('cMoonId', cMoonId.value)
   formData.append('set', set.value)
   formData.append('characters', JSON.stringify(characters.value.split(',').map(c => c.trim())))
   // Convert admin-entered CST/CDT time to UTC

--- a/composables/useCtoonModal.js
+++ b/composables/useCtoonModal.js
@@ -12,8 +12,16 @@ export function useCtoonModal() {
   const holidaySignal = useState('ctoon-modal-holiday-signal', () => 0)
   const holidayRedeem = useState('ctoon-modal-holiday-redeem', () => null)
 
-  async function open({ ctoonId, userCtoonId, assetPath, name } = {}) {
+  // `context` resets to neutral on every open() unless the caller passes one
+  // explicitly (context: { source: 'market', ... }) — context is a shared
+  // singleton, so resetting it here (rather than requiring every caller to
+  // remember a separate clearContext() call beforehand) is what keeps a
+  // stale source from a previous modal open (e.g. 'market') from silently
+  // leaking into an unrelated one opened later from a different page.
+  async function open({ ctoonId, userCtoonId, assetPath, name, context: nextContext } = {}) {
     if (!ctoonId && !userCtoonId) return
+
+    context.value = { source: '', isOwner: false, username: '', ...(nextContext || {}) }
 
     const token = requestToken.value + 1
     requestToken.value = token

--- a/pages/admin/addCtoon.vue
+++ b/pages/admin/addCtoon.vue
@@ -71,6 +71,13 @@
           <p v-if="errors.rarity" class="text-red-600 text-sm mt-1">{{ errors.rarity }}</p>
         </div>
 
+        <!-- cMoon -->
+        <div>
+          <label class="block mb-1 font-medium">cMoon (optional)</label>
+          <CtoonCMoonSelect v-model="cMoonId" />
+          <p class="text-sm text-gray-500">If set, this cToon's modal (outside cMart/Auction) is redesigned in this cMoon's colors, with a link to its cMoon page.</p>
+        </div>
+
         <!-- Name -->
         <div>
           <label class="block mb-1 font-medium">Name</label>
@@ -338,6 +345,7 @@ const name = ref('')
 const series = ref('')
 const type = ref('')
 const rarity = ref('')
+const cMoonId = ref(null)
 const set = ref('')
 const characters = ref('')
 const releaseDate = ref('')
@@ -587,6 +595,7 @@ async function submitForm() {
   formData.append('series', series.value)
   formData.append('type', type.value)
   formData.append('rarity', rarity.value)
+  if (cMoonId.value) formData.append('cMoonId', cMoonId.value)
   formData.append('set', set.value)
   formData.append('characters', JSON.stringify(characters.value.split(',').map(c => c.trim())))
   // Convert admin-entered CST/CDT time to UTC

--- a/pages/admin/editCtoon/[id].vue
+++ b/pages/admin/editCtoon/[id].vue
@@ -68,6 +68,13 @@
           </select>
         </div>
 
+        <!-- cMoon -->
+        <div>
+          <label class="block mb-1 font-medium">cMoon (optional)</label>
+          <CtoonCMoonSelect v-model="cMoonId" />
+          <p class="text-sm text-gray-500">If set, this cToon's modal (outside cMart/Auction) is redesigned in this cMoon's colors, with a link to its cMoon page.</p>
+        </div>
+
         <!-- Price -->
         <div>
           <label class="block mb-1 font-medium">Price</label>
@@ -303,6 +310,7 @@ const id = route.params.id
 /* core refs */
 const name = ref(''); const type = ref('')
 const series = ref(''); const rarity = ref('')
+const cMoonId = ref(null)
 const price = ref(0); const releaseDate = ref('')
 const rarityDefaults = ref(null)
 const ctoonLoaded = ref(false)
@@ -446,6 +454,7 @@ onMounted(async ()=>{
     type.value = ctoon.type
     series.value = ctoon.series
     rarity.value = ctoon.rarity
+    cMoonId.value = ctoon.cMoonId || null
     price.value = ctoon.price
     releaseDate.value = toDateTimeLocal(ctoon.releaseDate)
     perUserLimit.value = ctoon.perUserLimit
@@ -573,6 +582,7 @@ async function submitForm(){
     fd.append('name', name.value.trim())
     fd.append('series', series.value.trim())
     fd.append('rarity', rarity.value)
+    fd.append('cMoonId', cMoonId.value || '')
     fd.append('price', String(price.value))
     fd.append('releaseDate', localToUtcIso(releaseDate.value))
     fd.append('mintLimitType', mintLimitType.value)
@@ -630,6 +640,7 @@ async function submitForm(){
     name:            name.value.trim(),
     series:          series.value.trim(),
     rarity:          rarity.value,
+    cMoonId:         cMoonId.value || null,
     price:           price.value,
     releaseDate:     localToUtcIso(releaseDate.value),
 

--- a/pages/newsite/cmoon/[id].vue
+++ b/pages/newsite/cmoon/[id].vue
@@ -1,0 +1,12 @@
+<template>
+  <CMoonPage />
+</template>
+
+<script setup>
+definePageMeta({
+  layout: 'newsite-template',
+  middleware: 'newsite',
+  title: () => 'cMoon',
+  description: () => 'Browse this cMoon on Cartoon ReOrbit.'
+})
+</script>

--- a/prisma/migrations/20260821010307_add_cmoon_page_and_ctoon_display_assignment/migration.sql
+++ b/prisma/migrations/20260821010307_add_cmoon_page_and_ctoon_display_assignment/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "CMoon" ADD COLUMN     "pageDescription" TEXT,
+ADD COLUMN     "pageImageHeight" INTEGER,
+ADD COLUMN     "pageImagePath" TEXT,
+ADD COLUMN     "pageImageWidth" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Ctoon" ADD COLUMN     "cMoonId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Ctoon_cMoonId_idx" ON "Ctoon"("cMoonId");
+
+-- AddForeignKey
+ALTER TABLE "Ctoon" ADD CONSTRAINT "Ctoon_cMoonId_fkey" FOREIGN KEY ("cMoonId") REFERENCES "CMoon"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -343,8 +343,13 @@ model Ctoon {
   achievementRequiredCtoons  AchievementRequiredCtoon[]
   achievementClaimOptions    AchievementClaimOption[]
 
-  // cMoon back-relation
+  // cMoon back-relation (prize-on-join — distinct from the display assignment below)
   cMoonPrizeRows CMoonPrizeCtoon[]
+
+  // Optional cMoon this cToon is thematically displayed under (admin-assigned in the cToon
+  // editor). Purely a catalog/display categorization — unrelated to the player-faction system.
+  cMoonId String?
+  cMoon   CMoon?  @relation("CtoonCMoonDisplay", fields: [cMoonId], references: [id], onDelete: SetNull)
 
   cZoneSearchPrizeRows   CZoneSearchPrize[]
   cZoneSearchAppearances CZoneSearchAppearance[]
@@ -366,6 +371,7 @@ model Ctoon {
 
   @@index([isSecondEdition])
   @@index([name])
+  @@index([cMoonId])
 }
 
 model CtoonImageHash {
@@ -2808,16 +2814,27 @@ model AchievementRewardBackground {
 model CMoon {
   id            String   @id @default(uuid())
   name          String   @unique
-  color         String // "#RRGGBB", validated server-side; used as text color
+  color         String // "#RRGGBB", validated server-side; used as text color, and as the base
+  // color a palette is derived from for the cMoon page + themed cToon modals (see utils/cmoonPalette.js).
   discordRoleId String? // Discord role snowflake granted to members (add-only sync)
   // Denormalized to avoid COUNT(*) races/scans on every selection + the daily auto-assign job.
   memberCount   Int      @default(0)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  members     User[]
-  captains    CMoonCaptain[]
-  prizeCtoons CMoonPrizeCtoon[]
+  // Public "cMoon page" content (/newsite/cmoon/[id]) — a display/catalog feature, independent
+  // of the cMoonEnabled faction-join flag above. pageImagePath is exactly 800x600, matching CZone.
+  pageImagePath   String?
+  pageImageWidth  Int?
+  pageImageHeight Int?
+  pageDescription String?
+
+  members         User[]
+  captains        CMoonCaptain[]
+  prizeCtoons     CMoonPrizeCtoon[]
+  // cToons thematically displayed under this cMoon (admin-assigned in the cToon editor). Distinct
+  // from `members`/`prizeCtoons`, which are about the player-faction feature, not catalog display.
+  displayedCtoons Ctoon[]           @relation("CtoonCMoonDisplay")
 
   @@index([memberCount])
 }

--- a/server/api/admin/cmoons.get.js
+++ b/server/api/admin/cmoons.get.js
@@ -1,12 +1,10 @@
 // server/api/admin/cmoons.get.js
-import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { defineEventHandler } from 'h3'
 import { prisma as db } from '@/server/prisma'
+import { requireAdmin } from '@/server/utils/requireAdmin'
 
 export default defineEventHandler(async (event) => {
-  const cookie = getRequestHeader(event, 'cookie') || ''
-  let me
-  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
-  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  await requireAdmin(event)
 
   const [cmoons, config] = await Promise.all([
     db.cMoon.findMany({
@@ -14,6 +12,8 @@ export default defineEventHandler(async (event) => {
       include: {
         captains: { include: { user: { select: { id: true, username: true } } } },
         prizeCtoons: { include: { ctoon: { select: { id: true, name: true, assetPath: true } } } },
+        // Single grouped query, not a per-cMoon count() loop.
+        _count: { select: { displayedCtoons: true } },
       },
     }),
     db.globalGameConfig.findUnique({ where: { id: 'singleton' }, select: { cMoonEnabled: true, cMoonEnabledAt: true, cMoonSelectionDeadlineAt: true } }),
@@ -29,6 +29,9 @@ export default defineEventHandler(async (event) => {
       color: c.color,
       discordRoleId: c.discordRoleId,
       memberCount: c.memberCount,
+      pageImagePath: c.pageImagePath,
+      pageDescription: c.pageDescription,
+      displayedCtoonCount: c._count?.displayedCtoons ?? 0,
       captains: c.captains.map(cap => ({ userId: cap.userId, username: cap.user?.username || '' })),
       prizeCtoons: c.prizeCtoons.map(pc => ({ ctoonId: pc.ctoonId, quantity: pc.quantity, name: pc.ctoon?.name || '', assetPath: pc.ctoon?.assetPath || null })),
     })),

--- a/server/api/admin/cmoons.post.js
+++ b/server/api/admin/cmoons.post.js
@@ -1,19 +1,19 @@
 // server/api/admin/cmoons.post.js
-import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
+import { defineEventHandler, readBody, createError } from 'h3'
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { isValidHexColor, isValidDiscordSnowflake } from '@/server/utils/cmoon'
+import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
 
 export default defineEventHandler(async (event) => {
-  const cookie = getRequestHeader(event, 'cookie') || ''
-  let me
-  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
-  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  const me = await requireAdmin(event)
+  assertSameOrigin(event)
 
   const body = await readBody(event)
   const name = typeof body?.name === 'string' ? body.name.trim() : ''
   const color = typeof body?.color === 'string' ? body.color.trim() : ''
   const discordRoleId = typeof body?.discordRoleId === 'string' ? body.discordRoleId.trim() : ''
+  const pageDescription = typeof body?.pageDescription === 'string' ? body.pageDescription.trim().slice(0, 2000) || null : null
   const captainIds = Array.isArray(body?.captainIds) ? [...new Set(body.captainIds.filter(x => typeof x === 'string'))] : []
   const prizeCtoons = Array.isArray(body?.prizeCtoons) ? body.prizeCtoons : []
 
@@ -46,6 +46,7 @@ export default defineEventHandler(async (event) => {
       name,
       color,
       discordRoleId: discordRoleId || null,
+      pageDescription,
       captains: { create: captainIds.map(userId => ({ userId })) },
       prizeCtoons: { create: prizeCtoonRows },
     },

--- a/server/api/admin/cmoons/[id].delete.js
+++ b/server/api/admin/cmoons/[id].delete.js
@@ -1,13 +1,12 @@
 // server/api/admin/cmoons/[id].delete.js
-import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { defineEventHandler, createError } from 'h3'
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
 
 export default defineEventHandler(async (event) => {
-  const cookie = getRequestHeader(event, 'cookie') || ''
-  let me
-  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
-  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  const me = await requireAdmin(event)
+  assertSameOrigin(event)
 
   const id = event.context.params?.id
   const cmoon = await db.cMoon.findUnique({ where: { id } })
@@ -16,6 +15,10 @@ export default defineEventHandler(async (event) => {
   if (cmoon.memberCount > 0) {
     throw createError({ statusCode: 409, statusMessage: 'Cannot delete a cMoon that still has members — reassign them first' })
   }
+  // Display-assigned cToons (Ctoon.cMoonId) are NOT a delete-blocker like
+  // members are — that relation is `onDelete: SetNull`, so deleting a cMoon
+  // here just reverts those cToons' modals to the default (unthemed) look,
+  // which is a low-stakes, reversible outcome unlike losing faction members.
 
   await db.cMoon.delete({ where: { id } })
   await logAdminChange(db, { userId: me.id, area: 'cMoon', key: `delete:${id}`, prevValue: { name: cmoon.name }, newValue: null })

--- a/server/api/admin/cmoons/[id].put.js
+++ b/server/api/admin/cmoons/[id].put.js
@@ -1,14 +1,13 @@
 // server/api/admin/cmoons/[id].put.js
-import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
+import { defineEventHandler, readBody, createError } from 'h3'
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { isValidHexColor, isValidDiscordSnowflake } from '@/server/utils/cmoon'
+import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
 
 export default defineEventHandler(async (event) => {
-  const cookie = getRequestHeader(event, 'cookie') || ''
-  let me
-  try { me = await $fetch('/api/auth/me', { headers: { cookie } }) } catch { throw createError({ statusCode: 401, statusMessage: 'Unauthorized' }) }
-  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Forbidden — Admins only' })
+  const me = await requireAdmin(event)
+  assertSameOrigin(event)
 
   const id = event.context.params?.id
   const cmoon = await db.cMoon.findUnique({ where: { id } })
@@ -20,6 +19,9 @@ export default defineEventHandler(async (event) => {
   const discordRoleId = body?.discordRoleId === undefined ? cmoon.discordRoleId : (typeof body.discordRoleId === 'string' ? body.discordRoleId.trim() : '')
   const captainIds = Array.isArray(body?.captainIds) ? [...new Set(body.captainIds.filter(x => typeof x === 'string'))] : null
   const prizeCtoons = Array.isArray(body?.prizeCtoons) ? body.prizeCtoons : null
+  const pageDescription = body?.pageDescription === undefined
+    ? cmoon.pageDescription
+    : (typeof body.pageDescription === 'string' ? body.pageDescription.trim().slice(0, 2000) || null : null)
 
   if (!name) throw createError({ statusCode: 400, statusMessage: 'Name is required' })
   if (!isValidHexColor(color)) throw createError({ statusCode: 400, statusMessage: 'Color must be a hex value like #3366ff' })
@@ -53,7 +55,7 @@ export default defineEventHandler(async (event) => {
   await db.$transaction(async (tx) => {
     await tx.cMoon.update({
       where: { id },
-      data: { name, color, discordRoleId: discordRoleId || null },
+      data: { name, color, discordRoleId: discordRoleId || null, pageDescription },
     })
     if (captainIds) {
       await tx.cMoonCaptain.deleteMany({ where: { cMoonId: id } })

--- a/server/api/admin/cmoons/[id]/page-image.post.js
+++ b/server/api/admin/cmoons/[id]/page-image.post.js
@@ -1,0 +1,86 @@
+// server/api/admin/cmoons/[id]/page-image.post.js
+//
+// Uploads a cMoon page image, normalized to exactly 800x600 (the same
+// resolution as a cZone background). Rather than rejecting anything that
+// isn't already pixel-exact (which a phone camera essentially never is),
+// this auto-orients (EXIF) and center-crops/resizes to 800x600 server-side
+// via sharp, then re-encodes — which also means the stored file is never the
+// attacker-controlled bytes as-uploaded.
+//
+// Deliberately NOT a copy of server/api/admin/backgrounds.post.js: that file
+// imports sniffImageType/MAX_IMAGE_BYTES but never calls them, and has no
+// size cap or path-containment check. This endpoint calls every primitive
+// itemized below, in order, before any file I/O.
+import { defineEventHandler, readMultipartFormData, createError } from 'h3'
+import { mkdir, writeFile } from 'node:fs/promises'
+import sharp from 'sharp'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
+import { sniffImageType, sanitizePathSegment, assertInside, MAX_IMAGE_BYTES } from '@/server/utils/imageUploadValidation'
+import { cmoonPageUploadDir, cmoonPageFsPath, cmoonPagePublicPath } from '@/server/utils/cmoonPageStorage'
+
+const PAGE_IMAGE_WIDTH = 800
+const PAGE_IMAGE_HEIGHT = 600
+
+export default defineEventHandler(async (event) => {
+  const me = await requireAdmin(event)
+  assertSameOrigin(event)
+
+  const id = event.context.params?.id
+  const cmoon = id ? await db.cMoon.findUnique({ where: { id } }) : null
+  if (!cmoon) throw createError({ statusCode: 404, statusMessage: 'cMoon not found' })
+
+  const parts = await readMultipartFormData(event)
+  const filePart = parts?.find(p => p.filename)
+  if (!filePart) throw createError({ statusCode: 400, statusMessage: 'Image file is required.' })
+
+  if (filePart.data.length > MAX_IMAGE_BYTES) {
+    throw createError({ statusCode: 413, statusMessage: 'Image must be 5MB or smaller.' })
+  }
+
+  // The multipart "type" field is client-supplied and spoofable — verify
+  // from the actual bytes before doing anything with the file.
+  const sniffed = sniffImageType(filePart.data)
+  if (!sniffed) {
+    throw createError({ statusCode: 400, statusMessage: 'Only PNG, JPEG, GIF, or WebP images are allowed.' })
+  }
+
+  let output
+  try {
+    output = await sharp(filePart.data)
+      .rotate() // auto-orient per EXIF before anything else touches pixel data
+      .resize(PAGE_IMAGE_WIDTH, PAGE_IMAGE_HEIGHT, { fit: 'cover', position: 'centre' })
+      .webp({ quality: 88 })
+      .toBuffer()
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Could not process that image.' })
+  }
+
+  const uploadDir = cmoonPageUploadDir()
+  await mkdir(uploadDir, { recursive: true })
+  const filename = `${sanitizePathSegment(id, 'cmoon')}-${Date.now()}.webp`
+  const outPath = assertInside(uploadDir, cmoonPageFsPath(filename))
+  await writeFile(outPath, output)
+
+  const imagePath = cmoonPagePublicPath(filename)
+
+  await db.cMoon.update({
+    where: { id },
+    data: {
+      pageImagePath: imagePath,
+      pageImageWidth: PAGE_IMAGE_WIDTH,
+      pageImageHeight: PAGE_IMAGE_HEIGHT
+    }
+  })
+
+  await logAdminChange(db, {
+    userId: me.id,
+    area: `cMoon:${id}`,
+    key: 'pageImagePath',
+    prevValue: cmoon.pageImagePath,
+    newValue: imagePath
+  }).catch(() => {})
+
+  return { pageImagePath: imagePath }
+})

--- a/server/api/admin/ctoon.post.js
+++ b/server/api/admin/ctoon.post.js
@@ -1,7 +1,6 @@
 import {
   defineEventHandler,
   readMultipartFormData,
-  getRequestHeader,
   createError
 } from 'h3'
 import { mkdir, writeFile } from 'node:fs/promises'
@@ -13,6 +12,7 @@ import { computeMultiHash, bucketFromHash } from '@/server/utils/multiHash'
 import { scheduleMintEnd } from '@/server/utils/queues'
 import { parseSecondEditionFields } from '@/server/utils/secondEdition'
 import { sanitizePathSegment, sanitizeFilename, assertInside, sniffImageType, MAX_IMAGE_BYTES } from '@/server/utils/imageUploadValidation'
+import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
 
 // ── path helpers ──────────────────────────────────────────────
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -22,9 +22,8 @@ const baseDir = process.env.NODE_ENV === 'production'
 
 export default defineEventHandler(async (event) => {
   /* 1. Auth / admin check ------------------------------------ */
-  const cookie = getRequestHeader(event, 'cookie') || ''
-  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
-  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+  const me = await requireAdmin(event)
+  assertSameOrigin(event)
 
   /* 2. Parse multipart form ---------------------------------- */
   const parts  = await readMultipartFormData(event)
@@ -48,6 +47,7 @@ export default defineEventHandler(async (event) => {
     name, series, rarity, releaseDate: releaseRaw,
     totalQuantity, initialQuantity, perUserLimit,
     codeOnly, inCmart, price, set: setField, characters: charsRaw, type,
+    cMoonId: cMoonIdRaw,
 
     /* NEW G-toon fields */
     isGtoon, cost, power, abilityKey, abilityData, gtoonType,
@@ -71,6 +71,14 @@ export default defineEventHandler(async (event) => {
   if (!series?.trim()) throw createError({ statusCode: 400, statusMessage: 'Series is required.' })
   if (!rarity)         throw createError({ statusCode: 400, statusMessage: 'Rarity is required.' })
   if (!setField)       throw createError({ statusCode: 400, statusMessage: 'Set is required.' })
+
+  // Validated before any file I/O so a bad cMoonId never leaves an orphaned
+  // uploaded image on disk with no DB row to point to.
+  const cMoonId = cMoonIdRaw && String(cMoonIdRaw).trim() ? String(cMoonIdRaw).trim() : null
+  if (cMoonId) {
+    const cMoonExists = await prisma.cMoon.findUnique({ where: { id: cMoonId }, select: { id: true } })
+    if (!cMoonExists) throw createError({ statusCode: 400, statusMessage: 'Selected cMoon does not exist.' })
+  }
 
   const releaseDate = new Date(releaseRaw)
   if (isNaN(releaseDate)) throw createError({ statusCode: 400, statusMessage: 'Invalid release date.' })
@@ -197,6 +205,7 @@ export default defineEventHandler(async (event) => {
       set: setField,
       characters: charactersArr,
       type: type.trim(),
+      cMoonId,
 
       soundPath,
 

--- a/server/api/admin/ctoon/[id].get.js
+++ b/server/api/admin/ctoon/[id].get.js
@@ -1,14 +1,13 @@
 // /api/admin/ctoon/[id].get.js
-import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { defineEventHandler, createError } from 'h3'
 import { prisma } from '@/server/prisma'
+import { requireAdmin } from '@/server/utils/requireAdmin'
 
 export default defineEventHandler(async (event) => {
   const id = event.context.params.id
 
   /* ── Admin check ─────────────────────────────────────────── */
-  const cookie = getRequestHeader(event, 'cookie') || ''
-  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
-  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+  await requireAdmin(event)
 
   /* ── Fetch the cToon ─────────────────────────────────────── */
   try {
@@ -21,6 +20,7 @@ export default defineEventHandler(async (event) => {
         price: true, inCmart: true, codeOnly: true,
         quantity: true, initialQuantity: true, perUserLimit: true,
         characters: true, description: true, soundPath: true,
+        cMoonId: true,
 
         // NEW G-toon fields
         isGtoon:    true,

--- a/server/api/admin/ctoon/[id].put.js
+++ b/server/api/admin/ctoon/[id].put.js
@@ -1,7 +1,6 @@
 // /api/admin/ctoon/[id].put.js
 import {
   defineEventHandler,
-  getRequestHeader,
   createError,
   readBody,
   readMultipartFormData
@@ -15,6 +14,7 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import { join, dirname, extname, basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { sanitizePathSegment, sanitizeFilename, assertInside, sniffImageType, MAX_IMAGE_BYTES } from '@/server/utils/imageUploadValidation'
+import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
 
 // paths
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -26,9 +26,8 @@ export default defineEventHandler(async (event) => {
   const id = event.context.params.id
 
   // 1) Admin check
-  const cookie = getRequestHeader(event, 'cookie') || ''
-  const me = await $fetch('/api/auth/me', { headers: { cookie } }).catch(() => null)
-  if (!me?.isAdmin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+  const me = await requireAdmin(event)
+  assertSameOrigin(event)
 
   // 2) Accept JSON or multipart
   const contentType = (getRequestHeader(event, 'content-type') || '').toLowerCase()
@@ -51,6 +50,7 @@ export default defineEventHandler(async (event) => {
   const {
     name, series, rarity, price, releaseDate, perUserLimit,
     quantity, initialQuantity, inCmart, set, description, characters,
+    cMoonId: cMoonIdRaw,
     isGtoon, cost, power, abilityKey, abilityData, gtoonType,
     initialReleaseAt, finalReleaseAt, initialReleaseQty, finalReleaseQty,
     clearSound,
@@ -69,6 +69,14 @@ export default defineEventHandler(async (event) => {
 
   const newReleaseDate = new Date(releaseDate)
   if (isNaN(newReleaseDate)) throw createError({ statusCode: 400, statusMessage: 'Invalid release date.' })
+
+  // Validated before any file I/O so a bad cMoonId never leaves an orphaned
+  // uploaded image on disk with no successful update to point to.
+  const cMoonId = cMoonIdRaw && String(cMoonIdRaw).trim() ? String(cMoonIdRaw).trim() : null
+  if (cMoonId) {
+    const cMoonExists = await prisma.cMoon.findUnique({ where: { id: cMoonId }, select: { id: true } })
+    if (!cMoonExists) throw createError({ statusCode: 400, statusMessage: 'Selected cMoon does not exist.' })
+  }
 
   // 5) Normalizations
   const priceInt    = price == null || price === '' ? 0 : Number(price)
@@ -149,6 +157,7 @@ export default defineEventHandler(async (event) => {
     set,
     description: description?.trim() || null,
     characters: charactersArr,
+    cMoonId,
 
     isGtoon:    isGtoonBool,
     gtoonType:  isGtoonBool ? (gtoonType?.toString().trim() || null) : null,
@@ -261,7 +270,7 @@ export default defineEventHandler(async (event) => {
   try {
     const area = `Ctoon:${id}`
     const keys = [
-      'name','series','description','rarity','price','releaseDate','perUserLimit','quantity','initialQuantity','inCmart','set','characters',
+      'name','series','description','rarity','price','releaseDate','perUserLimit','quantity','initialQuantity','inCmart','set','characters','cMoonId',
       'isGtoon','gtoonType','cost','power','abilityKey','abilityData','assetPath','type','soundPath',
       'initialReleaseAt','finalReleaseAt','initialReleaseQty','finalReleaseQty',
       'mintLimitType','mintEndDate',

--- a/server/api/cmoon/[id].get.js
+++ b/server/api/cmoon/[id].get.js
@@ -1,0 +1,58 @@
+// server/api/cmoon/[id].get.js
+// Public "cMoon page" data — a display/catalog feature, independent of the
+// cMoonEnabled faction-join flag. Requires a logged-in session only (not
+// admin), matching the rest of /newsite. Explicit `select` throughout, never
+// a bare `include`, since CMoon also has `members`/`captains` relations that
+// pull full User rows (Discord tokens, email, ban status) — this endpoint
+// must never be able to leak those.
+import { defineEventHandler, createError } from 'h3'
+import { prisma as db } from '@/server/prisma'
+
+// Deterministic ordering (name, then id as a tiebreaker) so the visible page
+// of cToons doesn't silently shuffle between requests; ctoonsTruncated tells
+// the client when a cMoon has more than fit here so it isn't a silent cutoff.
+const CTOON_PAGE_SIZE = 200
+
+export default defineEventHandler(async (event) => {
+  if (!event.context.userId) throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+
+  const id = event.context.params?.id
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing cMoon id' })
+
+  const cmoon = await db.cMoon.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      color: true,
+      pageImagePath: true,
+      pageImageWidth: true,
+      pageImageHeight: true,
+      pageDescription: true,
+      _count: { select: { displayedCtoons: true } }
+    }
+  })
+  if (!cmoon) throw createError({ statusCode: 404, statusMessage: 'cMoon not found' })
+
+  const ctoons = await db.ctoon.findMany({
+    where: { cMoonId: id },
+    select: { id: true, name: true, assetPath: true },
+    orderBy: [{ name: 'asc' }, { id: 'asc' }],
+    take: CTOON_PAGE_SIZE
+  })
+
+  const ctoonCount = cmoon._count?.displayedCtoons ?? 0
+
+  return {
+    id: cmoon.id,
+    name: cmoon.name,
+    color: cmoon.color,
+    pageImagePath: cmoon.pageImagePath,
+    pageImageWidth: cmoon.pageImageWidth,
+    pageImageHeight: cmoon.pageImageHeight,
+    pageDescription: cmoon.pageDescription,
+    ctoonCount,
+    ctoons,
+    ctoonsTruncated: ctoonCount > ctoons.length
+  }
+})

--- a/server/api/ctoon/modal.get.js
+++ b/server/api/ctoon/modal.get.js
@@ -37,7 +37,12 @@ export default defineEventHandler(async (event) => {
   // For cz: tokens fall through to the ctoonId-only path so the modal still opens.
   const editionInclude = {
     relatedFirstEdition:  { select: { id: true, name: true, assetPath: true } },
-    relatedSecondEdition: { select: { id: true, name: true, assetPath: true } }
+    relatedSecondEdition: { select: { id: true, name: true, assetPath: true } },
+    // Explicit select, never a bare `cMoon: true` — CMoon also has `members`/
+    // `captains` relations that pull full User rows (Discord tokens, email);
+    // this endpoint must only ever expose the same public-safe fields as the
+    // cMoon-themed modal card needs.
+    cMoon: { select: { id: true, name: true, color: true } }
   }
 
   if (userCtoonId?.startsWith('uc|')) {
@@ -220,7 +225,8 @@ export default defineEventHandler(async (event) => {
       relatedFirstEdition: ctoon.relatedFirstEdition ?? null,
       relatedSecondEdition: ctoon.relatedSecondEdition ?? null,
       saleImagePath,
-      czoneDisplayCount: ctoon.czoneDisplayCount ?? 0
+      czoneDisplayCount: ctoon.czoneDisplayCount ?? 0,
+      cMoon: ctoon.cMoon ?? null
     },
     userCtoon: userStats,
     ownedCount,

--- a/server/utils/cmoonPageStorage.js
+++ b/server/utils/cmoonPageStorage.js
@@ -1,0 +1,23 @@
+import { join } from 'node:path'
+
+// Same layout convention as server/utils/backgroundStorage.js: production
+// serves from the sibling cartoon-reorbit-images directory, dev from public/.
+const baseDir = process.env.NODE_ENV === 'production'
+  ? join(process.cwd(), '..')
+  : process.cwd()
+
+export function cmoonPageUploadDir() {
+  return process.env.NODE_ENV === 'production'
+    ? join(baseDir, 'cartoon-reorbit-images', 'cmoon-pages')
+    : join(baseDir, 'public', 'cmoon-pages')
+}
+
+export function cmoonPageFsPath(filename) {
+  return join(cmoonPageUploadDir(), filename)
+}
+
+export function cmoonPagePublicPath(filename) {
+  return process.env.NODE_ENV === 'production'
+    ? `/images/cmoon-pages/${filename}`
+    : `/cmoon-pages/${filename}`
+}

--- a/utils/cmoonColor.js
+++ b/utils/cmoonColor.js
@@ -13,21 +13,23 @@ export function isSafeCMoonColor(color) {
   return typeof color === 'string' && HEX_RE.test(color)
 }
 
-function relativeLuminance(hex) {
+// Exported so other palette math (utils/cmoonPalette.js) shares one WCAG
+// implementation instead of re-deriving it.
+export function relativeLuminance(hex) {
   const channels = [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16) / 255)
   const lin = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4))
   const [r, g, b] = channels.map(lin)
   return 0.2126 * r + 0.7152 * g + 0.0722 * b
 }
 
-function contrast(l1, l2) {
+export function contrast(l1, l2) {
   return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05)
 }
 
 // Compare both candidates rather than guessing from a luminance threshold. A
 // fixed threshold mispicks across a wide band of ordinary mid-tone colors —
 // e.g. #b8860b and #808080 got white text at ~3.3:1 and ~3.9:1.
-function contrastTextColor(hex) {
+export function contrastTextColor(hex) {
   const bg = relativeLuminance(hex)
   const dark = contrast(relativeLuminance(DARK_TEXT), bg)
   const light = contrast(relativeLuminance(LIGHT_TEXT), bg)

--- a/utils/cmoonPalette.js
+++ b/utils/cmoonPalette.js
@@ -1,0 +1,191 @@
+// utils/cmoonPalette.js
+//
+// Derives a full, readable UI palette from a single admin-chosen cMoon.color
+// hex value, for the cMoon-themed cToon modal variant and the cMoon page.
+//
+// Deliberately cheap (a handful of HSL conversions + a bounded contrast-fix
+// loop) — call it inline in a `computed()`, no memoization needed.
+//
+// Every text/background pairing below is nudged, via WCAG contrast math
+// shared with utils/cmoonColor.js, until it clears a real contrast ratio —
+// never picked by a fixed lightness threshold alone — so an admin can choose
+// ANY hex (a pale pastel, a near-black, a saturated primary) and the modal
+// stays legible. Consumers must bind the result through a `:style` object
+// (never string-concatenate it into CSS), same rule utils/cmoonColor.js
+// already follows, so a hex value can never smuggle extra CSS declarations.
+import { isSafeCMoonColor, relativeLuminance, contrast } from './cmoonColor'
+
+const FALLBACK_COLOR = '#3a4a63'
+const BLACK = '#000000'
+const WHITE = '#ffffff'
+
+function clamp(n, min, max) {
+  return Math.min(max, Math.max(min, n))
+}
+
+function hexToRgb(hex) {
+  return [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16))
+}
+
+function rgbToHex(r, g, b) {
+  const c = (n) => clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0')
+  return `#${c(r)}${c(g)}${c(b)}`
+}
+
+function rgbToHsl(r, g, b) {
+  r /= 255; g /= 255; b /= 255
+  const max = Math.max(r, g, b), min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  const d = max - min
+  let h = 0, s = 0
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1))
+    switch (max) {
+      case r: h = ((g - b) / d) % 6; break
+      case g: h = (b - r) / d + 2; break
+      default: h = (r - g) / d + 4
+    }
+    h *= 60
+    if (h < 0) h += 360
+  }
+  return { h, s: s * 100, l: l * 100 }
+}
+
+function hslToRgb(h, s, l) {
+  s /= 100; l /= 100
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = l - c / 2
+  let r = 0, g = 0, b = 0
+  if (h < 60)       { r = c; g = x; b = 0 }
+  else if (h < 120) { r = x; g = c; b = 0 }
+  else if (h < 180) { r = 0; g = c; b = x }
+  else if (h < 240) { r = 0; g = x; b = c }
+  else if (h < 300) { r = x; g = 0; b = c }
+  else              { r = c; g = 0; b = x }
+  return [(r + m) * 255, (g + m) * 255, (b + m) * 255]
+}
+
+function hexToHsl(hex) { return rgbToHsl(...hexToRgb(hex)) }
+function hslToHex(h, s, l) { return rgbToHex(...hslToRgb(h, clamp(s, 0, 100), clamp(l, 0, 100))) }
+
+// Finds a background lightness (same hue/saturation) that clears `min`
+// contrast against a FIXED text color, nudging away from the seed lightness
+// toward whichever extreme helps that text color.
+function bgForFixedText(h, s, seedL, textHex, min, iterations = 8) {
+  const towardLighter = textHex === BLACK
+  let l = seedL
+  let hex = hslToHex(h, s, l)
+  for (let i = 0; i < iterations; i++) {
+    const ratio = contrast(relativeLuminance(textHex), relativeLuminance(hex))
+    if (ratio >= min) return hex
+    l = towardLighter ? clamp(l + 6, 0, 98) : clamp(l - 6, 2, 100)
+    hex = hslToHex(h, s, l)
+  }
+  return hex
+}
+
+// Finds a text lightness (same hue, usually desaturated) that clears `min`
+// contrast against a FIXED background hex.
+function textForFixedBg(h, s, seedL, bgHex, min, iterations = 8) {
+  const bgIsLight = relativeLuminance(bgHex) > 0.5
+  let l = seedL
+  let hex = hslToHex(h, s, l)
+  for (let i = 0; i < iterations; i++) {
+    const ratio = contrast(relativeLuminance(hex), relativeLuminance(bgHex))
+    if (ratio >= min) return hex
+    l = bgIsLight ? clamp(l - 6, 0, 42) : clamp(l + 6, 58, 100)
+    hex = hslToHex(h, s, l)
+  }
+  return hex
+}
+
+/**
+ * Returns a plain object of hex/rgba strings — never a CSS string — meant to
+ * be spread into a Vue `:style` object as `--cm-*` custom properties.
+ */
+export function cMoonPalette(color) {
+  const base = isSafeCMoonColor(color) ? color : FALLBACK_COLOR
+  const { h, s: rawS, l: baseL } = hexToHsl(base)
+  const s = Math.min(rawS, 55)
+
+  // One text regime for the whole card (never mix black-text and
+  // white-text surfaces in the same modal) — decided by whether the base
+  // color reads as light or dark.
+  const isDarkBase = baseL < 50
+  const text = isDarkBase ? WHITE : BLACK
+
+  const bg = bgForFixedText(h, s, isDarkBase ? 15 : 94, text, 4.5)
+  const tileBg = bgForFixedText(h, s, isDarkBase ? 23 : 86, text, 4.5)
+  const textMuted = textForFixedBg(h, Math.min(rawS, 30), isDarkBase ? 74 : 34, bg, 4.5)
+  const border = textForFixedBg(h, Math.min(rawS, 40), isDarkBase ? 48 : 56, bg, 3)
+
+  // A handful of hardcoded reds/greens in the modal (error text, sale-value
+  // text) were tuned only for the old fixed dark-navy background. Once the
+  // panel background itself can be an arbitrary light or dark tint, those
+  // need their own contrast-verified, hue-locked (red/green) text colors
+  // rather than inheriting a fixed hex that assumed a dark backdrop.
+  const danger = textForFixedBg(4, 75, isDarkBase ? 74 : 38, bg, 4.5)
+  const success = textForFixedBg(142, 55, isDarkBase ? 74 : 30, bg, 4.5)
+
+  // Banner keeps the admin's actual color as its hue/saturation (it's the
+  // one place meant to look like "their" color) — only lightness is nudged,
+  // and only if needed, so a hue that already clears 4.5:1 is left untouched.
+  let bannerL = baseL
+  let banner = hslToHex(h, rawS, bannerL)
+  // Pick whichever of black/white actually contrasts more against the raw base.
+  const pickBannerText = (hex) => {
+    const lum = relativeLuminance(hex)
+    const dark = contrast(relativeLuminance(BLACK), lum)
+    const light = contrast(relativeLuminance(WHITE), lum)
+    return dark >= light ? BLACK : WHITE
+  }
+  let bannerText = pickBannerText(banner)
+  for (let i = 0; i < 6; i++) {
+    const ratio = contrast(relativeLuminance(bannerText), relativeLuminance(banner))
+    if (ratio >= 4.5) break
+    bannerL = bannerText === BLACK ? clamp(bannerL + 5, 0, 90) : clamp(bannerL - 5, 10, 100)
+    banner = hslToHex(h, rawS, bannerL)
+  }
+
+  return {
+    bg,
+    tileBg,
+    text,
+    textMuted,
+    border,
+    banner,
+    bannerText,
+    // Links/focus rings reuse `text`, which is already contrast-verified
+    // against both `bg` and `tileBg` (both were solved for the same fixed
+    // text color), so nothing further to check here.
+    linkBg: tileBg,
+    linkText: text,
+    focusRing: text,
+    hairline: isDarkBase ? 'rgba(255,255,255,0.14)' : 'rgba(0,0,0,0.12)',
+    thumbBg: tileBg,
+    danger,
+    success
+  }
+}
+
+/** Converts a cMoonPalette() result into `--cm-*` CSS custom properties for `:style`. */
+export function cMoonPaletteStyle(color) {
+  const p = cMoonPalette(color)
+  return {
+    '--cm-bg': p.bg,
+    '--cm-tile-bg': p.tileBg,
+    '--cm-text': p.text,
+    '--cm-text-muted': p.textMuted,
+    '--cm-border': p.border,
+    '--cm-banner': p.banner,
+    '--cm-banner-text': p.bannerText,
+    '--cm-link-bg': p.linkBg,
+    '--cm-link-text': p.linkText,
+    '--cm-focus-ring': p.focusRing,
+    '--cm-hairline': p.hairline,
+    '--cm-thumb-bg': p.thumbBg,
+    '--cm-danger': p.danger,
+    '--cm-success': p.success
+  }
+}


### PR DESCRIPTION
## Summary

- Adds an optional cMoon assignment to each cToon (admin-only, in both the old and new admin cToon create/edit forms), reusing the existing `CMoon` faction model's `id`/`name`/`color` as a pure display/catalog categorization — independent of the (currently off-by-default) cMoon faction-join feature.
- When a cToon has a cMoon assigned, its info modal is redesigned in that cMoon's colors everywhere **except cMart and Auction House/Details, which stay pixel-identical to today**. A cToon with no cMoon assigned also keeps today's default modal untouched.
- The redesigned modal adds a "cWorld" tile linking to a new public `/newsite/cmoon/[id]` page for that cMoon: name, an admin-uploadable 800×600 image (same resolution as a cZone background, auto-cropped/oriented server-side via `sharp` so any photo works), an editable description, and a grid of every cToon assigned to it.
- All modal/page colors are derived from the admin's single chosen `CMoon.color` via a new `utils/cmoonPalette.js`, which iteratively nudges each background/text pairing until it clears real WCAG contrast (verified in an automated sanity sweep across light pastels, dark saturated colors, and grays) — so the redesign stays readable regardless of which color an admin picks, on both mobile and desktop.

## Implementation notes

- `Ctoon.cMoonId` is a new relation, distinct from the existing `CMoonPrizeCtoon` (prize-on-join) join — deleting a cMoon just clears the assignment (`onDelete: SetNull`), it doesn't block deletion the way member count does.
- The shared modal component (`CtoonInfoCard.vue`) gets a CSS-variable-driven variant rather than a fork; market context is now passed directly into `useCtoonModal().open({ context })` instead of separate `setContext()`/`clearContext()` calls, closing off a class of stale-context bugs.
- New admin endpoints and the cToon-assignment changes to existing admin endpoints use the hardened `requireAdmin()`/`assertSameOrigin()` helper rather than the older `$fetch('/api/auth/me')` pattern. The new page-image upload validates size/magic-bytes before any file I/O and re-encodes via `sharp` rather than trusting/storing the upload as-is.
- The public `GET /api/cmoon/[id]` endpoint uses an explicit Prisma `select` (never `include`) so it can't accidentally expose `CMoon.members`/`captains`, which carry Discord tokens and other user PII.

This plan went through adversarial review (mobile/UI, performance, integration-fit, security) before implementation; findings from all four were incorporated (loading-state theme flash fix, contrast-audited color overrides, deterministic ordering/lazy-loading on the cMoon page's cToon grid, and the auth/upload hardening above).

## Test plan

- [x] `npx prisma migrate dev` applied cleanly against a fresh Postgres instance; migration SQL reviewed to confirm it contains only this feature's changes (unrelated pre-existing schema drift was excluded).
- [x] `npx nuxt build` succeeds with no errors.
- [x] Automated contrast sanity sweep (`utils/cmoonPalette.js`) passes across 18 base colors spanning light/dark/saturated/gray.
- [x] Manually exercised via curl against a seeded test DB: `/api/ctoon/modal` returns `cMoon` with no PII, `/api/cmoon/[id]` returns page data, admin cToon create/update accept and validate `cMoonId` (rejects a nonexistent id before any file write), page-image upload normalizes a 1200×900 upload to exactly 800×600, and admin-gated routes correctly 403 for a real non-admin user.
- [x] Playwright screenshots (desktop + mobile viewports) confirm: My Collection modal renders the cMoon theme, cMart modal is unchanged, and the new cMoon page renders its banner/image/description/grid correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_014RJRSnZN6dSpvg34DMiY4j)_