### PR TITLE
Add uploadable poster art for cMoon selection screen

### DIFF
--- a/components/CMoonSelectModal.vue
+++ b/components/CMoonSelectModal.vue
@@ -1,33 +1,42 @@
 <template>
   <Teleport to="body">
     <div v-if="visible" class="cms-overlay">
-      <div class="cms-modal">
+      <div
+        ref="modalRef" class="cms-modal" role="dialog" aria-modal="true"
+        aria-labelledby="cms-title" @keydown="onModalKeydown"
+      >
         <div class="cms-header">
-          <h2 class="cms-title">Choose your cMoon</h2>
+          <h2 id="cms-title" class="cms-title">Choose your cMoon</h2>
           <p class="cms-sub">
             Pick a faction to represent. This can't be changed later, so choose carefully.
           </p>
           <p v-if="deadlineText" class="cms-deadline">Choose by {{ deadlineText }} or you'll be auto-assigned.</p>
         </div>
 
-        <div v-if="loading" class="cms-loading">Loading cMoons…</div>
-        <div v-else class="cms-body">
-          <button
-            v-for="c in cmoons" :key="c.id"
-            type="button"
-            class="cms-option"
-            :class="{ 'cms-option-selected': choice === c.id }"
-            role="radio"
-            :aria-checked="choice === c.id"
-            @click="choice = c.id"
-          >
-            <span class="cms-swatch" :style="{ background: safeColor(c.color) }"></span>
-            <span class="cms-option-body">
-              <span class="cms-option-name">{{ c.name }}</span>
-              <span class="cms-option-count">{{ c.memberCount }} member{{ c.memberCount === 1 ? '' : 's' }}</span>
-            </span>
-            <span class="cms-option-check" aria-hidden="true">{{ choice === c.id ? '●' : '○' }}</span>
-          </button>
+        <div class="cms-body">
+          <div class="cms-options" role="radiogroup" aria-labelledby="cms-title">
+            <button
+              v-for="(c, idx) in cmoons" :key="c.id"
+              type="button"
+              class="cms-card"
+              :class="{ 'cms-card-selected': choice === c.id, 'cms-card-dim': !!choice && choice !== c.id }"
+              role="radio"
+              :aria-checked="choice === c.id"
+              @click="choice = c.id"
+              @keydown="onCardKeydown($event, idx)"
+            >
+              <span class="cms-poster" :style="{ backgroundColor: safeColor(c.color) }">
+                <img
+                  v-if="c.imagePath && !imageErrors[c.id]"
+                  :src="c.imagePath" alt="" width="600" height="900" loading="eager"
+                  @error="onImageError(c.id)"
+                />
+                <span v-if="choice === c.id" class="cms-badge" aria-hidden="true">✓ Selected</span>
+              </span>
+              <span class="cms-card-name">{{ c.name }}</span>
+              <span class="cms-card-count">{{ c.memberCount }} member{{ c.memberCount === 1 ? '' : 's' }}</span>
+            </button>
+          </div>
           <div v-if="!cmoons.length" class="cms-empty">No cMoons are available yet.</div>
         </div>
 
@@ -45,15 +54,20 @@
 
 <script setup>
 const visible = ref(false)
-const loading = ref(false)
 const submitting = ref(false)
 const error = ref('')
 const cmoons = ref([])
 const choice = ref(null)
 const deadline = ref(null)
+const imageErrors = ref({})
+const modalRef = ref(null)
 
 function safeColor(color) {
   return /^#[0-9a-fA-F]{6}$/.test(color || '') ? color : '#3a4a63'
+}
+
+function onImageError(id) {
+  imageErrors.value = { ...imageErrors.value, [id]: true }
 }
 
 const deadlineText = computed(() => {
@@ -65,17 +79,19 @@ const deadlineText = computed(() => {
 
 async function checkStatus() {
   try {
-    const status = await $fetch('/api/cmoon/status')
+    // /api/cmoons is public and briefly cached, so fetching it alongside the eligibility check
+    // is free — this avoids waiting on it only after status comes back, which used to add a
+    // second full round trip before the modal had anything to show.
+    const [status, list] = await Promise.all([
+      $fetch('/api/cmoon/status'),
+      $fetch('/api/cmoons').catch(() => ({ cmoons: [] })),
+    ])
     if (!status?.cMoonEnabled || !status.canChoose) return
     deadline.value = status.deadline || null
-    loading.value = true
-    visible.value = true
-    const list = await $fetch('/api/cmoons')
     cmoons.value = list?.cmoons || []
+    visible.value = true
   } catch {
     // Not logged in, or feature off — silently skip.
-  } finally {
-    loading.value = false
   }
 }
 
@@ -93,14 +109,48 @@ async function confirm() {
   }
 }
 
-watch(visible, (v) => {
+function focusCardAt(index) {
+  const cards = modalRef.value?.querySelectorAll('.cms-card')
+  if (!cards?.length) return
+  const i = ((index % cards.length) + cards.length) % cards.length
+  cards[i].focus()
+}
+
+// Arrow-key navigation matches native <input type="radio"> group behavior; Tab/Shift+Tab is
+// handled separately below since a non-dismissible modal has no close button to trap focus around.
+function onCardKeydown(e, idx) {
+  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { e.preventDefault(); focusCardAt(idx + 1) }
+  else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { e.preventDefault(); focusCardAt(idx - 1) }
+}
+
+function onModalKeydown(e) {
+  if (e.key !== 'Tab' || !modalRef.value) return
+  const focusables = Array.from(modalRef.value.querySelectorAll('button:not(:disabled)'))
+  if (!focusables.length) return
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault(); last.focus()
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault(); first.focus()
+  }
+}
+
+watch(visible, async (v) => {
   if (typeof document === 'undefined') return
-  document.body.style.overflow = v ? 'hidden' : ''
+  // Locking `documentElement` rather than `body`: the newsite layout sets an explicit
+  // `overflow-y: scroll` on `<html>` (see app.vue), which breaks body→viewport overflow
+  // propagation and let the page keep scrolling behind this "must choose" modal.
+  document.documentElement.style.overflow = v ? 'hidden' : ''
+  if (v) {
+    await nextTick()
+    modalRef.value?.querySelector('.cms-card')?.focus()
+  }
 })
 
 onMounted(checkStatus)
 onBeforeUnmount(() => {
-  if (typeof document !== 'undefined') document.body.style.overflow = ''
+  if (typeof document !== 'undefined') document.documentElement.style.overflow = ''
 })
 </script>
 
@@ -114,6 +164,9 @@ onBeforeUnmount(() => {
   align-items: center;
   justify-content: center;
   padding: 16px;
+  padding-left: max(16px, env(safe-area-inset-left));
+  padding-right: max(16px, env(safe-area-inset-right));
+  overscroll-behavior: contain;
 }
 
 .cms-modal {
@@ -130,6 +183,13 @@ onBeforeUnmount(() => {
   padding-bottom: env(safe-area-inset-bottom);
   color: #fff;
   font-family: 'Nunito', sans-serif;
+}
+
+/* Only 4 cMoons ever exist, so widening the modal (rather than switching Tailwind-style
+   viewport breakpoints) is what lets the auto-fit grid below settle into 4 columns instead of 2
+   — the grid reflows off the modal's own width, so this is the only breakpoint that matters. */
+@media (min-width: 700px) {
+  .cms-modal { max-width: 640px; }
 }
 
 .cms-header {
@@ -156,7 +216,7 @@ onBeforeUnmount(() => {
   font-weight: 600;
 }
 
-.cms-loading, .cms-empty {
+.cms-empty {
   padding: 20px 16px;
   font-size: 0.8rem;
   color: rgba(255, 255, 255, 0.6);
@@ -165,58 +225,112 @@ onBeforeUnmount(() => {
 .cms-body {
   padding: 12px 16px;
   overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  overscroll-behavior: contain;
+  /* CSS-only "scroll shadow": two gradients scroll with the content and mask themselves out
+     against the two fixed radial shadows behind them, so a hint only shows on the edge that
+     still has more to scroll — needed because this grid can run two rows deep on a short phone
+     screen with no other affordance that more cMoons are below the fold. */
+  background:
+    linear-gradient(#0a1830 30%, rgba(10, 24, 48, 0)),
+    linear-gradient(rgba(10, 24, 48, 0), #0a1830 70%) 0 100%,
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0)),
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0)) 0 100%;
+  background-repeat: no-repeat;
+  background-color: #0a1830;
+  background-size: 100% 24px, 100% 24px, 100% 10px, 100% 10px;
+  background-attachment: local, local, scroll, scroll;
 }
 
-.cms-option {
-  display: flex;
-  align-items: center;
+.cms-options {
+  display: grid;
+  /* auto-fit (not a fixed 2/4-column split) sizes columns off the modal's real width and
+     naturally caps at however many of the (at most 4) cards fit — no viewport breakpoint to
+     keep in sync with the max-width rule above. */
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
   gap: 10px;
-  min-height: 48px;
-  padding: 8px 12px;
+}
+
+.cms-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
   border: 2px solid rgba(255, 255, 255, 0.15);
-  border-radius: 8px;
+  border-radius: 10px;
   background: rgba(255, 255, 255, 0.04);
   color: #fff;
   text-align: left;
   cursor: pointer;
+  min-height: 44px;
 }
 
-.cms-option-selected {
+.cms-card-selected {
   border-color: #ffd75e;
   background: rgba(255, 215, 94, 0.12);
 }
 
-.cms-swatch {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  flex: 0 0 auto;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+/* Dims non-selected cards once a choice is made — the ring alone reads poorly once cards carry
+   full-bleed admin-uploaded art instead of a flat color. */
+.cms-card-dim {
+  opacity: 0.55;
 }
 
-.cms-option-body {
-  flex: 1 1 auto;
-  min-width: 0;
+@media (hover: hover) and (pointer: fine) {
+  .cms-card:hover {
+    border-color: rgba(255, 215, 94, 0.45);
+  }
+}
+
+.cms-poster {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+/* aspect-ratio fallback for older engines: without it, width:100% + no height collapses the
+   box to zero height before the image finishes loading. */
+@supports not (aspect-ratio: 1 / 1) {
+  .cms-poster { height: 0; padding-top: 150%; }
+  .cms-poster img { position: absolute; inset: 0; }
+}
+
+.cms-poster img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cms-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  background: #256e45;
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 999px;
+  /* Never rely on the selected border alone against busy, unpredictable admin-uploaded art —
+     shape (checkmark) + a solid-background text label both read regardless of the art underneath. */
 }
 
-.cms-option-name {
+.cms-card-name {
   font-weight: 700;
   font-size: 0.85rem;
+  word-break: break-word;
 }
 
-.cms-option-count {
+.cms-card-count {
   font-size: 0.65rem;
   color: rgba(255, 255, 255, 0.55);
-}
-
-.cms-option-check {
-  flex: 0 0 auto;
-  color: #ffd75e;
 }
 
 .cms-error {
@@ -248,9 +362,24 @@ onBeforeUnmount(() => {
   cursor: not-allowed;
 }
 
-.cms-option:focus-visible,
+.cms-card:focus-visible,
 .cms-confirm-btn:focus-visible {
   outline: 3px solid #ffd75e;
   outline-offset: 2px;
+}
+
+/* Short viewports (landscape phones, small-screen split view): the header/footer chrome around
+   a 2-row poster grid can otherwise eat most of the available height before any cards show. */
+@media (max-height: 700px) {
+  .cms-header { padding: 10px 16px 6px; }
+  .cms-sub {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+  }
+  .cms-deadline { margin-top: 2px; }
+  .cms-body { padding: 8px 16px; }
+  .cms-footer { padding: 8px 16px 12px; }
 }
 </style>

--- a/components/newsite/AdminCMoon.vue
+++ b/components/newsite/AdminCMoon.vue
@@ -26,12 +26,22 @@
       <div class="space-y-3 mb-4">
         <div v-for="c in cmoons" :key="c.id" class="bg-white rounded border p-3">
           <div class="flex items-center flex-wrap gap-x-2 gap-y-1 mb-2">
-            <span class="inline-block w-4 h-4 rounded-full border flex-shrink-0" :style="{ background: safeColor(c.color) }"></span>
+            <img
+              v-if="c.imagePath" :src="c.imagePath" alt=""
+              class="w-6 h-9 object-cover rounded border flex-shrink-0"
+            />
+            <span v-else class="inline-block w-4 h-4 rounded-full border flex-shrink-0" :style="{ background: safeColor(c.color) }"></span>
             <span class="font-semibold break-words min-w-0">{{ c.name }}</span>
             <span class="text-xs text-gray-600">{{ c.memberCount }} member{{ c.memberCount === 1 ? '' : 's' }}</span>
             <!-- Kept together so they travel as a unit when the row wraps on narrow screens. -->
             <div class="ml-auto flex items-center gap-3 flex-shrink-0">
               <button class="cm-tap text-xs text-indigo-600 hover:underline" @click="startEdit(c)">Edit</button>
+              <button
+                v-if="c.imagePath"
+                class="cm-tap text-xs text-gray-600 hover:underline disabled:opacity-40"
+                :disabled="imageBusyId === c.id"
+                @click="removeImage(c)"
+              >{{ imageBusyId === c.id ? 'Removing…' : 'Remove graphic' }}</button>
               <button
                 class="cm-tap text-xs text-red-600 hover:underline disabled:opacity-40"
                 :disabled="c.memberCount > 0"
@@ -138,6 +148,25 @@
           </div>
         </div>
 
+        <div class="mt-3">
+          <label class="block text-xs font-medium mb-1">Starter choice graphic (selection-screen poster)</label>
+          <p class="text-xs text-gray-600 mb-2">
+            Shown as the choice for this cMoon on the "Choose your cMoon" screen new and existing
+            players see. Portrait images work best (about a 2:3 ratio, e.g. 600×900) — it's
+            automatically resized and cropped to fit. PNG, JPEG, or WebP, up to 5MB. Leave empty
+            to keep showing the color swatch instead.
+          </p>
+          <div class="flex items-center gap-3 flex-wrap">
+            <img
+              v-if="imagePreviewUrl || currentImagePath"
+              :src="imagePreviewUrl || currentImagePath" alt=""
+              class="w-16 h-24 object-cover rounded border flex-shrink-0"
+            />
+            <input type="file" accept="image/png,image/jpeg,image/webp" class="cm-field text-xs" @change="onImageFileChange" />
+          </div>
+          <p v-if="imageError" class="text-xs text-red-600 mt-1">{{ imageError }}</p>
+        </div>
+
         <div v-if="formError" class="text-xs text-red-600 mt-2">{{ formError }}</div>
 
         <div class="mt-3 flex gap-2">
@@ -153,6 +182,8 @@
 
 <script setup>
 import { cMoonPillStyle, isSafeCMoonColor, cMoonContrastRatio } from '~/utils/cmoonColor'
+
+const rs = useAdminResources()
 
 const loading = ref(false)
 const saving = ref(false)
@@ -170,6 +201,53 @@ const emptyForm = () => ({ name: '', color: '', discordRoleId: '', captainIds: [
 const form = reactive(emptyForm())
 const prizeCtoonSearch = ref('')
 const prizeCtoonQty = ref(1)
+
+// Starter-graphic upload state. Kept separate from `form` — the image is a separate multipart
+// request (POST/DELETE .../[id]/image), sent only after the name/color/etc save succeeds.
+const IMAGE_MAX_BYTES = 5 * 1024 * 1024
+const IMAGE_MIME_TYPES = ['image/png', 'image/jpeg', 'image/webp']
+const selectedImageFile = ref(null)
+const imagePreviewUrl = ref('')
+const currentImagePath = ref('')
+const imageError = ref('')
+const imageBusyId = ref('')
+
+function onImageFileChange(e) {
+  const file = e.target.files?.[0] || null
+  e.target.value = ''
+  imageError.value = ''
+  if (!file) return
+  if (!IMAGE_MIME_TYPES.includes(file.type)) {
+    imageError.value = 'Only PNG, JPEG, or WebP images are allowed'
+    return
+  }
+  if (file.size > IMAGE_MAX_BYTES) {
+    imageError.value = 'Image must be 5MB or smaller'
+    return
+  }
+  if (imagePreviewUrl.value) rs.revokeObjectUrl(imagePreviewUrl.value)
+  selectedImageFile.value = file
+  imagePreviewUrl.value = rs.objectUrl(file)
+}
+
+async function uploadImageIfNeeded(id) {
+  if (!selectedImageFile.value) return
+  const fd = new FormData()
+  fd.append('image', selectedImageFile.value)
+  await $fetch(`/api/admin/cmoons/${id}/image`, { method: 'POST', body: fd })
+}
+
+async function removeImage(c) {
+  imageBusyId.value = c.id
+  try {
+    await $fetch(`/api/admin/cmoons/${c.id}/image`, { method: 'DELETE' })
+    await load()
+  } catch (e) {
+    alert(e?.data?.statusMessage || 'Failed to remove graphic')
+  } finally {
+    imageBusyId.value = ''
+  }
+}
 
 // Share the validation/contrast helpers with the player-facing badges so the admin
 // preview here matches exactly what renders on leaderboards and cZones.
@@ -247,12 +325,23 @@ function startEdit(c) {
     prizeCtoons: c.prizeCtoons.map(p => ({ ctoonId: p.ctoonId, quantity: p.quantity })),
   })
   formError.value = ''
+  clearImageSelection()
+  currentImagePath.value = c.imagePath || ''
+}
+
+function clearImageSelection() {
+  if (imagePreviewUrl.value) rs.revokeObjectUrl(imagePreviewUrl.value)
+  selectedImageFile.value = null
+  imagePreviewUrl.value = ''
+  imageError.value = ''
 }
 
 function resetForm() {
   Object.assign(form, emptyForm())
   editId.value = ''
   formError.value = ''
+  clearImageSelection()
+  currentImagePath.value = ''
 }
 
 async function load() {
@@ -303,11 +392,16 @@ async function save() {
       captainIds: form.captainIds,
       prizeCtoons: form.prizeCtoons,
     }
-    if (!editId.value) {
-      await $fetch('/api/admin/cmoons', { method: 'POST', body })
+    let id = editId.value
+    if (!id) {
+      const res = await $fetch('/api/admin/cmoons', { method: 'POST', body })
+      id = res.id
     } else {
-      await $fetch(`/api/admin/cmoons/${editId.value}`, { method: 'PUT', body })
+      await $fetch(`/api/admin/cmoons/${id}`, { method: 'PUT', body })
     }
+    // Runs after the main save succeeds so a rejected image never blocks name/color/etc from
+    // saving; a failure here surfaces as formError below without undoing the save that already went through.
+    await uploadImageIfNeeded(id)
     resetForm()
     await load()
   } catch (e) {

--- a/prisma/migrations/20260821000000_add_cmoon_image/migration.sql
+++ b/prisma/migrations/20260821000000_add_cmoon_image/migration.sql
@@ -1,0 +1,9 @@
+-- Add the optional poster-art path for the cMoon selection modal.
+--
+-- Nullable with no default, so this is a metadata-only catalog change on PG 11+: no table
+-- rewrite. Still needs ACCESS EXCLUSIVE for the catalog update; "CMoon" has at most a handful
+-- of rows (the product assumes 4 total), so lock_timeout is a formality here rather than the
+-- real safeguard it is on a hot table.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE "CMoon" ADD COLUMN IF NOT EXISTS "imagePath" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2810,6 +2810,9 @@ model CMoon {
   name          String   @unique
   color         String // "#RRGGBB", validated server-side; used as text color
   discordRoleId String? // Discord role snowflake granted to members (add-only sync)
+  // Public "choose your cMoon" poster art. Server-normalized to a fixed 2:3 webp on upload
+  // (see server/api/admin/cmoons/[id]/image.post.js) — null falls back to the color swatch.
+  imagePath     String?
   // Denormalized to avoid COUNT(*) races/scans on every selection + the daily auto-assign job.
   memberCount   Int      @default(0)
   createdAt     DateTime @default(now())

--- a/server/api/admin/cmoons.get.js
+++ b/server/api/admin/cmoons.get.js
@@ -27,6 +27,7 @@ export default defineEventHandler(async (event) => {
       id: c.id,
       name: c.name,
       color: c.color,
+      imagePath: c.imagePath,
       discordRoleId: c.discordRoleId,
       memberCount: c.memberCount,
       captains: c.captains.map(cap => ({ userId: cap.userId, username: cap.user?.username || '' })),

--- a/server/api/admin/cmoons.post.js
+++ b/server/api/admin/cmoons.post.js
@@ -3,6 +3,7 @@ import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { isValidHexColor, isValidDiscordSnowflake } from '@/server/utils/cmoon'
+import { invalidateCMoonList } from '@/server/api/cmoons.get'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -52,6 +53,7 @@ export default defineEventHandler(async (event) => {
   })
 
   await logAdminChange(db, { userId: me.id, area: 'cMoon', key: `create:${created.id}`, prevValue: null, newValue: { id: created.id, name } })
+  invalidateCMoonList()
 
   return { id: created.id }
 })

--- a/server/api/admin/cmoons/[id].delete.js
+++ b/server/api/admin/cmoons/[id].delete.js
@@ -1,7 +1,10 @@
 // server/api/admin/cmoons/[id].delete.js
 import { defineEventHandler, getRequestHeader, createError } from 'h3'
+import { unlink } from 'node:fs/promises'
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { invalidateCMoonList } from '@/server/api/cmoons.get'
+import { uploadFsPath } from '@/server/utils/uploadStorage'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -19,6 +22,14 @@ export default defineEventHandler(async (event) => {
 
   await db.cMoon.delete({ where: { id } })
   await logAdminChange(db, { userId: me.id, area: 'cMoon', key: `delete:${id}`, prevValue: { name: cmoon.name }, newValue: null })
+  invalidateCMoonList()
+
+  // Best-effort: an orphaned poster costs nothing to leave behind, but there's no reason not
+  // to clean it up now that the row (and any stale cache pointing at it) is gone.
+  if (cmoon.imagePath) {
+    const filename = cmoon.imagePath.split('/').pop()
+    if (filename) { try { await unlink(uploadFsPath('cmoons', filename)) } catch {} }
+  }
 
   return { ok: true }
 })

--- a/server/api/admin/cmoons/[id].put.js
+++ b/server/api/admin/cmoons/[id].put.js
@@ -3,6 +3,7 @@ import { defineEventHandler, readBody, getRequestHeader, createError } from 'h3'
 import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { isValidHexColor, isValidDiscordSnowflake } from '@/server/utils/cmoon'
+import { invalidateCMoonList } from '@/server/api/cmoons.get'
 
 export default defineEventHandler(async (event) => {
   const cookie = getRequestHeader(event, 'cookie') || ''
@@ -66,6 +67,7 @@ export default defineEventHandler(async (event) => {
   })
 
   await logAdminChange(db, { userId: me.id, area: 'cMoon', key: `update:${id}`, prevValue: { name: cmoon.name, color: cmoon.color }, newValue: { name, color } })
+  invalidateCMoonList()
 
   return { ok: true }
 })

--- a/server/api/admin/cmoons/[id]/image.delete.js
+++ b/server/api/admin/cmoons/[id]/image.delete.js
@@ -1,0 +1,32 @@
+// server/api/admin/cmoons/[id]/image.delete.js
+// Removes a cMoon's poster art, reverting the picker back to its color-swatch fallback.
+import { defineEventHandler, createError } from 'h3'
+import { unlink } from 'node:fs/promises'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
+import { uploadFsPath } from '@/server/utils/uploadStorage'
+import { invalidateCMoonList } from '@/server/api/cmoons.get'
+
+export default defineEventHandler(async (event) => {
+  assertSameOrigin(event)
+  const me = await requireAdmin(event)
+
+  const id = event.context.params?.id
+  const cmoon = await db.cMoon.findUnique({ where: { id } })
+  if (!cmoon) throw createError({ statusCode: 404, statusMessage: 'cMoon not found' })
+  if (!cmoon.imagePath) return { id, imagePath: null }
+
+  const oldImagePath = cmoon.imagePath
+  await db.cMoon.update({ where: { id }, data: { imagePath: null } })
+  invalidateCMoonList()
+
+  const oldFilename = oldImagePath.split('/').pop()
+  if (oldFilename) { try { await unlink(uploadFsPath('cmoons', oldFilename)) } catch {} }
+
+  await logAdminChange(db, {
+    userId: me.id, area: 'cMoon', key: `image:${id}`, prevValue: oldImagePath, newValue: null,
+  })
+
+  return { id, imagePath: null }
+})

--- a/server/api/admin/cmoons/[id]/image.post.js
+++ b/server/api/admin/cmoons/[id]/image.post.js
@@ -1,0 +1,96 @@
+// server/api/admin/cmoons/[id]/image.post.js
+// Uploads (or replaces) a cMoon's poster art shown in the "choose your cMoon" picker.
+//
+// Kept as its own multipart endpoint rather than folding onto cmoons.post.js/[id].put.js
+// (which take plain JSON for name/color/captains/prizes): those two callers, tests, and the
+// admin form's existing save() all stay untouched, and image upload/removal becomes an
+// independent action the admin can retry without resubmitting the rest of the form — same
+// split already used for backgrounds (backgrounds.post.js vs backgrounds/[id]/replace-image.post.js).
+import { defineEventHandler, readMultipartFormData, getRequestHeader, createError } from 'h3'
+import { mkdir, writeFile, unlink } from 'node:fs/promises'
+import sharp from 'sharp'
+import { prisma as db } from '@/server/prisma'
+import { logAdminChange } from '@/server/utils/adminChangeLog'
+import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
+import { MAX_IMAGE_BYTES, sniffImageType } from '@/server/utils/imageUploadValidation'
+import { uploadDir, uploadFsPath, uploadPublicPath } from '@/server/utils/uploadStorage'
+import { invalidateCMoonList } from '@/server/api/cmoons.get'
+
+const FEATURE = 'cmoons'
+// Matches the poster proportions of the original "choose your world" screen this recreates.
+// Re-encoding to a fixed size (rather than validating the upload's own dimensions) means any
+// reasonably-sized source works, retina displays get a sharp image, and there's no exact-pixel
+// hoop for the admin to jump through.
+const OUTPUT_WIDTH = 600
+const OUTPUT_HEIGHT = 900
+// GIF is sniffable/allowed elsewhere in this codebase, but an animated poster in a blocking
+// post-login modal costs every player, so this feature only accepts static formats.
+const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp']
+// Rough multipart overhead margin on top of the real image cap, checked against the
+// client-declared Content-Length before the body is buffered into memory.
+const MAX_UPLOAD_BYTES = MAX_IMAGE_BYTES + 64 * 1024
+
+export default defineEventHandler(async (event) => {
+  assertSameOrigin(event)
+  const me = await requireAdmin(event)
+
+  const id = event.context.params?.id
+  const cmoon = await db.cMoon.findUnique({ where: { id } })
+  if (!cmoon) throw createError({ statusCode: 404, statusMessage: 'cMoon not found' })
+
+  const contentLength = Number(getRequestHeader(event, 'content-length') || 0)
+  if (contentLength > MAX_UPLOAD_BYTES) {
+    throw createError({ statusCode: 413, statusMessage: 'Image must be 5MB or smaller' })
+  }
+
+  const parts = await readMultipartFormData(event)
+  if (!parts?.length) throw createError({ statusCode: 400, statusMessage: 'No form data' })
+
+  const filePart = parts.find(p => p.filename)
+  if (!filePart) throw createError({ statusCode: 400, statusMessage: 'Image file is required.' })
+  if (filePart.data.length > MAX_IMAGE_BYTES) {
+    throw createError({ statusCode: 413, statusMessage: 'Image must be 5MB or smaller' })
+  }
+
+  // The multipart "type" field and filename are both client-supplied and spoofable — the
+  // extension on disk is derived from sniffed bytes below, never from either of those.
+  const sniffed = sniffImageType(filePart.data)
+  if (!sniffed || !ALLOWED_TYPES.includes(sniffed)) {
+    throw createError({ statusCode: 400, statusMessage: 'Only PNG, JPEG, or WebP images are allowed' })
+  }
+
+  let output
+  try {
+    output = await sharp(filePart.data, { limitInputPixels: 40_000_000 })
+      .timeout({ seconds: 15 })
+      .resize({ width: OUTPUT_WIDTH, height: OUTPUT_HEIGHT, fit: 'cover', position: 'attention' })
+      .webp({ quality: 85 })
+      .toBuffer()
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Could not process that image' })
+  }
+
+  const dir = uploadDir(FEATURE)
+  await mkdir(dir, { recursive: true })
+
+  // Server-generated name only — never the client's filename or extension, which is exactly
+  // what would let a mislabeled upload land as e.g. a same-origin .html file.
+  const filename = `cmoon-${id}-${Date.now()}.webp`
+  await writeFile(uploadFsPath(FEATURE, filename), output)
+  const newImagePath = uploadPublicPath(FEATURE, filename)
+
+  const oldImagePath = cmoon.imagePath
+  await db.cMoon.update({ where: { id }, data: { imagePath: newImagePath } })
+  invalidateCMoonList()
+
+  if (oldImagePath) {
+    const oldFilename = oldImagePath.split('/').pop()
+    if (oldFilename) { try { await unlink(uploadFsPath(FEATURE, oldFilename)) } catch {} }
+  }
+
+  await logAdminChange(db, {
+    userId: me.id, area: 'cMoon', key: `image:${id}`, prevValue: oldImagePath, newValue: newImagePath,
+  })
+
+  return { id, imagePath: newImagePath }
+})

--- a/server/api/cmoons.get.js
+++ b/server/api/cmoons.get.js
@@ -19,10 +19,19 @@ export default defineEventHandler(async () => {
   if (!cachedList || (now - cachedAt) >= TTL_MS) {
     cachedList = await db.cMoon.findMany({
       orderBy: { name: 'asc' },
-      select: { id: true, name: true, color: true, memberCount: true },
+      select: { id: true, name: true, color: true, memberCount: true, imagePath: true },
     })
     cachedAt = now
   }
 
   return { cMoonEnabled: true, cmoons: cachedList }
 })
+
+// Imported by the admin cMoon mutation routes (create/update/delete/image) so a name, color, or
+// poster change is visible immediately rather than waiting out the TTL — same
+// export-a-named-function-from-a-route-file pattern as clearSearchesCache in
+// server/api/czone/[username]/searches.get.js.
+export function invalidateCMoonList() {
+  cachedList = null
+  cachedAt = 0
+}

--- a/server/utils/uploadStorage.js
+++ b/server/utils/uploadStorage.js
@@ -1,0 +1,30 @@
+import { join } from 'node:path'
+
+// Generic version of the per-feature *Storage.js helpers (e.g. backgroundStorage.js): same
+// dev/prod path split, parameterized by a feature name instead of copy-pasted per feature.
+// New single-image-per-entity uploads should use this rather than adding another bespoke file.
+//
+// In production the real image store lives at /var/www/cartoon-reorbit-images, a SIBLING
+// directory to the app's checkout (/var/www/cartoon-reorbit) — kept outside the repo because of
+// its size, per the deploy's actual layout. PM2 launches `.output/server/index.mjs` with the
+// repo root as cwd, so process.cwd() is reliably the repo root in both dev and prod; one step up
+// from it is the parent directory containing both siblings.
+const baseDir = process.env.NODE_ENV === 'production'
+  ? join(process.cwd(), '..')
+  : process.cwd()
+
+export function uploadDir(feature) {
+  return process.env.NODE_ENV === 'production'
+    ? join(baseDir, 'cartoon-reorbit-images', feature)
+    : join(baseDir, 'public', feature)
+}
+
+export function uploadFsPath(feature, filename) {
+  return join(uploadDir(feature), filename)
+}
+
+export function uploadPublicPath(feature, filename) {
+  return process.env.NODE_ENV === 'production'
+    ? `/images/${feature}/${filename}`
+    : `/${feature}/${filename}`
+}


### PR DESCRIPTION
## Summary
- Admins can now upload a "starter choice graphic" per cMoon from the cMoon admin panel, alongside the existing name/color/captains/prize fields.
- The "Choose your cMoon" modal (shown to new and existing players who haven't picked yet) is redesigned to recreate the original Cartoon Orbit "choose your world" screen as a poster-card grid, instead of a plain color-swatch list. A cMoon with no uploaded graphic still falls back to today's color swatch.
- Uploaded images are re-encoded server-side (via `sharp`) to a fixed 2:3 webp poster, so any reasonably-sized source image works and there's no exact-pixel requirement for admins.
- Mobile-focused rework of the modal: a CSS `auto-fit` grid (rather than a viewport breakpoint, which didn't track the modal's own fixed width), a fix for a pre-existing scroll-lock bug that let the page scroll behind this non-dismissible modal, dialog/radiogroup ARIA + focus trap + arrow-key navigation, a non-color-only "selected" state, and a scroll-shadow affordance on short viewports where the grid runs two rows deep.

## Implementation notes
- `CMoon.imagePath` (nullable) + a new migration.
- New `POST`/`DELETE /api/admin/cmoons/[id]/image` endpoints, kept separate from the existing JSON create/update endpoints (same split the app already uses for background images vs. their metadata).
- `server/utils/uploadStorage.js`: a generic per-feature upload dir/path helper, reused instead of adding another bespoke storage file.
- The public cMoon list's in-process cache is now invalidated on every admin mutation (create/update/delete/image) instead of only expiring after its 30s TTL.

## Test plan
- [ ] `prisma migrate deploy` (or equivalent) run against dev DB to apply the new `imagePath` column
- [ ] Admin cMoon panel: upload, replace, and remove a poster graphic for a cMoon; verify preview and thumbnail render
- [ ] "Choose your cMoon" modal: verify poster art renders for cMoons with a graphic, swatch fallback renders for cMoons without one
- [ ] Manual check on a small mobile viewport (and in landscape) that all 4 cMoons are reachable and the Confirm flow still works
- [ ] Confirm selecting a cMoon still correctly assigns it and grants configured prize cToons

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NRwkbntL7D5yxHFA5woG3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRwkbntL7D5yxHFA5woG3B)_