### PR TITLE
Add cMoon banner graphic to themed cToon modal

### DIFF
--- a/components/newsite/AdminCMoon.vue
+++ b/components/newsite/AdminCMoon.vue
@@ -143,6 +143,27 @@
         </div>
 
         <div class="mt-3">
+          <label class="block text-xs font-medium mb-1">cToon modal banner (small wide graphic, replaces the "cWorld" text link)</label>
+          <template v-if="!editId">
+            <p class="text-xs text-gray-600">Save this cMoon first, then Edit it to upload a banner.</p>
+          </template>
+          <template v-else>
+            <img v-if="bannerImagePreview" :src="bannerImagePreview" class="cm-banner-image-preview" alt="Selected banner preview" />
+            <img v-else-if="currentBannerImagePath" :src="currentBannerImagePath" class="cm-banner-image-preview" alt="Current cMoon modal banner" />
+            <p v-else class="text-xs text-gray-600 mb-1">No banner uploaded yet — the modal shows a plain text link instead.</p>
+            <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" class="cm-field" @change="handleBannerImageFile" />
+            <p class="text-xs text-gray-500 mt-1">Any image works — it's auto-cropped/resized to a wide 800×200 banner on upload.</p>
+            <button
+              type="button"
+              class="cm-tap mt-2 px-3 border rounded bg-white"
+              :disabled="!bannerImageFile || bannerImageUploading"
+              @click="uploadBannerImage"
+            >{{ bannerImageUploading ? 'Uploading…' : 'Upload banner' }}</button>
+            <p v-if="bannerImageError" class="text-xs text-red-600 mt-1">{{ bannerImageError }}</p>
+          </template>
+        </div>
+
+        <div class="mt-3">
           <label class="block text-xs font-medium mb-1">Captains (from admins)</label>
           <div class="flex flex-wrap gap-2">
             <button
@@ -307,6 +328,13 @@ const pageImageUploading = ref(false)
 const pageImageError = ref('')
 const currentPageImagePath = ref('')
 
+// ── cToon modal banner (separate step — needs an existing cMoon row) ───
+const bannerImageFile = ref(null)
+const bannerImagePreview = ref('')
+const bannerImageUploading = ref(false)
+const bannerImageError = ref('')
+const currentBannerImagePath = ref('')
+
 const palettePreview = computed(() => isValidColor(form.color) ? cMoonPalette(form.color) : null)
 
 function handlePageImageFile(e) {
@@ -334,6 +362,34 @@ async function uploadPageImage() {
     pageImageError.value = e?.data?.statusMessage || 'Upload failed'
   } finally {
     pageImageUploading.value = false
+  }
+}
+
+function handleBannerImageFile(e) {
+  const file = e.target.files?.[0] || null
+  bannerImageFile.value = file
+  bannerImageError.value = ''
+  if (bannerImagePreview.value) URL.revokeObjectURL(bannerImagePreview.value)
+  bannerImagePreview.value = file ? URL.createObjectURL(file) : ''
+}
+
+async function uploadBannerImage() {
+  if (!editId.value || !bannerImageFile.value || bannerImageUploading.value) return
+  bannerImageUploading.value = true
+  bannerImageError.value = ''
+  try {
+    const body = new FormData()
+    body.append('image', bannerImageFile.value)
+    const res = await $fetch(`/api/admin/cmoons/${editId.value}/banner-image`, { method: 'POST', body })
+    currentBannerImagePath.value = res.bannerImagePath
+    bannerImageFile.value = null
+    if (bannerImagePreview.value) URL.revokeObjectURL(bannerImagePreview.value)
+    bannerImagePreview.value = ''
+    await load()
+  } catch (e) {
+    bannerImageError.value = e?.data?.statusMessage || 'Upload failed'
+  } finally {
+    bannerImageUploading.value = false
   }
 }
 
@@ -418,6 +474,11 @@ function startEdit(c) {
   if (pageImagePreview.value) URL.revokeObjectURL(pageImagePreview.value)
   pageImagePreview.value = ''
   pageImageError.value = ''
+  currentBannerImagePath.value = c.bannerImagePath || ''
+  bannerImageFile.value = null
+  if (bannerImagePreview.value) URL.revokeObjectURL(bannerImagePreview.value)
+  bannerImagePreview.value = ''
+  bannerImageError.value = ''
   formError.value = ''
   clearImageSelection()
   currentImagePath.value = c.imagePath || ''
@@ -441,6 +502,11 @@ function resetForm() {
   if (pageImagePreview.value) URL.revokeObjectURL(pageImagePreview.value)
   pageImagePreview.value = ''
   pageImageError.value = ''
+  currentBannerImagePath.value = ''
+  bannerImageFile.value = null
+  if (bannerImagePreview.value) URL.revokeObjectURL(bannerImagePreview.value)
+  bannerImagePreview.value = ''
+  bannerImageError.value = ''
 }
 
 async function load() {
@@ -615,6 +681,16 @@ onMounted(load)
   width: 100%;
   max-width: 320px;
   aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 6px;
+}
+
+.cm-banner-image-preview {
+  display: block;
+  width: 100%;
+  max-width: 320px;
+  aspect-ratio: 4 / 1;
   object-fit: cover;
   border-radius: 4px;
   margin-bottom: 6px;

--- a/components/newsite/CtoonInfoCard.vue
+++ b/components/newsite/CtoonInfoCard.vue
@@ -106,14 +106,29 @@
               <p>{{ ctoonDescription }}</p>
             </div>
             <div class="ctic-grid">
-              <div v-if="showCMoonTheme" class="ctic-tile ctic-tile-wide">
-                <div class="ctic-label">cWorld</div>
+              <div
+                v-if="showCMoonTheme"
+                class="ctic-tile ctic-tile-wide"
+                :class="{ 'ctic-tile--banner': !!ctoon.cMoon.bannerImagePath }"
+              >
                 <NuxtLink
+                  v-if="ctoon.cMoon.bannerImagePath"
                   :to="`/newsite/cmoon/${ctoon.cMoon.id}`"
-                  class="ctic-value ctic-value--link ctic-value--wrap"
+                  class="ctic-cmoon-banner-link"
                   :aria-label="`View the ${ctoon.cMoon.name} cMoon page`"
                   @click="close"
-                >{{ ctoon.cMoon.name }} <span aria-hidden="true">&rsaquo;</span></NuxtLink>
+                >
+                  <img :src="ctoon.cMoon.bannerImagePath" :alt="`${ctoon.cMoon.name} cMoon`" class="ctic-cmoon-banner-img" />
+                </NuxtLink>
+                <template v-else>
+                  <div class="ctic-label">cWorld</div>
+                  <NuxtLink
+                    :to="`/newsite/cmoon/${ctoon.cMoon.id}`"
+                    class="ctic-value ctic-value--link ctic-value--wrap"
+                    :aria-label="`View the ${ctoon.cMoon.name} cMoon page`"
+                    @click="close"
+                  >{{ ctoon.cMoon.name }} <span aria-hidden="true">&rsaquo;</span></NuxtLink>
+                </template>
               </div>
               <div class="ctic-tile">
                 <div class="ctic-label">Highest Mint</div>
@@ -1172,6 +1187,30 @@ function formatDate(value) {
   grid-column: 1 / -1;
 }
 
+/* ── cMoon banner tile ──────────────────────────────────────── */
+.ctic-tile--banner {
+  padding: 0;
+  overflow: hidden;
+}
+
+.ctic-cmoon-banner-link {
+  display: block;
+  line-height: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+.ctic-cmoon-banner-link:focus-visible {
+  outline: 2px solid var(--OrbitLightBlue);
+  outline-offset: -2px;
+}
+
+.ctic-cmoon-banner-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 4 / 1;
+  object-fit: cover;
+}
+
 .ctic-desc {
   margin-bottom: 0;
 }
@@ -1563,6 +1602,7 @@ function formatDate(value) {
 .ctic-panel--cmoon .ctic-value--link:hover,
 .ctic-panel--cmoon .ctic-value--link:active { opacity: 0.82; }
 .ctic-panel--cmoon .ctic-value--link:focus-visible { outline-color: var(--cm-focus-ring); }
+.ctic-panel--cmoon .ctic-cmoon-banner-link:focus-visible { outline-color: var(--cm-focus-ring); }
 .ctic-panel--cmoon .ctic-sub { color: var(--cm-text-muted); }
 
 .ctic-panel--cmoon .ctic-mint-title { color: var(--cm-text-muted); }

--- a/prisma/migrations/20260821025516_add_cmoon_banner_image/migration.sql
+++ b/prisma/migrations/20260821025516_add_cmoon_banner_image/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CMoon" ADD COLUMN     "bannerImagePath" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2831,6 +2831,9 @@ model CMoon {
   pageImageWidth  Int?
   pageImageHeight Int?
   pageDescription String?
+  // Small wide banner graphic (normalized to 800x200) shown on a themed cToon
+  // modal in place of the plain "cWorld" text tile, linking to the page above.
+  bannerImagePath String?
 
   members         User[]
   captains        CMoonCaptain[]

--- a/server/api/admin/cmoons.get.js
+++ b/server/api/admin/cmoons.get.js
@@ -32,6 +32,7 @@ export default defineEventHandler(async (event) => {
       memberCount: c.memberCount,
       pageImagePath: c.pageImagePath,
       pageDescription: c.pageDescription,
+      bannerImagePath: c.bannerImagePath,
       displayedCtoonCount: c._count?.displayedCtoons ?? 0,
       captains: c.captains.map(cap => ({ userId: cap.userId, username: cap.user?.username || '' })),
       prizeCtoons: c.prizeCtoons.map(pc => ({ ctoonId: pc.ctoonId, quantity: pc.quantity, name: pc.ctoon?.name || '', assetPath: pc.ctoon?.assetPath || null })),

--- a/server/api/admin/cmoons/[id].delete.js
+++ b/server/api/admin/cmoons/[id].delete.js
@@ -5,7 +5,7 @@ import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { invalidateCMoonList } from '@/server/api/cmoons.get'
 import { uploadFsPath } from '@/server/utils/uploadStorage'
-import { cmoonPageFsPath } from '@/server/utils/cmoonPageStorage'
+import { cmoonPageFsPath, cmoonBannerFsPath } from '@/server/utils/cmoonImageStorage'
 import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
 
 export default defineEventHandler(async (event) => {
@@ -37,6 +37,10 @@ export default defineEventHandler(async (event) => {
   if (cmoon.pageImagePath) {
     const filename = cmoon.pageImagePath.split('/').pop()
     if (filename) { try { await unlink(cmoonPageFsPath(filename)) } catch {} }
+  }
+  if (cmoon.bannerImagePath) {
+    const filename = cmoon.bannerImagePath.split('/').pop()
+    if (filename) { try { await unlink(cmoonBannerFsPath(filename)) } catch {} }
   }
 
   return { ok: true }

--- a/server/api/admin/cmoons/[id]/banner-image.post.js
+++ b/server/api/admin/cmoons/[id]/banner-image.post.js
@@ -1,16 +1,11 @@
-// server/api/admin/cmoons/[id]/page-image.post.js
+// server/api/admin/cmoons/[id]/banner-image.post.js
 //
-// Uploads a cMoon page image, normalized to exactly 800x600 (the same
-// resolution as a cZone background). Rather than rejecting anything that
-// isn't already pixel-exact (which a phone camera essentially never is),
-// this auto-orients (EXIF) and center-crops/resizes to 800x600 server-side
-// via sharp, then re-encodes — which also means the stored file is never the
-// attacker-controlled bytes as-uploaded.
-//
-// Deliberately NOT a copy of server/api/admin/backgrounds.post.js: that file
-// imports sniffImageType/MAX_IMAGE_BYTES but never calls them, and has no
-// size cap or path-containment check. This endpoint calls every primitive
-// itemized below, in order, before any file I/O.
+// Uploads the small wide banner graphic shown on a themed cToon modal in
+// place of the plain "cWorld" text tile. Same normalize-then-store approach
+// as page-image.post.js (auto-orient, cover-crop to a fixed size, re-encode
+// via sharp) rather than trusting/storing the upload as-is — see that file's
+// header comment for why this deliberately isn't a copy of
+// server/api/admin/backgrounds.post.js.
 import { defineEventHandler, readMultipartFormData, createError } from 'h3'
 import { mkdir, writeFile } from 'node:fs/promises'
 import sharp from 'sharp'
@@ -18,10 +13,13 @@ import { prisma as db } from '@/server/prisma'
 import { logAdminChange } from '@/server/utils/adminChangeLog'
 import { requireAdmin, assertSameOrigin } from '@/server/utils/requireAdmin'
 import { sniffImageType, sanitizePathSegment, assertInside, MAX_IMAGE_BYTES } from '@/server/utils/imageUploadValidation'
-import { cmoonPageUploadDir, cmoonPageFsPath, cmoonPagePublicPath } from '@/server/utils/cmoonImageStorage'
+import { cmoonBannerUploadDir, cmoonBannerFsPath, cmoonBannerPublicPath } from '@/server/utils/cmoonImageStorage'
 
-const PAGE_IMAGE_WIDTH = 800
-const PAGE_IMAGE_HEIGHT = 600
+// Wide banner strip (4:1) — big enough to look crisp across the modal's
+// full-width tile on desktop, small enough that it's clearly a "small
+// banner graphic" and not competing with the 800x600 cMoon page image.
+const BANNER_WIDTH = 800
+const BANNER_HEIGHT = 200
 
 export default defineEventHandler(async (event) => {
   const me = await requireAdmin(event)
@@ -39,8 +37,6 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 413, statusMessage: 'Image must be 5MB or smaller.' })
   }
 
-  // The multipart "type" field is client-supplied and spoofable — verify
-  // from the actual bytes before doing anything with the file.
   const sniffed = sniffImageType(filePart.data)
   if (!sniffed) {
     throw createError({ statusCode: 400, statusMessage: 'Only PNG, JPEG, GIF, or WebP images are allowed.' })
@@ -49,38 +45,34 @@ export default defineEventHandler(async (event) => {
   let output
   try {
     output = await sharp(filePart.data)
-      .rotate() // auto-orient per EXIF before anything else touches pixel data
-      .resize(PAGE_IMAGE_WIDTH, PAGE_IMAGE_HEIGHT, { fit: 'cover', position: 'centre' })
+      .rotate()
+      .resize(BANNER_WIDTH, BANNER_HEIGHT, { fit: 'cover', position: 'centre' })
       .webp({ quality: 88 })
       .toBuffer()
   } catch {
     throw createError({ statusCode: 400, statusMessage: 'Could not process that image.' })
   }
 
-  const uploadDir = cmoonPageUploadDir()
+  const uploadDir = cmoonBannerUploadDir()
   await mkdir(uploadDir, { recursive: true })
   const filename = `${sanitizePathSegment(id, 'cmoon')}-${Date.now()}.webp`
-  const outPath = assertInside(uploadDir, cmoonPageFsPath(filename))
+  const outPath = assertInside(uploadDir, cmoonBannerFsPath(filename))
   await writeFile(outPath, output)
 
-  const imagePath = cmoonPagePublicPath(filename)
+  const imagePath = cmoonBannerPublicPath(filename)
 
   await db.cMoon.update({
     where: { id },
-    data: {
-      pageImagePath: imagePath,
-      pageImageWidth: PAGE_IMAGE_WIDTH,
-      pageImageHeight: PAGE_IMAGE_HEIGHT
-    }
+    data: { bannerImagePath: imagePath }
   })
 
   await logAdminChange(db, {
     userId: me.id,
     area: `cMoon:${id}`,
-    key: 'pageImagePath',
-    prevValue: cmoon.pageImagePath,
+    key: 'bannerImagePath',
+    prevValue: cmoon.bannerImagePath,
     newValue: imagePath
   }).catch(() => {})
 
-  return { pageImagePath: imagePath }
+  return { bannerImagePath: imagePath }
 })

--- a/server/api/cmoon/[id].get.js
+++ b/server/api/cmoon/[id].get.js
@@ -29,6 +29,7 @@ export default defineEventHandler(async (event) => {
       pageImageWidth: true,
       pageImageHeight: true,
       pageDescription: true,
+      bannerImagePath: true,
       _count: { select: { displayedCtoons: true } }
     }
   })
@@ -51,6 +52,7 @@ export default defineEventHandler(async (event) => {
     pageImageWidth: cmoon.pageImageWidth,
     pageImageHeight: cmoon.pageImageHeight,
     pageDescription: cmoon.pageDescription,
+    bannerImagePath: cmoon.bannerImagePath,
     ctoonCount,
     ctoons,
     ctoonsTruncated: ctoonCount > ctoons.length

--- a/server/api/ctoon/modal.get.js
+++ b/server/api/ctoon/modal.get.js
@@ -42,7 +42,7 @@ export default defineEventHandler(async (event) => {
     // `captains` relations that pull full User rows (Discord tokens, email);
     // this endpoint must only ever expose the same public-safe fields as the
     // cMoon-themed modal card needs.
-    cMoon: { select: { id: true, name: true, color: true } }
+    cMoon: { select: { id: true, name: true, color: true, bannerImagePath: true } }
   }
 
   if (userCtoonId?.startsWith('uc|')) {

--- a/server/utils/cmoonImageStorage.js
+++ b/server/utils/cmoonImageStorage.js
@@ -21,3 +21,22 @@ export function cmoonPagePublicPath(filename) {
     ? `/images/cmoon-pages/${filename}`
     : `/cmoon-pages/${filename}`
 }
+
+// Small banner graphic shown in place of the plain "cWorld" text tile on a
+// themed cToon modal — a separate, smaller asset from the 800x600 page image
+// above, so its own directory rather than overloading cmoon-pages/.
+export function cmoonBannerUploadDir() {
+  return process.env.NODE_ENV === 'production'
+    ? join(baseDir, 'cartoon-reorbit-images', 'cmoon-banners')
+    : join(baseDir, 'public', 'cmoon-banners')
+}
+
+export function cmoonBannerFsPath(filename) {
+  return join(cmoonBannerUploadDir(), filename)
+}
+
+export function cmoonBannerPublicPath(filename) {
+  return process.env.NODE_ENV === 'production'
+    ? `/images/cmoon-banners/${filename}`
+    : `/cmoon-banners/${filename}`
+}


### PR DESCRIPTION
## Summary

Follow-up to #958 (already merged). Replaces the plain "cWorld" text link on the cMoon-themed cToon modal with a small admin-uploaded wide banner graphic, per feedback on that PR.

- When a cMoon has a banner uploaded, the modal's cWorld tile shows the banner image (edge-to-edge, clickable) instead of the text link — still linking to the cMoon page.
- A cMoon with no banner uploaded keeps today's plain text link, so this is fully backward compatible.
- Banner is uploaded from the admin cMoons page, alongside the existing page-image upload, and is normalized server-side (auto-oriented, center-cropped, re-encoded) to exactly 800×200 via `sharp` — any photo works, no exact-pixel requirement on the admin.

## Implementation notes

- New `CMoon.bannerImagePath` field + migration.
- New `POST /api/admin/cmoons/[id]/banner-image` endpoint, following the same validate-before-file-I/O pattern as the existing page-image upload (`requireAdmin`/`assertSameOrigin`, size cap, magic-byte sniff before touching the file, re-encode rather than storing the upload as-is).
- Renamed `server/utils/cmoonPageStorage.js` → `cmoonImageStorage.js` since it now covers both the page image and the banner; also fixed the one other file's import of it that was added by a PR merged in the interim.
- Also wired banner cleanup into the existing cMoon-delete route's best-effort orphaned-file cleanup, matching how it already handles the page image and poster-art paths.

## Test plan

- [x] `npx prisma migrate deploy` applies cleanly on top of `dev`'s current migration history (including the poster-art PR merged after #958).
- [x] `npx nuxt build` succeeds with no errors.
- [x] Manually exercised via curl: banner upload normalizes a 1000×400 PNG to exactly 800×200 webp, persists to `CMoon.bannerImagePath`, and flows through to `/api/ctoon/modal` and `/api/admin/cmoons`; non-admin upload attempt correctly 403s.
- [x] Playwright screenshots (desktop + mobile) confirm the banner renders full-width in place of the text tile on a themed modal, and the admin edit form shows the current banner preview + upload control.


---
_Generated by [Claude Code](https://claude.ai/code/session_014RJRSnZN6dSpvg34DMiY4j)_