### PR TITLE
Let trade offers request points, without locking or revealing a recipient's balance

### DIFF
--- a/components/newsite/AdminManageUsers.vue
+++ b/components/newsite/AdminManageUsers.vue
@@ -213,13 +213,14 @@
 
                 <div>
                   <div class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">Requested</div>
+                  <div v-if="trade.pointsRequested" class="mb-2 text-sm font-medium text-blue-700">{{ trade.pointsRequested }} pts</div>
                   <div v-if="trade.ctoonsRequested.length" class="flex flex-wrap gap-2">
                     <div v-for="ctoon in trade.ctoonsRequested" :key="ctoon.id" class="flex flex-col items-center gap-1">
                       <img :src="ctoon.assetPath" :alt="ctoon.name" class="w-16 h-16 object-contain rounded border" />
                       <span class="text-xs text-center text-gray-700 max-w-[4rem] leading-tight">{{ ctoon.name }}</span>
                     </div>
                   </div>
-                  <div v-if="!trade.ctoonsRequested.length" class="text-xs text-gray-400 italic">Nothing</div>
+                  <div v-if="!trade.ctoonsRequested.length && !trade.pointsRequested" class="text-xs text-gray-400 italic">Nothing</div>
                 </div>
               </div>
             </div>

--- a/components/newsite/AdminTradeLogs.vue
+++ b/components/newsite/AdminTradeLogs.vue
@@ -58,7 +58,8 @@
                 <th class="px-1.5 py-1 text-left">Status</th>
                 <th class="px-1.5 py-1 text-left">Created (CST)</th>
                 <th class="px-1.5 py-1 text-left">Accepted/Denied (CST)</th>
-                <th class="px-1.5 py-1 text-right">Pts</th>
+                <th class="px-1.5 py-1 text-right">Pts Off</th>
+                <th class="px-1.5 py-1 text-right">Pts Req</th>
                 <th class="px-1.5 py-1 text-right"># Off</th>
                 <th class="px-1.5 py-1 text-right"># Req</th>
                 <th class="px-1.5 py-1 text-right">Off Val</th>
@@ -73,8 +74,8 @@
                 class="border-t"
                 :class="{
                   'bg-yellow-100':
-                    computeTotalValue(trade.ctoonsOffered) <
-                    (trade.pointsOffered + computeTotalValue(trade.ctoonsRequested)) * 0.8
+                    (trade.pointsOffered + computeTotalValue(trade.ctoonsOffered)) <
+                    ((trade.pointsRequested || 0) + computeTotalValue(trade.ctoonsRequested)) * 0.8
                 }"
               >
                 <td class="px-1.5 py-1 align-top">
@@ -91,13 +92,14 @@
                   <span v-else>-</span>
                 </td>
                 <td class="px-1.5 py-1 text-right tabular-nums">{{ trade.pointsOffered }}</td>
+                <td class="px-1.5 py-1 text-right tabular-nums">{{ trade.pointsRequested || 0 }}</td>
                 <td class="px-1.5 py-1 text-right tabular-nums">{{ trade.ctoonsOffered.length }}</td>
                 <td class="px-1.5 py-1 text-right tabular-nums">{{ trade.ctoonsRequested.length }}</td>
                 <td class="px-1.5 py-1 text-right tabular-nums">
                   {{ trade.pointsOffered + computeTotalValue(trade.ctoonsOffered) }}
                 </td>
                 <td class="px-1.5 py-1 text-right tabular-nums">
-                  {{ computeTotalValue(trade.ctoonsRequested) }}
+                  {{ (trade.pointsRequested || 0) + computeTotalValue(trade.ctoonsRequested) }}
                 </td>
                 <td class="px-1.5 py-1">
                   <button @click="openModal(trade)" class="bg-blue-500 text-white px-2 py-0.5 rounded text-[11px]">
@@ -117,8 +119,8 @@
             class="border rounded p-2 shadow break-words text-[11px]"
             :class="{
               'bg-yellow-100':
-                computeTotalValue(trade.ctoonsOffered) <
-                (trade.pointsOffered + computeTotalValue(trade.ctoonsRequested)) * 0.8
+                (trade.pointsOffered + computeTotalValue(trade.ctoonsOffered)) <
+                ((trade.pointsRequested || 0) + computeTotalValue(trade.ctoonsRequested)) * 0.8
             }"
           >
             <div class="mb-1">
@@ -138,11 +140,12 @@
             </div>
 
             <div class="space-y-0.5">
-              <div><span class="font-medium">Points:</span> {{ trade.pointsOffered }}</div>
+              <div><span class="font-medium">Points Offered:</span> {{ trade.pointsOffered }}</div>
+              <div><span class="font-medium">Points Requested:</span> {{ trade.pointsRequested || 0 }}</div>
               <div><span class="font-medium">Offered:</span> {{ trade.ctoonsOffered.length }}</div>
               <div><span class="font-medium">Requested:</span> {{ trade.ctoonsRequested.length }}</div>
               <div><span class="font-medium">Total Offered Value:</span> {{ trade.pointsOffered + computeTotalValue(trade.ctoonsOffered) }}</div>
-              <div><span class="font-medium">Total Requested Value:</span> {{ computeTotalValue(trade.ctoonsRequested) }}</div>
+              <div><span class="font-medium">Total Requested Value:</span> {{ (trade.pointsRequested || 0) + computeTotalValue(trade.ctoonsRequested) }}</div>
             </div>
 
             <button @click="openModal(trade)" class="mt-2 bg-blue-500 text-white px-2 py-0.5 rounded text-[11px]">
@@ -200,6 +203,7 @@
             <!-- Recipient & Requests -->
             <div class="p-2 border rounded">
               <div><span class="font-medium">Recipient:</span> {{ selectedTrade.recipient.username }}</div>
+              <div class="mt-1"><span class="font-medium">Points Requested:</span> {{ selectedTrade.pointsRequested || 0 }}</div>
               <div class="font-medium mt-2">cToons Requested:</div>
               <div class="grid grid-cols-4 gap-2 mt-1">
                 <div v-for="item in selectedTrade.ctoonsRequested" :key="item.id" class="text-center">
@@ -208,7 +212,7 @@
                   <div class="text-[10px] text-gray-600">{{ item.rarity }}</div>
                 </div>
               </div>
-              <div class="mt-2"><span class="font-medium">Total Requested Value:</span> {{ computeTotalValue(selectedTrade.ctoonsRequested) }}</div>
+              <div class="mt-2"><span class="font-medium">Total Requested Value:</span> {{ (selectedTrade.pointsRequested || 0) + computeTotalValue(selectedTrade.ctoonsRequested) }}</div>
             </div>
           </div>
         </div>

--- a/components/newsite/Trade.vue
+++ b/components/newsite/Trade.vue
@@ -47,7 +47,7 @@
               <span class="tr-col-user">
                 <NuxtLink :to="`/newsite/czone/${offer.initiator.username}`" class="tr-link">{{ offer.initiator.username }}</NuxtLink>
               </span>
-              <span class="tr-col-pts">{{ Number(offer.pointsOffered).toLocaleString() }}</span>
+              <span class="tr-col-pts" :title="pointsCellTitle(offer)">{{ pointsCellText(offer) }}</span>
               <span class="tr-col-ct tr-col-off">{{ countByRole(offer, 'OFFERED') }}</span>
               <span class="tr-col-ct tr-col-req">{{ countByRole(offer, 'REQUESTED') }}</span>
               <span class="tr-col-stat"><span class="tr-badge" :class="statusBadgeClass(offer.status)">{{ offer.status.toLowerCase() }}</span></span>
@@ -81,7 +81,7 @@
               <span class="tr-col-user">
                 <NuxtLink :to="`/newsite/czone/${offer.recipient.username}`" class="tr-link">{{ offer.recipient.username }}</NuxtLink>
               </span>
-              <span class="tr-col-pts">{{ Number(offer.pointsOffered).toLocaleString() }}</span>
+              <span class="tr-col-pts" :title="pointsCellTitle(offer)">{{ pointsCellText(offer) }}</span>
               <span class="tr-col-ct tr-col-off">{{ countByRole(offer, 'OFFERED') }}</span>
               <span class="tr-col-ct tr-col-req">{{ countByRole(offer, 'REQUESTED') }}</span>
               <span class="tr-col-stat"><span class="tr-badge" :class="statusBadgeClass(offer.status)">{{ offer.status.toLowerCase() }}</span></span>
@@ -105,8 +105,12 @@
               Sending this will decline their original offer.
             </span>
             <span v-if="tradeCounterSummary?.theirPointsOffered" class="tr-counter-warn">
-              Their {{ tradeCounterSummary.theirPointsOffered.toLocaleString() }} pts can't be
-              requested back — points only travel from the sender of an offer.
+              They offered {{ tradeCounterSummary.theirPointsOffered.toLocaleString() }} pts —
+              not carried over automatically. Add it under "Points to request" if you still want it.
+            </span>
+            <span v-if="tradeCounterSummary?.theirPointsRequested" class="tr-counter-warn">
+              They asked you for {{ tradeCounterSummary.theirPointsRequested.toLocaleString() }} pts —
+              also not carried over. Add it under "Points to offer" if you're still willing to send it.
             </span>
             <span v-if="counterTrimmedCount" class="tr-counter-warn">
               {{ counterTrimmedCount }} cToon{{ counterTrimmedCount === 1 ? '' : 's' }} from the
@@ -236,19 +240,34 @@
           <div class="tr-step-header">
             <div class="tr-step-title-group">
               <span class="tr-step-title">{{ tradeTargetUser.username }}'s Collection</span>
-              <span class="tr-step-hint">Select cToons to request</span>
+              <span class="tr-step-hint">Select cToons and/or points to request</span>
+              <div class="tr-points-row">
+                <label class="tr-suggest-dim">Points to request:</label>
+                <input
+                  type="number"
+                  v-model.number="pointsToRequest"
+                  min="0"
+                  :max="MAX_TRADE_POINTS"
+                  @input="pointsToRequest = clampPoints(pointsToRequest)"
+                  class="tr-points-input"
+                  placeholder="0"
+                />
+              </div>
             </div>
-            <div v-if="selectedTargetCtoons.length" class="tr-sel-total">
+            <div v-if="selectedTargetCtoons.length || pointsToRequest > 0" class="tr-sel-total">
               <span class="tr-sel-total-label">Selected value</span>
-              <span v-if="isLoadingCreateValuations" class="tr-sel-total-val tr-sel-total-dim">…</span>
+              <span v-if="isLoadingCreateValuations && step1SelectedTotal == null" class="tr-sel-total-val tr-sel-total-dim">…</span>
               <span v-else-if="step1SelectedTotal != null" class="tr-sel-total-val">~{{ step1SelectedTotal.toLocaleString() }} pts</span>
             </div>
             <!--
               Countering an offer that was points-only leaves nothing to mirror
               into the request side, so requiring a selection here would dead-end
-              the flow. The server still rejects a wholly empty offer.
+              the flow. A pure points request (no cToons at all) is also allowed
+              through for the same reason: the server only rejects a wholly empty
+              offer, and gating on cToons alone would trap "just send me points"
+              on this step forever.
             -->
-            <button class="tr-btn-primary" :disabled="!selectedTargetCtoons.length && !isCounterMode" @click="tradeCurrentStep = 2">
+            <button class="tr-btn-primary" :disabled="!selectedTargetCtoons.length && pointsToRequest === 0 && !isCounterMode" @click="tradeCurrentStep = 2">
               Next →
             </button>
           </div>
@@ -305,12 +324,8 @@
           </template>
 
           <div class="tr-step-footer">
-            <!--
-              Countering an offer that was points-only leaves nothing to mirror
-              into the request side, so requiring a selection here would dead-end
-              the flow. The server still rejects a wholly empty offer.
-            -->
-            <button class="tr-btn-primary" :disabled="!selectedTargetCtoons.length && !isCounterMode" @click="tradeCurrentStep = 2">
+            <!-- Same gating as the header's Next button above. -->
+            <button class="tr-btn-primary" :disabled="!selectedTargetCtoons.length && pointsToRequest === 0 && !isCounterMode" @click="tradeCurrentStep = 2">
               Next →
             </button>
           </div>
@@ -328,7 +343,7 @@
                   v-model.number="pointsToOffer"
                   :max="user?.availablePoints ?? user?.points ?? 0"
                   min="0"
-                  @input="pointsToOffer = Math.max(0, pointsToOffer)"
+                  @input="pointsToOffer = Math.min(clampPoints(pointsToOffer), user?.availablePoints ?? user?.points ?? 0)"
                   class="tr-points-input"
                   placeholder="0"
                 />
@@ -441,7 +456,7 @@
             <template v-else-if="createFairnessData">
               <div class="tm-val-row">
                 <div class="tm-val-side">
-                  <div class="tm-val-label">You receive (cToons)</div>
+                  <div class="tm-val-label">You receive (cToons + pts)</div>
                   <div class="tm-val-amount">~{{ createFairnessData.requestedTotal.toLocaleString() }} pts</div>
                 </div>
                 <div class="tm-val-bar-wrap">
@@ -488,6 +503,7 @@
           <div class="tr-confirm-grid">
             <div class="tr-confirm-col">
               <div class="tr-confirm-label">Requesting from {{ tradeTargetUser.username }}</div>
+              <div v-if="pointsToRequest > 0" class="tr-confirm-points">Points: {{ Number(pointsToRequest).toLocaleString() }}</div>
               <div v-if="!selectedTargetCtoons.length" class="tr-suggest-dim tr-confirm-empty">No cToons selected.</div>
               <div v-else class="tr-confirm-cards">
                 <div v-for="c in selectedTargetCtoons" :key="c.id" class="tr-confirm-card">
@@ -536,7 +552,8 @@
                 <NuxtLink :to="`/newsite/czone/${currentOffer.recipient.username}`" class="tm-link">{{ currentOffer.recipient.username }}</NuxtLink>
               </div>
               <div class="tm-head-meta">
-                <span>Points: {{ Number(currentOffer.pointsOffered).toLocaleString() }}</span>
+                <span>Offered: {{ Number(currentOffer.pointsOffered).toLocaleString() }} pts</span>
+                <span v-if="currentOffer.pointsRequested">Requested: {{ Number(currentOffer.pointsRequested).toLocaleString() }} pts</span>
                 <span class="tr-badge" :class="statusBadgeClass(currentOffer.status)">{{ currentOffer.status.toLowerCase() }}</span>
                 <span class="tm-dim">{{ formatDateTime(currentOffer.createdAt) }}</span>
               </div>
@@ -572,7 +589,7 @@
                   </div>
                   <!-- Requested side total -->
                   <div class="tm-val-side tm-val-side-right">
-                    <div class="tm-val-label">Requested (cToons)</div>
+                    <div class="tm-val-label">Requested (cToons + pts)</div>
                     <div class="tm-val-amount">~{{ fairnessData.requestedTotal.toLocaleString() }} pts</div>
                   </div>
                 </div>
@@ -626,6 +643,10 @@
               <!-- Requested cToons -->
               <div class="tm-col">
                 <div class="tm-col-title">Requested cToons</div>
+                <div v-if="currentOffer.pointsRequested" class="tm-points-row">
+                  <span class="tm-points-label">Points Requested</span>
+                  <span class="tm-points-value">{{ Number(currentOffer.pointsRequested).toLocaleString() }}</span>
+                </div>
                 <div class="tm-cards">
                   <div
                     v-for="tc in currentOffer.ctoons.filter(c => c.role === 'REQUESTED')"
@@ -718,7 +739,7 @@ import { useAuth } from '@/composables/useAuth'
 import { formatQuantity } from '~/utils/formatQuantity'
 import { disabledReasonFor } from '~/server/utils/lockRules'
 import { duplicateCtoonIds } from '~/utils/duplicateCtoonIds'
-import { MAX_CTOONS_PER_SIDE } from '~/server/utils/tradeOfferLimits'
+import { MAX_CTOONS_PER_SIDE, MAX_TRADE_POINTS } from '~/server/utils/tradeOfferLimits'
 import CtoonCard from '@/components/trade/CtoonCard.vue'
 
 const route = useRoute()
@@ -892,12 +913,13 @@ const offeredTotal = computed(() => {
 /** Sum of mint-adjusted values for requested cToons */
 const requestedTotal = computed(() => {
   if (!currentOffer.value || !Object.keys(tradeValuations.value).length) return null
-  return currentOffer.value.ctoons
+  const ctoonSum = currentOffer.value.ctoons
     .filter(tc => tc.role === 'REQUESTED')
     .reduce((sum, tc) => {
       const val = getMintAdjustedValue(tradeValuations.value[tc.userCtoon.id])
       return sum + (val ?? 0)
     }, 0)
+  return ctoonSum + (Number(currentOffer.value.pointsRequested) || 0)
 })
 
 /**
@@ -993,11 +1015,17 @@ async function fetchValuationsForIds(ids) {
   }
 }
 
-/** Total mint-adjusted value of the cToons selected from the other user (Step 1 display) */
+/**
+ * Total mint-adjusted value of the cToons selected from the other user, plus
+ * points requested (Step 1 display). Must not go null just because no cToons
+ * are selected -- "just send me some points, no cToons" is a real, valid
+ * offer, and this total feeds the Next-button gating on this same step.
+ */
 const step1SelectedTotal = computed(() => {
-  if (!selectedTargetCtoons.value.length) return null
+  const points = Number(pointsToRequest.value) || 0
+  if (!selectedTargetCtoons.value.length) return points > 0 ? points : null
   if (!selectedTargetCtoons.value.some(c => createValuations.value[c.id])) return null
-  return selectedTargetCtoons.value.reduce((sum, c) => {
+  return points + selectedTargetCtoons.value.reduce((sum, c) => {
     return sum + (getMintAdjustedValue(createValuations.value[c.id]) ?? 0)
   }, 0)
 })
@@ -1316,7 +1344,7 @@ async function clearTarget(focusInput = false) {
   preselectTargetKeys.value = []; preselectSelfKeys.value = []; counterMissingCount.value = 0; counterTrimmedCount.value = 0
   pinnedTargetIds.value = new Set(); pinnedInitiatorIds.value = new Set()
   limitNotified.target = false; limitNotified.initiator = false
-  selectedTargetCtoons.value = []; selectedInitiatorCtoons.value = []; pointsToOffer.value = 0
+  selectedTargetCtoons.value = []; selectedInitiatorCtoons.value = []; pointsToOffer.value = 0; pointsToRequest.value = 0
   otherCtoons.value = []; selfCtoons.value = []; otherTradeList.value = []; selfTradeList.value = []
   pageOther.value = 1; pageSelf.value = 1
   tradeFiltersOther.value = { nameQuery: '', set: 'All', series: 'All', rarity: 'All', duplicates: 'all', owned: 'all' }
@@ -1681,7 +1709,21 @@ function buildNameSuggestions(q, list) {
 
 // ── Offer creation ────────────────────────────────────────────────
 const pointsToOffer = ref(0)
+const pointsToRequest = ref(0)
 const makingOffer = ref(false)
+
+/**
+ * Clamps a points input to [0, MAX_TRADE_POINTS], coercing NaN/Infinity (an
+ * empty field, a stray "-" mid-type, a pasted value past what Number can
+ * represent safely) to 0 rather than letting it through as-is. v-model.number
+ * on its own does not guard any of that -- an unclamped NaN silently poisons
+ * every total downstream and renders as the literal string "NaN".
+ */
+function clampPoints(v) {
+  const n = Number(v)
+  if (!Number.isFinite(n)) return 0
+  return Math.min(MAX_TRADE_POINTS, Math.max(0, Math.trunc(n)))
+}
 
 /**
  * Locks shield you from other people asking; they never stop you giving a
@@ -1709,7 +1751,7 @@ watch(selectedInitiatorIds, () => { lockAck.value = false })
 const isCounterMode = computed(() => !!tradeCounterSourceId.value)
 
 async function sendOffer() {
-  if (!tradeTargetUser.value || pointsToOffer.value < 0) return
+  if (!tradeTargetUser.value || pointsToOffer.value < 0 || pointsToRequest.value < 0) return
   // Last line before the network. The toggles and the counter mirror are both
   // capped, but this is the only check every path provably passes through.
   if (selectedTargetCtoons.value.length > MAX_CTOONS_PER_SIDE ||
@@ -1723,6 +1765,7 @@ async function sendOffer() {
     ctoonIdsRequested: selectedTargetCtoons.value.map(c => c.id),
     ctoonIdsOffered: selectedInitiatorCtoons.value.map(c => c.id),
     pointsOffered: pointsToOffer.value,
+    pointsRequested: pointsToRequest.value,
   }
   try {
     makingOffer.value = true
@@ -1764,10 +1807,11 @@ async function startCounter(offer) {
   tradeCounterSourceId.value = offer.id
   tradeCounterSummary.value = {
     username: offer.initiator.username,
-    // Carried purely to be shown: TradeOffer models points in one direction
-    // only (initiator → recipient), so points they offered cannot be mirrored
-    // into a request. Saying so beats silently dropping the value.
+    // Carried purely to be shown, in both directions: a counter is a brand new
+    // offer, so neither field auto-fills from the one being replaced. Saying
+    // so beats silently dropping the value.
     theirPointsOffered: Number(offer.pointsOffered) || 0,
+    theirPointsRequested: Number(offer.pointsRequested) || 0,
   }
   preselectTargetKeys.value = theirs.map(toonKey)
   preselectSelfKeys.value = mine.map(toonKey)
@@ -1840,6 +1884,30 @@ function sortMintResults(list) {
   })
 }
 function countByRole(offer, role) { return offer.ctoons.filter(c => c.role === role).length }
+
+/**
+ * Compact text for the list rows' one "Points" cell, now that an offer can
+ * carry points in both directions. Reuses the ↓/↑ convention the adjacent
+ * "↓ Off." / "↑ Req." columns already established, rather than adding a
+ * whole second column that the list grid (already 7 columns wide) has no
+ * room for on mobile.
+ */
+function pointsCellText(offer) {
+  const off = Number(offer.pointsOffered) || 0
+  const req = Number(offer.pointsRequested) || 0
+  if (!off && !req) return '—'
+  const parts = []
+  if (off) parts.push(`↓${off.toLocaleString()}`)
+  if (req) parts.push(`↑${req.toLocaleString()}`)
+  return parts.join(' ')
+}
+/** Full, unabbreviated values for a hover/long-press title on the cell above. */
+function pointsCellTitle(offer) {
+  const off = Number(offer.pointsOffered) || 0
+  const req = Number(offer.pointsRequested) || 0
+  if (!off && !req) return ''
+  return `Offered: ${off.toLocaleString()} pts · Requested: ${req.toLocaleString()} pts`
+}
 function formatDate(iso) { return new Date(iso).toLocaleDateString() }
 function formatDateTime(iso) { return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }) }
 function statusBadgeClass(status) {
@@ -1927,7 +1995,10 @@ onBeforeUnmount(() => {
 /* ── List (incoming / outgoing) ── */
 .tr-list-head, .tr-row {
   display: grid;
-  grid-template-columns: 1fr 60px 45px 45px 80px 72px 58px;
+  /* Points column widened from 60px: it now shows up to two directional
+     values ("↓1.2M ↑300K"), and 60px already clipped a single value near
+     the trade points ceiling. */
+  grid-template-columns: 1fr 100px 45px 45px 80px 72px 58px;
   align-items: center;
   gap: 4px;
   padding: 4px 8px;
@@ -1954,6 +2025,7 @@ onBeforeUnmount(() => {
 .tr-row:hover { background: rgba(0,0,0,0.3); }
 .tr-col-user { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tr-col-pts, .tr-col-ct, .tr-col-stat, .tr-col-date, .tr-col-act { text-align: center; }
+.tr-col-pts { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tr-link { color: var(--OrbitLightBlue); text-decoration: none; }
 .tr-link:hover { text-decoration: underline; }
 .tr-view-btn {

--- a/pages/admin/cheating-tool.vue
+++ b/pages/admin/cheating-tool.vue
@@ -167,11 +167,14 @@
               class="flex items-center justify-between text-sm border-b py-1.5"
             >
               <span class="font-medium">{{ row.suspectName }}</span>
-              <span class="text-gray-700">{{ row.pointsOffered.toLocaleString() }} pts offered</span>
+              <span class="text-gray-700">
+                {{ row.pointsOffered.toLocaleString() }} pts offered
+                <template v-if="row.pointsRequested">, {{ row.pointsRequested.toLocaleString() }} pts requested back</template>
+              </span>
             </div>
           </div>
           <div class="mt-2 pt-2 border-t flex justify-between font-semibold text-sm">
-            <span>Subtotal</span>
+            <span>Subtotal (net)</span>
             <span>{{ report.tradeOfferPointsToTarget.toLocaleString() }} pts</span>
           </div>
         </div>
@@ -217,6 +220,7 @@
               <p class="font-medium mb-1">Pending TradeOffers</p>
               <div v-for="(row, i) in report.pendingOffersDisplay" :key="i" class="ml-3 text-gray-700">
                 {{ row.suspectName }} ({{ row.role }}) — {{ row.pointsOffered.toLocaleString() }} pts offered
+                <template v-if="row.pointsRequested">, {{ row.pointsRequested.toLocaleString() }} pts requested</template>
               </div>
             </div>
           </div>

--- a/pages/admin/trades.vue
+++ b/pages/admin/trades.vue
@@ -59,6 +59,7 @@
               <th class="px-4 py-2">Created (CST)</th>
               <th class="px-4 py-2">Accepted/Denied (CST)</th>
               <th class="px-4 py-2">Points Offered</th>
+              <th class="px-4 py-2">Points Requested</th>
               <th class="px-4 py-2"># Offered</th>
               <th class="px-4 py-2"># Requested</th>
               <th class="px-4 py-2">Total Offered Value</th>
@@ -73,8 +74,8 @@
               class="border-t"
               :class="{
                 'bg-yellow-100':
-                  computeTotalValue(trade.ctoonsOffered) <
-                  (trade.pointsOffered + computeTotalValue(trade.ctoonsRequested)) * 0.8
+                  (trade.pointsOffered + computeTotalValue(trade.ctoonsOffered)) <
+                  ((trade.pointsRequested || 0) + computeTotalValue(trade.ctoonsRequested)) * 0.8
               }"
             >
               <td class="px-4 py-2 align-top">
@@ -91,13 +92,14 @@
                 <span v-else>-</span>
               </td>
               <td class="px-4 py-2">{{ trade.pointsOffered }}</td>
+              <td class="px-4 py-2">{{ trade.pointsRequested || 0 }}</td>
               <td class="px-4 py-2">{{ trade.ctoonsOffered.length }}</td>
               <td class="px-4 py-2">{{ trade.ctoonsRequested.length }}</td>
               <td class="px-4 py-2">
                 {{ trade.pointsOffered + computeTotalValue(trade.ctoonsOffered) }}
               </td>
               <td class="px-4 py-2">
-                {{ computeTotalValue(trade.ctoonsRequested) }}
+                {{ (trade.pointsRequested || 0) + computeTotalValue(trade.ctoonsRequested) }}
               </td>
               <td class="px-4 py-2">
                 <button @click="openModal(trade)" class="bg-blue-500 text-white px-3 py-1 rounded">
@@ -117,8 +119,8 @@
           class="border rounded p-4 shadow break-words"
           :class="{
             'bg-yellow-100':
-              computeTotalValue(trade.ctoonsOffered) <
-              (trade.pointsOffered + computeTotalValue(trade.ctoonsRequested)) * 0.8
+              (trade.pointsOffered + computeTotalValue(trade.ctoonsOffered)) <
+              ((trade.pointsRequested || 0) + computeTotalValue(trade.ctoonsRequested)) * 0.8
           }"
         >
           <div class="mb-2">
@@ -138,11 +140,12 @@
           </div>
 
           <div class="text-sm space-y-1">
-            <div><span class="font-medium">Points:</span> {{ trade.pointsOffered }}</div>
+            <div><span class="font-medium">Points Offered:</span> {{ trade.pointsOffered }}</div>
+            <div><span class="font-medium">Points Requested:</span> {{ trade.pointsRequested || 0 }}</div>
             <div><span class="font-medium">Offered:</span> {{ trade.ctoonsOffered.length }}</div>
             <div><span class="font-medium">Requested:</span> {{ trade.ctoonsRequested.length }}</div>
             <div><span class="font-medium">Total Offered Value:</span> {{ trade.pointsOffered + computeTotalValue(trade.ctoonsOffered) }}</div>
-            <div><span class="font-medium">Total Requested Value:</span> {{ computeTotalValue(trade.ctoonsRequested) }}</div>
+            <div><span class="font-medium">Total Requested Value:</span> {{ (trade.pointsRequested || 0) + computeTotalValue(trade.ctoonsRequested) }}</div>
           </div>
 
           <button @click="openModal(trade)" class="mt-3 bg-blue-500 text-white px-3 py-1 rounded">
@@ -200,6 +203,7 @@
           <!-- Recipient & Requests -->
           <div class="p-4 border rounded">
             <div><span class="font-medium">Recipient:</span> {{ selectedTrade.recipient.username }}</div>
+            <div class="mt-2"><span class="font-medium">Points Requested:</span> {{ selectedTrade.pointsRequested || 0 }}</div>
             <div class="font-medium mt-4">cToons Requested:</div>
             <div class="grid grid-cols-3 gap-4 mt-2">
               <div v-for="item in selectedTrade.ctoonsRequested" :key="item.id" class="text-center">
@@ -208,7 +212,7 @@
                 <div class="text-sm text-gray-600">{{ item.rarity }}</div>
               </div>
             </div>
-            <div class="mt-4"><span class="font-medium">Total Requested Value:</span> {{ computeTotalValue(selectedTrade.ctoonsRequested) }}</div>
+            <div class="mt-4"><span class="font-medium">Total Requested Value:</span> {{ (selectedTrade.pointsRequested || 0) + computeTotalValue(selectedTrade.ctoonsRequested) }}</div>
           </div>
         </div>
       </div>

--- a/pages/admin/users.vue
+++ b/pages/admin/users.vue
@@ -207,13 +207,14 @@
               <!-- Requested cToons -->
               <div>
                 <div class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">Requested</div>
+                <div v-if="trade.pointsRequested" class="mb-2 text-sm font-medium text-blue-700">{{ trade.pointsRequested }} pts</div>
                 <div v-if="trade.ctoonsRequested.length" class="flex flex-wrap gap-2">
                   <div v-for="ctoon in trade.ctoonsRequested" :key="ctoon.id" class="flex flex-col items-center gap-1">
                     <img :src="ctoon.assetPath" :alt="ctoon.name" class="w-16 h-16 object-contain rounded border" />
                     <span class="text-xs text-center text-gray-700 max-w-[4rem] leading-tight">{{ ctoon.name }}</span>
                   </div>
                 </div>
-                <div v-if="!trade.ctoonsRequested.length" class="text-xs text-gray-400 italic">Nothing</div>
+                <div v-if="!trade.ctoonsRequested.length && !trade.pointsRequested" class="text-xs text-gray-400 italic">Nothing</div>
               </div>
             </div>
           </div>

--- a/prisma/migrations/20260821000000_add_trade_offer_points_requested/migration.sql
+++ b/prisma/migrations/20260821000000_add_trade_offer_points_requested/migration.sql
@@ -1,0 +1,17 @@
+-- Adds the reverse points direction to a trade offer: pointsOffered already
+-- moves points initiator -> recipient, this lets the initiator ask for points
+-- recipient -> initiator in the same offer.
+--
+-- NOT NULL with a default, same as pointsOffered, so every existing row reads
+-- as "requesting nothing" for free. No LockedPoints row is ever created for
+-- this column (see the schema comment) -- it is intentionally the one amount
+-- on a pending trade that is never reserved, so a request can be sent for any
+-- amount without ever having to read the recipient's balance.
+--
+-- Metadata-only on PG 11+ (fixed default, no rewrite), but still needs
+-- ACCESS EXCLUSIVE for the catalog update; lock_timeout matches the other
+-- single-column adds in this migrations directory so this queues behind (and
+-- times out against, rather than stalls behind) a long-running trade accept.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE "TradeOffer" ADD COLUMN IF NOT EXISTS "pointsRequested" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1480,6 +1480,13 @@ model TradeOffer {
   initiatorId   String // who is making the offer
   recipientId   String // who will receive the offer
   pointsOffered Int      @default(0)
+  /// Points the initiator is asking the recipient to include, in the
+  /// opposite direction of pointsOffered. Unlike pointsOffered, this never
+  /// gets a LockedPoints row — the recipient's balance is never touched or
+  /// even queried until they try to accept, so a request can never be used
+  /// to fish for how many points someone else has. See accept.post.js for
+  /// the funds check this implies at accept time instead of creation time.
+  pointsRequested Int    @default(0)
   status        String   @default("PENDING") // e.g. PENDING, ACCEPTED, REJECTED, WITHDRAWN, COUNTERED
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt

--- a/server/api/admin/cheating-tool-apply-stream.post.js
+++ b/server/api/admin/cheating-tool-apply-stream.post.js
@@ -129,7 +129,7 @@ export default defineEventHandler(async (event) => {
       const offersInitBySuspect = await prisma.tradeOffer.findMany({
         where: { status: 'ACCEPTED', initiatorId: { in: suspectIds }, recipientId: targetId },
         select: {
-          id: true, pointsOffered: true,
+          id: true, pointsOffered: true, pointsRequested: true,
           ctoons: { where: { role: 'OFFERED' }, select: { userCtoonId: true } }
         }
       })
@@ -142,7 +142,12 @@ export default defineEventHandler(async (event) => {
         }
       })
 
-      const tradeOfferPointsToTarget = offersInitBySuspect.reduce((sum, o) => sum + (o.pointsOffered ?? 0), 0)
+      // Net of both directions -- see the identical comment in
+      // cheating-tool-report.post.js.
+      const tradeOfferPointsToTarget = offersInitBySuspect.reduce(
+        (sum, o) => sum + (o.pointsOffered ?? 0) - (o.pointsRequested ?? 0),
+        0
+      )
 
       const tradedToTarget = new Map()
       for (const tc of tradeRoomCtoons) tradedToTarget.set(tc.userCtoonId, true)

--- a/server/api/admin/cheating-tool-apply.post.js
+++ b/server/api/admin/cheating-tool-apply.post.js
@@ -82,7 +82,7 @@ export default defineEventHandler(async (event) => {
   const offersInitBySuspect = await prisma.tradeOffer.findMany({
     where: { status: 'ACCEPTED', initiatorId: { in: suspectIds }, recipientId: targetId },
     select: {
-      id: true, pointsOffered: true,
+      id: true, pointsOffered: true, pointsRequested: true,
       ctoons: { where: { role: 'OFFERED' }, select: { userCtoonId: true } }
     }
   })
@@ -95,7 +95,13 @@ export default defineEventHandler(async (event) => {
     }
   })
 
-  const tradeOfferPointsToTarget = offersInitBySuspect.reduce((sum, o) => sum + (o.pointsOffered ?? 0), 0)
+  // Net of both directions -- see the identical comment in
+  // cheating-tool-report.post.js. This total feeds directly into how many
+  // points get seized below, so it has to match what actually moved.
+  const tradeOfferPointsToTarget = offersInitBySuspect.reduce(
+    (sum, o) => sum + (o.pointsOffered ?? 0) - (o.pointsRequested ?? 0),
+    0
+  )
 
   const tradedToTarget = new Map()
   for (const tc of tradeRoomCtoons) tradedToTarget.set(tc.userCtoonId, true)

--- a/server/api/admin/cheating-tool-report.post.js
+++ b/server/api/admin/cheating-tool-report.post.js
@@ -145,7 +145,7 @@ export default defineEventHandler(async (event) => {
   const offersInitBySuspect = await prisma.tradeOffer.findMany({
     where: { status: 'ACCEPTED', initiatorId: { in: suspectIds }, recipientId: targetId },
     select: {
-      id: true, initiatorId: true, pointsOffered: true,
+      id: true, initiatorId: true, pointsOffered: true, pointsRequested: true,
       ctoons: {
         where: { role: 'OFFERED' },
         select: {
@@ -183,7 +183,14 @@ export default defineEventHandler(async (event) => {
     }
   })
 
-  const tradeOfferPointsToTarget = offersInitBySuspect.reduce((sum, o) => sum + (o.pointsOffered ?? 0), 0)
+  // Net of both directions: pointsRequested on one of these offers is real
+  // value flowing target -> suspect inside a suspect-initiated trade, and
+  // summing pointsOffered alone would overstate how many points the suspect
+  // actually funneled to the target (or miss that some flowed back).
+  const tradeOfferPointsToTarget = offersInitBySuspect.reduce(
+    (sum, o) => sum + (o.pointsOffered ?? 0) - (o.pointsRequested ?? 0),
+    0
+  )
 
   // pending TradeOffers (informational)
   const pendingOffers = await prisma.tradeOffer.findMany({
@@ -194,7 +201,7 @@ export default defineEventHandler(async (event) => {
         { initiatorId: targetId,           recipientId: { in: suspectIds } },
       ]
     },
-    select: { id: true, initiatorId: true, recipientId: true, pointsOffered: true }
+    select: { id: true, initiatorId: true, recipientId: true, pointsOffered: true, pointsRequested: true }
   })
 
   // ── Section C: Collate all ctoons traded TO target ────────────────────────
@@ -283,6 +290,7 @@ export default defineEventHandler(async (event) => {
   const tradeOfferBreakdown = offersInitBySuspect.map(o => ({
     suspectName: nameById.get(o.initiatorId) ?? String(o.initiatorId),
     pointsOffered: o.pointsOffered ?? 0,
+    pointsRequested: o.pointsRequested ?? 0,
   }))
 
   // Auction breakdown for display
@@ -300,6 +308,7 @@ export default defineEventHandler(async (event) => {
       suspectName: nameById.get(isSuspectInitiator ? o.initiatorId : o.recipientId) ?? '?',
       role: isSuspectInitiator ? 'initiator' : 'recipient',
       pointsOffered: o.pointsOffered ?? 0,
+      pointsRequested: o.pointsRequested ?? 0,
     }
   })
 

--- a/server/api/admin/ctoon-collection-analytics.get.js
+++ b/server/api/admin/ctoon-collection-analytics.get.js
@@ -256,6 +256,7 @@ export default defineEventHandler(async (event) => {
       initiatorId: true,
       recipientId: true,
       pointsOffered: true,
+      pointsRequested: true,
       ctoons: {
         select: {
           role: true,
@@ -283,10 +284,14 @@ export default defineEventHandler(async (event) => {
 
     if (requestedSetCtoons.length > 0 && oneSetCompleterIds.includes(offer.initiatorId)) {
       tradeCountByUser.set(offer.initiatorId, (tradeCountByUser.get(offer.initiatorId) || 0) + 1)
-      if (offer.pointsOffered > 0) {
+      // Net of what they also received back via pointsRequested in the same
+      // trade -- pointsOffered alone overstates the cost when both directions
+      // are in play.
+      const netCost = (offer.pointsOffered || 0) - (offer.pointsRequested || 0)
+      if (netCost > 0) {
         tradePointsByUser.set(
           offer.initiatorId,
-          (tradePointsByUser.get(offer.initiatorId) || 0) + offer.pointsOffered
+          (tradePointsByUser.get(offer.initiatorId) || 0) + netCost
         )
       }
     }

--- a/server/api/admin/trade-offers.post.js
+++ b/server/api/admin/trade-offers.post.js
@@ -39,7 +39,8 @@ export default defineEventHandler(async (event) => {
     recipientUsername,
     ctoonIdsRequested = [],
     ctoonIdsOffered = [],
-    pointsOffered = 0
+    pointsOffered = 0,
+    pointsRequested = 0
   } = await readBody(event)
 
   if (!recipientUsername) {
@@ -51,7 +52,7 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'ctoonIdsRequested and ctoonIdsOffered must be arrays'
     })
   }
-  if (Number(pointsOffered) > 0) {
+  if (Number(pointsOffered) > 0 || Number(pointsRequested) > 0) {
     throw createError({ statusCode: 400, statusMessage: 'Points are not supported for admin-initiated trades.' })
   }
   if (ctoonIdsOffered.length + ctoonIdsRequested.length === 0) {

--- a/server/api/admin/trades.get.js
+++ b/server/api/admin/trades.get.js
@@ -102,6 +102,7 @@ export default defineEventHandler(async (event) => {
       initiator: o.initiator,
       recipient: o.recipient,
       pointsOffered: o.pointsOffered,
+      pointsRequested: o.pointsRequested,
       ctoonsOffered,
       ctoonsRequested,
       status: o.status,

--- a/server/api/admin/users/[id]/pending-trades.get.js
+++ b/server/api/admin/users/[id]/pending-trades.get.js
@@ -42,6 +42,7 @@ export default defineEventHandler(async (event) => {
     initiator: o.initiator,
     recipient: o.recipient,
     pointsOffered: o.pointsOffered,
+    pointsRequested: o.pointsRequested,
     ctoonsOffered: o.ctoons.filter(x => x.role === 'OFFERED').map(x => x.userCtoon.ctoon),
     ctoonsRequested: o.ctoons.filter(x => x.role === 'REQUESTED').map(x => x.userCtoon.ctoon),
     createdAt: o.createdAt

--- a/server/api/trade/offers.post.js
+++ b/server/api/trade/offers.post.js
@@ -18,6 +18,7 @@ import {
   sendTradeOfferDM
 } from '@/server/utils/tradeOffer'
 import { notifyTradeOfferReceived } from '@/server/utils/notifications'
+import { checkTradeOfferRateLimit } from '@/server/utils/tradeOfferRateLimit'
 
 export default defineEventHandler(async (event) => {
   // 1) Authenticate user
@@ -38,18 +39,21 @@ export default defineEventHandler(async (event) => {
     recipientUsername,
     ctoonIdsRequested = [],
     ctoonIdsOffered = [],
-    pointsOffered = 0
+    pointsOffered = 0,
+    pointsRequested = 0
   } = await readBody(event)
 
   if (!recipientUsername || typeof recipientUsername !== 'string') {
     throw createError({ statusCode: 400, statusMessage: 'recipientUsername is required' })
   }
 
+  await checkTradeOfferRateLimit(event, initiatorId)
+
   const { resolvedOffered, resolvedRequested } = await resolveOfferCtoons({
     ctoonIdsOffered,
     ctoonIdsRequested
   })
-  assertOfferHasContent({ resolvedOffered, resolvedRequested, pointsOffered })
+  assertOfferHasContent({ resolvedOffered, resolvedRequested, pointsOffered, pointsRequested })
 
   // 3) Lookup recipient
   const recipient = await prisma.user.findUnique({
@@ -61,12 +65,13 @@ export default defineEventHandler(async (event) => {
   }
 
   // 4) Ownership, availability and funding
-  await validateTradeOfferInputs({
+  const { existingPendingCount } = await validateTradeOfferInputs({
     initiatorId,
     recipient,
     resolvedOffered,
     resolvedRequested,
-    pointsOffered
+    pointsOffered,
+    pointsRequested
   })
 
   // 5) Create the offer and lock the offered points
@@ -74,20 +79,26 @@ export default defineEventHandler(async (event) => {
     initiatorId,
     recipientId: recipient.id,
     pointsOffered,
+    pointsRequested,
     resolvedOffered,
     resolvedRequested
   }))
 
   // 6) Notify the recipient. Not awaited — the offer is already committed and
   // Discord's DM rate limits would otherwise stall the response for seconds.
-  sendTradeOfferDM({
-    recipientDiscordId: recipient.discordId,
-    fromUsername: me.username,
-    pointsOffered,
-    offeredCount: resolvedOffered.length,
-    requestedCount: resolvedRequested.length,
-    isCounter: false
-  }).catch(() => {})
+  // Only on the first pending offer between this pair (existingPendingCount
+  // was taken before this one was created) — see validateTradeOfferInputs.
+  if (existingPendingCount === 0) {
+    sendTradeOfferDM({
+      recipientDiscordId: recipient.discordId,
+      fromUsername: me.username,
+      pointsOffered,
+      pointsRequested,
+      offeredCount: resolvedOffered.length,
+      requestedCount: resolvedRequested.length,
+      isCounter: false
+    }).catch(() => {})
+  }
 
   // In-app notification, same placement and same reasoning as the DM above:
   // after the commit, not awaited.

--- a/server/api/trade/offers/[id]/accept.post.js
+++ b/server/api/trade/offers/[id]/accept.post.js
@@ -5,6 +5,14 @@ import {
 } from 'h3'
 import { prisma } from '@/server/prisma'
 import { notifyTradeOfferAccepted } from '@/server/utils/notifications'
+import { fmtPoints } from '@/server/utils/tradeOfferRules'
+
+// Postgres int4 max. Points columns are Int (32-bit); crediting a side past
+// this would make Postgres raise mid-transaction, and because that happens
+// inside the same transaction as the offer-row claim, the claim rolls back
+// too -- the offer would just go back to PENDING and fail identically on
+// every retry. Checked up front instead so this is a clean, explained 400.
+const INT4_MAX = 2147483647
 
 export default defineEventHandler(async (event) => {
   // 1) Authenticate
@@ -96,6 +104,43 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // 5b) Verify the RECIPIENT (the accepting user) can actually afford what's
+  // being requested, and that crediting either side won't overflow the Int
+  // column. Unlike steps 3-5 above, failure here must NOT reject the offer:
+  // pointsRequested was never locked when the offer arrived (see the schema
+  // comment on TradeOffer.pointsRequested), so the recipient has to be free
+  // to top up and retry later, or decline/counter instead. The message below
+  // only ever describes the caller's OWN balance -- it is never shown to the
+  // initiator, who has no way to trigger this check themselves (recipientId
+  // !== userId was already enforced above).
+  if (offer.pointsOffered > 0 || offer.pointsRequested > 0) {
+    const [recipientPts, recipientLockAgg] = await Promise.all([
+      prisma.userPoints.findUnique({ where: { userId: offer.recipientId }, select: { points: true } }),
+      prisma.lockedPoints.aggregate({
+        _sum: { amount: true },
+        where: { userId: offer.recipientId, status: 'ACTIVE' }
+      })
+    ])
+    const recipientGross = recipientPts?.points || 0
+    const recipientLocked = recipientLockAgg._sum.amount || 0
+    const recipientAvailable = Math.max(0, recipientGross - recipientLocked)
+
+    if (offer.pointsRequested > recipientAvailable) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: `You need ${fmtPoints(offer.pointsRequested - recipientAvailable)} more points to accept this trade — you have ${fmtPoints(recipientAvailable)} available.`
+      })
+    }
+
+    const initiatorGross = pts?.points || 0
+    if (initiatorGross + offer.pointsRequested > INT4_MAX || recipientGross + offer.pointsOffered > INT4_MAX) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'This trade would push a balance past the maximum allowed and cannot be completed.'
+      })
+    }
+  }
+
   // 6) Transfer cToons, move points, log, accept
   await prisma.$transaction(async (tx) => {
     // Claim the offer before touching anything else. The status check above
@@ -119,23 +164,57 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (offer.pointsOffered > 0) {
+    if (offer.pointsOffered > 0 || offer.pointsRequested > 0) {
+      // Both fields move in the same two rows: initiator loses pointsOffered
+      // and gains pointsRequested; recipient is the mirror image. Netted into
+      // one delta per user rather than four separate updates.
+      const initiatorNet = offer.pointsRequested - offer.pointsOffered
+      const recipientNet = offer.pointsOffered - offer.pointsRequested
+      const netFor = (userId) => (userId === offer.initiatorId ? initiatorNet : recipientNet)
+
       // Both UserPoints rows are taken in userId order, not initiator-then-
       // recipient. Two accepts between the same pair of users in opposite roles
       // would otherwise grab the same two rows in opposite orders and deadlock —
       // a narrow window at 50 cToons a side, seconds wide at 250.
       const [firstId, secondId] = [offer.initiatorId, offer.recipientId].sort()
-      const deltaFor = (userId) => userId === offer.initiatorId
-        ? { points: { decrement: offer.pointsOffered } }
-        : { points: { increment: offer.pointsOffered } }
 
-      const firstRow = await tx.userPoints.update({ where: { userId: firstId }, data: deltaFor(firstId) })
-      const secondRow = await tx.userPoints.update({ where: { userId: secondId }, data: deltaFor(secondId) })
+      // A user's net can be a decrement even though only pointsRequested (never
+      // locked) is driving it, not pointsOffered (locked at creation). The
+      // pre-transaction check above confirms the recipient can afford it at
+      // that instant, but nothing reserves it — a recipient with two separate
+      // PENDING offers whose pointsRequested both fit their balance alone can
+      // still accept both in quick succession, and the offer-row claim above
+      // only serializes accepts of the SAME offer, not two different offers
+      // touching the same UserPoints row. So the decrementing side of this net
+      // is a CONDITIONAL update gated on the row still covering it, and a miss
+      // aborts the whole transaction (rolling the claim back too) instead of
+      // ever letting a balance go negative.
+      async function applyNet (userId) {
+        const net = netFor(userId)
+        if (net >= 0) {
+          return tx.userPoints.update({ where: { userId }, data: { points: { increment: net } } })
+        }
+        const magnitude = -net
+        const guarded = await tx.userPoints.updateMany({
+          where: { userId, points: { gte: magnitude } },
+          data: { points: { decrement: magnitude } }
+        })
+        if (guarded.count !== 1) {
+          throw createError({
+            statusCode: 409,
+            statusMessage: 'A balance changed and this trade can no longer be completed. Please try again.'
+          })
+        }
+        return tx.userPoints.findUnique({ where: { userId } })
+      }
 
+      const firstRow = await applyNet(firstId)
+      const secondRow = await applyNet(secondId)
       const totalFor = (userId) => (userId === firstId ? firstRow : secondRow).points
 
-      await tx.pointsLog.createMany({
-        data: [
+      const logRows = []
+      if (offer.pointsOffered > 0) {
+        logRows.push(
           {
             userId:    offer.initiatorId,
             points:    offer.pointsOffered,
@@ -150,19 +229,42 @@ export default defineEventHandler(async (event) => {
             method:    'Accepted Trade',
             direction: 'increase'
           }
-        ]
-      })
+        )
+      }
+      if (offer.pointsRequested > 0) {
+        logRows.push(
+          {
+            userId:    offer.recipientId,
+            points:    offer.pointsRequested,
+            total:     totalFor(offer.recipientId),
+            method:    'Accepted Trade (points requested)',
+            direction: 'decrease'
+          },
+          {
+            userId:    offer.initiatorId,
+            points:    offer.pointsRequested,
+            total:     totalFor(offer.initiatorId),
+            method:    'Requested Trade (points requested)',
+            direction: 'increase'
+          }
+        )
+      }
+      await tx.pointsLog.createMany({ data: logRows })
 
-      // Mark the corresponding trade lock as consumed
-      await tx.lockedPoints.updateMany({
-        where: {
-          userId: offer.initiatorId,
-          status: 'ACTIVE',
-          contextType: 'TRADE',
-          contextId: offerId
-        },
-        data: { status: 'CONSUMED' }
-      })
+      // Mark the corresponding trade lock as consumed. pointsRequested never
+      // had one to begin with (see the schema comment on it), so this stays
+      // scoped to pointsOffered exactly as before.
+      if (offer.pointsOffered > 0) {
+        await tx.lockedPoints.updateMany({
+          where: {
+            userId: offer.initiatorId,
+            status: 'ACTIVE',
+            contextType: 'TRADE',
+            contextId: offerId
+          },
+          data: { status: 'CONSUMED' }
+        })
+      }
     }
 
     // Transfer both sides as two set-based updates rather than one update per

--- a/server/api/trade/offers/[id]/counter.post.js
+++ b/server/api/trade/offers/[id]/counter.post.js
@@ -27,6 +27,7 @@ import {
   MAX_COUNTER_CHAIN_DEPTH
 } from '@/server/utils/tradeOffer'
 import { notifyTradeOfferReceived } from '@/server/utils/notifications'
+import { checkTradeOfferRateLimit } from '@/server/utils/tradeOfferRateLimit'
 
 /// One response for every "you may not counter this" case. Distinguishing
 /// "no such offer" from "not yours" from "already settled" would make this
@@ -55,8 +56,11 @@ export default defineEventHandler(async (event) => {
   const {
     ctoonIdsRequested = [],
     ctoonIdsOffered = [],
-    pointsOffered = 0
+    pointsOffered = 0,
+    pointsRequested = 0
   } = await readBody(event)
+
+  await checkTradeOfferRateLimit(event, callerId)
 
   // 3) Load the offer being countered
   const original = await prisma.tradeOffer.findUnique({
@@ -94,7 +98,7 @@ export default defineEventHandler(async (event) => {
     ctoonIdsOffered,
     ctoonIdsRequested
   })
-  assertOfferHasContent({ resolvedOffered, resolvedRequested, pointsOffered })
+  assertOfferHasContent({ resolvedOffered, resolvedRequested, pointsOffered, pointsRequested })
 
   // 4) Ownership, availability and funding.
   //
@@ -102,12 +106,13 @@ export default defineEventHandler(async (event) => {
   // the very cToons committed to the offer it replaces, which the pending-trade
   // guard would otherwise reject. The exemption is scoped to this one offer, so
   // a cToon that is ALSO in some unrelated pending offer still fails.
-  await validateTradeOfferInputs({
+  const { existingPendingCount } = await validateTradeOfferInputs({
     initiatorId: callerId,
     recipient,
     resolvedOffered,
     resolvedRequested,
     pointsOffered,
+    pointsRequested,
     excludeOfferIds: [original.id]
   })
 
@@ -145,6 +150,7 @@ export default defineEventHandler(async (event) => {
       initiatorId: callerId,
       recipientId: recipient.id,
       pointsOffered,
+      pointsRequested,
       resolvedOffered,
       resolvedRequested,
       counteredOfferId: original.id
@@ -153,15 +159,19 @@ export default defineEventHandler(async (event) => {
 
   // 6) One DM, with counter wording. Not awaited, and reject.post.js is
   // deliberately never involved — otherwise the other party would get both a
-  // "rejected your offer" and a "countered your offer" message.
-  sendTradeOfferDM({
-    recipientDiscordId: recipient.discordId,
-    fromUsername: me.username,
-    pointsOffered,
-    offeredCount: resolvedOffered.length,
-    requestedCount: resolvedRequested.length,
-    isCounter: true
-  }).catch(() => {})
+  // "rejected your offer" and a "countered your offer" message. Same
+  // first-pending-offer-only gate as offers.post.js.
+  if (existingPendingCount === 0) {
+    sendTradeOfferDM({
+      recipientDiscordId: recipient.discordId,
+      fromUsername: me.username,
+      pointsOffered,
+      pointsRequested,
+      offeredCount: resolvedOffered.length,
+      requestedCount: resolvedRequested.length,
+      isCounter: true
+    }).catch(() => {})
+  }
 
   // Exactly one in-app notification too, mirroring the DM rule above. The
   // countered party IS this recipient — emitting a separate "your offer was

--- a/server/cron/economy-aggregate.js
+++ b/server/cron/economy-aggregate.js
@@ -128,6 +128,7 @@ async function aggregateTrades(sinceDate) {
     select: {
       updatedAt: true,
       pointsOffered: true,
+      pointsRequested: true,
       ctoons: { select: { userCtoon: { select: { ctoonId: true } } } }
     }
   })
@@ -147,7 +148,10 @@ async function aggregateTrades(sinceDate) {
     const ctoonIds = offer.ctoons.map(c => c.userCtoon.ctoonId)
     if (!ctoonIds.length) continue
 
-    let knownValueSum = offer.pointsOffered || 0
+    // Both directions count toward the trade's imputed value -- pointsRequested
+    // is real value moving from recipient to initiator in the same trade, not
+    // a discount on pointsOffered.
+    let knownValueSum = (offer.pointsOffered || 0) + (offer.pointsRequested || 0)
     let knownCount = 0
     for (const ctoonId of ctoonIds) {
       const ref = pickReferenceValue(ctoonId, auctionRefs, cmartPrices)

--- a/server/utils/suspiciousActivityMetrics.js
+++ b/server/utils/suspiciousActivityMetrics.js
@@ -168,6 +168,7 @@ async function computeAllUserMetrics(prisma, metricKeys, sinceDate) {
         initiatorId: true,
         recipientId: true,
         pointsOffered: true,
+        pointsRequested: true,
       },
     })
 
@@ -177,7 +178,7 @@ async function computeAllUserMetrics(prisma, metricKeys, sinceDate) {
     const pointsRx      = new Map() // userId → points received as recipient
 
     for (const offer of offers) {
-      const { initiatorId, recipientId, pointsOffered } = offer
+      const { initiatorId, recipientId, pointsOffered, pointsRequested } = offer
 
       // initiator side
       if (!partnerCounts.has(initiatorId)) partnerCounts.set(initiatorId, new Map())
@@ -191,9 +192,15 @@ async function computeAllUserMetrics(prisma, metricKeys, sinceDate) {
       rMap.set(initiatorId, (rMap.get(initiatorId) ?? 0) + 1)
       tradeTotal.set(recipientId, (tradeTotal.get(recipientId) ?? 0) + 1)
 
-      // points received by recipient
-      if (pointsOffered > 0) {
-        pointsRx.set(recipientId, (pointsRx.get(recipientId) ?? 0) + pointsOffered)
+      // Net points received, whichever side actually nets a gain -- with
+      // pointsRequested this trade system can now also move points recipient
+      // -> initiator in the same accepted offer, so pointsOffered alone
+      // understates (or points the wrong way for) what either party received.
+      const netToRecipient = (pointsOffered || 0) - (pointsRequested || 0)
+      if (netToRecipient > 0) {
+        pointsRx.set(recipientId, (pointsRx.get(recipientId) ?? 0) + netToRecipient)
+      } else if (netToRecipient < 0) {
+        pointsRx.set(initiatorId, (pointsRx.get(initiatorId) ?? 0) + (-netToRecipient))
       }
     }
 

--- a/server/utils/tradeOffer.js
+++ b/server/utils/tradeOffer.js
@@ -12,6 +12,9 @@ import {
   normalizeCtoonIdList,
   assertNoCrossSideOverlap,
   pendingTradeGuardWhere,
+  assertValidPointsAmount,
+  pendingOfferPairLimitExceeded,
+  MAX_PENDING_OFFERS_PER_PAIR,
   fmtPoints
 } from '@/server/utils/tradeOfferRules'
 import {
@@ -82,16 +85,41 @@ export async function validateTradeOfferInputs ({
   resolvedOffered,
   resolvedRequested,
   pointsOffered,
+  pointsRequested = 0,
   excludeOfferIds = []
 }) {
-  if (typeof pointsOffered !== 'number' || !Number.isInteger(pointsOffered) || pointsOffered < 0) {
-    throw createError({ statusCode: 400, statusMessage: 'pointsOffered must be a non-negative integer' })
-  }
+  assertValidPointsAmount(pointsOffered, 'pointsOffered')
+  // Deliberately the same shape of check as pointsOffered, and deliberately NOT
+  // a balance check — nothing here (or anywhere else in this function) ever
+  // queries the RECIPIENT's UserPoints/LockedPoints for this field. That is
+  // what keeps the initiator from using a request as a way to fish for how
+  // many points someone else has: whether this call succeeds or fails never
+  // depends on the recipient's balance. See accept.post.js for the funds check
+  // this defers to accept time instead.
+  assertValidPointsAmount(pointsRequested, 'pointsRequested')
+
   // Only the client blocked self-trades. Server-side they would make the points
   // release and re-lock in the counter transaction operate on one balance, where
   // the release is visible to the availability check that follows it.
   if (recipient.id === initiatorId) {
     throw createError({ statusCode: 400, statusMessage: 'You cannot trade with yourself.' })
+  }
+
+  // A points-request offer locks nothing and costs the sender no cToon, so it
+  // is free to send — the one thing standing between that and an unbounded,
+  // attacker-writable incoming list is a cap on how many of these one pair can
+  // have open at once. Counters aren't exempted: a counter chain alternates
+  // direction each hop, so at most one PENDING offer ever exists for a given
+  // (initiator, recipient) ordering within a single chain — this only ever
+  // fires against OTHER, unrelated pending offers between the same two users.
+  const existingPendingCount = await prisma.tradeOffer.count({
+    where: { initiatorId, recipientId: recipient.id, status: 'PENDING' }
+  })
+  if (pendingOfferPairLimitExceeded(existingPendingCount)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `You already have ${MAX_PENDING_OFFERS_PER_PAIR} pending offers to this user. Wait for a response, or withdraw one first.`
+    })
   }
 
   const allIds = [...resolvedOffered, ...resolvedRequested]
@@ -203,6 +231,11 @@ export async function validateTradeOfferInputs ({
       })
     }
   }
+
+  // Handed back so callers can decide whether to send a DM/notification: only
+  // on the first pending offer between this pair, so a sender who already has
+  // one open can't ring a recipient's phone again by sending 20 more.
+  return { existingPendingCount }
 }
 
 /**
@@ -214,6 +247,7 @@ export async function createTradeOfferTx (tx, {
   initiatorId,
   recipientId,
   pointsOffered,
+  pointsRequested = 0,
   resolvedOffered,
   resolvedRequested,
   counteredOfferId = null
@@ -244,6 +278,10 @@ export async function createTradeOfferTx (tx, {
       initiatorId,
       recipientId,
       pointsOffered,
+      // No LockedPoints row for this one, ever — see the schema comment on
+      // TradeOffer.pointsRequested. The recipient's balance is checked for the
+      // first time at accept.post.js, not here.
+      pointsRequested,
       counteredOfferId,
       // createMany, not create: a nested `create` array emits one INSERT per
       // element, so a full-size offer would be 500 statements inside this
@@ -307,6 +345,7 @@ export async function sendTradeOfferDM ({
   recipientDiscordId,
   fromUsername,
   pointsOffered,
+  pointsRequested = 0,
   offeredCount,
   requestedCount,
   isCounter = false
@@ -328,6 +367,9 @@ export async function sendTradeOfferDM ({
       ? `🔄 **${fromUsername}** has countered your trade offer!`
       : `👋 **${fromUsername}** has sent you a trade offer!`,
     `• Points offered: **${pointsOffered}**`,
+    // Only shown when nonzero: a bare "Points requested: 0" line on every DM
+    // would bury the (usually rare) offers that actually ask for points.
+    ...(pointsRequested > 0 ? [`• Points requested: **${pointsRequested}**`] : []),
     `• cToons offered: **${offeredCount}**`,
     `• cToons requested: **${requestedCount}**`,
     ``,

--- a/server/utils/tradeOfferLimits.js
+++ b/server/utils/tradeOfferLimits.js
@@ -20,3 +20,19 @@ export const MAX_CTOONS_PER_SIDE = 250
 /// How many counters deep one negotiation may go. A counter is cheap to send and
 /// DMs the other party, so an unbounded chain is a notification-spam vector.
 export const MAX_COUNTER_CHAIN_DEPTH = 20
+
+/// Ceiling on pointsOffered and pointsRequested alike. pointsOffered is already
+/// bounded in practice by the sender's real balance, but pointsRequested is not
+/// checked against anyone's balance at creation on purpose (see the schema
+/// comment on TradeOffer.pointsRequested) — nothing else stops a client sending
+/// Number.MAX_SAFE_INTEGER. Well under Postgres' int4 max (2,147,483,647) so a
+/// single offer can never get close to it on its own; accept.post.js still
+/// checks the actual resulting balances before moving anything, since this
+/// ceiling alone can't rule out overflow against a large existing balance.
+export const MAX_TRADE_POINTS = 1_000_000_000
+
+/// Cap on simultaneous PENDING offers from one initiator to one recipient.
+/// A points-request offer costs the sender nothing to send — no cToon, no
+/// locked points — so without this a recipient's incoming list is an
+/// unbounded, free-to-fill mailbox for one attacker to spam.
+export const MAX_PENDING_OFFERS_PER_PAIR = 5

--- a/server/utils/tradeOfferRateLimit.js
+++ b/server/utils/tradeOfferRateLimit.js
@@ -1,0 +1,39 @@
+// server/utils/tradeOfferRateLimit.js
+// Rate limit for trade-offer creation and countering (server/api/trade/offers.post.js,
+// server/api/trade/offers/[id]/counter.post.js).
+//
+// Modeled on server/utils/lockRequest.js's checkLockRateLimit (same Redis
+// INCR+EXPIRE shape), but deliberately fails CLOSED instead of open. A locked
+// cToon only ever affects its own owner, so lockRequest.js's "this is not a
+// security control" reasoning holds there. A trade offer is sent AT another
+// player — free to send (no cToon, no locked points required) once points can
+// be requested without offering anything back — so this limiter is the thing
+// standing between one account and an unbounded flood of offers landing in
+// other players' incoming lists. Failing open on a Redis outage would remove
+// that protection at exactly the moment it's easiest to abuse undetected.
+import { createError } from 'h3'
+import { redis } from '@/server/utils/redis'
+
+const RATE_LIMIT_MAX = 15
+const RATE_LIMIT_WINDOW_SEC = 60
+
+export async function checkTradeOfferRateLimit (event, userId) {
+  let count
+  try {
+    const key = `trade-offers:rl:${userId}`
+    count = await redis.incr(key)
+    if (count === 1) await redis.expire(key, RATE_LIMIT_WINDOW_SEC)
+  } catch (err) {
+    console.error('[tradeOfferRateLimit] Redis unavailable, failing closed:', err?.message || err)
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'Trade offers are temporarily unavailable. Please try again shortly.'
+    })
+  }
+  if (count > RATE_LIMIT_MAX) {
+    throw createError({
+      statusCode: 429,
+      statusMessage: 'Too many trade offers sent. Please wait a minute and try again.'
+    })
+  }
+}

--- a/server/utils/tradeOfferRules.js
+++ b/server/utils/tradeOfferRules.js
@@ -20,9 +20,9 @@ import { createError } from 'h3'
 // Imported by RELATIVE path, not the `@/` alias: this module is loaded directly
 // by `node --test`, which has no alias resolution — the same reason the header
 // above gives for keeping prisma out of here.
-import { MAX_CTOONS_PER_SIDE, MAX_COUNTER_CHAIN_DEPTH } from './tradeOfferLimits.js'
+import { MAX_CTOONS_PER_SIDE, MAX_COUNTER_CHAIN_DEPTH, MAX_TRADE_POINTS, MAX_PENDING_OFFERS_PER_PAIR } from './tradeOfferLimits.js'
 
-export { MAX_CTOONS_PER_SIDE, MAX_COUNTER_CHAIN_DEPTH }
+export { MAX_CTOONS_PER_SIDE, MAX_COUNTER_CHAIN_DEPTH, MAX_TRADE_POINTS, MAX_PENDING_OFFERS_PER_PAIR }
 
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
 
@@ -60,14 +60,41 @@ export function normalizeCtoonIdList (list, label) {
   return [...new Set(list)]
 }
 
-/** An offer has to actually offer something, or it is just a notification. */
-export function assertOfferHasContent ({ resolvedOffered, resolvedRequested, pointsOffered }) {
-  if (!resolvedOffered.length && !resolvedRequested.length && !pointsOffered) {
+/** An offer has to actually offer or ask for something, or it is just a notification. */
+export function assertOfferHasContent ({ resolvedOffered, resolvedRequested, pointsOffered, pointsRequested = 0 }) {
+  if (!resolvedOffered.length && !resolvedRequested.length && !pointsOffered && !pointsRequested) {
     throw createError({
       statusCode: 400,
       statusMessage: 'A trade offer must include at least one cToon or some points.'
     })
   }
+}
+
+/**
+ * Validates one points field (pointsOffered or pointsRequested): a
+ * non-negative integer under the shared ceiling.
+ *
+ * Deliberately the same ceiling for both fields, even though only
+ * pointsOffered is ever checked against a real balance — pointsRequested has
+ * no balance check at all at this stage (see the schema comment on
+ * TradeOffer.pointsRequested), so this ceiling is the only thing standing
+ * between it and Number.MAX_SAFE_INTEGER.
+ */
+export function assertValidPointsAmount (value, label) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw createError({ statusCode: 400, statusMessage: `${label} must be a non-negative integer` })
+  }
+  if (value > MAX_TRADE_POINTS) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `${label} may not exceed ${fmtPoints(MAX_TRADE_POINTS)} points`
+    })
+  }
+}
+
+/** True when a pair already has as many PENDING offers between them as allowed. */
+export function pendingOfferPairLimitExceeded (existingPendingCount) {
+  return existingPendingCount >= MAX_PENDING_OFFERS_PER_PAIR
 }
 
 /** The same physical cToon cannot sit on both sides of one offer. */

--- a/tests/tradeOfferRules.test.js
+++ b/tests/tradeOfferRules.test.js
@@ -5,12 +5,16 @@ import {
   isUuid,
   normalizeCtoonIdList,
   assertOfferHasContent,
+  assertValidPointsAmount,
+  pendingOfferPairLimitExceeded,
   assertNoCrossSideOverlap,
   pendingTradeGuardWhere,
   counterAuthorizationError,
   exceedsCounterChainDepth,
   MAX_CTOONS_PER_SIDE,
-  MAX_COUNTER_CHAIN_DEPTH
+  MAX_COUNTER_CHAIN_DEPTH,
+  MAX_TRADE_POINTS,
+  MAX_PENDING_OFFERS_PER_PAIR
 } from '../server/utils/tradeOfferRules.js'
 
 const OFFER_A = '11111111-1111-4111-8111-111111111111'
@@ -195,13 +199,53 @@ test('an offer with nothing in it is rejected', () => {
   )
 })
 
-test('any one of cToons, requests or points is enough content', () => {
+test('any one of cToons, requests, offered points or requested points is enough content', () => {
   const cases = [
     { resolvedOffered: ['a'], resolvedRequested: [], pointsOffered: 0 },
     { resolvedOffered: [], resolvedRequested: ['a'], pointsOffered: 0 },
-    { resolvedOffered: [], resolvedRequested: [], pointsOffered: 5 }
+    { resolvedOffered: [], resolvedRequested: [], pointsOffered: 5 },
+    { resolvedOffered: [], resolvedRequested: [], pointsOffered: 0, pointsRequested: 5 }
   ]
   for (const c of cases) assert.equal(statusOf(() => assertOfferHasContent(c)), null)
+})
+
+test('a pure points request with nothing else is still content', () => {
+  // The realistic "just send me some points" case: no cToons on either side,
+  // nothing offered, only a request. This must not fall through to the
+  // empty-offer rejection.
+  assert.equal(
+    statusOf(() => assertOfferHasContent({
+      resolvedOffered: [], resolvedRequested: [], pointsOffered: 0, pointsRequested: 100
+    })),
+    null
+  )
+})
+
+// ── assertValidPointsAmount ────────────────────────────────────────
+
+test('assertValidPointsAmount accepts zero and the ceiling itself', () => {
+  assert.equal(statusOf(() => assertValidPointsAmount(0, 'pointsRequested')), null)
+  assert.equal(statusOf(() => assertValidPointsAmount(MAX_TRADE_POINTS, 'pointsRequested')), null)
+})
+
+test('assertValidPointsAmount rejects negative, non-integer and non-number values', () => {
+  for (const bad of [-1, 1.5, NaN, Infinity, '100', null, undefined, {}, []]) {
+    assert.equal(statusOf(() => assertValidPointsAmount(bad, 'x')), 400, `expected ${JSON.stringify(bad)} to be rejected`)
+  }
+})
+
+test('assertValidPointsAmount rejects anything over the ceiling', () => {
+  assert.equal(statusOf(() => assertValidPointsAmount(MAX_TRADE_POINTS + 1, 'x')), 400)
+  assert.equal(statusOf(() => assertValidPointsAmount(Number.MAX_SAFE_INTEGER, 'x')), 400)
+})
+
+// ── pendingOfferPairLimitExceeded ────────────────────────────────────
+
+test('pendingOfferPairLimitExceeded allows up to the cap and blocks at it', () => {
+  assert.equal(pendingOfferPairLimitExceeded(MAX_PENDING_OFFERS_PER_PAIR - 1), false)
+  assert.equal(pendingOfferPairLimitExceeded(MAX_PENDING_OFFERS_PER_PAIR), true)
+  assert.equal(pendingOfferPairLimitExceeded(MAX_PENDING_OFFERS_PER_PAIR + 1), true)
+  assert.equal(pendingOfferPairLimitExceeded(0), false)
 })
 
 test('the same cToon cannot be on both sides of one offer', () => {


### PR DESCRIPTION
## Summary

- Adds `TradeOffer.pointsRequested` alongside the existing `pointsOffered`, so an initiator can ask a recipient for points in the same offer they're sending cToons/points in.
- Requested points are **never locked or balance-checked at creation** — the recipient's `UserPoints`/`LockedPoints` are never queried until they try to accept, which is what keeps a request from being usable as an oracle to fish for someone else's balance. Accept fails with the recipient's own shortfall (offer stays `PENDING`, no auto-reject) so they can top up, decline, or counter instead.
- Closes a concurrency gap this design opens: since requested points are never reserved, two different pending offers against the same recipient could otherwise both pass the pre-accept check and be accepted back-to-back, driving a balance negative. The point transfer in `accept.post.js` now nets both directions per user and uses a conditional guarded decrement so a second accept that would overdraw aborts cleanly instead.
- Extends the fraud-detection/admin trade-review tooling (suspicious-activity metrics, cheating-tool report/apply endpoints, the economy aggregator, admin trade log + lopsided-trade views) to account for the new reverse point flow — previously all of these only ever read `pointsOffered`.
- Adds a per-(initiator, recipient) cap on pending offers and rate limiting on offer creation/countering, since a points-only request costs the sender nothing to send.
- Frontend: a "points to request" input on the trade-creation wizard's first step, folded into the existing value/fairness totals throughout, plus display updates to the offer list, detail modal, and counter-offer banner. Also fixes two pre-existing gaps found along the way: a pure points-only request (no cToons) previously couldn't be advanced through the wizard, and the points-to-offer input had no NaN/overflow guard.

Design was drafted then adversarially reviewed from four angles (mobile/UX+perf, integration with existing systems, security, game-economy/abuse) before implementation; the findings from all four are folded into the changes above.

## Test plan

- [x] `node --test` — 405 tests, 403 pass; the 2 failures are pre-existing and unrelated (confirmed via `git stash` on a clean `dev`-based tree)
- [x] New pure-logic tests added to `tests/tradeOfferRules.test.js` for the new validation/limit helpers
- [x] All modified `.vue` files parse/compile cleanly via `@vue/compiler-sfc` (script + template)
- [ ] Manual click-through of the trade wizard (points-to-request input, mixed cToon+points offers, accept-with-insufficient-funds, counter flow) — not run in this environment (no live DB/browser session)
- [ ] Migration `20260821000000_add_trade_offer_points_requested` applied against a real Postgres instance on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLskSiyQnFfR6aqXu2S7nw

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLskSiyQnFfR6aqXu2S7nw)_